### PR TITLE
[JLINE-730] Support for comments in DefaultParser

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
@@ -31,7 +31,8 @@ public class DefaultParser implements Parser {
         private final String start;
         private final String end;
         public BlockCommentDelims(String start, String end) {
-            if (start == null || end == null || start.equals(end)) {
+            if (start == null || end == null
+              || start.isEmpty() || end.isEmpty() || start.equals(end)) {
                 throw new IllegalArgumentException("Bad block comment delimiter!");
             }
             this.start = start;

--- a/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
@@ -27,6 +27,26 @@ public class DefaultParser implements Parser {
         ANGLE    // <>
     }
 
+    public static class BlockCommentDelims {
+        private final String start;
+        private final String end;
+        public BlockCommentDelims(String start, String end) {
+            if (start == null || end == null || start.equals(end)) {
+                throw new IllegalArgumentException("Bad block comment delimiter!");
+            }
+            this.start = start;
+            this.end = end;
+        }
+
+        public String getStart() {
+            return start;
+        }
+
+        public String getEnd() {
+            return end;
+        }
+    }
+
     private char[] quoteChars = {'\'', '"'};
 
     private char[] escapeChars = {'\\'};
@@ -39,6 +59,10 @@ public class DefaultParser implements Parser {
 
     private char[] closingBrackets = null;
 
+    private String[] lineCommentDelims = null;
+
+    private BlockCommentDelims blockCommentDelims = null;
+
     private String regexVariable = "[a-zA-Z_]+[a-zA-Z0-9_-]*((\\.|\\['|\\[\"|\\[)[a-zA-Z0-9_-]*(|']|\"]|]))?";
     private String regexCommand = "[:]?[a-zA-Z]+[a-zA-Z0-9_-]*";
     private int commandGroup = 4;
@@ -46,6 +70,16 @@ public class DefaultParser implements Parser {
     //
     // Chainable setters
     //
+
+    public DefaultParser lineCommentDelims(final String[] lineCommentDelims) {
+        this.lineCommentDelims = lineCommentDelims;
+        return this;
+    }
+
+    public DefaultParser blockCommentDelims(final BlockCommentDelims blockCommentDelims) {
+        this.blockCommentDelims = blockCommentDelims;
+        return this;
+    }
 
     public DefaultParser quoteChars(final char[] chars) {
         this.quoteChars = chars;
@@ -105,6 +139,22 @@ public class DefaultParser implements Parser {
 
     public char[] getEscapeChars() {
         return this.escapeChars;
+    }
+
+    public void setLineCommentDelims(String[] lineCommentDelims) {
+        this.lineCommentDelims = lineCommentDelims;
+    }
+
+    public String[] getLineCommentDelims() {
+        return this.lineCommentDelims;
+    }
+
+    public void setBlockCommentDelims(BlockCommentDelims blockCommentDelims) {
+        this.blockCommentDelims = blockCommentDelims;
+    }
+
+    public BlockCommentDelims getBlockCommentDelims() {
+        return blockCommentDelims;
     }
 
     public void setEofOnUnclosedQuote(boolean eofOnUnclosedQuote) {
@@ -225,6 +275,10 @@ public class DefaultParser implements Parser {
         int rawWordStart = 0;
         BracketChecker bracketChecker = new BracketChecker(cursor);
         boolean quotedWord = false;
+        boolean lineCommented = false;
+        boolean blockCommented = false;
+        final String blockCommentEnd = blockCommentDelims == null ? null : blockCommentDelims.end;
+        final String blockCommentStart = blockCommentDelims == null ? null : blockCommentDelims.start;
 
         for (int i = 0; (line != null) && (i < line.length()); i++) {
             // once we reach the cursor, set the
@@ -237,7 +291,7 @@ public class DefaultParser implements Parser {
                 rawWordCursor = i - rawWordStart;
             }
 
-            if (quoteStart < 0 && isQuoteChar(line, i)) {
+            if (quoteStart < 0 && isQuoteChar(line, i) && !lineCommented && !blockCommented) {
                 // Start a quote block
                 quoteStart = i;
                 if (current.length()==0) {
@@ -258,17 +312,36 @@ public class DefaultParser implements Parser {
                 quoteStart = -1;
                 quotedWord = false;
             } else if (quoteStart < 0 && isDelimiter(line, i)) {
-                // Delimiter
-                if (current.length() > 0) {
-                    words.add(current.toString());
-                    current.setLength(0); // reset the arg
-                    if (rawWordCursor >= 0 && rawWordLength < 0) {
-                        rawWordLength = i - rawWordStart;
+                if (lineCommented) {
+                    if (isCommentDelim(line, i, System.lineSeparator())) {
+                        lineCommented = false;
                     }
+                } else if (blockCommented) {
+                    if (isCommentDelim(line, i, blockCommentEnd)) {
+                        blockCommented = false;
+                    }
+                } else {
+                    // Delimiter
+                    rawWordLength = handleDelimiterAndGetRawWordLength(current, words, rawWordStart, rawWordCursor, rawWordLength, i);
+                    rawWordStart = i + 1;
                 }
-                rawWordStart = i + 1;
             } else {
-                if (!isEscapeChar(line, i)) {
+                if (quoteStart < 0 && !blockCommented && (lineCommented || isLineCommentStarted(line, i))) {
+                    lineCommented = true;
+                } else if (quoteStart < 0 && !lineCommented
+                        && (blockCommented || isCommentDelim(line, i, blockCommentStart))) {
+                    if (blockCommented) {
+                        if (blockCommentEnd != null && isCommentDelim(line, i, blockCommentEnd)) {
+                            blockCommented = false;
+                            i += blockCommentEnd.length() - 1;
+                        }
+                    } else {
+                        blockCommented = true;
+                        rawWordLength = handleDelimiterAndGetRawWordLength(current, words, rawWordStart, rawWordCursor, rawWordLength, i);
+                        i += blockCommentStart == null ? 0 : blockCommentStart.length() - 1;
+                        rawWordStart = i + 1;
+                    }
+                } else if (!isEscapeChar(line, i)) {
                     current.append(line.charAt(i));
                     if (quoteStart < 0) {
                         bracketChecker.check(line, i);
@@ -300,6 +373,10 @@ public class DefaultParser implements Parser {
             if (eofOnUnclosedQuote && quoteStart >= 0) {
                 throw new EOFError(-1, -1, "Missing closing quote", line.charAt(quoteStart) == '\''
                         ? "quote" : "dquote");
+            }
+            if (blockCommented) {
+                throw new EOFError(-1, -1, "Missing closing block comment delimiter",
+                        blockCommentEnd);
             }
             if (bracketChecker.isClosingBracketMissing() || bracketChecker.isOpeningBracketMissing()) {
                 String message = null;
@@ -333,6 +410,17 @@ public class DefaultParser implements Parser {
         return !isQuoted(buffer, pos) && !isEscaped(buffer, pos) && isDelimiterChar(buffer, pos);
     }
 
+    private int handleDelimiterAndGetRawWordLength(StringBuilder current, List<String> words, int rawWordStart, int rawWordCursor, int rawWordLength, int pos) {
+        if (current.length() > 0) {
+            words.add(current.toString());
+            current.setLength(0); // reset the arg
+            if (rawWordCursor >= 0 && rawWordLength < 0) {
+                return pos - rawWordStart;
+            }
+        }
+        return rawWordLength;
+    }
+
     public boolean isQuoted(final CharSequence buffer, final int pos) {
         return false;
     }
@@ -345,6 +433,36 @@ public class DefaultParser implements Parser {
             for (char e : quoteChars) {
                 if (e == buffer.charAt(pos)) {
                     return !isEscaped(buffer, pos);
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isCommentDelim(final CharSequence buffer, final int pos, final String pattern) {
+        if (pos < 0) {
+            return false;
+        }
+
+        if (pattern != null) {
+            final int length = pattern.length();
+            if (length <= buffer.length() - pos) {
+                for (int i = 0; i < length; i++) {
+                    if (pattern.charAt(i) != buffer.charAt(pos + i)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isLineCommentStarted(final CharSequence buffer, final int pos) {
+        if (lineCommentDelims != null) {
+            for (String comment: lineCommentDelims) {
+                if (isCommentDelim(buffer, pos, comment)) {
+                    return true;
                 }
             }
         }

--- a/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
@@ -11,6 +11,7 @@ package org.jline.reader.completer;
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.jline.reader.EOFError;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.impl.DefaultParser;
 import org.jline.reader.impl.ReaderTestSupport;
@@ -241,5 +242,9 @@ public class DefaultParserTest extends ReaderTestSupport {
         assertEquals(Arrays.asList("select", "1", "as", "'a'\ns'd\n\n", "from", "t;"), delimited.words());
     }
 
-
+    @Test(expected = EOFError.class)
+    public void testMissingOpeningBlockComment() {
+        parser.setBlockCommentDelims(new DefaultParser.BlockCommentDelims("/*", "*/"));
+        delimited = parser.parse("1, 2, 3 */", 0);
+    }
 }

--- a/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
@@ -90,18 +90,28 @@ public class DefaultParserTest extends ReaderTestSupport {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNullBlockCommentDelim() {
+    public void testNullStartBlockCommentDelim() {
         parser.setBlockCommentDelims(new DefaultParser.BlockCommentDelims(null, "*/"));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNullBlockCommentsDelim() {
+    public void testNullEndBlockCommentsDelim() {
         parser.setBlockCommentDelims(new DefaultParser.BlockCommentDelims("/*", null));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testEqualBlockCommentsDelims() {
-        parser.setBlockCommentDelims(new DefaultParser.BlockCommentDelims("/*", null));
+        parser.setBlockCommentDelims(new DefaultParser.BlockCommentDelims("/*", "/*"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyStartBlockCommentsDelims() {
+        parser.setBlockCommentDelims(new DefaultParser.BlockCommentDelims("", "*/"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyEndBlockCommentsDelims() {
+        parser.setBlockCommentDelims(new DefaultParser.BlockCommentDelims("/*", ""));
     }
 
     @Test


### PR DESCRIPTION
The PR makes it possible to set multiline comment start and end.
Also it allows to specify several one-line comments as several engines support several one-line comments

fixes #730 