### PR TITLE
Fix console hangup on windows in combination with jansi after typing one char

### DIFF
--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
@@ -122,7 +122,7 @@ public class JansiWinSysTerminal extends AbstractWindowsTerminal {
         INPUT_RECORD[] events;
         long console = GetStdHandle (STD_INPUT_HANDLE);
         if (console != INVALID_HANDLE_VALUE
-                && WaitForSingleObject(console, 100) != 0) {
+                && WaitForSingleObject(console, 100) == 0) {
             events = readConsoleInputHelper(console, 1, false);
         } else {
             return false;


### PR DESCRIPTION
Looks like just a typo but it stopped the application from working correctly as 0 means signaled and other values are representing an error.

Closes #594