### PR TITLE
Keep argument sorting in large argument list when formatting candidates for terminal into multiple columns

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -5063,7 +5063,7 @@ public class LineReaderImpl implements LineReader, Flushable
                     redisplay(false);
                     buf.cursor(oldCursor);
                     println();
-                    List<AttributedString> ls = postResult.post.columnSplitLength(size.getColumns(), false, display.delayLineWrap());
+                    List<AttributedString> ls = pr.post.columnSplitLength(size.getColumns(), false, display.delayLineWrap());
                     Display d = new Display(terminal, false);
                     d.resize(size.getRows(), size.getColumns());
                     d.update(ls, -1);


### PR DESCRIPTION
Hi there!

Hope this finds you well.

I came across this issue today when JLine displayed/formatted a list of 400+ candidates for the terminal.
The candidates, formatted into two columns, where not sorted.

The fix is simple and limited to just one line. Please take a look.

Kind regards,
Markus