### PR TITLE
Force to use FreeBSD stty on Mac

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/ExecPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExecPty.java
@@ -97,19 +97,7 @@ public class ExecPty extends AbstractPty implements Pty {
                 commands.add(1, OSUtils.STTY_F_OPTION);
                 commands.add(2, getName());
             }
-            try {
-                exec(system, commands.toArray(new String[commands.size()]));
-            } catch (IOException e) {
-                // Handle partial failures with GNU stty, see #97
-                if (e.toString().contains("unable to perform all requested operations")) {
-                    commands = getFlagsToSet(attr, getAttr());
-                    if (!commands.isEmpty()) {
-                        throw new IOException("Could not set the following flags: " + String.join(", ", commands), e);
-                    }
-                } else {
-                    throw e;
-                }
-            }
+            exec(system, commands.toArray(new String[commands.size()]));
         }
     }
 

--- a/terminal/src/main/java/org/jline/utils/OSUtils.java
+++ b/terminal/src/main/java/org/jline/utils/OSUtils.java
@@ -66,12 +66,11 @@ public class OSUtils {
         } else {
             tty = "tty";
             stty = "stty";
+            sttyfopt = "-F";
             infocmp = "infocmp";
             if (IS_OSX) {
+                stty = "/bin/stty";
                 sttyfopt = "-f";
-            }
-            else {
-                sttyfopt = "-F";
             }
         }
         TTY_COMMAND = tty;


### PR DESCRIPTION
Fixes #703.

This fixes the issue by forcing to use FreeBSD stty on Mac regardless of whether coreutils is in the PATH.

In addition, the unnecessary code added in https://github.com/jline/jline3/commit/12219fa5a5fd56dbe0731519032c862fc4e39388 has been removed.