### PR TITLE
Change nested classes to static nested classes where possible

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -143,7 +143,7 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
         }
     }
 
-    private class InputStreamWrapper extends NonBlockingInputStream {
+    private static class InputStreamWrapper extends NonBlockingInputStream {
 
         private final NonBlockingInputStream in;
         private final AtomicBoolean closed = new AtomicBoolean();

--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -416,7 +416,7 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return this;
     }
     
-    private class TabStops {
+    private static class TabStops {
         private List<Integer> tabs = new ArrayList<>();
         private int lastStop = 0;
         private int lastSize = 0;


### PR DESCRIPTION
Non-static nested classes hold a link to their parent classes, which can be avoided.