### PR TITLE
On PosixSysTerminal implement handleDefaultSignal to call native handler

### DIFF
--- a/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -49,6 +49,20 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         ShutdownHooks.add(closer);
     }
 
+    @Override
+    protected void handleDefaultSignal(Signal signal) {
+        Object handler = nativeHandlers.get(signal);
+        if (handler != null) {
+            try {
+                Signals.invokeHandler(signal.name(), handler);
+            } catch (RuntimeException ex) {
+                throw ex;
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
     public NonBlockingReader reader() {
         return reader;
     }

--- a/src/main/java/org/jline/utils/Signals.java
+++ b/src/main/java/org/jline/utils/Signals.java
@@ -87,6 +87,15 @@ public final class Signals {
         }
     }
 
+    public static void invokeHandler(String name, Object handler)
+            throws Exception {
+        Class<?> signalClass = Class.forName("sun.misc.Signal");
+        Class<?> signalHandlerClass = Class.forName("sun.misc.SignalHandler");
+        Object signal = signalClass.getConstructor(String.class).newInstance(name);
+        signalHandlerClass.getMethod("handle", signalClass)
+            .invoke(handler, signal);
+    }
+
     private static Object doRegister(String name, Object handler) throws Exception {
         Class<?> signalClass = Class.forName("sun.misc.Signal");
         Class<?> signalHandlerClass = Class.forName("sun.misc.SignalHandler");


### PR DESCRIPTION
This fixes a problem when using native signals. If JLine has not installed a signal handler, then handleDefaultSignal is called.  But handleDefaultSignal does nothing.  Instead, it should defer to the native signal handler.  Currently ctrl-C gets ignored (except when actually inside LineReaderImpl.readLine).  It should terminate the process, unless some other signal handler is installed.

It might be better for handleDefaultSignal to invoke the "current" native handler, rather than the one active when PosixSysTerminal was constructed.  However, that seems more complicated and hard to specify - what *is* the "current" native handler?