### PR TITLE
Extension point for completion candidates matching

### DIFF
--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -467,6 +467,11 @@ public interface LineReader {
             this.def = def;
         }
 
+        public final boolean isSet(Map<Option, Boolean> options) {
+            Boolean b = options.get(this);
+            return b != null ? b : this.isDef();
+        }
+
         public boolean isDef() {
             return def;
         }

--- a/reader/src/main/java/org/jline/reader/MatcherFactory.java
+++ b/reader/src/main/java/org/jline/reader/MatcherFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2020, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader;
+
+import org.jline.reader.impl.ReaderUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class MatcherFactory {
+
+  /**
+   * @param prefix True if executing the complete-prefix command
+   * @param line The parsed line within which completion has been requested
+   * @param options The active options of the line reader
+   * @param originalGroupName
+   * @param matchers A map of matchers.
+   *
+   * Extension point to allow custom matches for filtering completion candidates. Add an entry to the provided map
+   * and/or remove entries that are not wanted.
+   */
+  public void updateMatchers(boolean prefix, CompletingParsedLine line, Map<LineReader.Option, Boolean> options, int errors,
+                            String originalGroupName, LinkedHashMap<Matchers.MatcherType,
+                            Function<Map<String, List<Candidate>>, Map<String, List<Candidate>>>> matchers) {
+  }
+
+  public static Function<Map<String, List<Candidate>>,
+      Map<String, List<Candidate>>> simpleMatcher(Predicate<String> pred) {
+    return m -> m.entrySet().stream()
+        .filter(e -> pred.test(e.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+  public static Function<Map<String, List<Candidate>>,
+      Map<String, List<Candidate>>> typoMatcher(String word, int errors, boolean caseInsensitive,
+                                                String originalGroupName) {
+    return m -> {
+      Map<String, List<Candidate>> map = m.entrySet().stream()
+          .filter(e -> ReaderUtils.distance(word, caseInsensitive ? e.getKey() : e.getKey().toLowerCase()) < errors)
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      if (map.size() > 1) {
+        map.computeIfAbsent(word, w -> new ArrayList<>())
+            .add(new Candidate(word, word, originalGroupName, null, null, null, false));
+      }
+      return map;
+    };
+  }
+}

--- a/reader/src/main/java/org/jline/reader/Matchers.java
+++ b/reader/src/main/java/org/jline/reader/Matchers.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2020, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public final class Matchers {
+  public interface MatcherType { String name(); }
+  public static final class CustomMatcherType implements MatcherType{
+    private String name;
+
+    public CustomMatcherType(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+  }
+  public enum StandardMatcherType implements MatcherType {
+    PREFIX_STARTS_WITH,
+    PREFIX_CONTAINS,
+    IN_WORD_STARTS_WITH,
+    IN_WORD_CONTAINS,
+    IN_WORD_TYPO,
+    STARTS_WITH,
+    CONTAINS,
+    TYPO,
+    EMPTY_WORD;
+  }
+  public Matchers(Predicate<String> exact, LinkedHashMap<MatcherType, Function<Map<String, List<Candidate>>, Map<String, List<Candidate>>>> matchers) {
+    this.exact = exact;
+    this.matchers = matchers;
+  }
+
+  public Predicate<String> getExact() {
+    return exact;
+  }
+
+  public LinkedHashMap<MatcherType, Function<Map<String, List<Candidate>>, Map<String, List<Candidate>>>> getMatchers() {
+    return matchers;
+  }
+
+  private Predicate<String> exact;
+  private LinkedHashMap<MatcherType, Function<Map<String, List<Candidate>>, Map<String, List<Candidate>>>> matchers;
+}

--- a/reader/src/main/java/org/jline/reader/impl/ReaderUtils.java
+++ b/reader/src/main/java/org/jline/reader/impl/ReaderUtils.java
@@ -9,6 +9,7 @@
 package org.jline.reader.impl;
 
 import org.jline.reader.LineReader;
+import org.jline.utils.Levenshtein;
 
 public class ReaderUtils {
 
@@ -67,4 +68,13 @@ public class ReaderUtils {
         return nb;
     }
 
+    public static int distance(String word, String cand) {
+        if (word.length() < cand.length()) {
+            int d1 = Levenshtein.distance(word, cand.substring(0, Math.min(cand.length(), word.length())));
+            int d2 = Levenshtein.distance(word, cand);
+            return Math.min(d1, d2);
+        } else {
+            return Levenshtein.distance(word, cand);
+        }
+    }
 }

--- a/reader/src/test/java/org/jline/reader/impl/CompletionWithCustomMatcherTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionWithCustomMatcherTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2028, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader.impl;
+
+import org.jline.reader.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class CompletionWithCustomMatcherTest extends ReaderTestSupport {
+
+    @Test
+    public void testComplete() throws IOException {
+        reader.setMatcherFactory(new MatcherFactory() {
+            final Matchers.CustomMatcherType camelMatcherType = new Matchers.CustomMatcherType("camel case");
+
+            @Override
+            public void updateMatchers(boolean prefix, CompletingParsedLine line, Map<LineReader.Option, Boolean> options,
+                                           int errors, String originalGroupName,
+                                           LinkedHashMap<Matchers.MatcherType, Function<Map<String, List<Candidate>>, Map<String, List<Candidate>>>> matchers) {
+                matchers.put(camelMatcherType, simpleMatcher(candidate ->
+                    camelMatch(line.word(), 0, candidate, 0)
+                ));
+            }
+
+            private boolean camelMatch(String word, int i, String candidate, int j) {
+                if (word.length() <= i) {
+                    return true;
+                } else {
+                    char c = word.charAt(i);
+                    if (candidate.length() <= j) {
+                        return false;
+                    }
+                    if (c == candidate.charAt(j)) {
+                        if (camelMatch(word, i + 1, candidate, j + 1)) {
+                            return true;
+                        }
+                    }
+                    for (int j1 = j; j1 < candidate.length(); j1++) {
+                        if (Character.isUpperCase(candidate.charAt(j1))) {
+                            if (Character.toUpperCase(c) == candidate.charAt(j1)) {
+                                if (camelMatch(word, i + 1, candidate, j1 + 1)) {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    return false;
+                }
+            }
+        });
+        reader.setCompleter((reader, line, candidates) -> {
+            candidates.add(newCandidate("getMethod"));
+            candidates.add(newCandidate("getMethods"));
+            candidates.add(newCandidate("getDeclaredMethod"));
+            candidates.add(newCandidate("getDeclaredMethods"));
+        });
+
+        reader.unsetOpt(LineReader.Option.AUTO_LIST);
+        reader.setOpt(LineReader.Option.AUTO_MENU);
+        assertBuffer("getDeclaredMethod", new TestBuffer("gdm").left().tab());
+        assertBuffer("getDeclaredMethods", new TestBuffer("gdm").left().tab().tab());
+        assertBuffer("getDeclaredMethods", new TestBuffer("gDMethods").left().tab());
+
+        assertBuffer("getMethod", new TestBuffer("getMe").left().tab());
+
+        assertBuffer("getDeclaredMethods", new TestBuffer("gmethods").left().tab());
+        assertBuffer("getMethods", new TestBuffer("gmethods").left().tab().tab());
+    }
+
+    private Candidate newCandidate(String name) {
+        return new Candidate(
+            /* value    = */ name,
+            /* displ    = */ name,
+            /* group    = */ null,
+            /* descr    = */ null,
+            /* suffix   = */ null,
+            /* key      = */ null,
+            /* complete = */ false);
+    }
+}


### PR DESCRIPTION
Allow the user to remove or augment the built-in matchers.

The Scala REPL used to support "camel case completion" when
it was build atop JLine2. We had to drop this feature when
upgrading but would like to contribtue this extension point
to JLine so let us bring it back.