### PR TITLE
Fix NullPointerException in PosixPtyTerminal#resume()

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -129,7 +129,7 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
                 inputPumpThread.start();
             }
             if (outputPumpThread == null) {
-                inputPumpThread = new Thread(this::pumpOut, toString() + " output pump thread");
+                outputPumpThread = new Thread(this::pumpOut, toString() + " output pump thread");
                 outputPumpThread.setDaemon(true);
                 outputPumpThread.start();
             }


### PR DESCRIPTION
This fixes a typo in PosixPtyTerminal#resume() which causes NullPointerException.