### PR TITLE
Fix PumpReader.read(CharBuffer) not being synchronized

### DIFF
--- a/terminal/src/main/java/org/jline/utils/PumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/PumpReader.java
@@ -183,7 +183,7 @@ public class PumpReader extends Reader {
     }
 
     @Override
-    public int read(CharBuffer target) throws IOException {
+    public synchronized int read(CharBuffer target) throws IOException {
         if (!target.hasRemaining()) {
             return 0;
         }


### PR DESCRIPTION
All other methods are synchronized so this was probably an oversight.