### PR TITLE
Avoid inserting duplicate line break in printAbove if line ends with ANSI reset

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -690,7 +690,7 @@ public class LineReaderImpl implements LineReader, Flushable
             if (reading) {
                 display.update(Collections.emptyList(), 0);
             }
-            if (str.endsWith("\n")) {
+            if (str.endsWith("\n") || str.endsWith("\n\033[m") || str.endsWith("\n\033[0m")) {
                 terminal.writer().print(str);
             } else {
                 terminal.writer().println(str);


### PR DESCRIPTION
In https://github.com/jline/jline3/issues/292 we decided to make `LineReader.printAbove` insert a line feed if the given string does not end with a new line. Unfortunately, this new line is tricky to detect reliably:

It's common practice to insert an ANSI reset code (i.e. `CSI m` or `CSI 0 m`) after using a styled message to restore all settings to normal. This ANSI reset code can be either placed before `\n`, or after it, with no visible differences.

Let's take this simplified example:

```java
reader.printAbove("Hello World!\n"); // No empty line
reader.printAbove(new AttributedString("Hello World!\n", // Empty line
        AttributedStyle.DEFAULT.bold().foreground(AttributedStyle.RED));
```

Having the `\n` within the `AttributedString` will produce an ANSI reset code after the new line (`\n\033[0m`) and will therefore not be detected as new line by the current code. This leads to the insertion of an extra empty line.

This can be avoided by removing the new lines, but that works only if you have control about the strings to print. As a real example, [TerminalConsoleAppender](https://github.com/Minecrell/TerminalConsoleAppender) uses `LineReader.printAbove` to print lines logged using [Log4j 2](https://logging.apache.org/log4j/2.x/). 

Log4j usually produces lines that end with `\n`. It also has `%highlight{...}` patterns for the configuration to style log messages with ANSI colors. Like in the example above, the lines will always end with a new line followed by an ANSI reset code (`\n\033[0m`). Therefore, JLine will insert a blank line after every single line that is printed to the console.

The only way to avoid that without changes in JLine, would be to modify the lines provided by Log4j.
Something like:

```java
if (str.endsWith("\n\033[m")) {
    str = str.substring(0, str.length() - 4) + "\033[m\n";
}
```

I feel like the extra string copies here are unnecessary here just to circumvent JLine's check.
Having an ANSI reset code at the end of the string will be common enough that it may warrant the checks added to JLine as part of this PR instead. This prevents inserting redundant new lines if the line feed is only followed by `CSI m` / `CSI 0 m`.

Obviously it does not handle all possible ANSI codes. That would require much more code. I don't think trying to handle all cases is worth the effort, though.

The other option would be to add a new method that avoids printing a new line in all cases. But we discussed this in https://github.com/jline/jline3/issues/292#issuecomment-403323726 before and decided not to do this to avoid the behavior of calling that method without a new line.

I've been trying to come up with a better solution for quite a while, without luck. What do you think?