### PR TITLE
JLine language REPL support

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Widgets.java
+++ b/builtins/src/main/java/org/jline/builtins/Widgets.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import org.jline.keymap.KeyMap;
 import org.jline.reader.Binding;
@@ -34,7 +35,7 @@ import org.jline.utils.AttributedStyle;
 import org.jline.utils.Status;
 
 /**
- * Brackets/quotes autopairing and command autosuggestion widgets for jline applications. 
+ * Brackets/quotes autopairing and command autosuggestion widgets for jline applications.
  *
  * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
@@ -153,6 +154,10 @@ public abstract class Widgets {
 
     public void setTailTip(String tailTip) {
         reader.setTailTip(tailTip);
+    }
+
+    public void setErrorPattern(Pattern errorPattern) {
+        reader.getHighlighter().setErrorPattern(errorPattern);
     }
 
     public void clearTailTip() {
@@ -725,6 +730,7 @@ public abstract class Widgets {
                 setSuggestionType(SuggestionType.COMPLETER);
             }
             clearDescription();
+            setErrorPattern(null);
             cmdDescs.clearTemporaryDescs();
             return clearTailTip(LineReader.ACCEPT_LINE);
         }
@@ -766,6 +772,7 @@ public abstract class Widgets {
                     doCommandTailTip(widget, cmdDesc, args);
                 } else {
                     doDescription(cmdDesc.getMainDescription(descriptionSize));
+                    setErrorPattern(cmdDesc.getErrorPattern());
                 }
             } else {
                 Pair<String,Boolean> cmdkey = cmdDescs.evaluateCommandLine(buffer.toString(), buffer.cursor());
@@ -775,6 +782,7 @@ public abstract class Widgets {
                     resetTailTip();
                 } else if (!cmdkey.getV()) {
                     doDescription(cmdDesc.getMainDescription(descriptionSize));
+                    setErrorPattern(cmdDesc.getErrorPattern());
                 }
             }
             return true;
@@ -1112,6 +1120,11 @@ public abstract class Widgets {
         private List<AttributedString> mainDesc;
         private List<ArgDesc> argsDesc;
         private TreeMap<String,List<AttributedString>> optsDesc;
+        private Pattern errorPattern;
+
+        public CmdDesc() {
+
+        }
 
         public CmdDesc(List<ArgDesc> argsDesc) {
             this(new ArrayList<>(), argsDesc, new HashMap<>());
@@ -1130,6 +1143,19 @@ public abstract class Widgets {
             } else {
                 this.mainDesc = new ArrayList<>(mainDesc);
             }
+        }
+
+        public CmdDesc mainDesc(List<AttributedString> mainDesc) {
+            this.mainDesc = new ArrayList<>(mainDesc);
+            return this;
+        }
+
+        public void setErrorPattern(Pattern errorPattern) {
+            this.errorPattern = errorPattern;
+        }
+
+        public Pattern getErrorPattern() {
+            return errorPattern;
         }
 
         public List<ArgDesc> getArgsDesc() {

--- a/builtins/src/main/java/org/jline/builtins/Widgets.java
+++ b/builtins/src/main/java/org/jline/builtins/Widgets.java
@@ -684,6 +684,10 @@ public abstract class Widgets {
             addWidget(TT_TOGGLE, this::toggleKeyBindings);
         }
 
+        public void setTailTips(Map<String,CmdDesc> tailTips) {
+            cmdDescs.setDescriptions(tailTips);
+        }
+
         public void setDescriptionSize(int descriptionSize) {
             this.descriptionSize = descriptionSize;
             initDescription(descriptionSize);
@@ -771,22 +775,28 @@ public abstract class Widgets {
                 Pair<String,Boolean> cmdkey = cmdDescs.evaluateCommandLine(buffer.toString(), args);
                 CmdDesc cmdDesc = cmdDescs.getDescription(cmdkey.getU());
                 if (cmdDesc == null) {
+                    setErrorPattern(null);
+                    setErrorIndex(-1);
                     clearDescription();
                     resetTailTip();
-                } else if (cmdkey.getV()) {
-                    doCommandTailTip(widget, cmdDesc, args);
-                } else {
-                    doDescription(cmdDesc.getMainDescription(descriptionSize));
-                    setErrorPattern(cmdDesc.getErrorPattern());
-                    setErrorIndex(cmdDesc.getErrorIndex());
+                } else if (cmdDesc.isValid()) {
+                    if (cmdkey.getV()) {
+                        doCommandTailTip(widget, cmdDesc, args);
+                    } else {
+                        doDescription(cmdDesc.getMainDescription(descriptionSize));
+                        setErrorPattern(cmdDesc.getErrorPattern());
+                        setErrorIndex(cmdDesc.getErrorIndex());
+                    }
                 }
             } else {
                 Pair<String,Boolean> cmdkey = cmdDescs.evaluateCommandLine(buffer.toString(), buffer.cursor());
                 CmdDesc cmdDesc = cmdDescs.getDescription(cmdkey.getU());
                 if (cmdDesc == null) {
+                    setErrorPattern(null);
+                    setErrorIndex(-1);
                     clearDescription();
                     resetTailTip();
-                } else if (!cmdkey.getV()) {
+                } else if (cmdDesc.isValid() && !cmdkey.getV()) {
                     doDescription(cmdDesc.getMainDescription(descriptionSize));
                     setErrorPattern(cmdDesc.getErrorPattern());
                     setErrorIndex(cmdDesc.getErrorIndex());
@@ -970,6 +980,10 @@ public abstract class Widgets {
                 this.descFun = descFun;
             }
 
+            public void setDescriptions(Map<String,CmdDesc> descriptions) {
+                this.descriptions = new HashMap<>(descriptions);
+            }
+
             public Pair<String,Boolean> evaluateCommandLine(String line, int curPos) {
                 return evaluateCommandLine(line, args(), curPos);
             }
@@ -1059,7 +1073,7 @@ public abstract class Widgets {
     public static class CmdLine {
         public enum DescriptionType {
             /**
-             * Cursor is at the end of line. The args[0] is completed, the line does not have unclosed opening parenthesis 
+             * Cursor is at the end of line. The args[0] is completed, the line does not have unclosed opening parenthesis
              * and does not end to the closing parenthesis.
              */
             COMMAND,
@@ -1150,9 +1164,13 @@ public abstract class Widgets {
         private TreeMap<String,List<AttributedString>> optsDesc;
         private Pattern errorPattern;
         private int errorIndex = -1;
+        private boolean valid = true;
 
         public CmdDesc() {
+        }
 
+        public CmdDesc(boolean valid) {
+            this.valid = valid;
         }
 
         public CmdDesc(List<ArgDesc> argsDesc) {
@@ -1174,11 +1192,15 @@ public abstract class Widgets {
             }
         }
 
+        public boolean isValid() {
+            return valid;
+        }
+
         public CmdDesc mainDesc(List<AttributedString> mainDesc) {
             this.mainDesc = new ArrayList<>(mainDesc);
             return this;
         }
-        
+
         public void setMainDesc(List<AttributedString> mainDesc) {
             this.mainDesc = new ArrayList<>(mainDesc);
         }
@@ -1192,13 +1214,13 @@ public abstract class Widgets {
         }
 
         public void setErrorIndex(int errorIndex) {
-            this.errorIndex = errorIndex;    
+            this.errorIndex = errorIndex;
         }
-        
+
         public int getErrorIndex() {
-            return errorIndex;    
+            return errorIndex;
         }
-        
+
         public List<ArgDesc> getArgsDesc() {
             return argsDesc;
         }

--- a/builtins/src/main/java/org/jline/builtins/Widgets.java
+++ b/builtins/src/main/java/org/jline/builtins/Widgets.java
@@ -192,11 +192,11 @@ public abstract class Widgets {
                 as.add(new AttributedString(""));
             }
             addDescription(as);
-            reader.runMacro(KeyMap.ctrl('M'));
+            executeWidget(LineReader.REDRAW_LINE);
         } else if (status != null) {
             if (size < 0) {
                 status.update(null);
-                reader.runMacro(KeyMap.ctrl('M'));
+                executeWidget(LineReader.REDRAW_LINE);
             } else {
                 status.clear();
             }
@@ -781,7 +781,9 @@ public abstract class Widgets {
                     resetTailTip();
                 } else if (cmdDesc.isValid()) {
                     if (cmdkey.getV()) {
-                        doCommandTailTip(widget, cmdDesc, args);
+                        if (cmdDesc.isCommand()) {
+                            doCommandTailTip(widget, cmdDesc, args);
+                        }
                     } else {
                         doDescription(cmdDesc.getMainDescription(descriptionSize));
                         setErrorPattern(cmdDesc.getErrorPattern());
@@ -1165,8 +1167,10 @@ public abstract class Widgets {
         private Pattern errorPattern;
         private int errorIndex = -1;
         private boolean valid = true;
+        private boolean command = false;
 
         public CmdDesc() {
+            command = false;
         }
 
         public CmdDesc(boolean valid) {
@@ -1190,10 +1194,15 @@ public abstract class Widgets {
             } else {
                 this.mainDesc = new ArrayList<>(mainDesc);
             }
+            this.command = true;
         }
 
         public boolean isValid() {
             return valid;
+        }
+        
+        public boolean isCommand() {
+            return command;
         }
 
         public CmdDesc mainDesc(List<AttributedString> mainDesc) {

--- a/builtins/src/test/java/org/jline/example/Example.java
+++ b/builtins/src/test/java/org/jline/example/Example.java
@@ -231,6 +231,7 @@ public class Example
                 out = methodDescription(line);
                 break;
             case SYNTAX:
+                out = new CmdDesc(false);
                 break;
             }
             return out;

--- a/reader/src/main/java/org/jline/reader/Highlighter.java
+++ b/reader/src/main/java/org/jline/reader/Highlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author or authors.
+ * Copyright (c) 2002-2019, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -16,4 +16,5 @@ public interface Highlighter {
 
     AttributedString highlight(LineReader reader, String buffer);
     public void setErrorPattern(Pattern errorPattern);
+    public void setErrorIndex(int errorIndex);
 }

--- a/reader/src/main/java/org/jline/reader/Highlighter.java
+++ b/reader/src/main/java/org/jline/reader/Highlighter.java
@@ -8,9 +8,12 @@
  */
 package org.jline.reader;
 
+import java.util.regex.Pattern;
+
 import org.jline.utils.AttributedString;
 
 public interface Highlighter {
 
     AttributedString highlight(LineReader reader, String buffer);
+    public void setErrorPattern(Pattern errorPattern);
 }

--- a/reader/src/main/java/org/jline/reader/impl/DefaultHighlighter.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author or authors.
+ * Copyright (c) 2002-2019, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -20,10 +20,16 @@ import org.jline.utils.WCWidth;
 
 public class DefaultHighlighter implements Highlighter {
     private Pattern errorPattern;
+    private int errorIndex = -1;
 
     @Override
     public void setErrorPattern(Pattern errorPattern) {
         this.errorPattern = errorPattern;
+    }
+
+    @Override
+    public void setErrorIndex(int errorIndex) {
+        this.errorIndex = errorIndex;
     }
 
     @Override
@@ -65,6 +71,10 @@ public class DefaultHighlighter implements Highlighter {
             if (i == negativeStart) {
                 sb.style(AttributedStyle::inverse);
             }
+            if (i == errorIndex) {
+                sb.style(AttributedStyle::inverse);
+            }
+
             char c = buffer.charAt(i);
             if (c == '\t' || c == '\n') {
                 sb.append(c);
@@ -83,6 +93,9 @@ public class DefaultHighlighter implements Highlighter {
                 sb.style(AttributedStyle::underlineOff);
             }
             if (i == negativeEnd) {
+                sb.style(AttributedStyle::inverseOff);
+            }
+            if (i == errorIndex) {
                 sb.style(AttributedStyle::inverseOff);
             }
         }

--- a/reader/src/main/java/org/jline/reader/impl/DefaultHighlighter.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultHighlighter.java
@@ -8,6 +8,8 @@
  */
 package org.jline.reader.impl;
 
+import java.util.regex.Pattern;
+
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReader.RegionType;
 import org.jline.reader.Highlighter;
@@ -17,6 +19,12 @@ import org.jline.utils.AttributedStyle;
 import org.jline.utils.WCWidth;
 
 public class DefaultHighlighter implements Highlighter {
+    private Pattern errorPattern;
+
+    @Override
+    public void setErrorPattern(Pattern errorPattern) {
+        this.errorPattern = errorPattern;
+    }
 
     @Override
     public AttributedString highlight(LineReader reader, String buffer) {
@@ -77,6 +85,9 @@ public class DefaultHighlighter implements Highlighter {
             if (i == negativeEnd) {
                 sb.style(AttributedStyle::inverseOff);
             }
+        }
+        if (errorPattern != null) {
+            sb.styleMatches(errorPattern, AttributedStyle.INVERSE);
         }
         return sb.toAttributedString();
     }

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1119,6 +1119,7 @@ public class LineReaderImpl implements LineReader, Flushable
     }
 
     protected void handleSignal(Signal signal) {
+        doAutosuggestion = false;
         if (signal == Signal.WINCH) {
             Status status = Status.getStatus(terminal, false);
             if (status != null) {

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -188,7 +188,7 @@ public class LineReaderImpl implements LineReader, Flushable
     protected boolean searchFailing;
     protected boolean searchBackward;
     protected int searchIndex = -1;
-    protected boolean inCompleterMenu;
+    protected boolean doAutosuggestion;
 
 
     // Reading buffers
@@ -2535,6 +2535,7 @@ public class LineReaderImpl implements LineReader, Flushable
         buf.cursor(buf.length());
         post = null;
         if (size.getColumns() > 0 || size.getRows() > 0) {
+            doAutosuggestion = false;
             redisplay(false);
             if (nl) {
                 println();
@@ -3986,7 +3987,7 @@ public class LineReaderImpl implements LineReader, Flushable
         AttributedStringBuilder full = new AttributedStringBuilder().tabs(TAB_WIDTH);
         full.append(prompt);
         full.append(tNewBuf);
-        if (!inCompleterMenu) {
+        if (doAutosuggestion) {
             String lastBinding = getLastBinding() != null ? getLastBinding() : "";
             if (autosuggestion == SuggestionType.HISTORY) {
                 AttributedStringBuilder sb = new AttributedStringBuilder();
@@ -4000,7 +4001,6 @@ public class LineReaderImpl implements LineReader, Flushable
                     listChoices(true);
                 } else if (!lastBinding.equals("\t")) {
                     clearChoices();
-                    clearStatus();
                 }
             } else if (autosuggestion == SuggestionType.TAIL_TIP) {
                 if (buf.length() == buf.cursor()) {
@@ -4024,8 +4024,6 @@ public class LineReaderImpl implements LineReader, Flushable
                     }
                     sb.styled(AttributedStyle::faint, tailTip);
                     full.append(sb.toAttributedString());
-                } else {
-                    clearStatus();
                 }
             }
         }
@@ -4033,15 +4031,8 @@ public class LineReaderImpl implements LineReader, Flushable
             full.append("\n");
             full.append(post.get());
         }
-        inCompleterMenu = false;
+        doAutosuggestion = true;
         return full.toAttributedString();
-    }
-
-    private void clearStatus() {
-        Status status = Status.getStatus(terminal, false);
-        if (status != null) {
-            status.clear();
-        }
     }
 
     private AttributedString getHighlightedBuffer(String buffer) {
@@ -4946,7 +4937,7 @@ public class LineReaderImpl implements LineReader, Flushable
                     return true;
                 }
             }
-            inCompleterMenu = true;
+            doAutosuggestion = false;
             redisplay();
         }
         return false;

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4557,6 +4557,7 @@ public class LineReaderImpl implements LineReader, Flushable
             if (hasUnambiguous) {
                 buf.backspace(line.rawWordLength());
                 buf.write(line.escape(commonPrefix, false));
+                callWidget(REDISPLAY);
                 current = commonPrefix;
                 if ((!isSet(Option.AUTO_LIST) && isSet(Option.AUTO_MENU))
                         || (isSet(Option.AUTO_LIST) && isSet(Option.LIST_AMBIGUOUS))) {
@@ -4882,7 +4883,7 @@ public class LineReaderImpl implements LineReader, Flushable
         // Build menu support
         MenuSupport menuSupport = new MenuSupport(original, completed, escaper);
         post = menuSupport;
-        redisplay();
+        callWidget(REDISPLAY);
 
         // Loop
         KeyMap<Binding> keyMap = keyMaps.get(MENU);
@@ -4939,7 +4940,7 @@ public class LineReaderImpl implements LineReader, Flushable
                 }
             }
             doAutosuggestion = false;
-            redisplay();
+            callWidget(REDISPLAY);
         }
         return false;
     }
@@ -5039,7 +5040,7 @@ public class LineReaderImpl implements LineReader, Flushable
                     }
                 } else if (SELF_INSERT.equals(name)) {
                     sb.append(getLastBinding());
-                    buf.write(getLastBinding());
+                    callWidget(name);
                     if (cands.isEmpty()) {
                         post = null;
                         return false;


### PR DESCRIPTION
Documented support for as you type syntax checking: [asciinema](https://asciinema.org/a/279397?t=10)
Fixes #46

**Additions**
New `TailTipWidgets` constructor
```java
public TailTipWidgets(LineReader reader, Function<CmdLine,CmdDesc> descFun, int descriptionSize, TipType tipType)
```

and two new methods in `Highlighter` interface:
```java
void setErrorPattern(Pattern errorPattern);
void setErrorIndex(int errorIndex);
```

**Functionality**
Description is requested by invoking `descFun` for
1. method: if the left side of the cursor we have an unclosed opening parenthesis.
2. syntax: the last char entered is closing parenthesis
3. command: cursor is at the end of line, `args[0]` is completed and it is not a case 1. or 2.

In order to avoid description recalculations the command and method descriptions are saved in permanent and temporary cache respectively. Permanent cache will be created on `TailTipWidgets` constructor and it is possible to populate also using method `setCmdDescs()`. Temporary cache will be cleared by widget `_tailtip-accept-line`.

**Example**
`descFun` that calculates only command descriptions for builtins commands:

```
CmdDesc commandDescription(CmdLine line) {
    CmdDesc out = null;
    switch (line.getDescriptionType()) {
    case COMMAND:
        out = commandDescription(line.getArgs().get(0));
        break;
    case METHOD:
    case SYNTAX:
        out = new CmdDesc(false);
        break;
    }
    return out;
}
```

where `commandDescription()` is like in [Example.java lines:269-319](https://github.com/mattirn/jline3/blob/tailtip-v2/builtins/src/test/java/org/jline/example/Example.java#L269-L319)