### PR TITLE
Changed to try with resources

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Completers.java
+++ b/builtins/src/main/java/org/jline/builtins/Completers.java
@@ -303,22 +303,22 @@ public class Completers {
                 curBuf = "";
                 current = getUserDir();
             }
-			try (DirectoryStream<Path> directory = Files.newDirectoryStream(current, this::accept)) {
-				directory.forEach(p -> {
-					String value = curBuf + p.getFileName().toString();
-					if (Files.isDirectory(p)) {
-						candidates.add(
-								new Candidate(value + (reader.isSet(LineReader.Option.AUTO_PARAM_SLASH) ? sep : ""),
-										getDisplay(reader.getTerminal(), p), null, null,
-										reader.isSet(LineReader.Option.AUTO_REMOVE_SLASH) ? sep : null, null, false));
-					} else {
-						candidates.add(new Candidate(value, getDisplay(reader.getTerminal(), p), null, null, null, null,
-								true));
-					}
-				});
-			} catch (IOException e) {
-				// Ignore
-			}
+            try (DirectoryStream<Path> directory = Files.newDirectoryStream(current, this::accept)) {
+                directory.forEach(p -> {
+                    String value = curBuf + p.getFileName().toString();
+                    if (Files.isDirectory(p)) {
+                        candidates.add(
+                                new Candidate(value + (reader.isSet(LineReader.Option.AUTO_PARAM_SLASH) ? sep : ""),
+                                        getDisplay(reader.getTerminal(), p), null, null,
+                                        reader.isSet(LineReader.Option.AUTO_REMOVE_SLASH) ? sep : null, null, false));
+                    } else {
+                        candidates.add(new Candidate(value, getDisplay(reader.getTerminal(), p), null, null, null, null,
+                                true));
+                    }
+                });
+            } catch (IOException e) {
+                // Ignore
+            }
         }
 
         protected boolean accept(Path path) {


### PR DESCRIPTION
I was testing the library and I noticed that the stream when reading the directory was not closed, and I couldn't delete the directory which I was using.
So I fixed it changing to read the directory using the try with resources.