### PR TITLE
Suppress outputting of group names in list and menu

### DIFF
--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -331,6 +331,7 @@ public interface LineReader {
         HISTORY_REDUCE_BLANKS(true),
         HISTORY_BEEP(true),
         HISTORY_INCREMENTAL(true),
+        AUTO_GROUP(true),
         AUTO_MENU(true),
         AUTO_LIST(true),
         RECOGNIZE_EXACT,

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4263,7 +4263,7 @@ public class LineReaderImpl implements LineReader, Flushable
                 if (group.isEmpty() && sorted.size() > 1) {
                     group = "others";
                 }
-                if (!group.isEmpty()) {
+                if (!group.isEmpty() && isSet(Option.AUTO_GROUP)) {
                     strings.add(group);
                 }
                 strings.add(new ArrayList<>(entry.getValue().values()));
@@ -4281,8 +4281,10 @@ public class LineReaderImpl implements LineReader, Flushable
                 }
                 sorted.put(cand.value(), cand);
             }
-            for (String group : groups) {
-                strings.add(group);
+            if (isSet(Option.AUTO_GROUP)) {
+                for (String group : groups) {
+                    strings.add(group);
+                }
             }
             strings.add(new ArrayList<>(sorted.values()));
             if (ordered != null) {


### PR DESCRIPTION
Sometimes it is nice to be able to suppress the display of candidate groups. I couldn't find another way of doing this without not providing groups to `Candidate` instances. And even in that case sometimes you end up with `original` as the sole group name.