### PR TITLE
Optimize Styles.isStylePattern() to avoid StackOverflowError

### DIFF
--- a/builtins/src/test/java/org/jline/builtins/StylesTest.java
+++ b/builtins/src/test/java/org/jline/builtins/StylesTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2023, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StylesTest {
+    private static final int TIMEOUT = 1000;
+
+    private static final String STANDARD_COLORS = "di=1;91:ex=1;92:ln=1;96:fi=";
+
+    private static final String SEPARATOR = ":";
+
+    private static final String DIRECTORY_STYLE_ELEMENT = "di=1";
+
+    private static final String ASTERISK_TILDE_STYLE_ELEMENT = "*~=00;90";
+
+    private static final int REPEATED_ELEMENTS = 1000;
+
+    @Test
+    public void testIsStylePatternStandardColors() {
+        final boolean stylePattern = Styles.isStylePattern(STANDARD_COLORS);
+
+        assertTrue(stylePattern);
+    }
+
+    @Test(timeout = TIMEOUT)
+    public void testIsStylePatternRepeatedDirectory() {
+        final StringBuilder builder = getRepeatedStyleBuilder();
+
+        final String style = builder.toString();
+        final boolean stylePattern = Styles.isStylePattern(style);
+
+        assertTrue(stylePattern);
+    }
+
+    @Test(timeout = TIMEOUT)
+    public void testIsStylePatternAsteriskTilde() {
+        final StringBuilder builder = getRepeatedStyleBuilder();
+        builder.append(ASTERISK_TILDE_STYLE_ELEMENT);
+        builder.append(SEPARATOR);
+
+        final String style = builder.toString();
+        final boolean stylePattern = Styles.isStylePattern(style);
+
+        assertFalse(stylePattern);
+    }
+
+    private StringBuilder getRepeatedStyleBuilder() {
+        final StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < REPEATED_ELEMENTS; i++) {
+            builder.append(DIRECTORY_STYLE_ELEMENT);
+            builder.append(SEPARATOR);
+        }
+        return builder;
+    }
+}


### PR DESCRIPTION
Changes for JLine 3.19.0 in commit a27bcd1b4832ff82af41e870ee3e90fe51910e30 adjusted pattern matching to support named colors in style declarations. These changes expanded the scope of valid style declarations, but also increased the possibility of performance problems when parsing long or malformed styles.

Fedora 37 has a default setting for the `LS_COLORS` environment variable that includes style elements which cause performance problems using `Styles.STYLE_PATTERN.matches()`. Calling `Styles.lsStyle()` with Azul Zulu Java 8 Update 352 on Fedora 37 causes the JVM to hang due to excessive iteration in regular expression matching. This issue does not occur on Java 11 or 17.

Changes in this pull request optimize style evaluation using a compiled `Pattern` for one key-value style element. `Styles.isStylePattern()` splits the input style string using the standard separator character, and then evaluates all elements against the compiled `STYLE_ELEMENT_PATTERN`. This approach avoids compiling the style pattern for every call to `Styles.isStylePattern()`, and also avoids a `StackOverflowError` that occurs with the current implementation when evaluating a test style constructed of 1000 style elements.

For reference, the default value of `LS_COLORS` on Fedora 37 is as follows:

```
rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=01;37;41:su=37;41:sg=30;43:ca=00:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.avif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.webp=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=01;36:*.au=01;36:*.flac=01;36:*.m4a=01;36:*.mid=01;36:*.midi=01;36:*.mka=01;36:*.mp3=01;36:*.mpc=01;36:*.ogg=01;36:*.ra=01;36:*.wav=01;36:*.oga=01;36:*.opus=01;36:*.spx=01;36:*.xspf=01;36:*~=00;90:*#=00;90:*.bak=00;90:*.old=00;90:*.orig=00;90:*.part=00;90:*.rej=00;90:*.swp=00;90:*.tmp=00;90:*.dpkg-dist=00;90:*.dpkg-old=00;90:*.ucf-dist=00;90:*.ucf-new=00;90:*.ucf-old=00;90:*.rpmnew=00;90:*.rpmorig=00;90:*.rpmsave=00;90:
```