### PR TITLE
Fix #23 - Add option to append command history instead of overwriting it

### DIFF
--- a/src/test/java/org/jline/reader/history/FileHistoryTest.java
+++ b/src/test/java/org/jline/reader/history/FileHistoryTest.java
@@ -10,9 +10,18 @@ package org.jline.reader.history;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.stream.IntStream;
 
 import org.jline.reader.impl.history.FileHistory;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests file history.
@@ -21,14 +30,47 @@ import org.junit.Test;
  */
 public class FileHistoryTest {
 
+    @Before
+    public void setUp() {
+        new File("test").delete();
+    }
+
+    @After
+    public void tearDown() {
+        new File("test").delete();
+    }
+
+    private void doTestFileHistory(int count, boolean append) {
+        try {
+            FileHistory history = new FileHistory(new File("test"), append);
+            IntStream.range(0, count)
+                    .forEach(i -> history.add("cmd" + i));
+            history.flush();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     @Test
     public void testFileHistory() throws IOException {
-        File file = new File("test");
-        try {
-            FileHistory history = new FileHistory(file);
-            history.flush();
-        } finally {
-            file.delete();
+        doTestFileHistory(3, false);
+
+        List<String> lines = Files.readAllLines(new File("test").toPath());
+        assertEquals(3, lines.size());
+    }
+
+    @Test
+    public void testFileHistoryAppend() throws Exception {
+        doTestFileHistory(3, true);
+        List<Thread> ts = IntStream.range(0, 3)
+                .mapToObj(i -> new Thread(() -> doTestFileHistory(3, true)))
+                .collect(toList());
+        ts.stream().forEach(Thread::start);
+        for (Thread t : ts) {
+            t.join();
         }
+
+        List<String> lines = Files.readAllLines(new File("test").toPath());
+        assertEquals(3 * 4, lines.size());
     }
 }


### PR DESCRIPTION
Fixes #23. Added a new constructor to `FileHistory` that accepts a boolean parameter `append`. The existing constructor remains to keep the original "overwrite" behaviour.