### PR TITLE
Prnt command customization

### DIFF
--- a/demo/src/main/scripts/hello2.jline
+++ b/demo/src/main/scripts/hello2.jline
@@ -13,6 +13,10 @@ array.each {
     :prnt $resp
 }.identity{}
 
+_reader = org.jline.builtins.SystemRegistry.get().consoleEngine().reader
+prnt $_reader
+prnt --toString $_reader
+
 params = $@
 prnt -s JSON $params
 

--- a/demo/src/main/scripts/init.jline
+++ b/demo/src/main/scripts/init.jline
@@ -17,7 +17,6 @@ _jnanorc << 'include ' + ROOT + 'nanorc/*.nanorc\n' > null
 #
 CONSOLE_OPTIONS = [:]
 CONSOLE_OPTIONS.trace = 1
-CONSOLE_OPTIONS.splitOutput = true
 #
 # customize prnt command
 #

--- a/demo/src/main/scripts/init.jline
+++ b/demo/src/main/scripts/init.jline
@@ -26,7 +26,7 @@ def _reader2map(reader){
   out['othersGroupName'] = reader.othersGroupName
   out['keyMap'] = reader.keyMap
   out['autosuggestion'] = reader.autosuggestion
-  out['terminalDumb'] = reader.terminalDumb
+  out['terminal.kind'] = reader.terminal.kind
   out
 }
 
@@ -35,7 +35,7 @@ def _reader2string(reader){
   out += 'othersGroupName:' + reader.othersGroupName + ', '
   out += 'keyMap:' + reader.keyMap + ', '
   out += 'autosuggestion:' + reader.autosuggestion + ', '
-  out += 'terminalDumb:' + reader.terminalDumb
+  out += 'terminal.kind:' + reader.terminal.kind
   out += ']'
   out
 }

--- a/demo/src/main/scripts/init.jline
+++ b/demo/src/main/scripts/init.jline
@@ -1,7 +1,9 @@
 #
 # All imports added here are imported also to your groovy shell
 #
-import java.nio.file.*;
+import java.nio.file.*
+import java.util.regex.*
+import org.jline.utils.*
 
 PATH = [ROOT + 'scripts']
 
@@ -19,18 +21,8 @@ CONSOLE_OPTIONS.splitOutput = true
 #
 # customize prnt command
 #
-def _number2date(number){
-  def out = null
-  try {
-    out = number instanceof Long ? new Date(number) : number
-  } catch (Exception e) {
-    out = number
-  }
-  new org.jline.utils.AttributedString(out.toString())
-}
-
 def _reader2map(reader){
-  out = [:]
+  def out = [:]
   out['othersGroupName'] = reader.othersGroupName
   out['keyMap'] = reader.keyMap
   out['autosuggestion'] = reader.autosuggestion
@@ -39,12 +31,36 @@ def _reader2map(reader){
 }
 
 def _reader2string(reader){
-  out = "["
+  def out = "["
   out += 'othersGroupName:' + reader.othersGroupName + ', '
   out += 'keyMap:' + reader.keyMap + ', '
   out += 'autosuggestion:' + reader.autosuggestion + ', '
   out += 'terminalDumb:' + reader.terminalDumb
   out += ']'
+  out
+}
+
+def _number2date(number){
+  def out = null
+  try {
+    out = number instanceof Long ? new Date(number) : number
+  } catch (Exception e) {
+    out = number
+  }
+  new AttributedString(out.toString())
+}
+
+def _orgJline(p) {
+  def out = p
+  if (p.toString().matches('org.jline.*')) {
+    def m = Pattern.compile('(org.jline)(.*)').matcher(p.toString())
+    if (m.find()) {
+      def asb = new AttributedStringBuilder()
+      asb.append(m.group(1),AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW + AttributedStyle.BRIGHT))
+      asb.append(m.group(2))
+      out = asb.toAttributedString()
+    }
+  }
   out
 }
 
@@ -55,6 +71,7 @@ PRNT_OPTIONS['highlightValue'] = [:]
 PRNT_OPTIONS['objectToMap'].put(org.jline.reader.impl.LineReaderImpl, _reader2map)
 PRNT_OPTIONS['objectToString'].put(org.jline.reader.impl.LineReaderImpl, _reader2string)
 PRNT_OPTIONS['highlightValue'].put('time.*', _number2date)
+PRNT_OPTIONS['highlightValue'].put('*', _orgJline)
 #
 # custom Groovy pipes
 #

--- a/demo/src/main/scripts/init.jline
+++ b/demo/src/main/scripts/init.jline
@@ -17,6 +17,45 @@ CONSOLE_OPTIONS = [:]
 CONSOLE_OPTIONS.trace = 1
 CONSOLE_OPTIONS.splitOutput = true
 #
+# customize prnt command
+#
+def _number2date(number){
+  def out = null
+  try {
+    out = number instanceof Long ? new Date(number) : number
+  } catch (Exception e) {
+    out = number
+  }
+  new org.jline.utils.AttributedString(out.toString())
+}
+
+def _reader2map(reader){
+  out = [:]
+  out['othersGroupName'] = reader.othersGroupName
+  out['keyMap'] = reader.keyMap
+  out['autosuggestion'] = reader.autosuggestion
+  out['terminalDumb'] = reader.terminalDumb
+  out
+}
+
+def _reader2string(reader){
+  out = "["
+  out += 'othersGroupName:' + reader.othersGroupName + ', '
+  out += 'keyMap:' + reader.keyMap + ', '
+  out += 'autosuggestion:' + reader.autosuggestion + ', '
+  out += 'terminalDumb:' + reader.terminalDumb
+  out += ']'
+  out
+}
+
+PRNT_OPTIONS = [:]
+PRNT_OPTIONS['objectToMap'] = [:]
+PRNT_OPTIONS['objectToString'] = [:]
+PRNT_OPTIONS['highlightValue'] = [:]
+PRNT_OPTIONS['objectToMap'].put(org.jline.reader.impl.LineReaderImpl, _reader2map)
+PRNT_OPTIONS['objectToString'].put(org.jline.reader.impl.LineReaderImpl, _reader2string)
+PRNT_OPTIONS['highlightValue'].put('time.*', _number2date)
+#
 # custom Groovy pipes
 #
 pipe --delete *

--- a/groovy/src/main/groovy/org/jline/groovy/Utils.groovy
+++ b/groovy/src/main/groovy/org/jline/groovy/Utils.groovy
@@ -29,7 +29,13 @@ public class Utils {
     }
 
     static Map<String,Object> toMap(Object object) {
-        object != null ? object.properties : null
+        def out = [:]
+        if (object instanceof Closure) {
+            out['closure'] = object.getClass().getName()
+        } else {
+            out = object != null ? object.properties : null
+        }
+        out
     }
 
     static String toJson(Object object) {


### PR DESCRIPTION
In REPL console evaluated result is converted to the `Map<String,Object>` or in case of collection to the `List<Map<String,Object>>` (or `List<Object>` in case of heterogeneous object collection) before printing it to the console.
 The command `prnt` default option values can be put to the console map variable `PRNT_OPTIONS`. In addition to the `prnt` command options REPL console print method has some 'hidden' options that can be used to customize object printing:

- **columnsIn**, list of map keys. These map values will be added to the table before all the other keys.
- **columnsOut**, list of map keys. These map values will not be inserted to the table.
- **objectToMap**, map<class, function>. Override the `ScriptEngine` `toMap()` method.
- **objectToString**, map<class, function>. Override the `ScriptEngine` `toString()` method.
- **highlightValue**, map<regex, function>. If map key matches with regex the highlight function is applied to the corresponding map value. If regex='*' then highlight function will be applied to all map values.

**Example:** see [init.jline](https://github.com/mattirn/jline3/blob/prnt-customize/demo/src/main/scripts/init.jline)

![Screenshot from 2020-03-14 17-32-56](https://user-images.githubusercontent.com/6079480/76686201-065a8580-661a-11ea-9915-51ff415837ce.png)

