### PR TITLE
Improve (nano & less) command configuration management

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Commands.java
+++ b/builtins/src/main/java/org/jline/builtins/Commands.java
@@ -45,6 +45,7 @@ import org.jline.builtins.Source.StdInSource;
 import org.jline.builtins.Source.URLSource;
 import org.jline.keymap.KeyMap;
 import org.jline.reader.Binding;
+import org.jline.reader.ConfigurationPath;
 import org.jline.reader.Highlighter;
 import org.jline.reader.History;
 import org.jline.reader.LineReader;
@@ -103,9 +104,9 @@ public class Commands {
     }
 
     public static void nano(Terminal terminal, PrintStream out, PrintStream err,
-                            Path currentDir,
-                            String[] argv,
-                            Path nanorc) throws Exception {
+            Path currentDir,
+            String[] argv,
+            ConfigurationPath configPath) throws Exception {
         final String[] usage = {
                 "nano -  edit files",
                 "Usage: nano [OPTIONS] [FILES]",
@@ -135,7 +136,7 @@ public class Commands {
         if (opt.isSet("help")) {
             throw new HelpException(opt.usage());
         }
-        Nano edit = new Nano(terminal, currentDir, opt, nanorc);
+        Nano edit = new Nano(terminal, currentDir, opt, configPath);
         edit.open(opt.args());
         edit.run();
     }
@@ -145,10 +146,11 @@ public class Commands {
             String[] argv) throws Exception {
         less(terminal, in, out, err, currentDir, argv, null);
     }
+
     public static void less(Terminal terminal, InputStream in, PrintStream out, PrintStream err,
                             Path currentDir,
                             String[] argv,
-                            Path lessrc) throws Exception {
+                            ConfigurationPath configPath) throws Exception {
         final String[] usage = {
                 "less -  file pager",
                 "Usage: less [OPTIONS] [FILES]",
@@ -166,7 +168,7 @@ public class Commands {
                 "  -Y --syntax=name             The name of the syntax highlighting to use.",
                 "     --no-init                 Disable terminal initialization",
                 "     --no-keypad               Disable keypad handling",
-                "     --ignorercfiles           Don't look at the system's lessrc nor at the user's lessrc." 
+                "     --ignorercfiles           Don't look at the system's lessrc nor at the user's lessrc."
 
         };
 
@@ -176,7 +178,7 @@ public class Commands {
             throw new HelpException(opt.usage());
         }
 
-        Less less = new Less(terminal, currentDir, opt, lessrc);
+        Less less = new Less(terminal, currentDir, opt, configPath);
         List<Source> sources = new ArrayList<>();
         if (opt.args().isEmpty()) {
             opt.args().add("-");

--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -37,6 +37,7 @@ import org.jline.builtins.Source.ResourceSource;
 import org.jline.builtins.Source.URLSource;
 import org.jline.keymap.BindingReader;
 import org.jline.keymap.KeyMap;
+import org.jline.reader.ConfigurationPath;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
@@ -115,16 +116,21 @@ public class Less {
 
 
     public Less(Terminal terminal, Path currentDir) {
-        this(terminal, currentDir, null, null);
+        this(terminal, currentDir, null);
     }
 
-    public Less(Terminal terminal, Path currentDir, Options opts, Path lessrc) {
+    public Less(Terminal terminal, Path currentDir, Options opts) {
+        this(terminal, currentDir, opts, null);
+    }
+
+    public Less(Terminal terminal, Path currentDir, Options opts, ConfigurationPath configPath) {
         this.terminal = terminal;
         this.display = new Display(terminal, true);
         this.bindingReader = new BindingReader(terminal.reader());
         this.currentDir = currentDir;
+        Path lessrc = configPath != null ? configPath.getConfig("jlessrc") : null;
         boolean ignorercfiles = opts!=null && opts.isSet("ignorercfiles");
-        if (lessrc != null && lessrc.toFile().exists() && !ignorercfiles) {
+        if (lessrc != null && !ignorercfiles) {
             try {
                 parseConfig(lessrc);
             } catch (IOException e) {
@@ -1103,7 +1109,7 @@ public class Less {
         int width = size.getColumns() - (printLineNumbers ? 8 : 0);
         int height = size.getRows();
         boolean doOffsets = firstColumnToDisplay == 0 && !chopLongLines;
-        if (lines >= size.getRows() - 1) { 
+        if (lines >= size.getRows() - 1) {
             display.clear();
         }
         if (lines == Integer.MAX_VALUE) {
@@ -1156,7 +1162,7 @@ public class Less {
     void moveBackward(int lines) throws IOException {
         Pattern dpCompiled = getPattern(true);
         int width = size.getColumns() - (printLineNumbers ? 8 : 0);
-        if (lines >= size.getRows() - 1) { 
+        if (lines >= size.getRows() - 1) {
             display.clear();
         }
         while (--lines >= 0) {
@@ -1302,7 +1308,7 @@ public class Less {
         if (MESSAGE_FILE_INFO.equals(message)){
             Source source = sources.get(sourceIdx);
             Long allLines = source.lines();
-            message = source.getName() 
+            message = source.getName()
                     + (sources.size() > 2 ? " (file " + sourceIdx + " of " + (sources.size() - 1) + ")" : "")
                     + " lines " + (firstLineToDisplay + 1) + "-" + inputLine + "/" + (allLines != null ? allLines : lines.size())
                     + (eof ? " (END)" : "");

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -43,6 +43,7 @@ import java.util.regex.Pattern;
 
 import org.jline.keymap.BindingReader;
 import org.jline.keymap.KeyMap;
+import org.jline.reader.ConfigurationPath;
 import org.jline.reader.Editor;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Attributes.ControlChar;
@@ -1572,10 +1573,10 @@ public class Nano implements Editor {
     }
 
     public Nano(Terminal terminal, Path root, Options opts) {
-        this(terminal, root, null, null);
+        this(terminal, root, opts, null);
     }
 
-    public Nano(Terminal terminal, Path root, Options opts, Path nanorc) {
+    public Nano(Terminal terminal, Path root, Options opts, ConfigurationPath configPath) {
         this.terminal = terminal;
         this.root = root;
         this.display = new Display(terminal, true);
@@ -1583,8 +1584,9 @@ public class Nano implements Editor {
         this.size = new Size();
         this.vsusp = terminal.getAttributes().getControlChar(ControlChar.VSUSP);
         bindKeys();
+        Path nanorc = configPath != null ? configPath.getConfig("jnanorc") : null;
         boolean ignorercfiles = opts!=null && opts.isSet("ignorercfiles");
-        if (nanorc != null && nanorc.toFile().exists() && !ignorercfiles) {
+        if (nanorc != null && !ignorercfiles) {
             try {
                 parseConfig(nanorc);
             } catch (IOException e) {

--- a/demo/src/main/java/org/apache/felix/gogo/jline/Posix.java
+++ b/demo/src/main/java/org/apache/felix/gogo/jline/Posix.java
@@ -967,7 +967,7 @@ public class Posix {
                 "  -Y --syntax=name             The name of the syntax highlighting to use.",
                 "     --no-init                 Disable terminal initialization",
                 "     --no-keypad               Disable keypad handling",
-                "     --ignorercfiles           Don't look at the system's lessrc nor at the user's lessrc." 
+                "     --ignorercfiles           Don't look at the system's lessrc nor at the user's lessrc."
 
         };
         try {
@@ -1003,7 +1003,7 @@ public class Posix {
             return;
         }
 
-        Less less = new Less(Shell.getTerminal(session), session.currentDir(), opt, null);
+        Less less = new Less(Shell.getTerminal(session), session.currentDir(), opt);
         less.run(sources);
     }
 

--- a/reader/src/main/java/org/jline/reader/ConfigurationPath.java
+++ b/reader/src/main/java/org/jline/reader/ConfigurationPath.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2019, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class ConfigurationPath {
+    private Path appConfig;
+    private Path userConfig;
+
+    /**
+     * Configuration class constructor.
+     * @param appConfig   Application configuration directory
+     * @param userConfig  User private configuration directory
+     */
+    public ConfigurationPath(Path appConfig, Path userConfig) {
+        this.appConfig = appConfig;
+        this.userConfig = userConfig;
+    }
+
+    /**
+     * Search configuration file first from userConfig and then appConfig directory. Returns null if file is not found.
+     * @param  name    Configuration file name.
+     * @return         Configuration file.
+     *
+     */
+    public Path getConfig(String name) {
+        Path out = null;
+        if (userConfig != null && userConfig.resolve(name).toFile().exists()) {
+            out = userConfig.resolve(name);
+        } else if (appConfig != null && appConfig.resolve(name).toFile().exists()) {
+            out = appConfig.resolve(name);
+        }
+        return out;
+    }
+
+    /**
+     * Search configuration file from userConfig directory. Returns null if file is not found.
+     * @param  name    Configuration file name.
+     * @return         Configuration file.
+     * @throws         IOException   When we do not have read access to the file or directory.
+     *
+     */
+    public Path getUserConfig(String name) throws IOException {
+        return getUserConfig(name, false);
+    }
+
+    /**
+     * Search configuration file from userConfig directory. Returns null if file is not found.
+     * @param  name    Configuration file name
+     * @param  create  When true configuration file is created if not found.
+     * @return         Configuration file.
+     * @throws         IOException   When we do not have read/write access to the file or directory.
+     */
+    public Path getUserConfig(String name, boolean create) throws IOException {
+        Path out = null;
+        if (userConfig != null) {
+            if (!userConfig.resolve(name).toFile().exists() && create) {
+                userConfig.resolve(name).toFile().createNewFile();
+            }
+            if (userConfig.resolve(name).toFile().exists()) {
+                out = userConfig.resolve(name);
+            }
+        }
+        return out;
+    }
+
+}


### PR DESCRIPTION
Added `ConfigurationPath` singleton class to help and simplify command configuration file management.  

Actually now `edit-and-execute` command launches `nano` editor without reading its `nanorc` configuration file. With `ConfigurationPath` `nano` editor will be correctly initialized.

**Example:** When installing your application `myApp` put `less` and `nano` default command configuration files `lessrc` and `nanorc` to the directory `/pub/myApp`. User can eventually customize these configurations by creating configuration files in `~/.myApp` directory.

```java
ConfigurationPath.getInstance().initialize(Paths.get("/pub/myApp"), 
                                         Paths.get(System.getProperty("user.home"), ".myApp"));
// other jline initializations...
Terminal terminal = builder.build();          
System.out.println(terminal.getName()+": "+terminal.getType());
System.out.println("\nhelp: list available commands");
LineReader reader = LineReaderBuilder.builder()
                    .terminal(terminal)
                    .completer(completer)
                    .parser(parser)
                    .variable(LineReader.SECONDARY_PROMPT_PATTERN, "%M%P > ")
                    .build();
...
...
...
```
