### PR TITLE
Clear internal history in case of corrupted history file

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -69,7 +69,7 @@ public class DefaultHistory implements History {
             try {
                 load();
             }
-            catch (IOException e) {
+            catch (IllegalArgumentException | IOException e) {
                 Log.warn("Failed to load history", e);
             }
         }
@@ -90,7 +90,7 @@ public class DefaultHistory implements History {
                         maybeResize();
                     }
                 }
-            } catch (IOException e) {
+            } catch (IllegalArgumentException | IOException e) {
                 Log.debug("Failed to load history; clearing", e);
                 internalClear();
                 throw e;


### PR DESCRIPTION
The expected behaviour when loading of a history files fails is that the issue is logged but the reader is usable.

The current behaviour results in a IllegalArgumentException (from the addHistoryLine(Path, String) function) which is never caught. This results is a different behaviour than for example the file permission does not allow to read the file.
As a consequence in Karaf the session is not useable because of returned "null" at some point which is interpreted as session end.

This commit introduces a fix which catches the IllegalArgumentException and keeps the reader usable without history information. Also this makes the behaviour consistent.