### PR TITLE
Add support for globally overriding TerminalBuilder.build

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -260,6 +260,11 @@ public final class TerminalBuilder {
     }
 
     public Terminal build() throws IOException {
+        if (terminalHolder.get() != null) {
+             Terminal terminal = terminalHolder.get();
+             Log.debug(() -> "Using terminal " + terminal.getClass().getSimpleName());
+             return terminal;
+        }
         Terminal terminal = doBuild();
         Log.debug(() -> "Using terminal " + terminal.getClass().getSimpleName());
         if (terminal instanceof AbstractPosixTerminal) {
@@ -485,5 +490,10 @@ public final class TerminalBuilder {
 
     private <S> S load(Class<S> clazz) {
         return ServiceLoader.load(clazz, clazz.getClassLoader()).iterator().next();
+    }
+
+    private static final AtomicReference<Terminal> terminalHolder = new AtomicReference<Terminal>(null);
+    public static final void setTerminal(final Terminal terminal) {
+        terminalHolder.set(terminal);
     }
 }


### PR DESCRIPTION
This is more of a proposal than a true PR. I am a contributor to sbt and have run into some issues with supporting the scala REPL (https://github.com/scala/scala/pull/9128). We have an unusual situation where sbt has a server mode where remote clients can connect and issue commands to the server so that users can bypass the long sbt startup time. In this scenario, we create a custom JLine3 Terminal that relays input and output from the client process to the server process. It implements a custom protocol that allows the client to report all of its Terminal properties to the server so that the experience is seamless. This works very well for sbt's built in LineReader but we run into problems when the user wants to use the scala REPL. The scala REPL creates a LineReader using `TerminalBuilder.builder().jna(true).build()` and provides no interface for the container application to pass in a custom builder. This completely breaks the remote client feature.

A workaround that I have verified works is to allows the container application to set a global `Terminal` that short circuits the `TerminalBuilder.build` method and returns the builder. The reason that this is more appealing than adding an interface to the scala REPL that takes a Terminal argument is that while that would fix the problem for future scala versions, it makes it impossible for sbt to support older versions. We previously forked jline 2 to do something similar but there is hesitation about forking jline 3 since it is under active development and we may want to bump the version in the future. I don't necessarily expect this PR to be merged, but I figured that it was worth proposing because it would really make a big difference for sbt and scala while having a relatively small impact here.