### PR TITLE
Introduce LineReaderCallback to provide hooks to customize line outputs

### DIFF
--- a/builtins/src/test/java/org/jline/example/ArgumentMaskCallbackReader.java
+++ b/builtins/src/test/java/org/jline/example/ArgumentMaskCallbackReader.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.example;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.LineReaderCallback;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+public  class ArgumentMaskCallbackReader
+{
+    /**
+     * Mask a certain argument for a given command in the console. So for example 'add-user 2', 'add-user username password'
+     * will be displayed as 'add-user username ********'.
+     */
+    public static void usage() {
+        System.out.println("Usage: java "
+            + ArgumentMaskCallbackReader.class.getName() + " [command] [argument-pos-to-mask]");
+    }
+
+    public static void main(String[] args) throws IOException {
+        Terminal terminal = TerminalBuilder.terminal();
+        LineReader reader = LineReaderBuilder.builder()
+            .terminal(terminal).build();
+
+        String command = args[0];
+        int pos = Integer.valueOf(args[1]);
+
+        LineReaderCallback lineReaderCallback = new CommandArgumentMask(command, pos);
+
+        String line;
+        do {
+            line = reader.readLineWithCallback("prompt> ", null, null, lineReaderCallback);
+            System.out.println("Got line: " + line);
+        }
+        while (line != null && line.length() > 0);
+    }
+
+    private static class CommandArgumentMask implements LineReaderCallback{
+
+        private final Pattern pattern;
+        private static final Character mask = '*';
+        private final int pos;
+
+        public CommandArgumentMask(String command, int pos) {
+            StringBuilder regex = new StringBuilder();
+            regex.append(Pattern.quote(command));
+            for (int i = 0; i < pos; i++) {
+                regex.append(" +([^ ]+)");
+            }
+            this.pattern = Pattern.compile(regex.toString());
+            this.pos = pos;
+        }
+
+        @Override
+        public String onDisplayLine(String line) {
+            return filter(line);
+        }
+
+        @Override
+        public String onAddLineToHistory(String line)
+        {
+            final String filter = filter(line);
+            System.out.println();
+            System.out.print("Adding to history: " + filter );
+            return filter;
+        }
+
+        @Override
+        public String onHighlightLine(String line) {
+            return filter(line);
+        }
+
+        public String filter(String line) {
+            Matcher m = pattern.matcher(line);
+
+            if( m.find() ) {
+                StringBuilder maskedLine = new StringBuilder(line);
+                for(int i = m.start(pos); i < m.end(pos); i++){
+                    maskedLine.replace(i,i+1, String.valueOf(mask));
+                }
+                return maskedLine.toString();
+            } else {
+                return line;
+            }
+        }
+    }
+}

--- a/builtins/src/test/java/org/jline/example/OptionMaskCallbackReader.java
+++ b/builtins/src/test/java/org/jline/example/OptionMaskCallbackReader.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.example;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.LineReaderCallback;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+public  class OptionMaskCallbackReader
+{
+    /**
+     * Mask a certain option value in the command line. So for example for the option '--password', '--password mypassword'
+     * will be displayed as '--password **********'.
+     */
+    public static void usage() {
+        System.out.println("Usage: java "
+            + OptionMaskCallbackReader.class.getName() + " [option-name-to-mask]");
+    }
+
+    public static void main(String[] args) throws IOException {
+        Terminal terminal = TerminalBuilder.terminal();
+        LineReader reader = LineReaderBuilder.builder()
+            .terminal(terminal).build();
+
+        String optionToMask = args[0];
+
+        LineReaderCallback lineReaderCallback = new OptionValueMask(optionToMask);
+
+        String line;
+        do {
+            line = reader.readLineWithCallback("prompt> ", null, null, lineReaderCallback);
+            System.out.println("Got line: " + line);
+        }
+        while (line != null && line.length() > 0);
+    }
+
+    private static class OptionValueMask implements LineReaderCallback{
+
+        private final Pattern pattern;
+        private static final Character mask = '*';
+
+        public OptionValueMask(String option) {
+            String patternString=  ".*?" + Pattern.quote(option) + " ??([^ ]+)";    
+            this.pattern = Pattern.compile(patternString);
+        }
+
+        @Override
+        public String onDisplayLine(String line) {
+            return filter(line);
+        }
+
+        @Override
+        public String onAddLineToHistory(String line)
+        {
+            final String filter = filter(line);
+            System.out.println();
+            System.out.print("Adding to history: " + filter );
+            return filter;
+        }
+
+        @Override
+        public String onHighlightLine(String line) {
+            return filter(line);
+        }
+
+        public String filter(String line) {
+            Matcher m = pattern.matcher(line);
+
+            if( m.find() ) {
+                StringBuilder maskedLine = new StringBuilder(line);
+                for(int i = m.start(1); i < m.end(1); i++){
+                    maskedLine.replace(i,i+1, String.valueOf(mask));
+                }
+                return maskedLine.toString();
+            } else {
+                return line;
+            }
+        }
+    }
+
+}

--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -455,6 +455,26 @@ public interface LineReader {
      */
     String readLine(String prompt, String rightPrompt, Character mask, String buffer) throws UserInterruptException, EndOfFileException;
 
+    /**
+     * Read a line from the <i>in</i> {@link InputStream}, and return the line
+     * (without any trailing newlines).
+     *
+     * @param prompt      The prompt to issue to the terminal, may be null.
+     *   This is a template, with optional {@code '%'} escapes, as
+     *   described in the class header.
+     * @param rightPrompt The right prompt
+     *   This is a template, with optional {@code '%'} escapes, as
+     *   described in the class header.
+     * @param buffer      The default value presented to the user to edit, may be null.
+     * @param lineReaderCallback  The {@link LineReaderCallback} to use when displaying lines and adding them to the line {@link History}
+     * @return            A line that is read from the terminal, can never be null.
+     *
+     * @throws UserInterruptException if readLine was interrupted (using Ctrl-C for example)
+     * @throws EndOfFileException if an EOF has been found (using Ctrl-D for example)
+     * @throws java.io.IOError in case of other i/o errors
+     */
+    String readLineWithCallback(String prompt, String rightPrompt, String buffer, LineReaderCallback lineReaderCallback) throws UserInterruptException, EndOfFileException;
+
     void callWidget(String name);
 
     Map<String, Object> getVariables();

--- a/reader/src/main/java/org/jline/reader/LineReaderCallback.java
+++ b/reader/src/main/java/org/jline/reader/LineReaderCallback.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.reader;
+
+public interface LineReaderCallback {
+    
+    String onDisplayLine(String line);
+    
+    String onAddLineToHistory(String line);
+
+    String onHighlightLine(String line);
+}

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderMaskCallback.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderMaskCallback.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.reader.impl;
+
+import org.jline.reader.LineReaderCallback;
+
+/**
+ * Simple {@Link LineReaderCallback} that will replace all the characters in the line with the given mask.
+ * If the given mask is equal to {@link LineReaderImpl#NULL_MASK} then the line will be replaced with an empty String.
+ */
+public final class LineReaderMaskCallback implements LineReaderCallback{
+    private final Character mask;
+
+    public LineReaderMaskCallback(Character mask) {
+        this.mask = mask;
+    }
+
+    @Override
+    public String onDisplayLine(String line) {
+        return getMaskedBuffer(line);
+    }
+
+    @Override
+    public String onAddLineToHistory(String line) {
+        return null;
+    }
+
+    @Override
+    public String onHighlightLine(String line) {
+        return getMaskedBuffer(line);
+    }
+
+    private String getMaskedBuffer(String buffer) {
+        if (mask.equals(LineReaderImpl.NULL_MASK)) {
+            return "";
+        } else {
+            StringBuilder sb = new StringBuilder();
+            for (int i = buffer.length(); i-- > 0;) {
+                sb.append((char) mask);
+            }
+            return sb.toString();
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the LineReaderCallback API that provides hooks to customize line outputs at various stages.

This can be useful for censoring sensitive data in the command line. See the ArgumentMaskCallbackReader and OptionMaskCallbackReader examples.

This enhancement can be used in the Apache Karaf project to [censor](https://github.com/johnpoth/karaf/commit/df49bffc2df4d1c7e1984a54c268e4870fafb3c2) the password argument for the jaas:user-add command. 

Thanks!