### PR TITLE
Avoid encoding console input on Windows when using Terminal.reader()

### DIFF
--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
@@ -20,10 +20,11 @@ import static org.fusesource.jansi.internal.Kernel32.WriteConsoleW;
 class JansiWinConsoleWriter extends AbstractWindowsConsoleWriter {
 
     private static final long console = GetStdHandle(STD_OUTPUT_HANDLE);
+    private final int[] writtenChars = new int[1];
 
     @Override
     protected void writeConsole(char[] text, int len) throws IOException {
-        if (WriteConsoleW(console, text, len, new int[1], 0) == 0) {
+        if (WriteConsoleW(console, text, len, writtenChars, 0) == 0) {
             throw new IOException("Failed to write to console: " + WindowsSupport.getLastErrorMessage());
         }
     }

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
@@ -36,6 +36,9 @@ public class JansiWinSysTerminal extends AbstractWindowsTerminal {
     public JansiWinSysTerminal(String name, int codepage, boolean nativeSignals, SignalHandler signalHandler) throws IOException {
         super(new WindowsAnsiWriter(new BufferedWriter(new JansiWinConsoleWriter())),
               name, codepage, nativeSignals, signalHandler);
+
+        // Start input pump thread
+        pump.start();
     }
 
     @Override

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
@@ -60,17 +60,18 @@ public class JansiWinSysTerminal extends AbstractWindowsTerminal {
         return size;
     }
 
-    protected String readConsoleInput() throws IOException {
+    protected boolean processConsoleInput() throws IOException {
         INPUT_RECORD[] events = WindowsSupport.readConsoleInput(1);
         if (events == null) {
-            return "";
+            return false;
         }
-        StringBuilder sb = new StringBuilder();
+
         for (INPUT_RECORD event : events) {
             KEY_EVENT_RECORD keyEvent = event.keyEvent;
-            sb.append(getEscapeSequenceFromConsoleInput(keyEvent.keyDown , keyEvent.keyCode, keyEvent.uchar, keyEvent.controlKeyState, keyEvent.repeatCount,keyEvent.scanCode));
+            processKeyEvent(keyEvent.keyDown , keyEvent.keyCode, keyEvent.uchar, keyEvent.controlKeyState);
         }
-        return sb.toString();
+
+        return true;
     }
 
     @Override

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinConsoleWriter.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinConsoleWriter.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 class JnaWinConsoleWriter extends AbstractWindowsConsoleWriter {
 
     private final Pointer consoleHandle;
+    private final IntByReference writtenChars = new IntByReference();
 
     JnaWinConsoleWriter(Pointer consoleHandle) {
         this.consoleHandle = consoleHandle;
@@ -26,7 +27,7 @@ class JnaWinConsoleWriter extends AbstractWindowsConsoleWriter {
     @Override
     protected void writeConsole(char[] text, int len) throws IOException {
         try {
-            Kernel32.INSTANCE.WriteConsoleW(this.consoleHandle, text, len, new IntByReference(), null);
+            Kernel32.INSTANCE.WriteConsoleW(this.consoleHandle, text, len, this.writtenChars, null);
         } catch (LastErrorException e) {
             throw new IOException("Failed to write to console", e);
         }

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
@@ -112,19 +112,16 @@ public class JnaWinSysTerminal extends AbstractWindowsTerminal {
         return sb.toString();
     }
 
+    private final Kernel32.INPUT_RECORD[] inputEvents = new Kernel32.INPUT_RECORD[1];
+    private final IntByReference eventsRead = new IntByReference();
+
     private Kernel32.INPUT_RECORD[] doReadConsoleInput() throws IOException {
-        Kernel32.INPUT_RECORD[] ir = new Kernel32.INPUT_RECORD[1];
-        IntByReference r = new IntByReference();
-        Kernel32.INSTANCE.ReadConsoleInput(consoleIn, ir, ir.length, r);
-        for (int i = 0; i < r.getValue(); ++i) {
-            switch (ir[i].EventType) {
-                case Kernel32.INPUT_RECORD.KEY_EVENT:
-                case Kernel32.INPUT_RECORD.WINDOW_BUFFER_SIZE_EVENT:
-                case Kernel32.INPUT_RECORD.MOUSE_EVENT:
-                    return ir;
-            }
+        Kernel32.INSTANCE.ReadConsoleInput(consoleIn, inputEvents, 1, eventsRead);
+        if (eventsRead.getValue() == 1) {
+            return inputEvents;
+        } else {
+            return null;
         }
-        return null;
     }
 
     @Override

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
@@ -32,6 +32,9 @@ public class JnaWinSysTerminal extends AbstractWindowsTerminal {
         super(new WindowsAnsiWriter(new BufferedWriter(new JnaWinConsoleWriter(consoleOut)), consoleOut),
               name, codepage, nativeSignals, signalHandler);
         strings.put(InfoCmp.Capability.key_mouse, "\\E[M");
+
+        // Start input pump thread
+        pump.start();
     }
 
     @Override

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
@@ -24,8 +24,6 @@ public class JnaWinSysTerminal extends AbstractWindowsTerminal {
     private static final Pointer consoleIn = Kernel32.INSTANCE.GetStdHandle(Kernel32.STD_INPUT_HANDLE);
     private static final Pointer consoleOut = Kernel32.INSTANCE.GetStdHandle(Kernel32.STD_OUTPUT_HANDLE);
 
-    private int prevButtonState;
-
     public JnaWinSysTerminal(String name, boolean nativeSignals) throws IOException {
         this(name, 0, nativeSignals, SignalHandler.SIG_DFL);
     }
@@ -59,66 +57,75 @@ public class JnaWinSysTerminal extends AbstractWindowsTerminal {
         return new Size(info.windowWidth(), info.windowHeight());
     }
 
+    protected boolean processConsoleInput() throws IOException {
+        Kernel32.INPUT_RECORD event = readConsoleInput();
+        if (event == null) {
+            return false;
+        }
+
+        switch (event.EventType) {
+            case Kernel32.INPUT_RECORD.KEY_EVENT:
+                processKeyEvent(event.Event.KeyEvent);
+                return true;
+            case Kernel32.INPUT_RECORD.WINDOW_BUFFER_SIZE_EVENT:
+                raise(Signal.WINCH);
+                return false;
+            case Kernel32.INPUT_RECORD.MOUSE_EVENT:
+                processMouseEvent(event.Event.MouseEvent);
+                return true;
+            default:
+                // Skip event
+                return false;
+        }
+    }
+
+    private void processKeyEvent(Kernel32.KEY_EVENT_RECORD keyEvent) throws IOException {
+        processKeyEvent(keyEvent.bKeyDown, keyEvent.wVirtualKeyCode, keyEvent.uChar.UnicodeChar, keyEvent.dwControlKeyState);
+    }
+
     private char[] mouse = new char[] { '\033', '[', 'M', ' ', ' ', ' ' };
 
-    protected String readConsoleInput() throws IOException {
-        Kernel32.INPUT_RECORD[] events = doReadConsoleInput();
-        if (events == null) {
-            return "";
+    private void processMouseEvent(Kernel32.MOUSE_EVENT_RECORD mouseEvent) throws IOException {
+        int dwEventFlags = mouseEvent.dwEventFlags;
+        int dwButtonState = mouseEvent.dwButtonState;
+        if (tracking == MouseTracking.Off
+                || tracking == MouseTracking.Normal && dwEventFlags == Kernel32.MOUSE_MOVED
+                || tracking == MouseTracking.Button && dwEventFlags == Kernel32.MOUSE_MOVED && dwButtonState == 0) {
+            return;
         }
-        StringBuilder sb = new StringBuilder();
-        for (Kernel32.INPUT_RECORD event : events) {
-            if (event.EventType == Kernel32.INPUT_RECORD.KEY_EVENT) {
-                Kernel32.KEY_EVENT_RECORD keyEvent = event.Event.KeyEvent;
-                sb.append(getEscapeSequenceFromConsoleInput(keyEvent.bKeyDown, keyEvent.wVirtualKeyCode, keyEvent.uChar.UnicodeChar, keyEvent.dwControlKeyState, keyEvent.wRepeatCount, keyEvent.wVirtualScanCode));
-            } else if (event.EventType == Kernel32.INPUT_RECORD.WINDOW_BUFFER_SIZE_EVENT) {
-                raise(Signal.WINCH);
-            } else if (event.EventType == Kernel32.INPUT_RECORD.MOUSE_EVENT) {
-                Kernel32.MOUSE_EVENT_RECORD mouseEvent = event.Event.MouseEvent;
-                int dwEventFlags = mouseEvent.dwEventFlags;
-                int dwButtonState = mouseEvent.dwButtonState;
-                if (tracking == MouseTracking.Off
-                        || tracking == MouseTracking.Normal && dwEventFlags == Kernel32.MOUSE_MOVED
-                        || tracking == MouseTracking.Button && dwEventFlags == Kernel32.MOUSE_MOVED && dwButtonState == 0) {
-                    continue;
-                }
-                int cb = 0;
-                dwEventFlags &= ~ Kernel32.DOUBLE_CLICK; // Treat double-clicks as normal
-                if (dwEventFlags == Kernel32.MOUSE_WHEELED) {
-                    cb |= 64;
-                    if ((dwButtonState >> 16) < 0) {
-                        cb |= 1;
-                    }
-                } else if (dwEventFlags == Kernel32.MOUSE_HWHEELED) {
-                    continue;
-                } else if ((dwButtonState & Kernel32.FROM_LEFT_1ST_BUTTON_PRESSED) != 0) {
-                    cb |= 0x00;
-                } else if ((dwButtonState & Kernel32.RIGHTMOST_BUTTON_PRESSED) != 0) {
-                    cb |= 0x01;
-                } else if ((dwButtonState & Kernel32.FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
-                    cb |= 0x02;
-                } else {
-                    cb |= 0x03;
-                }
-                int cx = mouseEvent.dwMousePosition.X;
-                int cy = mouseEvent.dwMousePosition.Y;
-                mouse[3] = (char) (' ' + cb);
-                mouse[4] = (char) (' ' + cx + 1);
-                mouse[5] = (char) (' ' + cy + 1);
-                sb.append(mouse);
-                prevButtonState = dwButtonState;
+        int cb = 0;
+        dwEventFlags &= ~ Kernel32.DOUBLE_CLICK; // Treat double-clicks as normal
+        if (dwEventFlags == Kernel32.MOUSE_WHEELED) {
+            cb |= 64;
+            if ((dwButtonState >> 16) < 0) {
+                cb |= 1;
             }
+        } else if (dwEventFlags == Kernel32.MOUSE_HWHEELED) {
+            return;
+        } else if ((dwButtonState & Kernel32.FROM_LEFT_1ST_BUTTON_PRESSED) != 0) {
+            cb |= 0x00;
+        } else if ((dwButtonState & Kernel32.RIGHTMOST_BUTTON_PRESSED) != 0) {
+            cb |= 0x01;
+        } else if ((dwButtonState & Kernel32.FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
+            cb |= 0x02;
+        } else {
+            cb |= 0x03;
         }
-        return sb.toString();
+        int cx = mouseEvent.dwMousePosition.X;
+        int cy = mouseEvent.dwMousePosition.Y;
+        mouse[3] = (char) (' ' + cb);
+        mouse[4] = (char) (' ' + cx + 1);
+        mouse[5] = (char) (' ' + cy + 1);
+        slaveInputPipe.write(mouse);
     }
 
     private final Kernel32.INPUT_RECORD[] inputEvents = new Kernel32.INPUT_RECORD[1];
     private final IntByReference eventsRead = new IntByReference();
 
-    private Kernel32.INPUT_RECORD[] doReadConsoleInput() throws IOException {
+    private Kernel32.INPUT_RECORD readConsoleInput() throws IOException {
         Kernel32.INSTANCE.ReadConsoleInput(consoleIn, inputEvents, 1, eventsRead);
         if (eventsRead.getValue() == 1) {
-            return inputEvents;
+            return inputEvents[0];
         } else {
             return null;
         }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -86,7 +86,9 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         }
         pump = new Thread(this::pump, "WindowsStreamPump");
         pump.setDaemon(true);
-        pump.start();
+        // This is called by the JNA/Jansi terminal implementation to avoid
+        // race conditions if they do initialization in their constructor
+        //pump.start();
         closer = this::close;
         ShutdownHooks.add(closer);
     }

--- a/terminal/src/main/java/org/jline/utils/PumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/PumpReader.java
@@ -21,7 +21,7 @@ import java.nio.charset.CodingErrorAction;
 public class PumpReader extends Reader {
 
     private static final int EOF = -1;
-    private static final int BUFFER_SIZE = 4096;
+    private static final int DEFAULT_BUFFER_SIZE = 4096;
 
     // Read and write buffer are backed by the same array
     private final CharBuffer readBuffer;
@@ -32,7 +32,11 @@ public class PumpReader extends Reader {
     private boolean closed;
 
     public PumpReader() {
-        char[] buf = new char[BUFFER_SIZE];
+        this(DEFAULT_BUFFER_SIZE);
+    }
+
+    public PumpReader(int bufferSize) {
+        char[] buf = new char[bufferSize];
         this.readBuffer = CharBuffer.wrap(buf);
         this.writeBuffer = CharBuffer.wrap(buf);
         this.writer = new Writer(this);
@@ -247,8 +251,11 @@ public class PumpReader extends Reader {
     }
 
     synchronized void flush() {
-        // Notify readers
-        notifyAll();
+        // Avoid waking up readers when there is nothing to read
+        if (readBuffer.hasRemaining()) {
+            // Notify readers
+            notifyAll();
+        }
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/utils/PumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/PumpReader.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.utils;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+
+public class PumpReader extends Reader {
+
+    private static final int EOF = -1;
+    private static final int BUFFER_SIZE = 4096;
+
+    // Read and write buffer are backed by the same array
+    private final CharBuffer readBuffer;
+    private final CharBuffer writeBuffer;
+
+    private final Writer writer;
+
+    private boolean closed;
+
+    public PumpReader() {
+        char[] buf = new char[BUFFER_SIZE];
+        this.readBuffer = CharBuffer.wrap(buf);
+        this.writeBuffer = CharBuffer.wrap(buf);
+        this.writer = new Writer(this);
+
+        // There are no bytes available to read after initialization
+        readBuffer.limit(0);
+    }
+
+    public java.io.Writer getWriter() {
+        return this.writer;
+    }
+
+    public java.io.InputStream createInputStream(Charset charset) {
+        return new InputStream(this, charset);
+    }
+
+    private boolean wait(CharBuffer buffer) throws InterruptedIOException {
+        if (closed) {
+            return false;
+        }
+
+        while (!buffer.hasRemaining()) {
+            // Wake up waiting readers/writers
+            notifyAll();
+
+            try {
+                wait();
+            } catch (InterruptedException e) {
+                throw new InterruptedIOException();
+            }
+
+            if (closed) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Blocks until more input is available or the reader is closed.
+     *
+     * @return true if more input is available, false if the reader is closed
+     * @throws InterruptedIOException If {@link #wait()} is interrupted
+     */
+    private boolean waitForInput() throws InterruptedIOException {
+        return wait(readBuffer);
+    }
+
+    /**
+     * Blocks until there is new space available for buffering or the
+     * reader is closed.
+     *
+     * @throws InterruptedIOException If {@link #wait()} is interrupted
+     * @throws ClosedException If the reader was closed
+     */
+    private void waitForBufferSpace() throws InterruptedIOException, ClosedException {
+        if (!wait(writeBuffer)) {
+            throw new ClosedException();
+        }
+    }
+
+    private static boolean rewind(CharBuffer buffer, CharBuffer other) {
+        // Extend limit of other buffer if there is additional input/output available
+        if (buffer.position() > other.position()) {
+            other.limit(buffer.position());
+        }
+
+        // If we have reached the end of the buffer, rewind and set the new limit
+        if (buffer.position() == buffer.capacity()) {
+            buffer.rewind();
+            buffer.limit(other.position());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to find additional input by rewinding the {@link #readBuffer}.
+     * Updates the {@link #writeBuffer} to make read bytes available for buffering.
+     *
+     * @return If more input is available
+     */
+    private boolean rewindReadBuffer() {
+        return rewind(readBuffer, writeBuffer) && readBuffer.hasRemaining();
+    }
+
+    /**
+     * Attempts to find additional buffer space by rewinding the {@link #writeBuffer}.
+     * Updates the {@link #readBuffer} to make written bytes available to the reader.
+     */
+    private void rewindWriteBuffer() {
+        rewind(writeBuffer, readBuffer);
+    }
+
+    @Override
+    public synchronized boolean ready() {
+        return readBuffer.hasRemaining();
+    }
+
+    public synchronized int available() {
+        int count = readBuffer.remaining();
+        if (writeBuffer.position() < readBuffer.position()) {
+            count += writeBuffer.position();
+        }
+        return count;
+    }
+
+    @Override
+    public synchronized int read() throws IOException {
+        if (!waitForInput()) {
+            return EOF;
+        }
+
+        int b = readBuffer.get();
+        rewindReadBuffer();
+        return b;
+    }
+
+    private int copyChars(char[] cbuf, int off, int len) {
+        len = Math.min(len, readBuffer.remaining());
+        readBuffer.get(cbuf, off, len);
+        return len;
+    }
+
+    @Override
+    public synchronized int read(char[] cbuf, int off, int len) throws IOException {
+        if (!waitForInput()) {
+            return EOF;
+        }
+
+        int count = copyChars(cbuf, off, len);
+        if (rewindReadBuffer() && count < len) {
+            count += copyChars(cbuf, off + count, len - count);
+            rewindReadBuffer();
+        }
+
+        return count;
+    }
+
+    @Override
+    public int read(CharBuffer target) throws IOException {
+        if (!waitForInput()) {
+            return EOF;
+        }
+
+        int count = readBuffer.read(target);
+        if (rewindReadBuffer() && target.hasRemaining()) {
+            count += readBuffer.read(target);
+            rewindReadBuffer();
+        }
+
+        return count;
+    }
+
+    synchronized int readBytes(CharsetEncoder encoder, byte[] b, int off, int len) throws IOException {
+        if (!waitForInput()) {
+            return EOF;
+        }
+
+        ByteBuffer output = ByteBuffer.wrap(b, off, len);
+        CoderResult result = encoder.encode(readBuffer, output, false);
+        if (rewindReadBuffer() && result.isUnderflow()) {
+            encoder.encode(readBuffer, output, false);
+            rewindReadBuffer();
+        }
+
+        return output.position();
+    }
+
+    synchronized void write(char c) throws IOException {
+        waitForBufferSpace();
+        writeBuffer.put(c);
+        rewindWriteBuffer();
+    }
+
+    synchronized void write(char[] cbuf, int off, int len) throws IOException {
+        while (len > 0) {
+            waitForBufferSpace();
+
+            // Copy as much characters as we can
+            int count = Math.min(len, writeBuffer.remaining());
+            writeBuffer.put(cbuf, off, count);
+
+            off += count;
+            len -= count;
+
+            // Update buffer states and rewind if necessary
+            rewindWriteBuffer();
+        }
+    }
+
+    synchronized void write(String str, int off, int len) throws IOException {
+        char[] buf = writeBuffer.array();
+
+        while (len > 0) {
+            waitForBufferSpace();
+
+            // Copy as much characters as we can
+            int count = Math.min(len, writeBuffer.remaining());
+            // CharBuffer.put(String) doesn't use getChars so do it manually
+            str.getChars(off, off + count, buf, writeBuffer.position());
+            writeBuffer.position(writeBuffer.position() + count);
+
+            off += count;
+            len -= count;
+
+            // Update buffer states and rewind if necessary
+            rewindWriteBuffer();
+        }
+    }
+
+    synchronized void flush() {
+        // Notify readers
+        notifyAll();
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        this.closed = true;
+        notifyAll();
+    }
+
+    private static class Writer extends java.io.Writer {
+
+        private final PumpReader reader;
+
+        private Writer(PumpReader reader) {
+            this.reader = reader;
+        }
+
+        @Override
+        public void write(int c) throws IOException {
+            reader.write((char) c);
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            reader.write(cbuf, off, len);
+        }
+
+        @Override
+        public void write(String str, int off, int len) throws IOException {
+            reader.write(str, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            reader.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            reader.close();
+        }
+
+    }
+
+    private static class InputStream extends java.io.InputStream {
+
+        private final PumpReader reader;
+        private final CharsetEncoder encoder;
+
+        private InputStream(PumpReader reader, Charset charset) {
+            this.reader = reader;
+            this.encoder = charset.newEncoder()
+                    .onUnmappableCharacter(CodingErrorAction.REPLACE)
+                    .onMalformedInput(CodingErrorAction.REPLACE);
+        }
+
+        @Override
+        public int available() throws IOException {
+            return (int) (reader.available() * (double) this.encoder.averageBytesPerChar());
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] buf = new byte[1];
+            int count = read(buf);
+            return count == 1 ? buf[0] : EOF;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            return reader.readBytes(this.encoder, b, off, len);
+        }
+
+        @Override
+        public void close() throws IOException {
+            reader.close();
+        }
+
+    }
+
+}

--- a/terminal/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
@@ -40,8 +40,8 @@ public class AbstractWindowsTerminalTest {
             protected void setConsoleMode(int mode) {
             }
             @Override
-            protected String readConsoleInput() throws IOException {
-                return "";
+            protected boolean processConsoleInput() throws IOException {
+                return false;
             }
             @Override
             public Size getSize() {

--- a/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
@@ -62,13 +62,14 @@ public class AttributedCharSequenceTest {
         }
 
         @Override
-        protected String readConsoleInput() throws IOException {
+        protected boolean processConsoleInput() throws IOException {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
                 throw new InterruptedIOException();
             }
-            return "";
+
+            return false;
         }
     }
 

--- a/terminal/src/test/java/org/jline/utils/PumpReaderTest.java
+++ b/terminal/src/test/java/org/jline/utils/PumpReaderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package org.jline.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+public class PumpReaderTest {
+
+    private PumpReader writeInput() {
+        PumpReader pump = new PumpReader();
+        PrintWriter writer = new PrintWriter(pump.getWriter());
+
+        // Write some input
+        writer.println("Hello world!");
+        writer.println("㐀");
+
+        return pump;
+    }
+
+    @Test
+    public void testReader() throws IOException {
+        PumpReader pump = writeInput();
+
+        // Read it again
+        BufferedReader reader = new BufferedReader(pump);
+        assertEquals("Hello world!", reader.readLine());
+        assertEquals("㐀", reader.readLine());
+    }
+
+    @Test
+    public void testInputStream() throws IOException {
+        PumpReader pump = writeInput();
+
+        // Read it using an input stream
+        BufferedReader reader = new BufferedReader(new InputStreamReader(pump.createInputStream(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
+        assertEquals("Hello world!", reader.readLine());
+        assertEquals("㐀", reader.readLine());
+    }
+
+}


### PR DESCRIPTION
On Windows, console input is read using the Windows API as UTF-16 characters. When using the provided Terminal.reader(), input is encoded using UTF-8 just to decode it again shortly after.

Similar to the changes made in #168, change Terminal.reader() to consume the characters directly to avoid unnecessary encoding.

Instead of a `PipedInput/OutputStream` a new `PumpReader` is now used that works very much like a `PipedReader/Writer`. However, it additionally supports reading input using an `InputStream` with a specific `Charset`. It's much easier and more reliable to implement this directly in the `Reader` because you need to buffer to encode characters correctly.
