### PR TITLE
fix readStringUntil for empty sequence

### DIFF
--- a/reader/src/main/java/org/jline/keymap/BindingReader.java
+++ b/reader/src/main/java/org/jline/keymap/BindingReader.java
@@ -133,7 +133,7 @@ public class BindingReader {
                 }
                 int l = reader.readBuffered(buf);
                 if (l < 0) {
-                    throw new ClosedException();
+                    return sb.toString();
                 }
                 sb.append(buf, 0, l);
             }


### PR DESCRIPTION
Please see https://github.com/jline/jline3/issues/757
For the context of this pull request. This is just my guess at a fix. I don't know the jline codebase very well, but this passes all the unit tests and fixes my issue.