### PR TITLE
LineReader: add a `writeAbove()` method

### DIFF
--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -638,6 +638,16 @@ public interface LineReader {
     void printAbove(AttributedString str);
 
     /**
+     * Writes characters above the prompt and redraw everything.
+     * If the LineReader is not actually reading a line, the characters will simply be printed to the terminal.
+     *
+     * @param cbuf Array of characters
+     * @param off Offset from which to start writing characters
+     * @param len Number of characters to write
+     */
+    void writeAbove(char[] cbuf, int off, int len);
+
+    /**
      * Check if a thread is currently in a <code>readLine()</code> call.
      *
      * @return <code>true</code> if there is an ongoing <code>readLine()</code> call.

--- a/reader/src/main/java/org/jline/reader/WriteAboveOutputStream.java
+++ b/reader/src/main/java/org/jline/reader/WriteAboveOutputStream.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2017, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Redirects an {@link OutputStream} to a {@link LineReader}'s {@link LineReader#writeAbove(char[], int, int)} method,
+ * which draws output above the current prompt / input line.
+ *
+ * <p>Example:</p>
+ * <pre>
+ *     LineReader reader = LineReaderBuilder.builder().terminal(terminal).parser(parser).build();
+ *     WriteAboveOutputStream waos = new WriteAboveOutputStream(reader);
+ *     waos.write(new byte[] { 0x68, 0x69, 0x21});
+ * </pre>
+ *
+ */
+public class WriteAboveOutputStream extends OutputStream {
+
+    private final LineReader reader;
+
+    public WriteAboveOutputStream(LineReader reader) {
+        this.reader = reader;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        write(new byte[] { (byte)b }, 0, 1);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        write(b, 0, b.length);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        char[] c = new char[len];
+        for (int i = off; i < len; i++) {
+            c[i] = (char) (b[i] & 0xff);
+        }
+        reader.writeAbove(c, off, len);
+    }
+}

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -789,6 +789,25 @@ public class LineReaderImpl implements LineReader, Flushable
     }
 
     @Override
+    public void writeAbove(char[] cbuf, int off, int len) {
+        try {
+            lock.lock();
+
+            boolean reading = this.reading;
+            if (reading) {
+                display.update(Collections.emptyList(), 0);
+            }
+            terminal.writer().write(cbuf, off, len);
+            if (reading) {
+                redisplay(false);
+            }
+            terminal.flush();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
     public boolean isReading() {
         try {
             lock.lock();


### PR DESCRIPTION
LineReader: add a `writeAbove()` method which writes arbitrary bytes above the prompt while input is being read.

Also adds a WriteAboveOutputStream to translate from OutputStreams.

Motivation: I needed a way to display log output from a logger (log4j 2 in my case) above the prompt asynchronously.  We were starting a thread in the background and it logged important information, but it would append these logs after the prompt was written and after any input that had already been typed, which made it difficult to see what was happening.

The `writeAbove()` method is a clone of `printAbove()`, adapted to write a character array directly to the writer.

The `WriteAboveOutputStream` takes in a `LineReader` and uses its `writeAbove()` method to write the bytes that come into the `OutputStream`.

I didn't add any example code to use this to the repo, I can do that if needed.

see #630