### PR TITLE
#683 - Allow emojis to be used on prompt for linereader

### DIFF
--- a/terminal/src/main/java/org/jline/utils/WCWidth.java
+++ b/terminal/src/main/java/org/jline/utils/WCWidth.java
@@ -57,6 +57,10 @@ public final class WCWidth {
         if (bisearch(ucs, combining, combining.length - 1))
             return 0;
 
+        if (ucs >= 0x1f000 && ucs <= 0x1feee) { // emoji
+            return 2;
+        }
+        
         /* if we arrive here, ucs is not a combining or C0/C1 control character */
         return 1 +
                 ((ucs >= 0x1100 &&


### PR DESCRIPTION

When emojis are used in linereader prompt, buffer location is misaligned when completer is called or multiline .
An adjustment for emojis in the WCWidth allows the buffer location to be accurate when emojis are used in the prompts