### PR TITLE
[JLINE-733] Parsing with ParserContext.SPLIT_LINE should throw except…

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
@@ -293,7 +293,7 @@ public class DefaultParser implements Parser {
             rawWordLength = rawWordCursor;
         }
 
-        if (context != ParseContext.COMPLETE && context != ParseContext.SPLIT_LINE) {
+        if (context != ParseContext.COMPLETE) {
             if (eofOnEscapedNewLine && isEscapeChar(line, line.length() - 1)) {
                 throw new EOFError(-1, -1, "Escaped new line", "newline");
             }

--- a/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
@@ -10,7 +10,10 @@ package org.jline.reader.completer;
 
 import java.util.Arrays;
 
+import org.jline.reader.EOFError;
+import org.jline.reader.EndOfFileException;
 import org.jline.reader.ParsedLine;
+import org.jline.reader.Parser;
 import org.jline.reader.impl.DefaultParser;
 import org.jline.reader.impl.ReaderTestSupport;
 import org.junit.Before;
@@ -41,6 +44,12 @@ public class DefaultParserTest extends ReaderTestSupport {
 
         delimited = parser.parse("1  2  3", 0);
         assertEquals(Arrays.asList("1", "2", "3"), delimited.words());
+    }
+
+    @Test(expected = EOFError.class)
+    public void testThatExceptionThrows() {
+        parser.setEofOnUnclosedQuote(true);
+        delimited = parser.parse("'1 2 3", 0, Parser.ParseContext.SPLIT_LINE);
     }
 
     @Test


### PR DESCRIPTION
The PR fixes #733 by turning behavior back according to javadocs as mentioned at #733