### PR TITLE
Fix possible ArrayStoreException in stream

### DIFF
--- a/terminal/src/main/java/org/jline/utils/InfoCmp.java
+++ b/terminal/src/main/java/org/jline/utils/InfoCmp.java
@@ -503,7 +503,7 @@ public final class InfoCmp {
         public String[] getNames() {
             return getCapabilitiesByName().entrySet().stream()
                     .filter(e -> e.getValue() == this)
-                    .map(Map.Entry::getValue)
+                    .map(Map.Entry::getKey)
                     .toArray(String[]::new);
         }
 

--- a/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
+++ b/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
@@ -12,7 +12,6 @@ import org.jline.utils.InfoCmp.Capability;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystems;
@@ -29,8 +28,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -50,6 +49,12 @@ public class InfoCmpTest {
         InfoCmp.parseInfoCmp(infocmp, bools, ints, strings);
         assertEquals(4, bools.size());
         assertTrue(strings.containsKey(Capability.byName("acsc")));
+    }
+
+    @Test
+    public void testGetNames() {
+        String[] result = Capability.bit_image_entwining.getNames();
+        assertArrayEquals(new String[]{"bit_image_entwining", "bitwin"}, result);
     }
 
     @Test


### PR DESCRIPTION
Fix ArratStoreException in `Capability.getNames()`
```
java.lang.ArrayStoreException: arraycopy: element type mismatch: can not cast one of the elements of java.lang.Object[] to the type of the destination array, java.lang.String

	at java.base/java.lang.System.arraycopy(Native Method)
	at java.base/java.util.stream.SpinedBuffer.copyInto(SpinedBuffer.java:194)
	at java.base/java.util.stream.Nodes$SpinedNodeBuilder.copyInto(Nodes.java:1298)
	at java.base/java.util.stream.SpinedBuffer.asArray(SpinedBuffer.java:215)
	at java.base/java.util.stream.Nodes$SpinedNodeBuilder.asArray(Nodes.java:1304)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:518)
	at org.jline.utils.InfoCmp$Capability.getNames(InfoCmp.java:507)
```