### PR TITLE
Bad REPL experience in cygwin, fixes #669

### DIFF
--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/JansiSupportImpl.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/JansiSupportImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author or authors.
+ * Copyright (c) 2002-2021, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -139,7 +139,7 @@ public class JansiSupportImpl implements JansiSupport {
 
     @Override
     public boolean isConsoleOutput() {
-        if (OSUtils.IS_CYGWIN || OSUtils.IS_MSYSTEM) {
+        if (OSUtils.IS_MSYSTEM) {
             if (isAtLeast(2,1)) {
                 return JansiNativePty.isConsoleOutput();
             } else {
@@ -153,7 +153,7 @@ public class JansiSupportImpl implements JansiSupport {
 
     @Override
     public boolean isConsoleInput() {
-        if (OSUtils.IS_CYGWIN || OSUtils.IS_MSYSTEM) {
+        if (OSUtils.IS_MSYSTEM) {
             if (isAtLeast(2,1)) {
                 return JansiNativePty.isConsoleInput();
             } else {

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/JnaSupportImpl.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/JnaSupportImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author or authors.
+ * Copyright (c) 2002-2021, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -47,7 +47,7 @@ public class JnaSupportImpl implements JnaSupport {
 
     @Override
     public boolean isConsoleOutput() {
-        if (OSUtils.IS_CYGWIN || OSUtils.IS_MSYSTEM) {
+        if (OSUtils.IS_MSYSTEM) {
             throw new UnsupportedOperationException();
         } else if (OSUtils.IS_WINDOWS) {
             return JnaWinSysTerminal.isConsoleOutput();
@@ -57,7 +57,7 @@ public class JnaSupportImpl implements JnaSupport {
 
     @Override
     public boolean isConsoleInput() {
-        if (OSUtils.IS_CYGWIN || OSUtils.IS_MSYSTEM) {
+        if (OSUtils.IS_MSYSTEM) {
             throw new UnsupportedOperationException();
         } else if (OSUtils.IS_WINDOWS) {
             return JnaWinSysTerminal.isConsoleInput();

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author or authors.
+ * Copyright (c) 2002-2021, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -333,7 +333,7 @@ public final class TerminalBuilder {
                     Log.warn("Attributes and size fields are ignored when creating a system terminal");
                 }
                 if (OSUtils.IS_WINDOWS) {
-                    if (!OSUtils.IS_CYGWIN && !OSUtils.IS_MSYSTEM) {
+                    if (!OSUtils.IS_MSYSTEM) {
                         boolean ansiPassThrough = OSUtils.IS_CONEMU;
                         if (tbs.hasJnaSupport()) {
                             try {


### PR DESCRIPTION
Fixes regression caused by commit

[2ec403f7](https://github.com/jline/jline3/commit/2ec403f745d31810e5036f4b9e9aa038bc5b5606) JLine3 should not allow building a system terminal if input or output is not a tty