### PR TITLE
SyntaxHighlighter & SystemHighlighter: add refresh() method

### DIFF
--- a/console/src/main/java/org/jline/console/impl/SystemHighlighter.java
+++ b/console/src/main/java/org/jline/console/impl/SystemHighlighter.java
@@ -54,6 +54,21 @@ public class SystemHighlighter extends DefaultHighlighter {
         this.specificHighlighter.put(command, highlighter);
     }
 
+    public void refresh() {
+        if (commandHighlighter != null) {
+            commandHighlighter.refresh();
+        }
+        if (argsHighlighter != null) {
+            argsHighlighter.refresh();
+        }
+        if (langHighlighter != null) {
+            langHighlighter.refresh();
+        }
+        for (SyntaxHighlighter sh : specificHighlighter.values()) {
+            sh.refresh();
+        }
+    }
+
     @Override
     public AttributedString highlight(LineReader reader, String buffer) {
         return doDefaultHighlight(reader) ? super.highlight(reader, buffer) : systemHighlight(reader, buffer);


### PR DESCRIPTION
When using `SystemHighlighter` to highlight command line (via `LineReader.highlight`) and updating nanorc syntax files it is necessary to restart JLine app in order to use updated highlighting.
The `refresh()` methods has been added in order to avoid restart the CLI.