### PR TITLE
prnt command: add option --multiColumns

### DIFF
--- a/console/src/main/java/org/jline/console/Printer.java
+++ b/console/src/main/java/org/jline/console/Printer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author or authors.
+ * Copyright (c) 2002-2022, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -189,8 +189,16 @@ public interface Printer {
      */
     String VALUE_STYLE_ALL = "valueStyleAll";
 
+    /**
+     * Value: Boolean<br>
+     * Applies: TABLE<br>
+     * List the collection of simple values in multiple columns
+     * DEFAULT: list values in one column
+     */
+    String MULTI_COLUMNS = "multiColumns";
+
     List<String> BOOLEAN_KEYS = Arrays.asList(ALL, ONE_ROW_TABLE, ROWNUM, SHORT_NAMES, SKIP_DEFAULT_OPTIONS
-            , STRUCT_ON_TABLE, TO_STRING, VALUE_STYLE_ALL);
+            , STRUCT_ON_TABLE, TO_STRING, VALUE_STYLE_ALL, MULTI_COLUMNS);
 
     default void println(Object object) {
         println(new HashMap<>(), object);


### PR DESCRIPTION
displays the collection of simple values in multiple columns. 

Example:
```
groovy-repl> 
groovy-repl> keymap |; prnt --multiColumns
"^@" set-mark-command                    "^A" beginning-of-line                   "^B" backward-char                       
"^D" delete-char-or-list                 "^E" end-of-line                         "^F" forward-char                        
"^G" abort                               "^H" backward-delete-char                "^I" expand-or-complete                  
"^J" accept-line                         "^K" kill-line                           "^L" clear-screen                        
"^M" accept-line                         "^N" down-line-or-history                "^O" accept-line-and-down-history        
"^P" up-line-or-history                  "^R" history-incremental-search-backward "^S" history-incremental-search-forward  
"^T" transpose-chars                     "^U" kill-whole-line                     "^V" quoted-insert                       
"^W" backward-kill-word                  "^Y" yank                                "^]" character-search                    
"^_" undo                                " "-"(" self-insert                      ")" insert-close-paren                   
"*"-"\\" self-insert                     "]" insert-close-square                  "\^"-"|" self-insert                     
"}" insert-close-curly                   "~" self-insert                          "^?" backward-delete-char                
.......
```
