### PR TITLE
Fix TerminalProvider sorting

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -404,7 +404,8 @@ public final class TerminalBuilder {
         List<String> order = Arrays.asList(
                 System.getProperty(PROP_PROVIDERS, PROP_PROVIDERS_DEFAULT).split(","));
         providers.sort(Comparator.comparing(l -> {
-            int idx = order.indexOf(l);
+            String tpName = l.name();
+            int idx = tpName != null ? order.indexOf(tpName) : -1;
             return idx >= 0 ? idx : Integer.MAX_VALUE;
         }));
 


### PR DESCRIPTION
- Change provider sorting so that it uses provider name instead of provider object itself. This fixes getting a proper sorting list index to compare the order. Uses null check in case provider wrongly gives name as null.
- Fixes #846

Unfortunately there's no testing infra(unless I missed something) for `TerminalBuilder` so didn't find any easy way to add any tests. Though I did some manual testing.