### PR TITLE
Use WriteConsoleW to write to Windows console

### DIFF
--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
@@ -9,37 +9,23 @@
 package org.jline.terminal.impl.jansi.win;
 
 import org.fusesource.jansi.internal.WindowsSupport;
+import org.jline.terminal.impl.AbstractWindowsConsoleWriter;
 
 import java.io.IOException;
-import java.io.Writer;
 
 import static org.fusesource.jansi.internal.Kernel32.GetStdHandle;
 import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.WriteConsoleW;
 
-class JansiWinConsoleWriter extends Writer {
+class JansiWinConsoleWriter extends AbstractWindowsConsoleWriter {
 
     private static final long console = GetStdHandle(STD_OUTPUT_HANDLE);
 
     @Override
-    public void write(char[] cbuf, int off, int len) throws IOException {
-        char[] text = cbuf;
-        if (off != 0) {
-            text = new char[len];
-            System.arraycopy(cbuf, off, text, 0, len);
-        }
-
+    protected void writeConsole(char[] text, int len) throws IOException {
         if (WriteConsoleW(console, text, len, new int[1], 0) == 0) {
             throw new IOException("Failed to write to console: " + WindowsSupport.getLastErrorMessage());
         }
-    }
-
-    @Override
-    public void flush() throws IOException {
-    }
-
-    @Override
-    public void close() throws IOException {
     }
 
 }

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.terminal.impl.jansi.win;
+
+import org.fusesource.jansi.internal.WindowsSupport;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import static org.fusesource.jansi.internal.Kernel32.GetStdHandle;
+import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
+import static org.fusesource.jansi.internal.Kernel32.WriteConsoleW;
+
+class JansiWinConsoleWriter extends Writer {
+
+    private static final long console = GetStdHandle(STD_OUTPUT_HANDLE);
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        char[] text = cbuf;
+        if (off != 0) {
+            text = new char[len];
+            System.arraycopy(cbuf, off, text, 0, len);
+        }
+
+        if (WriteConsoleW(console, text, len, new int[1], 0) == 0) {
+            throw new IOException("Failed to write to console: " + WindowsSupport.getLastErrorMessage());
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+}

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
@@ -8,9 +8,7 @@
  */
 package org.jline.terminal.impl.jansi.win;
 
-import java.io.BufferedOutputStream;
-import java.io.FileDescriptor;
-import java.io.FileOutputStream;
+import java.io.BufferedWriter;
 import java.io.IOError;
 import java.io.IOException;
 import java.util.function.IntConsumer;
@@ -36,18 +34,13 @@ public class JansiWinSysTerminal extends AbstractWindowsTerminal {
     }
 
     public JansiWinSysTerminal(String name, int codepage, boolean nativeSignals, SignalHandler signalHandler) throws IOException {
-        super(new WindowsAnsiOutputStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.out))),
+        super(new WindowsAnsiWriter(new BufferedWriter(new JansiWinConsoleWriter())),
               name, codepage, nativeSignals, signalHandler);
     }
 
     @Override
     protected int getConsoleOutputCP() {
         return Kernel32.GetConsoleOutputCP();
-    }
-
-    @Override
-    protected void setConsoleOutputCP(int cp) {
-        Kernel32.SetConsoleOutputCP(cp);
     }
 
     @Override

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/WindowsAnsiWriter.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/WindowsAnsiWriter.java
@@ -17,10 +17,10 @@ package org.jline.terminal.impl.jansi.win;
 
 import org.fusesource.jansi.internal.Kernel32.*;
 import org.fusesource.jansi.internal.WindowsSupport;
-import org.jline.utils.AnsiOutputStream;
+import org.jline.utils.AnsiWriter;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.Writer;
 
 import static org.fusesource.jansi.internal.Kernel32.*;
 
@@ -32,7 +32,7 @@ import static org.fusesource.jansi.internal.Kernel32.*;
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  * @author Joris Kuipers
  */
-public final class WindowsAnsiOutputStream extends AnsiOutputStream {
+public final class WindowsAnsiWriter extends AnsiWriter {
 
     private static final long console = GetStdHandle(STD_OUTPUT_HANDLE);
 
@@ -77,8 +77,8 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
     private short savedX = -1;
     private short savedY = -1;
 
-    public WindowsAnsiOutputStream(OutputStream os) throws IOException {
-        super(os);
+    public WindowsAnsiWriter(Writer out) throws IOException {
+        super(out);
         getConsoleInfo();
         originalColors = info.attributes;
     }

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinConsoleWriter.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinConsoleWriter.java
@@ -11,11 +11,11 @@ package org.jline.terminal.impl.jna.win;
 import com.sun.jna.LastErrorException;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
+import org.jline.terminal.impl.AbstractWindowsConsoleWriter;
 
 import java.io.IOException;
-import java.io.Writer;
 
-class JnaWinConsoleWriter extends Writer {
+class JnaWinConsoleWriter extends AbstractWindowsConsoleWriter {
 
     private final Pointer consoleHandle;
 
@@ -24,26 +24,12 @@ class JnaWinConsoleWriter extends Writer {
     }
 
     @Override
-    public synchronized void write(char[] cbuf, int off, int len) throws IOException {
-        char[] text = cbuf;
-        if (off != 0) {
-            text = new char[len];
-            System.arraycopy(cbuf, off, text, 0, len);
-        }
-
+    protected void writeConsole(char[] text, int len) throws IOException {
         try {
             Kernel32.INSTANCE.WriteConsoleW(this.consoleHandle, text, len, new IntByReference(), null);
         } catch (LastErrorException e) {
             throw new IOException("Failed to write to console", e);
         }
-    }
-
-    @Override
-    public void flush() {
-    }
-
-    @Override
-    public void close() {
     }
 
 }

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinConsoleWriter.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinConsoleWriter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.terminal.impl.jna.win;
+
+import com.sun.jna.LastErrorException;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.IntByReference;
+
+import java.io.IOException;
+import java.io.Writer;
+
+class JnaWinConsoleWriter extends Writer {
+
+    private final Pointer consoleHandle;
+
+    JnaWinConsoleWriter(Pointer consoleHandle) {
+        this.consoleHandle = consoleHandle;
+    }
+
+    @Override
+    public synchronized void write(char[] cbuf, int off, int len) throws IOException {
+        char[] text = cbuf;
+        if (off != 0) {
+            text = new char[len];
+            System.arraycopy(cbuf, off, text, 0, len);
+        }
+
+        try {
+            Kernel32.INSTANCE.WriteConsoleW(this.consoleHandle, text, len, new IntByReference(), null);
+        } catch (LastErrorException e) {
+            throw new IOException("Failed to write to console", e);
+        }
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
@@ -8,20 +8,16 @@
  */
 package org.jline.terminal.impl.jna.win;
 
-import java.io.BufferedOutputStream;
-import java.io.FileDescriptor;
-import java.io.FileOutputStream;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.function.IntConsumer;
 
-import com.sun.jna.LastErrorException;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import org.jline.terminal.Cursor;
 import org.jline.terminal.Size;
 import org.jline.terminal.impl.AbstractWindowsTerminal;
 import org.jline.utils.InfoCmp;
-import org.jline.utils.Log;
 
 public class JnaWinSysTerminal extends AbstractWindowsTerminal {
 
@@ -35,7 +31,7 @@ public class JnaWinSysTerminal extends AbstractWindowsTerminal {
     }
 
     public JnaWinSysTerminal(String name, int codepage, boolean nativeSignals, SignalHandler signalHandler) throws IOException {
-        super(new WindowsAnsiOutputStream(new BufferedOutputStream(new FileOutputStream(FileDescriptor.out)), consoleOut),
+        super(new WindowsAnsiWriter(new BufferedWriter(new JnaWinConsoleWriter(consoleOut)), consoleOut),
               name, codepage, nativeSignals, signalHandler);
         strings.put(InfoCmp.Capability.key_mouse, "\\E[M");
     }
@@ -43,16 +39,6 @@ public class JnaWinSysTerminal extends AbstractWindowsTerminal {
     @Override
     protected int getConsoleOutputCP() {
         return Kernel32.INSTANCE.GetConsoleOutputCP();
-    }
-
-    @Override
-    protected void setConsoleOutputCP(int cp) {
-        try {
-            Kernel32.INSTANCE.SetConsoleOutputCP(cp);
-        } catch (LastErrorException e) {
-            // Not sure why it throws exceptions, just log at trace
-            Log.trace("Error setting console output code page", e);
-        }
     }
 
     @Override

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/Kernel32.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/Kernel32.java
@@ -237,6 +237,16 @@ interface Kernel32 extends StdCallLibrary {
                               boolean in_bAbsolute, SMALL_RECT in_lpConsoleWindow)
             throws LastErrorException;
 
+    // BOOL WINAPI WriteConsole(
+    //  _In_             HANDLE  hConsoleOutput,
+    //  _In_       const VOID    *lpBuffer,
+    //  _In_             DWORD   nNumberOfCharsToWrite,
+    //  _Out_            LPDWORD lpNumberOfCharsWritten,
+    //  _Reserved_       LPVOID  lpReserved
+    // );
+    void WriteConsoleW(Pointer in_hConsoleOutput, char[] in_lpBuffer, int in_nNumberOfCharsToWrite,
+                          IntByReference out_lpNumberOfCharsWritten, Pointer reserved_lpReserved) throws LastErrorException;
+
     // BOOL WINAPI WriteConsoleOutput(
     // _In_ HANDLE hConsoleOutput,
     // _In_ const CHAR_INFO *lpBuffer,

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/WindowsAnsiWriter.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/WindowsAnsiWriter.java
@@ -9,11 +9,11 @@
 package org.jline.terminal.impl.jna.win;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.Writer;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
-import org.jline.utils.AnsiOutputStream;
+import org.jline.utils.AnsiWriter;
 
 import static org.jline.terminal.impl.jna.win.Kernel32.BACKGROUND_BLUE;
 import static org.jline.terminal.impl.jna.win.Kernel32.BACKGROUND_GREEN;
@@ -33,7 +33,7 @@ import static org.jline.terminal.impl.jna.win.Kernel32.FOREGROUND_RED;
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  * @author Joris Kuipers
  */
-public final class WindowsAnsiOutputStream extends AnsiOutputStream {
+public final class WindowsAnsiWriter extends AnsiWriter {
 
     private static final short FOREGROUND_BLACK   = 0;
     private static final short FOREGROUND_YELLOW  = (short) (FOREGROUND_RED|FOREGROUND_GREEN);
@@ -80,8 +80,8 @@ public final class WindowsAnsiOutputStream extends AnsiOutputStream {
     private short savedX = -1;
     private short savedY = -1;
 
-    public WindowsAnsiOutputStream(OutputStream os, Pointer console) throws IOException {
-        super(os);
+    public WindowsAnsiWriter(Writer out, Pointer console) throws IOException {
+        super(out);
         this.console = console;
         getConsoleInfo();
         originalColors = info.wAttributes;

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsConsoleWriter.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsConsoleWriter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.terminal.impl;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public abstract class AbstractWindowsConsoleWriter extends Writer {
+
+    protected abstract void writeConsole(char[] text, int len) throws IOException;
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        char[] text = cbuf;
+        if (off != 0) {
+            text = new char[len];
+            System.arraycopy(cbuf, off, text, 0, len);
+        }
+
+        synchronized (this.lock) {
+            writeConsole(text, len);
+        }
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -16,18 +16,21 @@ import org.jline.utils.Log;
 import org.jline.utils.NonBlockingReader;
 import org.jline.utils.ShutdownHooks;
 import org.jline.utils.Signals;
+import org.jline.utils.WriterOutputStream;
 
+import java.io.BufferedOutputStream;
 import java.io.FilterInputStream;
 import java.io.InputStream;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,8 +40,6 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
 
     private static final int PIPE_SIZE = 1024;
 
-    private static final String UTF8 = "UTF-8";
-    private static final Charset UTF8_CHARSET = Charset.forName(UTF8);
     private static final int UTF8_CODE_PAGE = 65001;
 
     protected static final int ENABLE_PROCESSED_INPUT = 0x0001;
@@ -58,35 +59,20 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
     protected final ShutdownHooks.Task closer;
     protected final Attributes attributes = new Attributes();
     protected final Thread pump;
-    protected final int consoleOutputCP;
 
     protected MouseTracking tracking = MouseTracking.Off;
     private volatile boolean closing;
 
-    public AbstractWindowsTerminal(OutputStream output, String name, int codepage, boolean nativeSignals, SignalHandler signalHandler) throws IOException {
+    public AbstractWindowsTerminal(Writer writer, String name, int codepage, boolean nativeSignals, SignalHandler signalHandler) throws IOException {
         super(name, TYPE_WINDOWS, signalHandler);
         PipedInputStream input = new PipedInputStream(PIPE_SIZE); // UTF-8 encoded
         this.slaveInputPipe = new PipedOutputStream(input); // UTF-8 encoded
         this.input = new FilterInputStream(input) {}; // UTF-8 encoded
-        this.output = output;
-        if (codepage > 0) {
-            // Find out the console code page and save it
-            this.consoleOutputCP = getConsoleOutputCP();
-            // Try to set the code page
-            if (this.consoleOutputCP != codepage) {
-                setConsoleOutputCP(codepage);
-            }
-        } else {
-            this.consoleOutputCP = 0;
-        }
-        // Whether the above call succeeded or failed, grab the console
-        // code page and find a matching charset to encode
-        String encoding = getConsoleEncoding();
-        if (encoding == null) {
-            encoding = Charset.defaultCharset().name();
-        }
-        this.reader = new NonBlockingReader(getName(), new org.jline.utils.InputStreamReader(input, UTF8_CHARSET));
-        this.writer = new PrintWriter(new OutputStreamWriter(output, encoding));
+        this.reader = new NonBlockingReader(getName(), new org.jline.utils.InputStreamReader(input, StandardCharsets.UTF_8));
+        this.writer = new PrintWriter(writer);
+        // Grab the console code page and find a matching charset to encode
+        Charset charset = getConsoleEncoding(codepage);
+        this.output = new BufferedOutputStream(new WriterOutputStream(writer, charset));
         parseInfoCmp();
         // Attributes
         attributes.setLocalFlag(Attributes.LocalFlag.ISIG, true);
@@ -110,21 +96,24 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         ShutdownHooks.add(closer);
     }
 
-    protected String getConsoleEncoding() {
-        int codepage = getConsoleOutputCP();
+    protected Charset getConsoleEncoding(int codepage) {
+        if (codepage <= 0) {
+            codepage = getConsoleOutputCP();
+        }
+
         //http://docs.oracle.com/javase/6/docs/technotes/guides/intl/encoding.doc.html
         if (codepage == UTF8_CODE_PAGE) {
-            return UTF8;
+            return StandardCharsets.UTF_8;
         }
         String charsetMS = "ms" + codepage;
         if (Charset.isSupported(charsetMS)) {
-            return charsetMS;
+            return Charset.forName(charsetMS);
         }
         String charsetCP = "cp" + codepage;
         if (Charset.isSupported(charsetCP)) {
-            return charsetCP;
+            return Charset.forName(charsetCP);
         }
-        return null;
+        return Charset.defaultCharset();
     }
 
     @Override
@@ -205,9 +194,6 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         }
         reader.close();
         writer.close();
-        if (consoleOutputCP > 0) {
-            setConsoleOutputCP(consoleOutputCP);
-        }
     }
 
     static final int SHIFT_FLAG = 0x01;
@@ -396,7 +382,7 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         try {
             while (!closing) {
                 String buf = readConsoleInput();
-                for (byte b : buf.getBytes(UTF8_CHARSET)) {
+                for (byte b : buf.getBytes(StandardCharsets.UTF_8)) {
                     processInputByte(b);
                 }
             }
@@ -448,8 +434,6 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
     }
 
     protected abstract int getConsoleOutputCP();
-
-    protected abstract void setConsoleOutputCP(int cp);
 
     protected abstract int getConsoleMode();
 

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -72,7 +72,7 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         this.writer = new PrintWriter(writer);
         // Grab the console code page and find a matching charset to encode
         Charset charset = getConsoleEncoding(codepage);
-        this.output = new BufferedOutputStream(new WriterOutputStream(writer, charset));
+        this.output = new WriterOutputStream(writer, charset);
         parseInfoCmp();
         // Attributes
         attributes.setLocalFlag(Attributes.LocalFlag.ISIG, true);

--- a/terminal/src/main/java/org/jline/utils/WriterOutputStream.java
+++ b/terminal/src/main/java/org/jline/utils/WriterOutputStream.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.utils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.charset.Charset;
+
+/**
+ * Redirects an {@link OutputStream} to a {@link Writer} by decoding the data
+ * using the specified {@link Charset}.
+ *
+ * <p><b>Note:</b> This class should only be used if it is necessary to
+ * redirect an {@link OutputStream} to a {@link Writer} for compatibility
+ * purposes. It is much more efficient to write to the {@link Writer}
+ * directly.</p>
+ */
+public class WriterOutputStream extends OutputStream {
+
+    private final Writer out;
+    private final Charset charset;
+
+    public WriterOutputStream(Writer out, Charset charset) {
+        this.out = out;
+        this.charset = charset;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        out.write(new String(b, this.charset));
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(new String(b, off, len, this.charset));
+    }
+
+    @Override
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+
+}

--- a/terminal/src/main/java/org/jline/utils/WriterOutputStream.java
+++ b/terminal/src/main/java/org/jline/utils/WriterOutputStream.java
@@ -35,16 +35,19 @@ public class WriterOutputStream extends OutputStream {
     @Override
     public void write(int b) throws IOException {
         out.write(b);
+        flush();
     }
 
     @Override
     public void write(byte[] b) throws IOException {
         out.write(new String(b, this.charset));
+        flush();
     }
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
         out.write(new String(b, off, len, this.charset));
+        flush();
     }
 
     @Override

--- a/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
@@ -11,13 +11,11 @@ package org.jline.utils;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.AbstractWindowsTerminal;
-import org.jline.terminal.impl.DumbTerminal;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.io.OutputStream;
+import java.io.StringWriter;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,7 +38,7 @@ public class AttributedCharSequenceTest {
     private static class DumbWindowsTerminal extends AbstractWindowsTerminal {
 
         public DumbWindowsTerminal() throws IOException {
-            super(new ByteArrayOutputStream(), "windows", 0, false, SignalHandler.SIG_DFL);
+            super(new StringWriter(), "windows", 0, false, SignalHandler.SIG_DFL);
         }
 
         @Override
@@ -51,11 +49,6 @@ public class AttributedCharSequenceTest {
         @Override
         protected int getConsoleOutputCP() {
             return 0;
-        }
-
-        @Override
-        protected void setConsoleOutputCP(int cp) {
-
         }
 
         @Override


### PR DESCRIPTION
This is an attempt to fix #133 and #164 at the same time, without having to set a code page manually.

Further investigation of #164 has shown: Even when the UTF-8 code page is supported just fine (e.g. on Windows 10), it seems to be partially broken. As an example, with the system locale set to Chinese, the UTF-8 code page will produce incorrect characters to be displayed.

Since we avoid all encoding problems for the input mechanism by using the Windows API to read a Unicode char directly, I've been looking for solutions to apply the same for console output. This pull request changes the Windows terminal implementation to use [`WriteConsoleW`](https://docs.microsoft.com/en-us/windows/console/writeconsole) to write Unicode text directly to the console window - bypassing all problems caused by the code pages.

Since the Windows API accepts characters directly, the primary output for the Windows terminal now operates as `Writer`: the encoding step is skipped entirely. For compatibility reasons, we still need to support a `OutputStream`: some applications may use it directly through `Terminal.output()`.
The output stream now emulates the old behavior: it decodes the written bytes using the configured code page. Consequently, Unicode works only properly when using the `Writer` directly (through `Terminal.writer()`). This is the case for JLine's `LineReader` implementation and probably most other applications.

I've tested this on Windows 10 with the system locale set to English, German and Chinese and various code pages and it now handles both #133 and #164 automatically, without having to change the code page. We still need to test if it works properly on older Windows versions.