### PR TITLE
Expose encoding used for Terminal input/output streams

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -1679,7 +1679,7 @@ public class Tmux {
                     name,
                     type,
                     masterOutput,
-                    Charset.defaultCharset().name()) {
+                    null) {
                 @Override
                 public void close() throws IOException {
                     super.close();

--- a/builtins/src/test/java/org/jline/builtins/NanoTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NanoTest.java
@@ -15,13 +15,14 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 public class NanoTest {
 
     @Test(timeout = 1000)
     public void nanoBufferLineOverflow() throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        LineDisciplineTerminal terminal = new LineDisciplineTerminal("nano", "xterm", output, "UTF-8");
+        LineDisciplineTerminal terminal = new LineDisciplineTerminal("nano", "xterm", output, StandardCharsets.UTF_8);
         terminal.setSize(new Size(80, 25));
         for (int i = 0; i < 100; i++) {
             terminal.processInputByte(' ');

--- a/reader/src/test/java/org/jline/keymap/BindingReaderTest.java
+++ b/reader/src/test/java/org/jline/keymap/BindingReaderTest.java
@@ -11,6 +11,7 @@ package org.jline.keymap;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -45,7 +46,7 @@ public class BindingReaderTest {
 
         in = new EofPipedInputStream();
         out = new ByteArrayOutputStream();
-        terminal = new DumbTerminal("dumb", "dumb", in, out, "UTF-8");
+        terminal = new DumbTerminal("dumb", "dumb", in, out, StandardCharsets.UTF_8);
         terminal.setSize(new Size(160, 80));
     }
 

--- a/reader/src/test/java/org/jline/reader/impl/ReaderTestSupport.java
+++ b/reader/src/test/java/org/jline/reader/impl/ReaderTestSupport.java
@@ -10,6 +10,7 @@ package org.jline.reader.impl;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.ConsoleHandler;
@@ -65,7 +66,7 @@ public abstract class ReaderTestSupport
 
         in = new EofPipedInputStream();
         out = new ByteArrayOutputStream();
-        terminal = new DumbTerminal("terminal", "ansi", in, out, "UTF-8");
+        terminal = new DumbTerminal("terminal", "ansi", in, out, StandardCharsets.UTF_8);
         terminal.setSize(new Size(160, 80));
         reader = new TestLineReader(terminal, "JLine", null);
         reader.setKeyMap(LineReaderImpl.EMACS);

--- a/reader/src/test/java/org/jline/terminal/impl/ExternalTerminalTest.java
+++ b/reader/src/test/java/org/jline/terminal/impl/ExternalTerminalTest.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 
 import org.jline.reader.LineReader;
@@ -38,7 +39,7 @@ public class ExternalTerminalTest {
         PipedInputStream in = new PipedInputStream();
         PipedOutputStream outIn = new PipedOutputStream(in);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ExternalTerminal console = new ExternalTerminal("foo", "ansi", in, out, "UTF-8");
+        ExternalTerminal console = new ExternalTerminal("foo", "ansi", in, out, StandardCharsets.UTF_8);
 
         testConsole(outIn, out, console);
     }
@@ -78,7 +79,7 @@ public class ExternalTerminalTest {
         PipedInputStream in = new PipedInputStream();
         final PipedOutputStream outIn = new PipedOutputStream(in);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ExternalTerminal console = new ExternalTerminal("foo", "ansi", in, out, "UTF-8");
+        ExternalTerminal console = new ExternalTerminal("foo", "ansi", in, out, StandardCharsets.UTF_8);
         Attributes attributes = console.getAttributes();
         attributes.setLocalFlag(LocalFlag.ISIG, true);
         attributes.setControlChar(ControlChar.VINTR, 3);
@@ -118,7 +119,7 @@ public class ExternalTerminalTest {
         PipedInputStream in = new PipedInputStream();
         final PipedOutputStream outIn = new PipedOutputStream(in);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ExternalTerminal console = new ExternalTerminal("foo", "ansi", in, out, "UTF-8");
+        ExternalTerminal console = new ExternalTerminal("foo", "ansi", in, out, StandardCharsets.UTF_8);
 
         outIn.write(new byte[] { 'a', '\033', 'b', '\033', '[', '2', ';', '3', 'R', 'f'});
         outIn.flush();

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/JansiSupportImpl.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/JansiSupportImpl.java
@@ -20,6 +20,7 @@ import org.jline.terminal.spi.JansiSupport;
 import org.jline.terminal.spi.Pty;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -92,9 +93,9 @@ public class JansiSupportImpl implements JansiSupport {
     }
 
     @Override
-    public Terminal winSysTerminal(String name, int codepage, boolean nativeSignals, Terminal.SignalHandler signalHandler) throws IOException {
+    public Terminal winSysTerminal(String name, Charset encoding, int codepage, boolean nativeSignals, Terminal.SignalHandler signalHandler) throws IOException {
         if (JANSI_MAJOR_VERSION > 1 || JANSI_MAJOR_VERSION == 1 && JANSI_MINOR_VERSION >= 12) {
-            JansiWinSysTerminal terminal = new JansiWinSysTerminal(name, codepage, nativeSignals, signalHandler);
+            JansiWinSysTerminal terminal = new JansiWinSysTerminal(name, encoding, codepage, nativeSignals, signalHandler);
             if (JANSI_MAJOR_VERSION == 1 && JANSI_MINOR_VERSION < 16) {
                 terminal.disableScrolling();
             }

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
@@ -11,6 +11,7 @@ package org.jline.terminal.impl.jansi.win;
 import java.io.BufferedWriter;
 import java.io.IOError;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.function.IntConsumer;
 
 import org.fusesource.jansi.internal.Kernel32;
@@ -30,12 +31,12 @@ import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
 public class JansiWinSysTerminal extends AbstractWindowsTerminal {
 
     public JansiWinSysTerminal(String name, boolean nativeSignals) throws IOException {
-        this(name, 0, nativeSignals, SignalHandler.SIG_DFL);
+        this(name, null, 0, nativeSignals, SignalHandler.SIG_DFL);
     }
 
-    public JansiWinSysTerminal(String name, int codepage, boolean nativeSignals, SignalHandler signalHandler) throws IOException {
+    public JansiWinSysTerminal(String name, Charset encoding, int codepage, boolean nativeSignals, SignalHandler signalHandler) throws IOException {
         super(new WindowsAnsiWriter(new BufferedWriter(new JansiWinConsoleWriter())),
-              name, codepage, nativeSignals, signalHandler);
+              name, encoding, codepage, nativeSignals, signalHandler);
 
         // Start input pump thread
         pump.start();

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/JnaSupportImpl.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/JnaSupportImpl.java
@@ -8,6 +8,7 @@ import org.jline.terminal.spi.JnaSupport;
 import org.jline.terminal.spi.Pty;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 public class JnaSupportImpl implements JnaSupport {
     @Override
@@ -21,7 +22,7 @@ public class JnaSupportImpl implements JnaSupport {
     }
 
     @Override
-    public Terminal winSysTerminal(String name, int codepage, boolean nativeSignals, Terminal.SignalHandler signalHandler) throws IOException {
-        return new JnaWinSysTerminal(name, codepage, nativeSignals, signalHandler);
+    public Terminal winSysTerminal(String name, Charset encoding, int codepage, boolean nativeSignals, Terminal.SignalHandler signalHandler) throws IOException {
+        return new JnaWinSysTerminal(name, encoding, codepage, nativeSignals, signalHandler);
     }
 }

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/win/JnaWinSysTerminal.java
@@ -10,6 +10,7 @@ package org.jline.terminal.impl.jna.win;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.function.IntConsumer;
 
 import com.sun.jna.Pointer;
@@ -25,12 +26,12 @@ public class JnaWinSysTerminal extends AbstractWindowsTerminal {
     private static final Pointer consoleOut = Kernel32.INSTANCE.GetStdHandle(Kernel32.STD_OUTPUT_HANDLE);
 
     public JnaWinSysTerminal(String name, boolean nativeSignals) throws IOException {
-        this(name, 0, nativeSignals, SignalHandler.SIG_DFL);
+        this(name, null, 0, nativeSignals, SignalHandler.SIG_DFL);
     }
 
-    public JnaWinSysTerminal(String name, int codepage, boolean nativeSignals, SignalHandler signalHandler) throws IOException {
+    public JnaWinSysTerminal(String name, Charset encoding, int codepage, boolean nativeSignals, SignalHandler signalHandler) throws IOException {
         super(new WindowsAnsiWriter(new BufferedWriter(new JnaWinConsoleWriter(consoleOut)), consoleOut),
-              name, codepage, nativeSignals, signalHandler);
+              name, encoding, codepage, nativeSignals, signalHandler);
         strings.put(InfoCmp.Capability.key_mouse, "\\E[M");
 
         // Start input pump thread

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -13,6 +13,7 @@ import java.io.Flushable;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 
@@ -67,6 +68,14 @@ public interface Terminal extends Closeable, Flushable {
     NonBlockingReader reader();
 
     PrintWriter writer();
+
+    /**
+     * Returns the {@link Charset} that should be used to encode characters
+     * for {@link #input()} and {@link #output()}.
+     *
+     * @return The terminal encoding
+     */
+    Charset encoding();
 
     InputStream input();
 

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
@@ -10,6 +10,7 @@ package org.jline.terminal.impl;
 
 import java.io.IOError;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Objects;
 import java.util.function.IntConsumer;
 
@@ -24,11 +25,11 @@ public abstract class AbstractPosixTerminal extends AbstractTerminal {
     protected final Attributes originalAttributes;
 
     public AbstractPosixTerminal(String name, String type, Pty pty) throws IOException {
-        this(name, type, pty, SignalHandler.SIG_DFL);
+        this(name, type, pty, null, SignalHandler.SIG_DFL);
     }
 
-    public AbstractPosixTerminal(String name, String type, Pty pty, SignalHandler signalHandler) throws IOException {
-        super(name, type, signalHandler);
+    public AbstractPosixTerminal(String name, String type, Pty pty, Charset encoding, SignalHandler signalHandler) throws IOException {
+        super(name, type, encoding, signalHandler);
         Objects.requireNonNull(pty);
         this.pty = pty;
         this.originalAttributes = this.pty.getAttr();

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -10,6 +10,7 @@ package org.jline.terminal.impl;
 
 import java.io.IOError;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,18 +36,20 @@ public abstract class AbstractTerminal implements Terminal {
 
     protected final String name;
     protected final String type;
+    protected final Charset encoding;
     protected final Map<Signal, SignalHandler> handlers = new HashMap<>();
     protected final Set<Capability> bools = new HashSet<>();
     protected final Map<Capability, Integer> ints = new HashMap<>();
     protected final Map<Capability, String> strings = new HashMap<>();
 
     public AbstractTerminal(String name, String type) throws IOException {
-        this(name, type, SignalHandler.SIG_DFL);
+        this(name, type, null, SignalHandler.SIG_DFL);
     }
 
-    public AbstractTerminal(String name, String type, SignalHandler signalHandler) throws IOException {
+    public AbstractTerminal(String name, String type, Charset encoding, SignalHandler signalHandler) throws IOException {
         this.name = name;
         this.type = type;
+        this.encoding = encoding != null ? encoding : Charset.defaultCharset();
         for (Signal signal : Signal.values()) {
             handlers.put(signal, signalHandler);
         }
@@ -122,6 +125,11 @@ public abstract class AbstractTerminal implements Terminal {
 
     public String getKind() {
         return getClass().getSimpleName();
+    }
+
+    @Override
+    public Charset encoding() {
+        return this.encoding;
     }
 
     public void flush() {

--- a/terminal/src/main/java/org/jline/terminal/impl/DumbTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DumbTerminal.java
@@ -32,15 +32,15 @@ public class DumbTerminal extends AbstractTerminal {
     private final Size size;
 
     public DumbTerminal(InputStream in, OutputStream out) throws IOException {
-        this(TYPE_DUMB, TYPE_DUMB, in, out, Charset.defaultCharset().name());
+        this(TYPE_DUMB, TYPE_DUMB, in, out, null);
     }
 
-    public DumbTerminal(String name, String type, InputStream in, OutputStream out, String encoding) throws IOException {
+    public DumbTerminal(String name, String type, InputStream in, OutputStream out, Charset encoding) throws IOException {
         this(name, type, in, out, encoding, SignalHandler.SIG_DFL);
     }
 
-    public DumbTerminal(String name, String type, InputStream in, OutputStream out, String encoding, SignalHandler signalHandler) throws IOException {
-        super(name, type, signalHandler);
+    public DumbTerminal(String name, String type, InputStream in, OutputStream out, Charset encoding, SignalHandler signalHandler) throws IOException {
+        super(name, type, encoding, signalHandler);
         this.input = new InputStream() {
             @Override
             public int read() throws IOException {
@@ -91,8 +91,8 @@ public class DumbTerminal extends AbstractTerminal {
             }
         };
         this.output = out;
-        this.reader = new NonBlockingReader(getName(), new InputStreamReader(input, encoding));
-        this.writer = new PrintWriter(new OutputStreamWriter(output, encoding));
+        this.reader = new NonBlockingReader(getName(), new InputStreamReader(input, encoding()));
+        this.writer = new PrintWriter(new OutputStreamWriter(output, encoding()));
         this.attributes = new Attributes();
         this.attributes.setControlChar(ControlChar.VERASE,  (char) 127);
         this.attributes.setControlChar(ControlChar.VWERASE, (char) 23);

--- a/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
@@ -13,6 +13,7 @@ import org.jline.terminal.Cursor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntConsumer;
 
@@ -36,14 +37,14 @@ public class ExternalTerminal extends LineDisciplineTerminal {
     public ExternalTerminal(String name, String type,
                             InputStream masterInput,
                             OutputStream masterOutput,
-                            String encoding) throws IOException {
+                            Charset encoding) throws IOException {
         this(name, type, masterInput, masterOutput, encoding, SignalHandler.SIG_DFL);
     }
 
     public ExternalTerminal(String name, String type,
                             InputStream masterInput,
                             OutputStream masterOutput,
-                            String encoding,
+                            Charset encoding,
                             SignalHandler signalHandler) throws IOException {
         super(name, type, masterOutput, encoding, signalHandler);
         this.masterInput = masterInput;

--- a/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
@@ -16,6 +16,7 @@ import java.io.OutputStreamWriter;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.util.Objects;
 
 import org.jline.terminal.Attributes;
@@ -90,16 +91,16 @@ public class LineDisciplineTerminal extends AbstractTerminal {
     public LineDisciplineTerminal(String name,
                                   String type,
                                   OutputStream masterOutput,
-                                  String encoding) throws IOException {
+                                  Charset encoding) throws IOException {
         this(name, type, masterOutput, encoding, SignalHandler.SIG_DFL);
     }
 
     public LineDisciplineTerminal(String name,
                                   String type,
                                   OutputStream masterOutput,
-                                  String encoding,
+                                  Charset encoding,
                                   SignalHandler signalHandler) throws IOException {
-        super(name, type, signalHandler);
+        super(name, type, encoding, signalHandler);
         PipedInputStream input = new PipedInputStream(PIPE_SIZE);
         this.slaveInputPipe = new PipedOutputStream(input);
         // This is a hack to fix a problem in gogo where closure closes
@@ -107,9 +108,9 @@ public class LineDisciplineTerminal extends AbstractTerminal {
         // So we need to get around and make sure it's not an instance of
         // that class by using a dumb FilterInputStream class to wrap it.
         this.slaveInput = new FilterInputStream(input) {};
-        this.slaveReader = new NonBlockingReader(getName(), new InputStreamReader(slaveInput, encoding));
+        this.slaveReader = new NonBlockingReader(getName(), new InputStreamReader(slaveInput, encoding()));
         this.slaveOutput = new FilteringOutputStream();
-        this.slaveWriter = new PrintWriter(new OutputStreamWriter(slaveOutput, encoding));
+        this.slaveWriter = new PrintWriter(new OutputStreamWriter(slaveOutput, encoding()));
         this.masterOutput = masterOutput;
         this.attributes = ExecPty.doGetAttr(DEFAULT_TERMINAL_ATTRIBUTES);
         this.size = new Size(160, 50);

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -31,19 +32,19 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
     private final Thread inputPumpThread;
     private final Thread outputPumpThread;
 
-    public PosixPtyTerminal(String name, String type, Pty pty, InputStream in, OutputStream out, String encoding) throws IOException {
+    public PosixPtyTerminal(String name, String type, Pty pty, InputStream in, OutputStream out, Charset encoding) throws IOException {
         this(name, type, pty, in, out, encoding, SignalHandler.SIG_DFL);
     }
 
-    public PosixPtyTerminal(String name, String type, Pty pty, InputStream in, OutputStream out, String encoding, SignalHandler signalHandler) throws IOException {
-        super(name, type, pty, signalHandler);
+    public PosixPtyTerminal(String name, String type, Pty pty, InputStream in, OutputStream out, Charset encoding, SignalHandler signalHandler) throws IOException {
+        super(name, type, pty, encoding, signalHandler);
         Objects.requireNonNull(in);
         Objects.requireNonNull(out);
         this.input = new InputStreamWrapper(pty.getSlaveInput());
         this.output = pty.getSlaveOutput();
-        this.innerReader = new InputStreamReader(input, encoding);
+        this.innerReader = new InputStreamReader(input, encoding());
         this.reader = new NonBlockingReader(name, innerReader);
-        this.writer = new PrintWriter(new OutputStreamWriter(output, encoding));
+        this.writer = new PrintWriter(new OutputStreamWriter(output, encoding()));
         this.inputPumpThread = new PumpThread(in, getPty().getMasterOutput());
         this.outputPumpThread = new PumpThread(getPty().getMasterInput(), out);
         parseInfoCmp();

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -33,14 +34,16 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
     protected final Map<Signal, Object> nativeHandlers = new HashMap<>();
     protected final Task closer;
 
-    public PosixSysTerminal(String name, String type, Pty pty, String encoding,
+    public PosixSysTerminal(String name, String type, Pty pty, Charset encoding,
                             boolean nativeSignals, SignalHandler signalHandler) throws IOException {
-        super(name, type, pty, signalHandler);
-        Objects.requireNonNull(encoding);
+        super(name, type, pty, encoding, signalHandler);
+        if (encoding == null) {
+            encoding = Charset.defaultCharset();
+        }
         this.input = pty.getSlaveInput();
         this.output = pty.getSlaveOutput();
-        this.reader = new NonBlockingReader(getName(), new InputStreamReader(input, encoding));
-        this.writer = new PrintWriter(new OutputStreamWriter(output, encoding));
+        this.reader = new NonBlockingReader(getName(), new InputStreamReader(input, encoding()));
+        this.writer = new PrintWriter(new OutputStreamWriter(output, encoding()));
         parseInfoCmp();
         if (nativeSignals) {
             for (final Signal signal : Signal.values()) {

--- a/terminal/src/main/java/org/jline/terminal/spi/JansiSupport.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/JansiSupport.java
@@ -5,6 +5,7 @@ import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 public interface JansiSupport {
 
@@ -12,6 +13,6 @@ public interface JansiSupport {
 
     Pty open(Attributes attributes, Size size) throws IOException;
 
-    Terminal winSysTerminal(String name, int codepage, boolean nativeSignals, Terminal.SignalHandler signalHandler) throws IOException;
+    Terminal winSysTerminal(String name, Charset encoding, int codepage, boolean nativeSignals, Terminal.SignalHandler signalHandler) throws IOException;
 
 }

--- a/terminal/src/main/java/org/jline/terminal/spi/JnaSupport.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/JnaSupport.java
@@ -5,6 +5,7 @@ import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 public interface JnaSupport {
 
@@ -12,6 +13,6 @@ public interface JnaSupport {
 
     Pty open(Attributes attributes, Size size) throws IOException;
 
-    Terminal winSysTerminal(String name, int codepage, boolean nativeSignals, Terminal.SignalHandler signalHandler) throws IOException;
+    Terminal winSysTerminal(String name, Charset encoding, int codepage, boolean nativeSignals, Terminal.SignalHandler signalHandler) throws IOException;
 
 }

--- a/terminal/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
@@ -18,6 +18,7 @@ import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 
 import static org.junit.Assert.assertEquals;
 
@@ -26,7 +27,7 @@ public class AbstractWindowsTerminalTest {
     @Test
     public void testWriterBuffering() throws Exception {
         StringWriter sw = new StringWriter();
-        Terminal terminal = new AbstractWindowsTerminal(new AnsiWriter(new BufferedWriter(sw)), "name", 0,
+        Terminal terminal = new AbstractWindowsTerminal(new AnsiWriter(new BufferedWriter(sw)), "name", Charset.defaultCharset(),0,
                 false, Terminal.SignalHandler.SIG_DFL) {
             @Override
             protected int getConsoleOutputCP() {

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -31,9 +31,7 @@ public class PosixSysTerminalTest {
         EasyMock.expect(pty.getSlaveOutput()).andReturn(new ByteArrayOutputStream()).anyTimes();
         EasyMock.replay(pty);
         try (PosixSysTerminal terminal = new PosixSysTerminal(
-                "name", "ansi", pty,
-                Charset.defaultCharset().name(), true,
-                SignalHandler.SIG_DFL)) {
+                "name", "ansi", pty, null, true, SignalHandler.SIG_DFL)) {
             assertEquals(Signal.values().length, terminal.nativeHandlers.size());
         }
     }
@@ -46,8 +44,7 @@ public class PosixSysTerminalTest {
         EasyMock.expect(pty.getSlaveOutput()).andReturn(new ByteArrayOutputStream()).anyTimes();
         EasyMock.replay(pty);
         try (PosixSysTerminal terminal = new PosixSysTerminal(
-                "name", "ansi", pty,
-                Charset.defaultCharset().name(), true,
+                "name", "ansi", pty,null, true,
                 SignalHandler.SIG_IGN)) {
             assertEquals(Signal.values().length, terminal.nativeHandlers.size());
         }
@@ -61,8 +58,7 @@ public class PosixSysTerminalTest {
         EasyMock.expect(pty.getSlaveOutput()).andReturn(new ByteArrayOutputStream()).anyTimes();
         EasyMock.replay(pty);
         try (PosixSysTerminal terminal = new PosixSysTerminal(
-                "name", "ansi", pty,
-                Charset.defaultCharset().name(), true,
+                "name", "ansi", pty,null, true,
                 SignalHandler.SIG_DFL)) {
             assertEquals(Signal.values().length, terminal.nativeHandlers.size());
             SignalHandler prev = terminal.handle(Signal.INT, s -> {});

--- a/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
@@ -38,7 +38,7 @@ public class AttributedCharSequenceTest {
     private static class DumbWindowsTerminal extends AbstractWindowsTerminal {
 
         public DumbWindowsTerminal() throws IOException {
-            super(new StringWriter(), "windows", 0, false, SignalHandler.SIG_DFL);
+            super(new StringWriter(), "windows", null,0, false, SignalHandler.SIG_DFL);
         }
 
         @Override

--- a/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
@@ -107,7 +107,7 @@ public class AttributedStringTest {
         assertEquals("\033[48;5;254mHello\033[0m", sb.toAnsi(
                 new DumbTerminal("dumb", "xterm-256color",
                         new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream(),
-                        Charset.defaultCharset().name())));
+                        null)));
     }
 
     @Test


### PR DESCRIPTION
`Terminal.encoding()` now exposes the charset that should be used for `Terminal` input/output streams.

`TerminalBuilder.encoding` is now nullable, if null JLine will automatically select the best encoding (usually default system encoding), except on Windows where UTF-8 is used by default. I've also added `TerminalBuilder.encoding(Charset)` to avoid several lookups of the charset later (it's also more convenient to use with `StandardCharsets`). 

`TerminalBuilder.codepage(int)` is now deprecated because it really doesn't affect anything now that we use the Windows API for input and output. If it's used then we attempt to emulate that code page for the input/output stream.

Closes #174. 