### PR TITLE
Fix for typo in javadoc

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -221,7 +221,7 @@ public final class TerminalBuilder {
     /**
      * Initial size to use when creating a non system terminal,
      * i.e. when the builder has been given the input and
-     * outut streams using the {@link #streams(InputStream, OutputStream)} method
+     * output streams using the {@link #streams(InputStream, OutputStream)} method
      * or when {@link #system(boolean)} has been explicitely called with
      * <code>false</code>.
      *


### PR DESCRIPTION
output instead of outut