### PR TITLE
supports Ctrl/Shift in Windows keymap

### DIFF
--- a/builtins/src/test/java/org/jline/example/Example.java
+++ b/builtins/src/test/java/org/jline/example/Example.java
@@ -22,6 +22,7 @@ import org.jline.builtins.Completers.TreeCompleter;
 import org.jline.keymap.KeyMap;
 import org.jline.reader.*;
 import org.jline.reader.impl.DefaultParser;
+import org.jline.reader.impl.LineReaderImpl;
 import org.jline.reader.impl.completer.ArgumentCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
 import org.jline.terminal.Cursor;
@@ -310,6 +311,18 @@ public class Example
                             terminal.writer().println("Unknown capability");
                         }
                     }
+                }
+                else if ("testkey".equals(pl.word())) {
+                    terminal.writer().write("Input the key event(Enter to complete): ");
+                    terminal.writer().flush();
+                    StringBuilder sb = new StringBuilder();
+                    while (true) {
+                        int c = ((LineReaderImpl) reader).readCharacter();
+                        if (c == 10 || c == 13) break;
+                        sb.append(new String(Character.toChars(c)));
+                    }
+                    terminal.writer().println(KeyMap.display(sb.toString()));
+                    terminal.writer().flush();
                 }
                 else if ("bindkey".equals(pl.word())) {
                     if (pl.words().size() == 1) {

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
@@ -76,7 +76,7 @@ public class JansiWinSysTerminal extends AbstractWindowsTerminal {
         StringBuilder sb = new StringBuilder();
         for (INPUT_RECORD event : events) {
             KEY_EVENT_RECORD keyEvent = event.keyEvent;
-            sb.append(getEscapeSequenceFromConsoleInput(new int[]{keyEvent.keyDown?1:0 , keyEvent.keyCode, keyEvent.uchar, keyEvent.controlKeyState, keyEvent.repeatCount,keyEvent.scanCode}));
+            sb.append(getEscapeSequenceFromConsoleInput(keyEvent.keyDown , keyEvent.keyCode, keyEvent.uchar, keyEvent.controlKeyState, keyEvent.repeatCount,keyEvent.scanCode));
         }
         return sb.toString();
     }

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
@@ -84,45 +84,7 @@ public class JnaWinSysTerminal extends AbstractWindowsTerminal {
         for (Kernel32.INPUT_RECORD event : events) {
             if (event.EventType == Kernel32.INPUT_RECORD.KEY_EVENT) {
                 Kernel32.KEY_EVENT_RECORD keyEvent = event.Event.KeyEvent;
-                // support some C1 control sequences: ALT + [@-_] (and [a-z]?) => ESC <ascii>
-                // http://en.wikipedia.org/wiki/C0_and_C1_control_codes#C1_set
-                final int altState = Kernel32.LEFT_ALT_PRESSED | Kernel32.RIGHT_ALT_PRESSED;
-                // Pressing "Alt Gr" is translated to Alt-Ctrl, hence it has to be checked that Ctrl is _not_ pressed,
-                // otherwise inserting of "Alt Gr" codes on non-US keyboards would yield errors
-                final int ctrlState = Kernel32.LEFT_CTRL_PRESSED | Kernel32.RIGHT_CTRL_PRESSED;
-                // Compute the overall alt state
-                boolean isAlt = ((keyEvent.dwControlKeyState & altState) != 0) && ((keyEvent.dwControlKeyState & ctrlState) == 0);
-
-                //Log.trace(keyEvent.keyDown? "KEY_DOWN" : "KEY_UP", "key code:", keyEvent.keyCode, "char:", (long)keyEvent.uchar);
-                if (keyEvent.bKeyDown) {
-                    if (keyEvent.uChar.UnicodeChar > 0) {
-                        boolean shiftPressed = (keyEvent.dwControlKeyState & Kernel32.SHIFT_PRESSED) != 0;
-                        if (keyEvent.uChar.UnicodeChar == '\t' && shiftPressed) {
-                            sb.append(getSequence(InfoCmp.Capability.key_btab));
-                        } else {
-                            if (isAlt) {
-                                sb.append('\033');
-                            }
-                            sb.append(keyEvent.uChar.UnicodeChar);
-                        }
-                    } else {
-                        String escapeSequence = getEscapeSequence(keyEvent.wVirtualKeyCode);
-                        if (escapeSequence != null) {
-                            for (int k = 0; k < keyEvent.wRepeatCount; k++) {
-                                if (isAlt) {
-                                    sb.append('\033');
-                                }
-                                sb.append(escapeSequence);
-                            }
-                        }
-                    }
-                } else {
-                    // key up event
-                    // support ALT+NumPad input method
-                    if (keyEvent.wVirtualKeyCode == 0x12/*VK_MENU ALT key*/ && keyEvent.uChar.UnicodeChar > 0) {
-                        sb.append(keyEvent.uChar.UnicodeChar);
-                    }
-                }
+                sb.append(getEscapeSequenceFromConsoleInput(new int[]{keyEvent.bKeyDown ? 1 : 0, keyEvent.wVirtualKeyCode, keyEvent.uChar.UnicodeChar, keyEvent.dwControlKeyState, keyEvent.wRepeatCount, keyEvent.wVirtualScanCode}));
             } else if (event.EventType == Kernel32.INPUT_RECORD.WINDOW_BUFFER_SIZE_EVENT) {
                 raise(Signal.WINCH);
             } else if (event.EventType == Kernel32.INPUT_RECORD.MOUSE_EVENT) {

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
@@ -84,7 +84,7 @@ public class JnaWinSysTerminal extends AbstractWindowsTerminal {
         for (Kernel32.INPUT_RECORD event : events) {
             if (event.EventType == Kernel32.INPUT_RECORD.KEY_EVENT) {
                 Kernel32.KEY_EVENT_RECORD keyEvent = event.Event.KeyEvent;
-                sb.append(getEscapeSequenceFromConsoleInput(new int[]{keyEvent.bKeyDown ? 1 : 0, keyEvent.wVirtualKeyCode, keyEvent.uChar.UnicodeChar, keyEvent.dwControlKeyState, keyEvent.wRepeatCount, keyEvent.wVirtualScanCode}));
+                sb.append(getEscapeSequenceFromConsoleInput(keyEvent.bKeyDown, keyEvent.wVirtualKeyCode, keyEvent.uChar.UnicodeChar, keyEvent.dwControlKeyState, keyEvent.wRepeatCount, keyEvent.wVirtualScanCode));
             } else if (event.EventType == Kernel32.INPUT_RECORD.WINDOW_BUFFER_SIZE_EVENT) {
                 raise(Signal.WINCH);
             } else if (event.EventType == Kernel32.INPUT_RECORD.MOUSE_EVENT) {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -176,9 +176,9 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         setConsoleOutputCP(consoleOutputCP);
     }
 
-    final int ctrlFlag = 4;
-    final int altFlag = 2;
-    final int shiftFlag = 1;
+    final int CTRL_FLAG = 4;
+    final int ALT_FLAG = 2;
+    final int SHIFT_FLAG = 1;
 
     protected String getEscapeSequenceFromConsoleInput(final boolean isKeyDown, final short virtualKeyCode, final char uchar, final int controlKeyState, final short repeatCount, final short scanCode) {
         final int altState = 0x0002 | 0x0001;
@@ -191,7 +191,7 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         StringBuilder sb = new StringBuilder(32);
         // key down event
         if (isKeyDown && ch != '\3') {
-            final String keySeq = getEscapeSequence(virtualKeyCode, (isCtrl ? ctrlFlag : 0) + (isAlt ? altFlag : 0) + (isShift ? shiftFlag : 0));
+            final String keySeq = getEscapeSequence(virtualKeyCode, (isCtrl ? CTRL_FLAG : 0) + (isAlt ? ALT_FLAG : 0) + (isShift ? SHIFT_FLAG : 0));
             if (keySeq != null) return keySeq;
             /* uchar value in Windows when CTRL is pressed:
              * 1). Ctrl +  <0x41 to 0x5e>      : uchar=<keyCode> - 'A' + 1
@@ -234,91 +234,103 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         String escapeSequence = null;
         switch (keyCode) {
             case 0x08: // VK_BACK BackSpace
-                escapeSequence = (keyState & altFlag) > 0 ? "\\E^H" : strings.get(InfoCmp.Capability.key_backspace);
+                escapeSequence = (keyState & ALT_FLAG) > 0 ? "\\E^H" : getRawSequence(InfoCmp.Capability.key_backspace);
                 break;
             case 0x09:
-                escapeSequence = (keyState & shiftFlag) > 0 ? strings.get(InfoCmp.Capability.key_btab) : null;
+                escapeSequence = (keyState & SHIFT_FLAG) > 0 ? getRawSequence(InfoCmp.Capability.key_btab) : null;
                 break;
             case 0x21: // VK_PRIOR PageUp
-                escapeSequence = strings.get(InfoCmp.Capability.key_ppage);
+                escapeSequence = getRawSequence(InfoCmp.Capability.key_ppage);
                 break;
             case 0x22: // VK_NEXT PageDown
-                escapeSequence = strings.get(InfoCmp.Capability.key_npage);
+                escapeSequence = getRawSequence(InfoCmp.Capability.key_npage);
                 break;
             case 0x23: // VK_END
-                escapeSequence = keyState > 0 ? "\\E[1;%dF" : strings.get(InfoCmp.Capability.key_end);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dF" : getRawSequence(InfoCmp.Capability.key_end);
                 break;
             case 0x24: // VK_HOME
-                escapeSequence = keyState > 0 ? "\\E[1;%dH" : strings.get(InfoCmp.Capability.key_home);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dH" : getRawSequence(InfoCmp.Capability.key_home);
                 break;
             case 0x25: // VK_LEFT
-                escapeSequence = keyState > 0 ? "\\E[1;%dD" : strings.get(InfoCmp.Capability.key_left);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dD" : getRawSequence(InfoCmp.Capability.key_left);
                 break;
             case 0x26: // VK_UP
-                escapeSequence = keyState > 0 ? "\\E[1;%dA" : strings.get(InfoCmp.Capability.key_up);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dA" : getRawSequence(InfoCmp.Capability.key_up);
                 break;
             case 0x27: // VK_RIGHT
-                escapeSequence = keyState > 0 ? "\\E[1;%dC" : strings.get(InfoCmp.Capability.key_right);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dC" : getRawSequence(InfoCmp.Capability.key_right);
                 break;
             case 0x28: // VK_DOWN
-                escapeSequence = keyState > 0 ? "\\E[1;%dB" : strings.get(InfoCmp.Capability.key_down);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dB" : getRawSequence(InfoCmp.Capability.key_down);
                 break;
             case 0x2D: // VK_INSERT
-                escapeSequence = strings.get(InfoCmp.Capability.key_ic);
+                escapeSequence = getRawSequence(InfoCmp.Capability.key_ic);
                 break;
             case 0x2E: // VK_DELETE
-                escapeSequence = strings.get(InfoCmp.Capability.key_dc);
+                escapeSequence = getRawSequence(InfoCmp.Capability.key_dc);
                 break;
             case 0x70: // VK_F1
-                escapeSequence = keyState > 0 ? "\\E[1;%dP" : strings.get(InfoCmp.Capability.key_f1);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dP" : getRawSequence(InfoCmp.Capability.key_f1);
                 break;
             case 0x71: // VK_F2
-                escapeSequence = keyState > 0 ? "\\E[1;%dQ" : strings.get(InfoCmp.Capability.key_f2);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dQ" : getRawSequence(InfoCmp.Capability.key_f2);
                 break;
             case 0x72: // VK_F3
-                escapeSequence = keyState > 0 ? "\\E[1;%dR" : strings.get(InfoCmp.Capability.key_f3);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dR" : getRawSequence(InfoCmp.Capability.key_f3);
                 break;
             case 0x73: // VK_F4
-                escapeSequence = keyState > 0 ? "\\E[1;%dS" : strings.get(InfoCmp.Capability.key_f4);
+                escapeSequence = keyState > 0 ? "\\E[1;%p1%dS" : getRawSequence(InfoCmp.Capability.key_f4);
                 break;
             case 0x74: // VK_F5
-                escapeSequence = keyState > 0 ? "\\E[15;%d~" : strings.get(InfoCmp.Capability.key_f5);
+                escapeSequence = keyState > 0 ? "\\E[15;%p1%d~" : getRawSequence(InfoCmp.Capability.key_f5);
                 break;
             case 0x75: // VK_F6
-                escapeSequence = keyState > 0 ? "\\E[17;%d~" : strings.get(InfoCmp.Capability.key_f6);
+                escapeSequence = keyState > 0 ? "\\E[17;%p1%d~" : getRawSequence(InfoCmp.Capability.key_f6);
                 break;
             case 0x76: // VK_F7
-                escapeSequence = keyState > 0 ? "\\E[18;%d~" : strings.get(InfoCmp.Capability.key_f7);
+                escapeSequence = keyState > 0 ? "\\E[18;%p1%d~" : getRawSequence(InfoCmp.Capability.key_f7);
                 break;
             case 0x77: // VK_F8
-                escapeSequence = keyState > 0 ? "\\E[19;%d~" : strings.get(InfoCmp.Capability.key_f8);
+                escapeSequence = keyState > 0 ? "\\E[19;%p1%d~" : getRawSequence(InfoCmp.Capability.key_f8);
                 break;
             case 0x78: // VK_F9
-                escapeSequence = keyState > 0 ? "\\E[20;%d~" : strings.get(InfoCmp.Capability.key_f9);
+                escapeSequence = keyState > 0 ? "\\E[20;%p1%d~" : getRawSequence(InfoCmp.Capability.key_f9);
                 break;
             case 0x79: // VK_F10
-                escapeSequence = keyState > 0 ? "\\E[21;%d~" : strings.get(InfoCmp.Capability.key_f10);
+                escapeSequence = keyState > 0 ? "\\E[21;%p1%d~" : getRawSequence(InfoCmp.Capability.key_f10);
                 break;
             case 0x7A: // VK_F11
-                escapeSequence = keyState > 0 ? "\\E[23;%d~" : strings.get(InfoCmp.Capability.key_f11);
+                escapeSequence = keyState > 0 ? "\\E[23;%p1%d~" : getRawSequence(InfoCmp.Capability.key_f11);
                 break;
             case 0x7B: // VK_F12
-                escapeSequence = keyState > 0 ? "\\E[24;%d~" : strings.get(InfoCmp.Capability.key_f12);
+                escapeSequence = keyState > 0 ? "\\E[24;%p1%d~" : getRawSequence(InfoCmp.Capability.key_f12);
                 break;
             case 0x5D: // VK_CLOSE_BRACKET(Menu key)
             case 0x5B: // VK_OPEN_BRACKET(Window key)
                 break;
         }
-        if (escapeSequence != null) {
+        return translate(escapeSequence, keyState + 1);
+    }
+
+    protected String getRawSequence(InfoCmp.Capability cap) {
+        return strings.get(cap);
+    }
+
+    protected String getSequence(InfoCmp.Capability cap) {
+        return translate(getRawSequence(cap));
+    }
+
+    private String translate(String str, Object... params) {
+        if (str != null) {
             StringWriter sw = new StringWriter();
             try {
-                Curses.tputs(sw, String.format(escapeSequence, keyState + 1));
+                Curses.tputs(sw, str, params);
             } catch (IOException e) {
                 throw new IOError(e);
             }
             return sw.toString();
         }
-        return escapeSequence;
+        return null;
     }
 
     protected void pump() {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -210,6 +210,7 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
                     sb.append(ch);
                 }
             } else if (ch > 0) {
+                if (isAlt) sb.append('\033');
                 sb.append(ch);
             } else if (isCtrl && code >= 'A' && code <= 'Z') { //Handles the ctrl key events(uchar=0)
                 if (code >= 'A' && code <= 'Z') {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -191,7 +191,6 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         StringBuilder sb = new StringBuilder(32);
         // key down event
         if (isKeyDown && ch != '\3') {
-            if (isShift && ch == '\t') return getSequence(InfoCmp.Capability.key_btab);
             final String keySeq = getEscapeSequence(virtualKeyCode, (isCtrl ? ctrlFlag : 0) + (isAlt ? altFlag : 0) + (isShift ? shiftFlag : 0));
             if (keySeq != null) return keySeq;
             /* uchar value in Windows when CTRL is pressed:
@@ -233,126 +232,93 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         // virtual keycodes: http://msdn.microsoft.com/en-us/library/windows/desktop/dd375731(v=vs.85).aspx
         // TODO: numpad keys, modifiers
         String escapeSequence = null;
-        String fmt = null;
         switch (keyCode) {
             case 0x08: // VK_BACK BackSpace
-                escapeSequence = getSequence(InfoCmp.Capability.key_backspace);
-                if ((keyState & altFlag) > 0)
-                    fmt = "\\E^H";
+                escapeSequence = (keyState & altFlag) > 0 ? "\\E^H" : strings.get(InfoCmp.Capability.key_backspace);
+                break;
+            case 0x09:
+                escapeSequence = (keyState & shiftFlag) > 0 ? strings.get(InfoCmp.Capability.key_btab) : null;
                 break;
             case 0x21: // VK_PRIOR PageUp
-                escapeSequence = getSequence(InfoCmp.Capability.key_ppage);
+                escapeSequence = strings.get(InfoCmp.Capability.key_ppage);
                 break;
             case 0x22: // VK_NEXT PageDown
-                escapeSequence = getSequence(InfoCmp.Capability.key_npage);
+                escapeSequence = strings.get(InfoCmp.Capability.key_npage);
                 break;
             case 0x23: // VK_END
-                escapeSequence = getSequence(InfoCmp.Capability.key_end);
-                fmt = "\\E[1;%dF";
+                escapeSequence = keyState > 0 ? "\\E[1;%dF" : strings.get(InfoCmp.Capability.key_end);
                 break;
             case 0x24: // VK_HOME
-                escapeSequence = getSequence(InfoCmp.Capability.key_home);
-                fmt = "\\E[1;%dH";
+                escapeSequence = keyState > 0 ? "\\E[1;%dH" : strings.get(InfoCmp.Capability.key_home);
                 break;
             case 0x25: // VK_LEFT
-                escapeSequence = getSequence(InfoCmp.Capability.key_left);
-                fmt = "\\E[1;%dD";
+                escapeSequence = keyState > 0 ? "\\E[1;%dD" : strings.get(InfoCmp.Capability.key_left);
                 break;
             case 0x26: // VK_UP
-                escapeSequence = getSequence(InfoCmp.Capability.key_up);
-                fmt = "\\E[1;%dA";
+                escapeSequence = keyState > 0 ? "\\E[1;%dA" : strings.get(InfoCmp.Capability.key_up);
                 break;
             case 0x27: // VK_RIGHT
-                escapeSequence = getSequence(InfoCmp.Capability.key_right);
-                fmt = "\\E[1;%dC";
+                escapeSequence = keyState > 0 ? "\\E[1;%dC" : strings.get(InfoCmp.Capability.key_right);
                 break;
             case 0x28: // VK_DOWN
-                escapeSequence = getSequence(InfoCmp.Capability.key_down);
-                fmt = "\\E[1;%dB";
+                escapeSequence = keyState > 0 ? "\\E[1;%dB" : strings.get(InfoCmp.Capability.key_down);
                 break;
             case 0x2D: // VK_INSERT
-                escapeSequence = getSequence(InfoCmp.Capability.key_ic);
+                escapeSequence = strings.get(InfoCmp.Capability.key_ic);
                 break;
             case 0x2E: // VK_DELETE
-                escapeSequence = getSequence(InfoCmp.Capability.key_dc);
+                escapeSequence = strings.get(InfoCmp.Capability.key_dc);
                 break;
             case 0x70: // VK_F1
-                escapeSequence = getSequence(InfoCmp.Capability.key_f1);
-                fmt = "\\E[1;%dP";
+                escapeSequence = keyState > 0 ? "\\E[1;%dP" : strings.get(InfoCmp.Capability.key_f1);
                 break;
             case 0x71: // VK_F2
-                escapeSequence = getSequence(InfoCmp.Capability.key_f2);
-                fmt = "\\E[1;%dQ";
+                escapeSequence = keyState > 0 ? "\\E[1;%dQ" : strings.get(InfoCmp.Capability.key_f2);
                 break;
             case 0x72: // VK_F3
-                escapeSequence = getSequence(InfoCmp.Capability.key_f3);
-                fmt = "\\E[1;%dR";
+                escapeSequence = keyState > 0 ? "\\E[1;%dR" : strings.get(InfoCmp.Capability.key_f3);
                 break;
             case 0x73: // VK_F4
-                escapeSequence = getSequence(InfoCmp.Capability.key_f4);
-                fmt = "\\E[1;%dS";
+                escapeSequence = keyState > 0 ? "\\E[1;%dS" : strings.get(InfoCmp.Capability.key_f4);
                 break;
             case 0x74: // VK_F5
-                escapeSequence = getSequence(InfoCmp.Capability.key_f5);
-                fmt = "\\E[15;%d";
+                escapeSequence = keyState > 0 ? "\\E[15;%d~" : strings.get(InfoCmp.Capability.key_f5);
                 break;
             case 0x75: // VK_F6
-                escapeSequence = getSequence(InfoCmp.Capability.key_f6);
-                fmt = "\\E[17;%d";
+                escapeSequence = keyState > 0 ? "\\E[17;%d~" : strings.get(InfoCmp.Capability.key_f6);
                 break;
             case 0x76: // VK_F7
-                escapeSequence = getSequence(InfoCmp.Capability.key_f7);
-                fmt = "\\E[18;%d";
+                escapeSequence = keyState > 0 ? "\\E[18;%d~" : strings.get(InfoCmp.Capability.key_f7);
                 break;
             case 0x77: // VK_F8
-                escapeSequence = getSequence(InfoCmp.Capability.key_f8);
-                fmt = "\\E[19;%d";
+                escapeSequence = keyState > 0 ? "\\E[19;%d~" : strings.get(InfoCmp.Capability.key_f8);
                 break;
             case 0x78: // VK_F9
-                escapeSequence = getSequence(InfoCmp.Capability.key_f9);
-                fmt = "\\E[20;%d";
+                escapeSequence = keyState > 0 ? "\\E[20;%d~" : strings.get(InfoCmp.Capability.key_f9);
                 break;
             case 0x79: // VK_F10
-                escapeSequence = getSequence(InfoCmp.Capability.key_f10);
-                fmt = "\\E[21;%d";
+                escapeSequence = keyState > 0 ? "\\E[21;%d~" : strings.get(InfoCmp.Capability.key_f10);
                 break;
             case 0x7A: // VK_F11
-                escapeSequence = getSequence(InfoCmp.Capability.key_f11);
-                fmt = "\\E[23;%d";
+                escapeSequence = keyState > 0 ? "\\E[23;%d~" : strings.get(InfoCmp.Capability.key_f11);
                 break;
             case 0x7B: // VK_F12
-                escapeSequence = getSequence(InfoCmp.Capability.key_f12);
-                fmt = "\\E[24;%d";
+                escapeSequence = keyState > 0 ? "\\E[24;%d~" : strings.get(InfoCmp.Capability.key_f12);
                 break;
             case 0x5D: // VK_CLOSE_BRACKET(Menu key)
             case 0x5B: // VK_OPEN_BRACKET(Window key)
                 break;
         }
-        if (fmt != null && keyState > 0) {
-            if (fmt.indexOf("%d") > -1) fmt = String.format(fmt, keyState + 1);
+        if (escapeSequence != null) {
             StringWriter sw = new StringWriter();
             try {
-                Curses.tputs(sw, fmt);
+                Curses.tputs(sw, String.format(escapeSequence, keyState + 1));
             } catch (IOException e) {
                 throw new IOError(e);
             }
             return sw.toString();
         }
         return escapeSequence;
-    }
-
-    protected String getSequence(InfoCmp.Capability cap) {
-        String str = strings.get(cap);
-        if (str != null) {
-            StringWriter sw = new StringWriter();
-            try {
-                Curses.tputs(sw, str);
-            } catch (IOException e) {
-                throw new IOError(e);
-            }
-            return sw.toString();
-        }
-        return null;
     }
 
     protected void pump() {


### PR DESCRIPTION
Supports following keymaps in Windows platform:
* Combination of Ctrl/Alt/Shift + function keys that listed in AbstractWindowsTerminal.getEscapeSequence
* Combination of Ctrl/Alt + alphabet keys(A-Z)