### PR TITLE
REPL demo: add nanorctheme.template

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -213,6 +213,7 @@
                                     <includes>
                                         <include>init.jline</include>
                                         <include>data.json</include>
+                                        <include>apply-colors.sh</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/demo/src/main/scripts/apply-colors.sh
+++ b/demo/src/main/scripts/apply-colors.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+theme=${PROFILE_NAME,,}
+theme=${theme// /-}'.nanorctheme'
+cp nanorctheme.template ${theme}
+sed -i "s/%COLOR_01/${COLOR_01}/g" ${theme}
+sed -i "s/%COLOR_02/${COLOR_02}/g" ${theme}
+sed -i "s/%COLOR_03/${COLOR_03}/g" ${theme}
+sed -i "s/%COLOR_04/${COLOR_04}/g" ${theme}
+sed -i "s/%COLOR_05/${COLOR_05}/g" ${theme}
+sed -i "s/%COLOR_06/${COLOR_06}/g" ${theme}
+sed -i "s/%COLOR_07/${COLOR_07}/g" ${theme}
+sed -i "s/%COLOR_08/${COLOR_08}/g" ${theme}
+sed -i "s/%COLOR_09/${COLOR_09}/g" ${theme}
+sed -i "s/%COLOR_10/${COLOR_10}/g" ${theme}
+sed -i "s/%COLOR_11/${COLOR_11}/g" ${theme}
+sed -i "s/%COLOR_12/${COLOR_12}/g" ${theme}
+sed -i "s/%COLOR_13/${COLOR_13}/g" ${theme}
+sed -i "s/%COLOR_14/${COLOR_14}/g" ${theme}
+sed -i "s/%COLOR_15/${COLOR_15}/g" ${theme}
+sed -i "s/%COLOR_16/${COLOR_16}/g" ${theme}
+exit

--- a/demo/src/main/scripts/nanorc/nanorctheme.template
+++ b/demo/src/main/scripts/nanorc/nanorctheme.template
@@ -1,0 +1,60 @@
+#
+# This file describes a default scheme template for nanorc syntax highlighting for terminals with dark background
+#
+# Actual nanorc themes can be generated using the themes available on https://mayccoll.github.io/Gogh/themes.
+#
+# Linux:
+# \> cd git/jline3
+# \> ./build rebuild
+# \> cd git/jline3/demo/target/nanorc
+# \> bash -c  "$(wget -qO- https://git.io/vQgMr)"
+# ...
+#
+
+PLAIN        %COLOR_08
+FUNCTION     %COLOR_11
+STRING       %COLOR_15
+COMMENT      %COLOR_07
+DOC_COMMENT  %COLOR_15
+TYPE         %COLOR_13
+BOOLEAN      %COLOR_16
+NULL         %COLOR_07
+NUMBER       %COLOR_05
+VARIABLE     %COLOR_12
+PACKAGE      %COLOR_03
+CLASS        %COLOR_03
+CONSTANT     %COLOR_04
+OPERATOR     %COLOR_04
+COMMAND      %COLOR_11
+OPTION       %COLOR_04
+KEYWORD      %COLOR_16
+JUMP         %COLOR_15
+SECTION      %COLOR_11
+ATTRIBUTE    %COLOR_03
+PATH         %COLOR_13
+EXECUTABLE   %COLOR_03
+LINK         %COLOR_07
+TITLE        %COLOR_13
+ESCAPE       %COLOR_01,%COLOR_07
+DEBUG        %COLOR_14
+ERROR        %COLOR_02
+TODO         %COLOR_16,%COLOR_07
+WARNING     ,%COLOR_02
+WHITESPACE  ,%COLOR_03
+HEADER      bold,%COLOR_13,~grey7,underline
+ROW_NUMBER  bold,%COLOR_13,~grey7
+ROW_STYLE   ,~grey15
+LIST_BACKGROUND ,~grey42
+LIST_GROUP       %COLOR_04
+#
+# mixin
+#
++FUNCTION           FUNCTION: "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[(]" \n PLAIN:    "[(]"
++LINT               WHITESPACE: "[[:space:]]+$" \n WARNING: "\t*"
++LONG_LINE_WARNING  WARNING: "^.{81,}$"
+#
+# parser
+#
+$LINE_COMMENT           COMMENT \n TODO: "FIXME|TODO|XXX"
+$BLOCK_COMMENT          COMMENT \n DOC_COMMENT: startWith=/** \n TODO: "FIXME|TODO|XXX"
+$BALANCED_DELIMITERS    STRING  \n VARIABLE: continueAs=\s*:


### PR DESCRIPTION
Nanorc theme system helps to keep colors uniform across different languages and also to keep the definitions clear and maintainable. The system allows rules in nanorc files to be specified in terms of token type names or mixins, instead of hard-coded colors.

In REPL demo the theme system has been extended to define highlight rules also for `COLORS` variables (`HELP_COLORS`, `LS_COLORS`, etc) and `lineReader`'s `COMPLETION_STYLE`s. Extended theme system requires that CLI app supports `Map` type console variables. Below is shown all relevant console variables needed by the theme system. Console option `NANORC_THEME` map is created when executing the builtins command: `highlighter --refresh` or `highlighter --switch=<new-theme>`. The `highlighter` command will refresh also `lineReader`'s `COMPLETION_STYLE`s and all `syntaxHighlighter`s used by REPL demo.

![nanorctheme-template](https://user-images.githubusercontent.com/6079480/146740472-0ef75c2c-69da-462a-8e62-9c618089e410.png)

You can define your nanorc theme using 16 colors and switch between different color themes by changing your terminal 16 colors palette, see for example [Gogh](https://mayccoll.github.io/Gogh/).

If your terminal color palette is not easily replaceable you can use hard-coded color definitions in your nanorc theme file. Nanorc theme with hard-coded color definitions can be created using `nanorctheme.template`, `apply-colors.sh` and [Gogh](https://mayccoll.github.io/Gogh/) install:

Linux:
```
\> cd git/jline3
\> ./build rebuild
\> cd demo/target/nanorc
\> bash -c  "$(wget -qO- https://git.io/vQgMr)" 
```
