### PR TITLE
Use new 24bit support when parsing ANSI sequences

### DIFF
--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -292,12 +292,10 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
                                             int r = Integer.parseInt(params[++j]);
                                             int g = Integer.parseInt(params[++j]);
                                             int b = Integer.parseInt(params[++j]);
-                                            // convert to 256 colors
-                                            int col = 16 + (r >> 3) * 36 + (g >> 3) * 6 + (b >> 3);
                                             if (ansiParam == 38) {
-                                                current = current.foreground(col);
+                                                current = current.foreground(r, g, b);
                                             } else {
-                                                current = current.background(col);
+                                                current = current.background(r, g, b);
                                             }
                                         }
                                     } else if (ansiParam2 == 5) {


### PR DESCRIPTION
Previous method for converting to 256colors/8bit was incorrect
and produced invalid values.

eg rgb(255,255,255) was converted to 1349 instead of a valid 8 bit value.