### PR TITLE
Add a new option for complete to avoid to add a tailing space when a …

### DIFF
--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -365,6 +365,8 @@ public interface LineReader {
         LIST_ROWS_FIRST,
         GLOB_COMPLETE,
         MENU_COMPLETE,
+        /** do not add an extra space in case of exact completion */
+        NO_EXTRA_SPACE, 
         /** if set and not at start of line before prompt, move to new line */
         AUTO_FRESH_LINE,
 

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4044,7 +4044,9 @@ public class LineReaderImpl implements LineReader, Flushable
             buf.write(line.escape(completion.value(), completion.complete()));
             if (completion.complete()) {
                 if (buf.currChar() != ' ') {
-                    buf.write(" ");
+                    if (!isSet(Option.NO_EXTRA_SPACE)) {
+                        buf.write(" ");
+                    }
                 } else {
                     buf.move(1);
                 }

--- a/reader/src/test/java/org/jline/reader/completer/ArgumentCompleterTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/ArgumentCompleterTest.java
@@ -8,6 +8,7 @@
  */
 package org.jline.reader.completer;
 
+import org.jline.reader.LineReader;
 import org.jline.reader.impl.ReaderTestSupport;
 import org.jline.reader.impl.completer.ArgumentCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
@@ -64,5 +65,13 @@ public class ArgumentCompleterTest
                         new StringsCompleter("foo", "bar", "baz")));
 
         assertBuffer("some foo ", new TestBuffer("some fo").tab());
+    }
+    
+    @Test
+    public void testOptionNoExtraSpace() throws Exception {
+        reader.setCompleter(new ArgumentCompleter(new StringsCompleter("foo", "bar", "baz")));
+        reader.setOpt(LineReader.Option.NO_EXTRA_SPACE);
+
+        assertBuffer("foo foo", new TestBuffer("foo f").tab());
     }
 }


### PR DESCRIPTION
…completion is selected.

I am working on a beanshell console and we are completing java methods found in the classpath or beanshell command. It is not desirable to add an extra space, ence the PR.
