### PR TITLE
fix signal handling problems

### DIFF
--- a/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -42,7 +42,10 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         parseInfoCmp();
         if (nativeSignals) {
             for (final Signal signal : Signal.values()) {
-                nativeHandlers.put(signal, Signals.register(signal.name(), () -> raise(signal)));
+                String signame = signal.name();
+                Object old = Signals.registerDefault(signame);
+                Signals.unregister(signame, old);
+                nativeHandlers.put(signal, old);
             }
         }
         closer = PosixSysTerminal.this::close;

--- a/src/main/java/org/jline/utils/Signals.java
+++ b/src/main/java/org/jline/utils/Signals.java
@@ -49,31 +49,31 @@ public final class Signals {
                             return null;
                         }
                     });
-            doRegister(name, signalHandler);
+            return doRegister(name, signalHandler);
         } catch (Exception e) {
             // Ignore this one too, if the above failed, the signal API is incompatible with what we're expecting
+            return null;
         }
-        return null;
     }
 
     public static Object registerDefault(String name) {
         try {
             Class<?> signalHandlerClass = Class.forName("sun.misc.SignalHandler");
-            doRegister(name, signalHandlerClass.getField("SIG_DFL").get(null));
+            return doRegister(name, signalHandlerClass.getField("SIG_DFL").get(null));
         } catch (Exception e) {
             // Ignore this one too, if the above failed, the signal API is incompatible with what we're expecting
+            return null;
         }
-        return null;
     }
 
     public static Object registerIgnore(String name) {
         try {
             Class<?> signalHandlerClass = Class.forName("sun.misc.SignalHandler");
-            doRegister(name, signalHandlerClass.getField("SIG_IGN").get(null));
+            return doRegister(name, signalHandlerClass.getField("SIG_IGN").get(null));
         } catch (Exception e) {
             // Ignore this one too, if the above failed, the signal API is incompatible with what we're expecting
+            return null;
         }
-        return null;
     }
 
     public static void unregister(String name, Object previous) {


### PR DESCRIPTION
When `nativeSignals` is true (and it is always true) the `PosixSysTerminal` constructor saves the original signal handlers so we can restore them on close.  But as a side-effect, the code changed the existing signal handlers.  These handlers call `AbstractTerminal#raise`, which calls the handler from the `handlers` mapping - which has been changed to `SIG_DFL`.  So we call `handleDefaultSignal`, which does nothing.
 
Specifically, this means ctrl/C does nothing, so you can't use it to stop an infinite loop.  I feel if the programmer wants to trap `INT` (outside of `LineReader#parse`), they should do so explicitly.
    
So I changed the code to restore the previous signal handler after we stash it away.

I then noticed that the return value of `register`/`registerDefault`/`registerIgnore` is always null, which means `unregister` is a no-op.  So I fixed that to, in a separate commit.