### PR TITLE
Fix case insensitive typo matching

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
@@ -152,7 +152,7 @@ public class CompletionMatcherImpl implements CompletionMatcher {
             Map<String, List<Candidate>>> typoMatcher(String word, int errors, boolean caseInsensitive, String originalGroupName) {
         return m -> {
             Map<String, List<Candidate>> map = m.entrySet().stream()
-                    .filter(e -> ReaderUtils.distance(word, caseInsensitive ? e.getKey() : e.getKey().toLowerCase()) < errors)
+                    .filter(e -> ReaderUtils.distance(word, caseInsensitive ? e.getKey().toLowerCase() : e.getKey()) < errors)
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             if (map.size() > 1) {
                 map.computeIfAbsent(word, w -> new ArrayList<>())


### PR DESCRIPTION
This appears to have been the only instance of this bug
in fe2b8c0d74cd37a11c5d5a30bf9daac33805b656 or in the current
code base.

After this change:
```
builtins/src/main/java/org/jline/builtins/Completers.java:            return candidates.stream().anyMatch(c -> caseInsensitive ? c.value().equalsIgnoreCase(arg) : c.value().equals(arg));
builtins/src/main/java/org/jline/builtins/Nano.java:            return caseInsensitive ? Pattern.compile(regex, Pattern.CASE_INSENSITIVE)
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:            String wdi = caseInsensitive ? wd.toLowerCase() : wd;
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:                    simpleMatcher(s -> (caseInsensitive ? s.toLowerCase() : s).startsWith(wp)),
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:                    simpleMatcher(s -> (caseInsensitive ? s.toLowerCase() : s).contains(wp)),
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:            exact = s -> caseInsensitive ? s.equalsIgnoreCase(wp) : s.equals(wp);
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:            String wdi = caseInsensitive ? wd.toLowerCase() : wd;
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:                    simpleMatcher(s -> p1.matcher(caseInsensitive ? s.toLowerCase() : s).matches()),
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:                    simpleMatcher(s -> p2.matcher(caseInsensitive ? s.toLowerCase() : s).matches()),
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:            exact = s -> caseInsensitive ? s.equalsIgnoreCase(wd) : s.equals(wd);
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:            String wdi = caseInsensitive ? wd.toLowerCase() : wd;
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:                        simpleMatcher(s -> (caseInsensitive ? s.toLowerCase() : s).startsWith(wdi)),
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:                        simpleMatcher(s -> (caseInsensitive ? s.toLowerCase() : s).contains(wdi)),
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:            exact = s -> caseInsensitive ? s.equalsIgnoreCase(wd) : s.equals(wd);
reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java:                    .filter(e -> ReaderUtils.distance(word, caseInsensitive ? e.getKey().toLowerCase() : e.getKey()) < errors)
reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java:                    Pattern pat = Pattern.compile(pattern, caseInsensitive ? Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE
reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java:        String wdi = caseInsensitive ? word.toLowerCase() : word;
reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java:        ToIntFunction<String> wordDistance = w -> ReaderUtils.distance(wdi, caseInsensitive ? w.toLowerCase() : w);
```