### PR TITLE
Use Objects.hashCode instead of Objects.hash to avoid vararg array creation

### DIFF
--- a/reader/src/main/java/org/jline/reader/Candidate.java
+++ b/reader/src/main/java/org/jline/reader/Candidate.java
@@ -188,7 +188,7 @@ public class Candidate implements Comparable<Candidate> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hashCode(value);
     }
 
     @Override


### PR DESCRIPTION
Objects.hash accepts vararg array. We can use Objects.hashCode to avoid redundant array creation.