### PR TITLE
duplicated implementation of `Terminal#handle`

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -144,19 +144,6 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
         return Charset.defaultCharset();
     }
 
-    @Override
-    public SignalHandler handle(Signal signal, SignalHandler handler) {
-        SignalHandler prev = super.handle(signal, handler);
-        if (prev != handler) {
-            if (handler == SignalHandler.SIG_DFL) {
-                Signals.registerDefault(signal.name());
-            } else {
-                Signals.register(signal.name(), () -> raise(signal));
-            }
-        }
-        return prev;
-    }
-
     public NonBlockingReader reader() {
         return reader;
     }

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -55,19 +55,6 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         ShutdownHooks.add(closer);
     }
 
-    @Override
-    public SignalHandler handle(Signal signal, SignalHandler handler) {
-        SignalHandler prev = super.handle(signal, handler);
-        if (prev != handler) {
-            if (handler == SignalHandler.SIG_DFL) {
-                Signals.registerDefault(signal.name());
-            } else {
-                Signals.register(signal.name(), () -> raise(signal));
-            }
-        }
-        return prev;
-    }
-
     public NonBlockingReader reader() {
         return reader;
     }


### PR DESCRIPTION
Hello, 

it looks like `AbstractWindowTerminal` and `PosixSysTerminal` have exactly the same
implementation of `Terminal#handle`. This PR simply moves the implementation in `AbstractTerminal`. 

