### PR TITLE
Add Automatic Module Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-						<manifestEntries>
+                        <manifestEntries>
                             <Automatic-Module-Name>org.jline</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>

--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+						<manifestEntries>
+                            <Automatic-Module-Name>org.jline</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Added org.jline as the automatic module name to the maven-jar-plugin section of the pom. This is required if jline is going to be used in modules.

I noticed that this was mentioned in #70, but it looks a pull request was never submitted.