### PR TITLE
Added URL for Javadoc, hosted on javadoc.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ JLine is distributed under the [BSD License](http://www.opensource.org/licenses/
 
 * [demos](https://github.com/jline/jline3/wiki/Demos)
 * [wiki](https://github.com/jline/jline3/wiki)
+* [javadoc](https://www.javadoc.io/doc/org.jline/jline/)
 
 # Forums
 


### PR DESCRIPTION
The URL I provided automatically selects the latest version of `jline`, and users can select from all available versions.