### PR TITLE
spotless: set the line endings to <lf>

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
On Windows the command 
```
$ mvn spotless:apply
```
changes the source file line endings to `<cr><lf>`.

Set the file line endings to `<lf>` using a .gitattributes file.