### PR TITLE
Make ShellParams and ExecuteParams aware of the session

### DIFF
--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellCommand.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellCommand.java
@@ -67,7 +67,7 @@ public class ShellCommand implements Command, SessionAware {
     private void run() {
         int exitStatus = 0;
         try {
-            execute.accept(new Ssh.ExecuteParams(command, env.getEnv(), in, out, err));
+            execute.accept(new Ssh.ExecuteParams(command, env.getEnv(), session, in, out, err));
         } catch (RuntimeException e) {
             exitStatus = 1;
             LOGGER.log(Level.SEVERE, "Unable to start shell", e);

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
@@ -222,7 +222,7 @@ public class ShellFactoryImpl implements Factory<Command> {
                     terminal.raise(Terminal.Signal.WINCH);
                 }, Signal.WINCH);
 
-                shell.accept(new Ssh.ShellParams(env.getEnv(), terminal, this::destroy));
+                shell.accept(new Ssh.ShellParams(env.getEnv(), session, terminal, this::destroy));
             } catch (Throwable t) {
                 t.printStackTrace();
             }

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
@@ -27,6 +27,7 @@ import org.apache.sshd.common.util.io.NoCloseOutputStream;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.scp.ScpCommandFactory;
+import org.apache.sshd.server.session.ServerSession;
 import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
 import org.jline.builtins.Options;
 import org.jline.builtins.Options.HelpException;
@@ -43,13 +44,18 @@ public class Ssh {
         private final Map<String, String> env;
         private final Terminal terminal;
         private final Runnable closer;
-        public ShellParams(Map<String, String> env, Terminal terminal, Runnable closer) {
+        private final ServerSession session;
+        public ShellParams(Map<String, String> env, ServerSession session, Terminal terminal, Runnable closer) {
             this.env = env;
+            this.session = session;
             this.terminal = terminal;
             this.closer = closer;
         }
         public Map<String, String> getEnv() {
             return env;
+        }
+        public ServerSession getSession() {
+            return session;
         }
         public Terminal getTerminal() {
             return terminal;
@@ -62,11 +68,13 @@ public class Ssh {
     public static class ExecuteParams {
         private final String command;
         private final Map<String, String> env;
+        private final ServerSession session;
         private final InputStream in;
         private final OutputStream out;
         private final OutputStream err;
-        public ExecuteParams(String command, Map<String, String> env, InputStream in, OutputStream out, OutputStream err) {
+        public ExecuteParams(String command, Map<String, String> env, ServerSession session, InputStream in, OutputStream out, OutputStream err) {
             this.command = command;
+            this.session = session;
             this.env = env;
             this.in = in;
             this.out = out;
@@ -77,6 +85,9 @@ public class Ssh {
         }
         public Map<String, String> getEnv() {
             return env;
+        }
+        public ServerSession getSession() {
+            return session;
         }
         public InputStream getIn() {
             return in;


### PR DESCRIPTION
This allows shell implementations to have access to the session.
Fixes #382

The ShellImpl and ShellCommand already implement SessionAware but the session is never used and is inaccessible. This lets client implementations use the session if required.