### PR TITLE
Avoid redundant Map.containsKey call

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Options.java
+++ b/builtins/src/main/java/org/jline/builtins/Options.java
@@ -127,10 +127,11 @@ public class Options {
     }
 
     public boolean isSet(String name) {
-        if (!optSet.containsKey(name))
+        Boolean isSet = optSet.get(name);
+        if (isSet == null) {
             throw new IllegalArgumentException("option not defined in spec: " + name);
-
-        return optSet.get(name);
+        }
+        return isSet;
     }
 
     public Object getObject(String name) {
@@ -311,9 +312,8 @@ public class Options {
                 final String name = (opt != null) ? opt : m.group(GROUP_SHORT_OPT_1);
 
                 if (name != null) {
-                    if (myOptSet.containsKey(name))
+                    if (myOptSet.putIfAbsent(name, false) != null)
                         throw new IllegalArgumentException("duplicate option in spec: --" + name);
-                    myOptSet.put(name, false);
                 }
 
                 String dflt = (m.group(GROUP_DEFAULT) != null) ? m.group(GROUP_DEFAULT) : "";
@@ -331,9 +331,8 @@ public class Options {
                 for (int i = 0; i < 2; ++i) {
                     String sopt = m.group(i == 0 ? GROUP_SHORT_OPT_1 : GROUP_SHORT_OPT_2);
                     if (sopt != null) {
-                        if (optName.containsKey(sopt))
+                        if (optName.putIfAbsent(sopt, name) != null)
                             throw new IllegalArgumentException("duplicate option in spec: -" + sopt);
-                        optName.put(sopt, name);
                     }
                 }
             }

--- a/builtins/src/main/java/org/jline/builtins/Styles.java
+++ b/builtins/src/main/java/org/jline/builtins/Styles.java
@@ -132,9 +132,6 @@ public class Styles {
         }
 
         public String getStyle(String reference) {
-            if (!colors.containsKey(reference)) {
-                return null;
-            }
             String rawStyle = colors.get(reference);
             if (rawStyle == null) {
                 return null;

--- a/builtins/src/main/java/org/jline/builtins/SyntaxHighlighter.java
+++ b/builtins/src/main/java/org/jline/builtins/SyntaxHighlighter.java
@@ -543,8 +543,9 @@ public class SyntaxHighlighter {
                             }
                         } else if (!addHighlightRule(parts, idx, TOKEN_NANORC) && parts.get(0).matches("\\+" + REGEX_TOKEN_NAME)) {
                             String key = themeKey(parts.get(0));
-                            if (colorTheme.containsKey(key)) {
-                                for (String l : colorTheme.get(key).split("\\\\n")) {
+                            String theme = colorTheme.get(key);
+                            if (theme != null) {
+                                for (String l : theme.split("\\\\n")) {
                                     idx++;
                                     addHighlightRule(RuleSplitter.split(fixRegexes(l)), idx, TOKEN_NANORC);
                                 }
@@ -584,18 +585,20 @@ public class SyntaxHighlighter {
                 addHighlightRule(syntaxName + idx, parts, true, tokenName);
             } else if (parts.get(0).matches(REGEX_TOKEN_NAME + "[:]?")) {
                 String key = themeKey(parts.get(0));
-                if (colorTheme.containsKey(key)) {
+                String theme = colorTheme.get(key);
+                if (theme != null) {
                     parts.set(0, "color");
-                    parts.add(1, colorTheme.get(key));
+                    parts.add(1, theme);
                     addHighlightRule(syntaxName + idx, parts, false, tokenName);
                 } else {
                     Log.warn("Unknown token type: ", key);
                 }
             } else if (parts.get(0).matches("~" + REGEX_TOKEN_NAME + "[:]?")) {
                 String key = themeKey(parts.get(0));
-                if (colorTheme.containsKey(key)) {
+                String theme = colorTheme.get(key);
+                if (theme != null) {
                     parts.set(0, "icolor");
-                    parts.add(1, colorTheme.get(key));
+                    parts.add(1, theme);
                     addHighlightRule(syntaxName + idx, parts, true, tokenName);
                 } else {
                     Log.warn("Unknown token type: ", key);

--- a/console/src/main/java/org/jline/console/impl/AbstractCommandRegistry.java
+++ b/console/src/main/java/org/jline/console/impl/AbstractCommandRegistry.java
@@ -185,12 +185,7 @@ public abstract class AbstractCommandRegistry implements CommandRegistry {
 
         public T command(String name) {
             T out;
-            if (!hasCommand(name)) {
-                throw new IllegalArgumentException("Command does not exists!");
-            }
-            if (aliasCommand.containsKey(name)) {
-                name = aliasCommand.get(name);
-            }
+            name = aliasCommand.getOrDefault(name, name);
             if (nameCommand.containsKey(name)) {
                 out = nameCommand.get(name);
             } else {
@@ -248,10 +243,8 @@ public abstract class AbstractCommandRegistry implements CommandRegistry {
         public String command(String name) {
             if (commandExecute.containsKey(name)) {
                 return name;
-            } else if (aliasCommand.containsKey(name)) {
-                return aliasCommand.get(name);
             }
-            return null;
+            return aliasCommand.get(name);
         }
 
         public CommandMethods getCommandMethods(String command) {

--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -1283,8 +1283,8 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
             if (words.size() > 1) {
                 String h = words.get(words.size() - 2);
                 if (h != null && h.length() > 0) {
-                     if(aliases.containsKey(h)){
-                          String v = aliases.get(h);
+                     String v = aliases.get(h);
+                     if (v != null){
                           candidates.add(new Candidate(AttributedString.stripAnsi(v)
                                            , v, null, null, null, null, true));
                      }

--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -1284,7 +1284,7 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
                 String h = words.get(words.size() - 2);
                 if (h != null && h.length() > 0) {
                      String v = aliases.get(h);
-                     if (v != null){
+                     if (v != null) {
                           candidates.add(new Candidate(AttributedString.stripAnsi(v)
                                            , v, null, null, null, null, true));
                      }

--- a/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
+++ b/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
@@ -274,7 +274,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
     protected void manageBooleanOptions(Map<String, Object> options) {
         for (String key : Printer.BOOLEAN_KEYS) {
             Object option = options.get(key);
-            boolean value = option instanceof Boolean && (boolean)option;
+            boolean value = option instanceof Boolean && (boolean) option;
             if (!value) {
                 options.remove(key);
             }
@@ -512,14 +512,11 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
     private List<String> optionList(String key, Map<String,Object> options) {
         List<String> out = new ArrayList<>();
         Object option = options.get(key);
-        if (option == null) {
-            return out;
-        }
         if (option instanceof String) {
             out.addAll(Arrays.asList(((String)option).split(",")));
         } else if (option instanceof Collection) {
             out.addAll((Collection<String>)option);
-        } else {
+        } else if (option != null) {
             throw new IllegalArgumentException("Unsupported option list: {key: " + key
                                              + ", type: " + option.getClass() + "}");
         }
@@ -635,14 +632,14 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
             } else {
                 out = new AttributedString(columnValue(objectToString(options, raw)));
             }
-       }
-       if ((simpleObject(raw) || raw == null) && (hv.containsKey("*") || highlightValue.containsKey("*"))
+        }
+        if ((simpleObject(raw) || raw == null) && (hv.containsKey("*") || highlightValue.containsKey("*"))
                 && !isHighlighted(out)) {
             if (hv.containsKey("*")) {
-                out = (AttributedString) engine.execute(hv.get("*"), out);
+                out = (AttributedString)engine.execute(hv.get("*"), out);
             }
-           Function<Object, AttributedString> func = highlightValue.get("*");
-           if (func != null) {
+            Function<Object, AttributedString> func = highlightValue.get("*");
+            if (func != null) {
                 out = func.apply(out);
             }
         }

--- a/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
+++ b/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
@@ -191,8 +191,9 @@ public class SystemRegistryImpl implements SystemRegistry {
 
     private List<String> localCommandInfo(String command) {
         try {
-            if (subcommands.containsKey(command)) {
-                registryHelp(subcommands.get(command));
+            CommandRegistry subCommand = subcommands.get(command);
+            if (subCommand != null) {
+                registryHelp(subCommand);
             } else {
                 localExecute(command, new String[] { "--help" });
             }
@@ -275,8 +276,9 @@ public class SystemRegistryImpl implements SystemRegistry {
         SystemCompleter out = CommandRegistry.aggregateCompleters(commandRegistries);
         SystemCompleter local = new SystemCompleter();
         for (String command : commandExecute.keySet()) {
-            if (subcommands.containsKey(command)) {
-                for(Map.Entry<String,List<Completer>> entry : subcommands.get(command).compileCompleters().getCompleters().entrySet()) {
+            CommandRegistry subCommand = subcommands.get(command);
+            if (subCommand != null) {
+                for (Map.Entry<String,List<Completer>> entry : subCommand.compileCompleters().getCompleters().entrySet()) {
                     for (Completer cc : entry.getValue()) {
                         if (!(cc instanceof ArgumentCompleter)) {
                             throw new IllegalArgumentException();
@@ -369,18 +371,19 @@ public class SystemRegistryImpl implements SystemRegistry {
         case COMMAND:
             if (isCommandOrScript(cmd) && !names.hasPipes(line.getArgs())) {
                 List<String> args = line.getArgs();
-                if (subcommands.containsKey(cmd)) {
+                CommandRegistry subCommand = subcommands.get(cmd);
+                if (subCommand != null) {
                     String c = args.size() > 1 ? args.get(1) : null;
-                    if (c == null || subcommands.get(cmd).hasCommand(c)) {
+                    if (c == null || subCommand.hasCommand(c)) {
                         if (c != null && c.equals("help")) {
                             out = null;
                         } else if (c != null) {
-                            out = subcommands.get(cmd).commandDescription(Collections.singletonList(c));
+                            out = subCommand.commandDescription(Collections.singletonList(c));
                         } else {
-                            out = commandDescription(subcommands.get(cmd));
+                            out = commandDescription(subCommand);
                         }
                     } else {
-                        out = commandDescription(subcommands.get(cmd));
+                        out = commandDescription(subCommand);
                     }
                     if (out != null) {
                         out.setSubcommand(true);

--- a/console/src/main/java/org/jline/widget/TailTipWidgets.java
+++ b/console/src/main/java/org/jline/widget/TailTipWidgets.java
@@ -744,14 +744,13 @@ public class TailTipWidgets extends Widgets {
         }
 
         public CmdDesc getDescription(String command) {
-            CmdDesc out = null;
+            CmdDesc out;
             if (descriptions.containsKey(command)) {
                 out = descriptions.get(command);
             } else if (temporaryDescs.containsKey(command)) {
                 out = temporaryDescs.get(command);
-            } else if (volatileDescs.containsKey(command)) {
-                out = volatileDescs.get(command);
-                volatileDescs.remove(command);
+            } else {
+                out = volatileDescs.remove(command);
             }
             return out;
         }

--- a/console/src/test/java/org/jline/example/Console.java
+++ b/console/src/test/java/org/jline/example/Console.java
@@ -153,10 +153,8 @@ public class Console
         private String command(String name) {
             if (commandExecute.containsKey(name)) {
                 return name;
-            } else if (aliasCommand.containsKey(name)) {
-                return aliasCommand.get(name);
             }
-            return null;
+            return aliasCommand.get(name);
         }
 
         public SystemCompleter compileCompleters() {

--- a/reader/src/main/java/org/jline/reader/impl/completer/SystemCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/SystemCompleter.java
@@ -67,7 +67,7 @@ public class SystemCompleter implements Completer {
         if (cmd != null) {
             if (completers.containsKey(cmd)) {
                 out = cmd;
-            } else if (aliasCommand.containsKey(cmd)) {
+            } else {
                 out = aliasCommand.get(cmd);
             }
         }


### PR DESCRIPTION
Often Map.containsKey call is redundant or pair of Map.containsKey+some can be replaced with another single Map call.
I propose to cleanup such calls. I believe it makes code a bit shorter and easier to read. Also it improves performance a bit.