### PR TITLE
Allow specify Candidates with group, keys and etc for StringCompleters

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/completer/StringsCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/StringsCompleter.java
@@ -43,6 +43,11 @@ public class StringsCompleter implements Completer
         }
     }
 
+    public StringsCompleter(Candidate ... candidates) {
+        assert candidates != null;
+        this.candidates.addAll(Arrays.asList(candidates));
+    }
+
     public void complete(LineReader reader, final ParsedLine commandLine, final List<Candidate> candidates) {
         assert commandLine != null;
         assert candidates != null;


### PR DESCRIPTION
The PR allows to specify Candidates objects in `StringsCompleter` constructor which simplifies work with cases where custom keys, groups, description for Candidates are required