### PR TITLE
Option to disable Undo in LineReader

### DIFF
--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -467,6 +467,9 @@ public interface LineReader {
 
         /** Show command options tab completion candidates for zero length word */
         EMPTY_WORD_OPTIONS(true),
+        
+        /** Disable the undo feature */
+        DISABLE_UNDO
         ;
 
         private final boolean def;

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -633,7 +633,8 @@ public class LineReaderImpl implements LineReader, Flushable
 
                 callWidget(CALLBACK_INIT);
 
-                undo.newState(buf.copy());
+                if (!isSet(Option.DISABLE_UNDO))
+                    undo.newState(buf.copy());
 
                 // Draw initial prompt
                 redrawLine();
@@ -679,7 +680,7 @@ public class LineReaderImpl implements LineReader, Flushable
                     if (!w.apply()) {
                         beep();
                     }
-                    if (!isUndo && copy != null && buf.length() <= getInt(FEATURES_MAX_BUFFER_SIZE, DEFAULT_FEATURES_MAX_BUFFER_SIZE)
+                    if (!isSet(Option.DISABLE_UNDO) && !isUndo && copy != null && buf.length() <= getInt(FEATURES_MAX_BUFFER_SIZE, DEFAULT_FEATURES_MAX_BUFFER_SIZE)
                             && !copy.toString().equals(buf.toString())) {
                         undo.newState(buf.copy());
                     }


### PR DESCRIPTION
The Undo feature in LineReader consumes a bit of memory. It is not a big deal for typical commands, but for large commands (1MBytes) the amount of consumed memory becomes huge (100MB+).

Such extremely large commands are typically seen when the user is trying to upload data using the command line. User can paste the data, or use a script to create a script that contains such huge commands and feed it via redirection. While workarounds exist, eg not using JLine when stdin is not a terminal, workarounds are messy and require a lot of effort. And they still fail in some corner cases and environments. It would be good to simply disable the feature when the user has any problems.

This simple commit adds a LineReader Option, DISABLE_UNDO, that prevents undo from creating new states.