### PR TITLE
Output redirection

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/CommandRegistry.java
+++ b/builtins/src/main/java/org/jline/builtins/CommandRegistry.java
@@ -29,6 +29,7 @@ public interface CommandRegistry {
 
     /**
      * Aggregate SystemCompleters of commandRegisteries
+     * @param commandRegistries command registeries which completers is to be aggregated
      * @return uncompiled SystemCompleter
      */
     static Completers.SystemCompleter aggregateCompleters(CommandRegistry ... commandRegistries) {
@@ -41,6 +42,7 @@ public interface CommandRegistry {
 
     /**
      * Aggregate and compile SystemCompleters of commandRegisteries
+     * @param commandRegistries command registeries which completers is to be aggregated and compile
      * @return compiled SystemCompleter
      */
     static Completers.SystemCompleter compileCompleters(CommandRegistry ... commandRegistries) {
@@ -51,7 +53,7 @@ public interface CommandRegistry {
 
     /**
      * Returns the name of this registry.
-     * @return name
+     * @return the name of the registry
      */
     default String name() {
         return this.getClass().getSimpleName();
@@ -93,7 +95,6 @@ public interface CommandRegistry {
     /**
      * Returns a {@code SystemCompleter} that can provide detailed completion
      * information for all registered commands.
-     *
      * @return a SystemCompleter that can provide command completion for all registered commands
      */
     Completers.SystemCompleter compileCompleters();
@@ -118,11 +119,11 @@ public interface CommandRegistry {
     /**
      * Execute a command that have only string parameters and options. Implementation of the method is required
      * when aggregating command registries using SystemRegistry.
-     * @param session
-     * @param command
-     * @param args
-     * @return result
-     * @throws Exception
+     * @param session the data of the current command session
+     * @param command the name of the command
+     * @param args arguments of the command
+     * @return result of the command execution
+     * @throws Exception in case of error
      */
     default Object execute(CommandSession session, String command, String[] args) throws Exception {
         throw new IllegalArgumentException("CommandRegistry method execute(String command, String[] args) is not implemented!");
@@ -131,11 +132,11 @@ public interface CommandRegistry {
     /**
      * Execute a command. If command has other than string parameters a custom implementation is required.
      * This method will be called only when we have ConsoleEngine in SystemRegistry.
-     * @param session
-     * @param command
-     * @param args
-     * @return result
-     * @throws Exception
+     * @param session the data of the current command session
+     * @param command the name of the command
+     * @param args arguments of the command
+     * @return result of the command execution
+     * @throws Exception in case of error
      */
     default Object invoke(CommandSession session, String command, Object... args) throws Exception {
         String[] _args = new String[args.length];
@@ -147,13 +148,13 @@ public interface CommandRegistry {
         }
         return execute(session, command, _args);
     }
-    
+
     public static class CommandSession {
         private final Terminal terminal;
         private final InputStream in;
         private final PrintStream out;
         private final PrintStream err;
-        
+
         public CommandSession() {
             this.in = System.in;
             this.out = System.out;
@@ -164,22 +165,22 @@ public interface CommandRegistry {
         public CommandSession(Terminal terminal) {
             this(terminal, terminal.input(), new PrintStream(terminal.output()), new PrintStream(terminal.output()));
         }
-        
+
         public CommandSession(Terminal terminal, InputStream in, PrintStream out, PrintStream err) {
             this.terminal = terminal;
             this.in = in;
             this.out = out;
             this.err = err;
         }
-        
+
         public Terminal terminal() {
             return terminal;
         }
-        
+
         public InputStream in() {
             return in;
         }
-        
+
         public PrintStream out() {
             return out;
         }

--- a/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
+++ b/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
@@ -26,9 +26,9 @@ import org.jline.reader.Widget;
 public interface ConsoleEngine extends CommandRegistry {
 
     /**
-     * Removes command first character if it is colon
-     * @param command name to complete
-     * @return command name without colon
+     * Removes the command name first character if it is colon
+     * @param command the name of the command to complete
+     * @return command name without starting colon
      */
     static String plainCommand(String command) {
         return command.startsWith(":") ? command.substring(1) : command;
@@ -42,47 +42,47 @@ public interface ConsoleEngine extends CommandRegistry {
 
     /**
      * Sets systemRegistry
-     * @param systemRegistry
+     * @param systemRegistry SystemRegistry
      */
     void setSystemRegistry(SystemRegistry systemRegistry);
 
     /**
      * Substituting args references with their values.
-     * @param args
-     * @return Substituted args
+     * @param args the arguments to be expanded
+     * @return expanded arguments
      * @throws Exception in case of error
      */
     Object[] expandParameters(String[] args) throws Exception;
 
     /**
      * Returns all scripts found from PATH
-     * @return script names
+     * @return script file names
      */
     List<String> scripts();
 
     /**
      * Sets file name extension used by console scripts
-     * @param console script file extension
+     * @param extension console script file extension
      */
     public void setScriptExtension(String extension);
 
     /**
      * Returns true if alias 'name' exists
-     * @param alias name
+     * @param name alias name
      * @return true if alias exists
      */
     boolean hasAlias(String name);
 
     /**
      * Returns alias 'name' value
-     * @param alias name
+     * @param name alias name
      * @return value of alias
      */
     String getAlias(String name);
 
     /**
      * Returns script and variable completers
-     * @return script completers
+     * @return script and variable completers
      */
     List<Completer> scriptCompleters();
 
@@ -90,7 +90,7 @@ public interface ConsoleEngine extends CommandRegistry {
      * Executes parsed line that does not contain known command by the system registry.
      * If parsed line is neither JLine or ScriptEngine script it will be evaluated
      * as ScriptEngine statement.
-     * @param parsed command line
+     * @param parsedLine parsed command line
      * @return command line execution result
      * @throws Exception in case of error
      */
@@ -98,7 +98,7 @@ public interface ConsoleEngine extends CommandRegistry {
 
     /**
      * Executes either JLine or ScriptEngine script.
-     * @param script file
+     * @param script script file
      * @return script execution result
      * @throws Exception in case of error
      */
@@ -108,9 +108,9 @@ public interface ConsoleEngine extends CommandRegistry {
 
     /**
      * Executes either JLine or ScriptEngine script.
-     * @param script file
+     * @param script script file
      * @param cmdLine complete command line
-     * @param script arguments
+     * @param args script arguments
      * @return script execution result
      * @throws Exception in case of error
      */
@@ -119,28 +119,29 @@ public interface ConsoleEngine extends CommandRegistry {
     /**
      * Post processes execution result. If result is to be assigned to the console variable
      * then method will return null.
-     * @param command line
-     * @param result to process
+     * @param line command line
+     * @param result command result to process
+     * @param output command redirected output
      * @return processed result
      */
     Object postProcess(String line, Object result, String output);
 
     /**
      * Displays object.
-     * @param object to print
+     * @param object object to print
      */
     void println(Object object);
 
     /**
      * Displays object.
      * @param options println options
-     * @param object to print
+     * @param object object to print
      */
     void println(Map<String, Object> options, Object object);
 
     /**
      * Get variable value
-     * @param name of variable
+     * @param name name of the variable
      * @return variable value
      */
     Object getVariable(String name);
@@ -152,8 +153,12 @@ public interface ConsoleEngine extends CommandRegistry {
      */
     boolean executeWidget(Object function);
 
+    /**
+     *
+     * @return true if consoleEngine is executing script
+     */
     boolean isExecuting();
-    
+
     static class WidgetCreator implements Widget {
         private ConsoleEngine consoleEngine;
         private Object function;
@@ -169,7 +174,7 @@ public interface ConsoleEngine extends CommandRegistry {
         public boolean apply() {
             return consoleEngine.executeWidget(function);
         }
-        
+
         @Override
         public String toString() {
             return name;

--- a/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
+++ b/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import org.jline.builtins.CommandRegistry;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
-import org.jline.reader.ParsedLine;
 import org.jline.reader.Widget;
 
 /**
@@ -87,14 +86,16 @@ public interface ConsoleEngine extends CommandRegistry {
     List<Completer> scriptCompleters();
 
     /**
-     * Executes parsed line that does not contain known command by the system registry.
-     * If parsed line is neither JLine or ScriptEngine script it will be evaluated
+     * Executes command line that does not contain known command by the system registry.
+     * If the line is neither JLine or ScriptEngine script it will be evaluated
      * as ScriptEngine statement.
-     * @param parsedLine parsed command line
+     * @param name parsed command/script name
+     * @param rawLine raw command line
+     * @param args parsed arguments of the command
      * @return command line execution result
      * @throws Exception in case of error
      */
-    Object execute(ParsedLine parsedLine) throws Exception;
+    Object execute(String name, String rawLine, String[] args) throws Exception;
 
     /**
      * Executes either JLine or ScriptEngine script.
@@ -109,12 +110,12 @@ public interface ConsoleEngine extends CommandRegistry {
     /**
      * Executes either JLine or ScriptEngine script.
      * @param script script file
-     * @param cmdLine complete command line
+     * @param rawLine raw command line
      * @param args script arguments
      * @return script execution result
      * @throws Exception in case of error
      */
-    Object execute(File script, String cmdLine, String[] args) throws Exception;
+    Object execute(File script, String rawLine, String[] args) throws Exception;
 
     /**
      * Post processes execution result. If result is to be assigned to the console variable
@@ -127,17 +128,24 @@ public interface ConsoleEngine extends CommandRegistry {
     Object postProcess(String line, Object result, String output);
 
     /**
-     * Displays object.
+     * Print object.
      * @param object object to print
      */
     void println(Object object);
 
     /**
-     * Displays object.
+     * Print object.
      * @param options println options
      * @param object object to print
      */
     void println(Map<String, Object> options, Object object);
+
+    /**
+     * Create console variable
+     * @param name name of the variable
+     * @param value value of the variable
+     */
+    void putVariable(String name, Object value);
 
     /**
      * Get variable value
@@ -150,7 +158,7 @@ public interface ConsoleEngine extends CommandRegistry {
      * Delete temporary console variables
      */
     void purge();
-    
+
     /**
      * Execute widget function
      * @param function to execute

--- a/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
+++ b/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
@@ -147,6 +147,11 @@ public interface ConsoleEngine extends CommandRegistry {
     Object getVariable(String name);
 
     /**
+     * Delete temporary console variables
+     */
+    void purge();
+    
+    /**
      * Execute widget function
      * @param function to execute
      * @return true on success

--- a/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
+++ b/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
@@ -63,7 +63,7 @@ public interface ConsoleEngine extends CommandRegistry {
      * Sets file name extension used by console scripts
      * @param extension console script file extension
      */
-    public void setScriptExtension(String extension);
+    void setScriptExtension(String extension);
 
     /**
      * Returns true if alias 'name' exists

--- a/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
+++ b/builtins/src/main/java/org/jline/builtins/ConsoleEngine.java
@@ -123,7 +123,7 @@ public interface ConsoleEngine extends CommandRegistry {
      * @param result to process
      * @return processed result
      */
-    Object postProcess(String line, Object result);
+    Object postProcess(String line, Object result, String output);
 
     /**
      * Displays object.
@@ -152,6 +152,8 @@ public interface ConsoleEngine extends CommandRegistry {
      */
     boolean executeWidget(Object function);
 
+    boolean isExecuting();
+    
     static class WidgetCreator implements Widget {
         private ConsoleEngine consoleEngine;
         private Object function;

--- a/builtins/src/main/java/org/jline/builtins/ConsoleEngineImpl.java
+++ b/builtins/src/main/java/org/jline/builtins/ConsoleEngineImpl.java
@@ -111,7 +111,7 @@ public class ConsoleEngineImpl implements ConsoleEngine {
     private Terminal terminal() {
         return systemRegistry.terminal();
     }
-    
+
     public boolean isExecuting() {
         return executing;
     }
@@ -585,6 +585,11 @@ public class ConsoleEngineImpl implements ConsoleEngine {
         }
         return out;
     }
+    
+    @Override
+    public void purge() {
+        engine.del("_*");
+    }
 
     @Override
     public Object getVariable(String name) {
@@ -624,10 +629,10 @@ public class ConsoleEngineImpl implements ConsoleEngine {
                 engine.put(Parser.getVariable(line), output);
             }
             out = null;
-        } 
+        }
         return out;
     }
-    
+
     private Object postProcess(String line, Object result) {
         Object out = result instanceof String && ((String)result).trim().length() == 0 ? null : result;
         if (Parser.getVariable(line) != null) {
@@ -676,7 +681,7 @@ public class ConsoleEngineImpl implements ConsoleEngine {
     @Override
     public void println(Object object) {
         Map<String,Object> options = defaultPrntOptions();
-        options.putIfAbsent("exception", "stack");
+        options.putIfAbsent("exception", "message");
         println(options, object);
     }
 

--- a/builtins/src/main/java/org/jline/builtins/ConsoleEngineImpl.java
+++ b/builtins/src/main/java/org/jline/builtins/ConsoleEngineImpl.java
@@ -241,7 +241,7 @@ public class ConsoleEngineImpl implements ConsoleEngine {
                 out.add(name.substring(0, name.lastIndexOf(".")));
             }
         } catch (Exception e) {
-            println(e);
+            systemRegistry.println(e);
         }
         return out;
     }
@@ -614,7 +614,7 @@ public class ConsoleEngineImpl implements ConsoleEngine {
             }
             engine.execute("_widgetFunction()");
         } catch (Exception e) {
-            println(e);
+            systemRegistry.println(e);
             return false;
         }
         return true;
@@ -628,7 +628,7 @@ public class ConsoleEngineImpl implements ConsoleEngine {
                 out = (boolean) ((Map<String, Object>) engine.get(VAR_CONSOLE_OPTIONS)).getOrDefault("splitOutput", true);
             }
         } catch (Exception e) {
-            println(new Exception("Bad CONSOLE_OPTION value: " + e.getMessage()));
+            systemRegistry.println(new Exception("Bad CONSOLE_OPTION value: " + e.getMessage()));
         }
         return out;
     }
@@ -700,7 +700,6 @@ public class ConsoleEngineImpl implements ConsoleEngine {
     @Override
     public void println(Object object) {
         Map<String,Object> options = defaultPrntOptions();
-        options.putIfAbsent("exception", "message");
         println(options, object);
     }
 
@@ -746,9 +745,9 @@ public class ConsoleEngineImpl implements ConsoleEngine {
         }
         SyntaxHighlighter highlighter = nanorc != null ? SyntaxHighlighter.build(nanorc, style)
                                                        : null;
-        for (String s: object.split("\n")) {
+        for (String s: object.split("\\r?\\n")) {
             AttributedStringBuilder asb = new AttributedStringBuilder();
-            asb.append(s).setLength(width);
+            asb.append(s).subSequence(0, width);   // setLength(width) fill nul-chars at the end of line
             if (highlighter != null) {
                 highlighter.highlight(asb).println(terminal());
             } else {

--- a/builtins/src/main/java/org/jline/builtins/SystemRegistry.java
+++ b/builtins/src/main/java/org/jline/builtins/SystemRegistry.java
@@ -59,6 +59,10 @@ public interface SystemRegistry extends CommandRegistry {
     Object execute(String line) throws Exception;
 
     /**
+     * Delete temporary console variables and reset output streams
+     */
+    void cleanUp();
+    /**
      *
      * @return terminal
      */

--- a/builtins/src/main/java/org/jline/builtins/SystemRegistry.java
+++ b/builtins/src/main/java/org/jline/builtins/SystemRegistry.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jline.reader.Completer;
-import org.jline.reader.ParsedLine;
 import org.jline.terminal.Terminal;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
@@ -27,13 +26,13 @@ public interface SystemRegistry extends CommandRegistry {
 
     /**
      * Set command registeries
-     * @param commandRegistries defined in app
+     * @param commandRegistries command registeries used by the application
      */
     void setCommandRegistries(CommandRegistry... commandRegistries);
 
     /**
      * Initialize consoleEngine environment by executing console script
-     * @param initialization script
+     * @param script initialization script
      */
     void initialize(File script);
 
@@ -45,49 +44,49 @@ public interface SystemRegistry extends CommandRegistry {
 
     /**
      * Returns a command, method or syntax description for use in the JLine Widgets framework.
-     * @param command line whose description to return
+     * @param line command line whose description to return
      * @return command description for JLine TailTipWidgets to be displayed
      *         in the terminal status bar.
      */
     Widgets.CmdDesc commandDescription(Widgets.CmdLine line);
-    
+
    /**
      * Execute a command, script or evaluate scriptEngine statement
-     * @param command line
+     * @param line command line to be executed
      * @return execution result
-     * @throws Exception
+     * @throws Exception in case of error
      */
     Object execute(String line) throws Exception;
-    
+
     /**
-     * 
+     *
      * @return terminal
      */
     Terminal terminal();
 
     /**
-     * Execute command with args
-     * @param command to execute
-     * @param args command arguments
-     * @return execution result
+     * Execute command with arguments
+     * @param command command to be executed
+     * @param args arguments of the command
+     * @return command execution result
      * @throws Exception in case of error
      */
     Object execute(String command, String[] args) throws Exception;
-    
+
     /**
-     * Execute command with args
-     * @param command to execute
-     * @param args command arguments
-     * @return execution result
+     * Execute command with arguments
+     * @param command command to be executed
+     * @param args arguments of the command
+     * @return command execution result
      * @throws Exception in case of error
      */
     Object invoke(String command, Object... args) throws Exception;
 
     /**
-     * Print exception 
-     * @param print stack trace if stack true otherwise message
-     * @param JLine terminal 
-     * @param exception to print
+     * Print exception
+     * @param stack print stack trace if stack true otherwise message
+     * @param terminal JLine terminal
+     * @param exception exception to be printed
      */
     static void println(boolean stack, Terminal terminal, Exception exception) {
         if (exception instanceof Options.HelpException) {
@@ -104,7 +103,7 @@ public interface SystemRegistry extends CommandRegistry {
                 asb.append(exception.getClass().getCanonicalName(), AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
             }
             asb.toAttributedString().println(terminal);
-        }                
+        }
     }
 
     /**

--- a/builtins/src/main/java/org/jline/builtins/SystemRegistry.java
+++ b/builtins/src/main/java/org/jline/builtins/SystemRegistry.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import org.jline.reader.Completer;
 import org.jline.reader.ParsedLine;
 import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
 
 /**
  * Aggregate command registries and dispatch command executions.
@@ -25,19 +27,19 @@ public interface SystemRegistry extends CommandRegistry {
 
     /**
      * Set command registeries
-     * @param commandRegistries
+     * @param commandRegistries defined in app
      */
     void setCommandRegistries(CommandRegistry... commandRegistries);
 
     /**
      * Initialize consoleEngine environment by executing console script
-     * @param script
+     * @param initialization script
      */
     void initialize(File script);
 
     /**
      * Returns command completer that includes also console variable and script completion.
-     * @return complater
+     * @return command completer
      */
     Completer completer();
 
@@ -51,11 +53,59 @@ public interface SystemRegistry extends CommandRegistry {
     
    /**
      * Execute a command, script or evaluate scriptEngine statement
-     * @param line
-     * @return result
+     * @param command line
+     * @return execution result
      * @throws Exception
      */
     Object execute(String line) throws Exception;
+    
+    /**
+     * 
+     * @return terminal
+     */
+    Terminal terminal();
+
+    /**
+     * Execute command with args
+     * @param command to execute
+     * @param args command arguments
+     * @return execution result
+     * @throws Exception in case of error
+     */
+    Object execute(String command, String[] args) throws Exception;
+    
+    /**
+     * Execute command with args
+     * @param command to execute
+     * @param args command arguments
+     * @return execution result
+     * @throws Exception in case of error
+     */
+    Object invoke(String command, Object... args) throws Exception;
+
+    /**
+     * Print exception 
+     * @param print stack trace if stack true otherwise message
+     * @param JLine terminal 
+     * @param exception to print
+     */
+    static void println(boolean stack, Terminal terminal, Exception exception) {
+        if (exception instanceof Options.HelpException) {
+            Options.HelpException.highlight((exception).getMessage(), Options.HelpException.defaultStyle()).print(terminal);
+        } else if (stack) {
+            exception.printStackTrace();
+        } else {
+            String message = exception.getMessage();
+            AttributedStringBuilder asb = new AttributedStringBuilder();
+            if (message != null) {
+                asb.append(message, AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
+            } else {
+                asb.append("Caught exception: ", AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
+                asb.append(exception.getClass().getCanonicalName(), AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
+            }
+            asb.toAttributedString().println(terminal);
+        }                
+    }
 
     /**
      * @return systemRegistry of the current thread

--- a/builtins/src/main/java/org/jline/builtins/SystemRegistry.java
+++ b/builtins/src/main/java/org/jline/builtins/SystemRegistry.java
@@ -62,8 +62,14 @@ public interface SystemRegistry extends CommandRegistry {
      * Delete temporary console variables and reset output streams
      */
     void cleanUp();
+
     /**
-     *
+     * Print exception on terminal
+     * @param exception exception to print on terminal
+     */
+    void println(Exception exception);
+
+    /**
      * @return terminal
      */
     Terminal terminal();

--- a/builtins/src/test/java/org/jline/example/Example.java
+++ b/builtins/src/test/java/org/jline/example/Example.java
@@ -295,9 +295,9 @@ public class Example
             return out;
         }
 
-        public Object execute(String command, String[] args) throws Exception {
+        public Object execute(CommandRegistry.CommandSession session, String command, String[] args) throws Exception {
             exception = null;
-            commandExecute.get(command(command)).execute().accept(new Builtins.CommandInput(args));
+            commandExecute.get(command(command)).execute().accept(new Builtins.CommandInput(args, session));
             if (exception != null) {
                 throw exception;
             }
@@ -722,6 +722,7 @@ public class Example
             //
             // REPL-loop
             //
+            CommandRegistry.CommandSession session = new CommandRegistry.CommandSession(terminal);
             while (true) {
                 try {
                     String line = reader.readLine(prompt, rightPrompt, (MaskingCallback) null, null);
@@ -752,10 +753,10 @@ public class Example
                         masterRegistry.help();
                     }
                     else if (builtins.hasCommand(cmd)) {
-                        builtins.execute(cmd, argv, System.in, System.out, System.err);
+                        builtins.execute(session, cmd, argv);
                     }
                     else if (exampleCommands.hasCommand(cmd)) {
-                        exampleCommands.execute(cmd, argv);
+                        exampleCommands.execute(session, cmd, argv);
                     }
                 }
                 catch (HelpException e) {

--- a/demo/src/main/java/org/jline/demo/Repl.java
+++ b/demo/src/main/java/org/jline/demo/Repl.java
@@ -308,8 +308,7 @@ public class Repl {
                     break;
                 }
                 catch (Exception e) {
-                    consoleEngine.println(e);
-                    scriptEngine.put("exception", e); // save exception to console variable
+                    systemRegistry.println(e);        // print exception and save it to console variable
                 }
             }
         }

--- a/demo/src/main/java/org/jline/demo/Repl.java
+++ b/demo/src/main/java/org/jline/demo/Repl.java
@@ -296,7 +296,7 @@ public class Repl {
             consoleEngine.println(terminal.getName()+": "+terminal.getType());
             while (true) {
                 try {
-                    scriptEngine.del("_*");           // delete temporary variables
+                    systemRegistry.cleanUp();         // delete temporary variables and reset output streams
                     String line = reader.readLine("groovy-repl> ");
                     Object result = systemRegistry.execute(line);
                     consoleEngine.println(result);

--- a/demo/src/main/java/org/jline/demo/Repl.java
+++ b/demo/src/main/java/org/jline/demo/Repl.java
@@ -113,9 +113,9 @@ public class Repl {
             return out;
         }
 
-        public Object execute(String command, String[] args) throws Exception {
+        public Object execute(CommandRegistry.CommandSession session, String command, String[] args) throws Exception {
             exception = null;
-            commandExecute.get(command(command)).execute().accept(new Builtins.CommandInput(args));
+            commandExecute.get(command(command)).execute().accept(new Builtins.CommandInput(args, session));
             if (exception != null) {
                 throw exception;
             }
@@ -199,7 +199,7 @@ public class Repl {
 
         private List<OptDesc> commandOptions(String command) {
             try {
-                execute(command, new String[] {"--help"});
+                execute(new CommandRegistry.CommandSession(), command, new String[] {"--help"});
             } catch (HelpException e) {
                 return Builtins.compileCommandOptions(e.getMessage());
             } catch (Exception e) {

--- a/groovy/src/main/java/org/jline/script/GroovyEngine.java
+++ b/groovy/src/main/java/org/jline/script/GroovyEngine.java
@@ -339,7 +339,7 @@ public class GroovyEngine implements ScriptEngine {
                             asb.append("\t");
                         }
                         if (asb.columnLength() > width) {
-                            asb.setLength(width);
+                            asb.subSequence(0, width);
                         }
                         out.add(asb.toAttributedString());
                         Integer row = 0;
@@ -356,7 +356,7 @@ public class GroovyEngine implements ScriptEngine {
                                 asb2.append("\t");
                             }
                             if (asb2.columnLength() > width) {
-                                asb2.setLength(width);
+                                asb2.subSequence(0, width);
                             }
                             out.add(asb2.toAttributedString());
                         }
@@ -391,7 +391,7 @@ public class GroovyEngine implements ScriptEngine {
                                 asb.append("\t");
                             }
                             if (asb.columnLength() > width) {
-                                asb.setLength(width);
+                                asb.subSequence(0, width);
                             }
                             out.add(asb.toAttributedString());
                         }
@@ -407,7 +407,7 @@ public class GroovyEngine implements ScriptEngine {
                             }
                             asb.append(Utils.toString(o));
                             if (asb.columnLength() > width) {
-                                asb.setLength(width);
+                                asb.subSequence(0, width);
                             }
                             out.add(asb.toAttributedString());
                         }
@@ -435,13 +435,16 @@ public class GroovyEngine implements ScriptEngine {
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             AttributedStringBuilder asb = new AttributedStringBuilder().tabs(Arrays.asList(0, max + 1));
             asb.append(entry.getKey(), AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE + AttributedStyle.BRIGHT));
-            for (String v : Utils.toString(entry.getValue()).split("\n")) {
+            for (String v : Utils.toString(entry.getValue()).split("\\r?\\n")) {
                 asb.append("\t");
                 asb.append(v, AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW));
                 if (asb.columnLength() > width) {
-                    asb.setLength(width);
+                    asb.subSequence(0, width);
                 }
                 out.add(asb.toAttributedString());
+                if (map.size() > 1) {
+                    break;
+                }
                 asb = new AttributedStringBuilder().tabs(Arrays.asList(0, max + 1));
             }
         }


### PR DESCRIPTION
Command output redirection to variable and file.

**Example**:
```
 % ./build repl 
JLine terminal: xterm-256color                             
groovy-repl> # redirect to variable 
groovy-repl> resp=widget -la
groovy-repl> resp.split('\n').findAll{it=~/accept/}
.accept-and-hold
.accept-and-infer-next-history
.accept-line
.accept-line-and-down-history
_tailtip-accept-line
accept-and-hold
accept-and-infer-next-history
accept-line
accept-line-and-down-history
groovy-repl> 
groovy-repl> # redirect to file
groovy-repl> show > data.dat
groovy-repl> 
groovy-repl> # append to file
groovy-repl> keymap >> data.dat
```