### PR TITLE
Remove duplicate 'to see' from warning message

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4683,7 +4683,7 @@ public class LineReaderImpl implements LineReader, Flushable
         if (listMax > 0 && possible.size() >= listMax
                 || lines >= size.getRows() - promptLines) {
             // prompt
-            post = () -> new AttributedString(getAppName() + ": do you wish to see to see all " + possible.size()
+            post = () -> new AttributedString(getAppName() + ": do you wish to see all " + possible.size()
                     + " possibilities (" + lines + " lines)?");
             redisplay(true);
             int c = readCharacter();


### PR DESCRIPTION
While completion in case there are to many candidates for completion there will be a message appear e.g. 
`do you wish to see to see all 780 possibilities (156 lines)?`.
It looks like `to see` should be only once in the message.
The PR removes duplication of it
