### PR TITLE
Fix DiffHelper.diff logic for comparing strings of "hidden" characters

### DIFF
--- a/terminal/src/main/java/org/jline/utils/DiffHelper.java
+++ b/terminal/src/main/java/org/jline/utils/DiffHelper.java
@@ -93,8 +93,8 @@ public class DiffHelper {
             commonStart++;
         }
         if (startHiddenRange >= 0
-            && (commonStart == l1 || ! text1.isHidden(commonStart))
-            && (commonStart == l2 || ! text2.isHidden(commonStart)))
+            && ((l1 > commonStart && text1.isHidden(commonStart))
+                || (l2 > commonStart && text2.isHidden(commonStart))))
             commonStart = startHiddenRange;
 
         startHiddenRange = -1;


### PR DESCRIPTION
The logic in DiffHelper.diff for making sequences of hidden characters be "atomic" was broken.  (The goal is that for a sequence of hidden characters, which are sequences of uninterrupted escape sequences, we always want to print either the entire run or none of it - never a part of it.)
The logic for finding the common prefix was too conservative (in terms of hidden characters).  This caused a string of hidden characters in an initial prompt to be printed twice: once when we print the prompt, and once when the first input character is echoed.