### PR TITLE
Remove unnecessary t.getCause() call

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Completers.java
+++ b/builtins/src/main/java/org/jline/builtins/Completers.java
@@ -103,7 +103,6 @@ public class Completers {
                     try {
                         res = environment.evaluate(reader, line, completion.condition);
                     } catch (Throwable t) {
-                        t.getCause();
                         // Ignore
                     }
                     conditionValue = isTrue(res);


### PR DESCRIPTION
Discovered thanks to https://github.com/google/error-prone/commit/691836e92aa01837865e0d4e0e7ecad0f4666424