### PR TITLE
Fix issue #270, throw EOFException after all the bytes that already read are consumed

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
@@ -116,6 +116,7 @@ public class ExternalTerminal extends LineDisciplineTerminal {
     }
 
     public void pump() {
+        boolean closeInput = false;
         try {
             while (true) {
                 int c = masterInput.read();
@@ -123,6 +124,7 @@ public class ExternalTerminal extends LineDisciplineTerminal {
                     processInputByte((char) c);
                 }
                 if (c < 0 || closed.get()) {
+                    closeInput = true;
                     break;
                 }
                 synchronized (lock) {
@@ -139,10 +141,13 @@ public class ExternalTerminal extends LineDisciplineTerminal {
                 pumpThread = null;
             }
         }
-        try {
-            slaveInput.close();
-        } catch (IOException e) {
-            // ignore
+
+        if (closeInput) {
+            try {
+                slaveInput.close();
+            } catch (IOException e) {
+                // ignore
+            }
         }
     }
 

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpReader.java
@@ -60,10 +60,10 @@ public class NonBlockingPumpReader extends NonBlockingReader {
                 timeout = end - System.currentTimeMillis();
             }
         }
-        return closed
-                ? EOF
-                : buffer.hasRemaining()
-                    ? 0
+        return buffer.hasRemaining()
+                ? 0
+                : closed
+                    ? EOF
                     : READ_EXPIRED;
     }
 


### PR DESCRIPTION
Fix an issue with #270, throw EOFException after all the bytes that already read are consumed

Description of the change:
* terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
  -- Do not close slave input when IOException is thrown

* terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
  -- Throw IOException in InputStreamWrapper#read()
  -- Throw ClosedException after all the bytes that already read are consumed.

* terminal/src/main/java/org/jline/utils/NonBlockingPumpReader.java
  -- Throw EOF after all the bytes that already read are consumed