### PR TITLE
Enable jdk17 for testing

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        java: [ '1.8', '11', '14' ]
+        java: [ '1.8', '11', '17' ]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
From one side jdk14 is not supported anymore
from another side jdk17 (LTS) is GA
So the PR enables testing for new LTS jdk17