### PR TITLE
Add constructor with collection of Candidates

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/completer/StringsCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/StringsCompleter.java
@@ -48,6 +48,11 @@ public class StringsCompleter implements Completer
         this.candidates.addAll(Arrays.asList(candidates));
     }
 
+    public StringsCompleter(Collection<Candidate> candidates) {
+        assert candidates != null;
+        this.candidates.addAll(candidates);
+    }
+
     public void complete(LineReader reader, final ParsedLine commandLine, final List<Candidate> candidates) {
         assert commandLine != null;
         assert candidates != null;


### PR DESCRIPTION
The PR adds StringCompleter constructor which takes Collection of Candidates.
It's better to have to cope with cases when in custom code there is already a collection of Candidates but need to convert to array (while inside jline3's code it will be converted again to a new list)