### PR TITLE
Example: fix hung on exit with 'status' option

### DIFF
--- a/builtins/src/test/java/org/jline/example/Example.java
+++ b/builtins/src/test/java/org/jline/example/Example.java
@@ -176,20 +176,24 @@ public class Example
                     case "status":
                         completer = new StringsCompleter("foo", "bar", "baz");
                         callbacks.add(reader -> {
-                            new Thread(() -> {
+                            Thread thread = new Thread(() -> {
                                 int counter = 0;
                                 while (true) {
                                     try {
                                         Status status = Status.getStatus(reader.getTerminal());
                                         counter++;
-                                        status.update(Arrays.asList(new AttributedStringBuilder().append("counter: " + counter).toAttributedString()));
+                                        status.update(Arrays.asList(new AttributedStringBuilder()
+                                                .append("counter: " + counter)
+                                                .toAttributedString()));
                                         ((LineReaderImpl) reader).redisplay();
                                         Thread.sleep(1000);
                                     } catch (InterruptedException e) {
                                         e.printStackTrace();
                                     }
                                 }
-                            }).start();
+                            });
+                            thread.setDaemon(true);
+                            thread.start();
                         });
                         break;
                     case "argument":


### PR DESCRIPTION
When launch this example with argument `status`, and then type 'exit' to close application normally. I think the thread should be a daemon thread to prevent JVM waiting for this user thread.