### PR TITLE
[JLINE-699] Make candidates for completion unique

### DIFF
--- a/reader/src/main/java/org/jline/reader/Candidate.java
+++ b/reader/src/main/java/org/jline/reader/Candidate.java
@@ -139,6 +139,19 @@ public class Candidate implements Comparable<Candidate> {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Candidate candidate = (Candidate) o;
+        return Objects.equals(value, candidate.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
     public String toString() {
         return "Candidate{" + value + "}";
     }

--- a/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
@@ -54,7 +54,7 @@ public class CompletionMatcherImpl implements CompletionMatcher {
                 break;
             }
         }
-        return !matching.isEmpty() ? matching.entrySet().stream().flatMap(e -> e.getValue().stream()).collect(Collectors.toList())
+        return !matching.isEmpty() ? matching.entrySet().stream().flatMap(e -> e.getValue().stream()).distinct().collect(Collectors.toList())
                                    : new ArrayList<>();
     }
 

--- a/reader/src/test/java/org/jline/reader/impl/CompletionWithCustomMatcherTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionWithCustomMatcherTest.java
@@ -12,7 +12,10 @@ import org.jline.reader.*;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 
 public class CompletionWithCustomMatcherTest extends ReaderTestSupport {
@@ -30,6 +33,8 @@ public class CompletionWithCustomMatcherTest extends ReaderTestSupport {
                     // add custom matcher before typo matcher
                     int pos = matchers.size() + (LineReader.Option.COMPLETE_MATCHER_TYPO.isSet(options) ? -1 : 0);
                     matchers.add(pos, simpleMatcher(candidate -> camelMatch(line.word(), 0, candidate, 0)));
+                    Candidate c = new Candidate(line.word());
+                    assertEquals("Expected only one element", 1, matches(Arrays.asList(c, c)).size());
                 }
             }
         });


### PR DESCRIPTION
The behavior with unique candidates within a list was before 3.19.0
The PR enables it again + adds a test checking such behavior

fixes #699 