### PR TITLE
Fix NPE on close() in cmder

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -216,7 +216,9 @@ public abstract class AbstractWindowsTerminal extends AbstractTerminal {
     public void close() throws IOException {
         super.close();
         closing = true;
-        pump.interrupt();
+        if (pump != null) {
+            pump.interrupt();
+        }
         ShutdownHooks.remove(closer);
         for (Map.Entry<Signal, Object> entry : nativeHandlers.entrySet()) {
             Signals.unregister(entry.getKey().name(), entry.getValue());


### PR DESCRIPTION
Hello.

Sometimes in `cmder` (windows terminal) variable `pump` has a `null`-value and code crashes with NPE.

This PR adds null-check to avoid NPE