### PR TITLE
Enhance extensibility of DefaultHistory

### DIFF
--- a/reader/src/main/java/org/jline/reader/History.java
+++ b/reader/src/main/java/org/jline/reader/History.java
@@ -74,6 +74,15 @@ public interface History extends Iterable<History.Entry>
         Instant time();
 
         String line();
+
+        /**
+         * By default an entry should be persisted to e.g. a history file (if configured).
+         * @return true
+         */
+        default boolean isPersistable() {
+            return true;
+        }
+
     }
 
     ListIterator<Entry> iterator(int index);

--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -121,7 +121,9 @@ public class DefaultHistory implements History {
             try (BufferedWriter writer = Files.newBufferedWriter(path.toAbsolutePath(),
               StandardOpenOption.WRITE, StandardOpenOption.APPEND, StandardOpenOption.CREATE)) {
                 for (Entry entry : items.subList(lastLoaded, items.size())) {
-                    writer.append(format(entry));
+                    if (entry.isPersistable()) {
+                        writer.append(format(entry));
+                    }
                 }
             }
             nbEntriesInFile += items.size() - lastLoaded;
@@ -143,7 +145,7 @@ public class DefaultHistory implements History {
                 int idx = l.indexOf(':');
                 Instant time = Instant.ofEpochMilli(Long.parseLong(l.substring(0, idx)));
                 String line = unescape(l.substring(idx + 1));
-                allItems.add(new EntryImpl(allItems.size(), time, line));
+                allItems.add(createEntry(allItems.size(), time, line));
             });
         }
         // Remove duplicates
@@ -163,6 +165,17 @@ public class DefaultHistory implements History {
         lastLoaded = items.size();
         nbEntriesInFile = items.size();
         maybeResize();
+    }
+
+    /**
+     * Create a history entry. Subclasses may override to use their own entry implementations.
+     * @param index index of history entry
+     * @param time entry creation time
+     * @param line the entry text
+     * @return entry object
+     */
+    protected Entry createEntry(int index, Instant time, String line) {
+        return new EntryImpl(index, time, line);
     }
 
     private void internalClear() {
@@ -273,7 +286,7 @@ public class DefaultHistory implements History {
     }
 
     protected void internalAdd(Instant time, String line) {
-        Entry entry = new EntryImpl(offset + items.size(), time, line);
+        Entry entry = createEntry(offset + items.size(), time, line);
         items.add(entry);
         maybeResize();
     }
@@ -291,7 +304,7 @@ public class DefaultHistory implements History {
         return items.listIterator(index - offset);
     }
 
-    static class EntryImpl implements Entry {
+    protected static class EntryImpl implements Entry {
 
         private final int index;
         private final Instant time;


### PR DESCRIPTION
We've enhanced extensibility of DefaultHistory a little e.g. to selectively persist to history file.
In our use case we'd like to only persist successful commands to file while keeping all commands in the history list in memory.
Our change is non-intrusive and does not change the behaviour of the class.