### PR TITLE
Fix Maven property to skip tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
 build_script:
-  - mvn clean package --batch-mode -DskipTest
+  - mvn clean package --batch-mode -DskipTests
 test_script:
   - mvn clean install --batch-mode
 cache:


### PR DESCRIPTION
The Maven property to skip tests is misspelled, so the tests are run twice, increasing the build execution time.