### PR TITLE
add a PrintAboveWriter class to print text above the prompt

### DIFF
--- a/reader/src/main/java/org/jline/reader/PrintAboveWriter.java
+++ b/reader/src/main/java/org/jline/reader/PrintAboveWriter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2021, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader;
+
+import java.io.StringWriter;
+import java.io.Writer;
+
+/**
+ * Redirects a {@link Writer} to a {@link LineReader}'s {@link LineReader#printAbove(String)} method,
+ * which draws output above the current prompt / input line.
+ *
+ * <p>Example:</p>
+ * <pre>
+ *     LineReader reader = LineReaderBuilder.builder().terminal(terminal).parser(parser).build();
+ *     PrintAboveWriter printAbove = new PrintAboveWriter(reader);
+ *     printAbove.write(new char[] { 'h', 'i', '!', '\n'});
+ * </pre>
+ *
+ */
+public class PrintAboveWriter extends StringWriter {
+    private final LineReader reader;
+
+    public PrintAboveWriter(LineReader reader) {
+        this.reader = reader;
+    }
+
+    @Override
+    public void flush() {
+        StringBuffer buffer = getBuffer();
+        int lastNewline = buffer.lastIndexOf("\n");
+        if (lastNewline > 0) {
+            reader.printAbove(buffer.substring(0, lastNewline + 1));
+            buffer.delete(0, lastNewline + 1);
+        }
+    }
+}


### PR DESCRIPTION
add a `PrintAboveWriter` which buffers input until a newline is reached, and then forwards to LineReader's `printAbove()` method

see #630 and #634