### PR TITLE
Docs typo: `Columns separated` -> `Colon separated`

### DIFF
--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -352,7 +352,7 @@ public interface LineReader {
     String AMBIGUOUS_BINDING = "ambiguous-binding";
 
     /**
-     * Columns separated list of patterns that will not be saved in history.
+     * Colon separated list of patterns that will not be saved in history.
      */
     String HISTORY_IGNORE = "history-ignore";
 


### PR DESCRIPTION
I believe "colon" was intended because *HISTORY_IGNORE*'s value is
passed to `matchPatterns` which converts colons to Regex `|`.

https://github.com/jline/jline3/blob/c6ae2c1295c81893456a38ae69509693a690b50d/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java#L402-L403