### PR TITLE
#226 - Blocking pause() until pump threads terminate

### DIFF
--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/JansiSupportImpl.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/JansiSupportImpl.java
@@ -75,7 +75,8 @@ public class JansiSupportImpl implements JansiSupport {
         if (JANSI_MAJOR_VERSION > 1 || JANSI_MAJOR_VERSION == 1 && JANSI_MINOR_VERSION >= 16) {
             String osName = System.getProperty("os.name");
             if (osName.startsWith("Linux")) {
-                return LinuxNativePty.open(attributes, size);
+                // TODO: the terminals using openpty are broken on linux
+                // return LinuxNativePty.open(attributes, size);
             }
             else if (osName.startsWith("Mac") || osName.startsWith("Darwin")) {
                 return OsXNativePty.open(attributes, size);

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/JansiSupportImpl.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/JansiSupportImpl.java
@@ -75,8 +75,7 @@ public class JansiSupportImpl implements JansiSupport {
         if (JANSI_MAJOR_VERSION > 1 || JANSI_MAJOR_VERSION == 1 && JANSI_MINOR_VERSION >= 16) {
             String osName = System.getProperty("os.name");
             if (osName.startsWith("Linux")) {
-                // TODO: the terminals using openpty are broken on linux
-                // return LinuxNativePty.open(attributes, size);
+                 return LinuxNativePty.open(attributes, size);
             }
             else if (osName.startsWith("Mac") || osName.startsWith("Darwin")) {
                 return OsXNativePty.open(attributes, size);

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/freebsd/FreeBsdNativePty.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/freebsd/FreeBsdNativePty.java
@@ -30,7 +30,7 @@ public class FreeBsdNativePty extends JansiNativePty {
         }
     }
 
-    public static OsXNativePty open(Attributes attr, Size size) throws IOException {
+    public static FreeBsdNativePty open(Attributes attr, Size size) throws IOException {
         int[] master = new int[1];
         int[] slave = new int[1];
         byte[] buf = new byte[64];
@@ -42,7 +42,7 @@ public class FreeBsdNativePty extends JansiNativePty {
             len++;
         }
         String name = new String(buf, 0, len);
-        return new OsXNativePty(master[0], newDescriptor(master[0]), slave[0], newDescriptor(slave[0]), name);
+        return new FreeBsdNativePty(master[0], newDescriptor(master[0]), slave[0], newDescriptor(slave[0]), name);
     }
 
     public FreeBsdNativePty(int master, FileDescriptor masterFD, int slave, FileDescriptor slaveFD, String name) {

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/linux/LinuxNativePty.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/linux/LinuxNativePty.java
@@ -30,7 +30,7 @@ public class LinuxNativePty extends JansiNativePty {
         }
     }
 
-    public static OsXNativePty open(Attributes attr, Size size) throws IOException {
+    public static LinuxNativePty open(Attributes attr, Size size) throws IOException {
         int[] master = new int[1];
         int[] slave = new int[1];
         byte[] buf = new byte[64];
@@ -42,7 +42,7 @@ public class LinuxNativePty extends JansiNativePty {
             len++;
         }
         String name = new String(buf, 0, len);
-        return new OsXNativePty(master[0], newDescriptor(master[0]), slave[0], newDescriptor(slave[0]), name);
+        return new LinuxNativePty(master[0], newDescriptor(master[0]), slave[0], newDescriptor(slave[0]), name);
     }
 
     public LinuxNativePty(int master, FileDescriptor masterFD, int slave, FileDescriptor slaveFD, String name) {

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/freebsd/CLibrary.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/freebsd/CLibrary.java
@@ -31,11 +31,7 @@ public interface CLibrary extends com.sun.jna.Library {
 
     void ioctl(int fd, long cmd, winsize data) throws LastErrorException;
 
-//    int isatty(int fd);
-
     void ttyname_r(int fd, byte[] buf, int len) throws LastErrorException;
-
-    void openpty(int[] master, int[] slave, byte[] name, termios t, winsize s) throws LastErrorException;
 
     class winsize extends Structure {
         public short ws_row;

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/freebsd/FreeBsdNativePty.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/freebsd/FreeBsdNativePty.java
@@ -11,6 +11,7 @@ package org.jline.terminal.impl.jna.freebsd;
 import java.io.FileDescriptor;
 import java.io.IOException;
 
+import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
 import org.jline.terminal.Attributes;
@@ -26,6 +27,13 @@ import static org.jline.terminal.impl.jna.freebsd.CLibrary.winsize;
 public class FreeBsdNativePty extends JnaNativePty {
 
     private static final CLibrary C_LIBRARY = (CLibrary) Native.loadLibrary(Platform.C_LIBRARY_NAME, CLibrary.class);
+
+    public interface UtilLibrary extends com.sun.jna.Library {
+
+        void openpty(int[] master, int[] slave, byte[] name, CLibrary.termios t, CLibrary.winsize s) throws LastErrorException;
+
+        UtilLibrary INSTANCE = (UtilLibrary) Native.loadLibrary("util", UtilLibrary.class);
+    }
 
     public static FreeBsdNativePty current() throws IOException {
         int slave = 0;
@@ -43,7 +51,7 @@ public class FreeBsdNativePty extends JnaNativePty {
         int[] master = new int[1];
         int[] slave = new int[1];
         byte[] buf = new byte[64];
-        C_LIBRARY.openpty(master, slave, buf,
+        UtilLibrary.INSTANCE.openpty(master, slave, buf,
                 attr != null ? new termios(attr) : null,
                 size != null ? new winsize(size) : null);
         int len = 0;

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/linux/CLibrary.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/linux/CLibrary.java
@@ -31,11 +31,7 @@ public interface CLibrary extends com.sun.jna.Library {
 
     void ioctl(int fd, int cmd, winsize data) throws LastErrorException;
 
-//    int isatty(int fd);
-
     void ttyname_r(int fd, byte[] buf, int len) throws LastErrorException;
-
-    void openpty(int[] master, int[] slave, byte[] name, termios t, winsize s) throws LastErrorException;
 
     class winsize extends Structure {
         public short ws_row;

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/linux/LinuxNativePty.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/linux/LinuxNativePty.java
@@ -11,6 +11,7 @@ package org.jline.terminal.impl.jna.linux;
 import java.io.FileDescriptor;
 import java.io.IOException;
 
+import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
 import org.jline.terminal.Attributes;
@@ -26,6 +27,13 @@ import static org.jline.terminal.impl.jna.linux.CLibrary.winsize;
 public class LinuxNativePty extends JnaNativePty {
 
     private static final CLibrary C_LIBRARY = (CLibrary) Native.loadLibrary(Platform.C_LIBRARY_NAME, CLibrary.class);
+
+    public interface UtilLibrary extends com.sun.jna.Library {
+
+        void openpty(int[] master, int[] slave, byte[] name, CLibrary.termios t, CLibrary.winsize s) throws LastErrorException;
+
+        UtilLibrary INSTANCE = (UtilLibrary) Native.loadLibrary("util", UtilLibrary.class);
+    }
 
     public static LinuxNativePty current() throws IOException {
         int slave = 0;
@@ -43,7 +51,7 @@ public class LinuxNativePty extends JnaNativePty {
         int[] master = new int[1];
         int[] slave = new int[1];
         byte[] buf = new byte[64];
-        C_LIBRARY.openpty(master, slave, buf,
+        UtilLibrary.INSTANCE.openpty(master, slave, buf,
                 attr != null ? new termios(attr) : null,
                 size != null ? new winsize(size) : null);
         int len = 0;

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/osx/CLibrary.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/osx/CLibrary.java
@@ -32,8 +32,6 @@ public interface CLibrary extends com.sun.jna.Library {
 
     void ioctl(int fd, NativeLong cmd, winsize data) throws LastErrorException;
 
-//    int isatty(int fd);
-
     void ttyname_r(int fd, byte[] buf, int len) throws LastErrorException;
 
     void openpty(int[] master, int[] slave, byte[] name, termios t, winsize s) throws LastErrorException;


### PR DESCRIPTION
#226 - By adding a thrown InterruptionException and a Thread.join on the pump thread(s), pause() and resume() can safely be called without spawning double threads.