### PR TITLE
history: currentDir parameter and pattern match option Pattern.DOTALL

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Commands.java
+++ b/builtins/src/main/java/org/jline/builtins/Commands.java
@@ -164,7 +164,7 @@ public class Commands {
         less.run(sources);
     }
 
-    public static void history(LineReader reader, PrintStream out, PrintStream err,
+    public static void history(LineReader reader, PrintStream out, PrintStream err, Path currentDir,
                                String[] argv) throws Exception {
         final String[] usage = {
                 "history -  list history of commands",
@@ -205,13 +205,13 @@ public class Commands {
         } else if (opt.isSet("save")) {
             history.save();
         } else if (opt.isSet("A")) {
-            Path file = opt.args().size() > 0 ? Paths.get(opt.args().get(0)) : null;
+            Path file = opt.args().size() > 0 ? currentDir.resolve(opt.args().get(0)) : null;
             history.append(file, increment);
         } else if (opt.isSet("R")) {
-            Path file = opt.args().size() > 0 ? Paths.get(opt.args().get(0)) : null;
+            Path file = opt.args().size() > 0 ? currentDir.resolve(opt.args().get(0)) : null;
             history.read(file, increment);
         } else if (opt.isSet("W")) {
-            Path file = opt.args().size() > 0 ? Paths.get(opt.args().get(0)) : null;
+            Path file = opt.args().size() > 0 ? currentDir.resolve(opt.args().get(0)) : null;
             history.write(file, increment);
         } else {
             done = false;
@@ -231,7 +231,7 @@ public class Commands {
                 sb.append(c);
                 prev = c;
             }
-            pattern = Pattern.compile(sb.toString());
+            pattern = Pattern.compile(sb.toString(), Pattern.DOTALL);
         }
         int firstId = opt.args().size() > argId ? retrieveHistoryId(history, opt.args().get(argId++)) : -17;
         int lastId  = opt.args().size() > argId ? retrieveHistoryId(history, opt.args().get(argId++)) : -1;

--- a/builtins/src/test/java/org/jline/builtins/CommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CommandsTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 
@@ -57,7 +58,7 @@ public class CommandsTest {
             lineReader.setVariable(LineReader.HISTORY_FILE_SIZE, maxLines);
             lineReader.getHistory().save();
             PrintStream out = new PrintStream(os, false);
-            Commands.history(lineReader, out, out, new String[] {"-d"});
+            Commands.history(lineReader, out, out, Paths.get(""), new String[] {"-d"});
             assertEquals(maxLines + 1,
                     os.toString("UTF8").split("\\s+\\d{2}:\\d{2}:\\d{2}\\s+").length);
         } catch (Exception e) {

--- a/builtins/src/test/java/org/jline/example/Example.java
+++ b/builtins/src/test/java/org/jline/example/Example.java
@@ -431,7 +431,7 @@ public class Example
                                 argv);
                     }
                     else if ("history".equals(pl.word())) {
-                        Commands.history(reader, System.out, System.err, argv);
+                        Commands.history(reader, System.out, System.err, Paths.get(""),argv);
                     }
                     else if ("complete".equals(pl.word())) {
                         Commands.complete(reader, System.out, System.err,


### PR DESCRIPTION
Two changes:
1)  Added to `history()` method a new parameter `currentDir` in order to have a control to the `history` command `file` parameter directory.
2) `history` command pattern match is now performed using option `Pattern.DOTALL` to facilitate pattern matching on multi line commands.