### PR TITLE
Add parseForComplete method to Parser interface and use it.

### DIFF
--- a/src/main/java/org/jline/reader/Parser.java
+++ b/src/main/java/org/jline/reader/Parser.java
@@ -12,4 +12,8 @@ public interface Parser {
 
     ParsedLine parse(String line, int cursor) throws SyntaxError;
 
+    default ParsedLine parseForComplete(String line, int cursor)
+        throws SyntaxError {
+        return parse(line, cursor);
+    }
 }

--- a/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -3526,7 +3526,7 @@ public class LineReaderImpl implements LineReader, Flushable
         List<Candidate> candidates = new ArrayList<>();
         ParsedLine line;
         try {
-            line = parser.parse(buf.toString(), buf.cursor());
+            line = parser.parseForComplete(buf.toString(), buf.cursor());
             if (completer != null) {
                 completer.complete(this, line, candidates);
             }


### PR DESCRIPTION
We provide a default implementation of parseForComplete (just call parse),
but an override allows clients more flexibility with less overhead.

I was having problems getting tab-completion working with Kawa.  One reason is that Kawa's parser is fairly complex, and I want completion to be context dependent - which means it also needs to parse and analyze the partial line.  So you're getting two parses (which is wasteful), plus the first parse doesn't know it's in completion context (and thus shouldn't throw EOFError).

Creating and using a new parseForComplete method seemed like a simple and clean solution. Kawa command completion now works again with jline3.

An alternative is to add a flag to the parse method (perhaps an enum, since there are a multiple different contexts that parse is called).