### PR TITLE
Various fixes

### DIFF
--- a/reader/src/main/java/org/jline/reader/Candidate.java
+++ b/reader/src/main/java/org/jline/reader/Candidate.java
@@ -188,7 +188,7 @@ public class Candidate implements Comparable<Candidate> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hashCode(value);
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -404,7 +404,7 @@ public final class TerminalBuilder {
         List<String> order = Arrays.asList(
                 System.getProperty(PROP_PROVIDERS, PROP_PROVIDERS_DEFAULT).split(","));
         providers.sort(Comparator.comparing(l -> {
-            int idx = order.indexOf(l);
+            int idx = order.indexOf(l.name());
             return idx >= 0 ? idx : Integer.MAX_VALUE;
         }));
 

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -559,7 +559,7 @@ public final class TerminalBuilder {
                         color ? Terminal.TYPE_DUMB_COLOR : Terminal.TYPE_DUMB,
                         new FileInputStream(FileDescriptor.in),
                         new FileOutputStream(
-                                console == TerminalProvider.Stream.Output ? FileDescriptor.out : FileDescriptor.err),
+                                console == TerminalProvider.Stream.Error ? FileDescriptor.err : FileDescriptor.out),
                         encoding,
                         signalHandler);
             }

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -25,9 +25,12 @@ import org.jline.terminal.impl.PosixSysTerminal;
 import org.jline.terminal.spi.Pty;
 import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.ExecHelper;
+import org.jline.utils.Log;
 import org.jline.utils.OSUtils;
 
 public class ExecTerminalProvider implements TerminalProvider {
+
+    private static boolean warned;
 
     public String name() {
         return "exec";
@@ -142,11 +145,21 @@ public class ExecTerminalProvider implements TerminalProvider {
                 return result.trim();
             }
         } catch (Throwable t) {
+            if ("java.lang.reflect.InaccessibleObjectException"
+                            .equals(t.getClass().getName())
+                    && !warned) {
+                Log.warn(
+                        "The ExecTerminalProvider requires the JVM options: '--add-opens java.base/java.lang=ALL-UNNAMED'");
+                warned = true;
+            }
             // ignore
         }
         return null;
     }
 
+    /**
+     * This requires --add-opens java.base/java.lang=ALL-UNNAMED
+     */
     private ProcessBuilder.Redirect getRedirect(FileDescriptor fd) throws ReflectiveOperationException {
         // This is not really allowed, but this is the only way to redirect the output or error stream
         // to the input.  This is definitely not something you'd usually want to do, but in the case of

--- a/terminal/src/main/java/org/jline/utils/OSUtils.java
+++ b/terminal/src/main/java/org/jline/utils/OSUtils.java
@@ -46,54 +46,48 @@ public class OSUtils {
     public static String TEST_COMMAND;
 
     static {
-        String tty;
-        String stty;
-        String sttyfopt;
-        String infocmp;
-        String test;
-        if (OSUtils.IS_CYGWIN || OSUtils.IS_MSYSTEM) {
-            tty = null;
-            stty = null;
-            sttyfopt = null;
-            infocmp = null;
-            test = null;
-            String path = System.getenv("PATH");
-            if (path != null) {
-                String[] paths = path.split(";");
-                for (String p : paths) {
-                    if (tty == null && new File(p, "tty.exe").exists()) {
-                        tty = new File(p, "tty.exe").getAbsolutePath();
-                    }
-                    if (stty == null && new File(p, "stty.exe").exists()) {
-                        stty = new File(p, "stty.exe").getAbsolutePath();
-                    }
-                    if (infocmp == null && new File(p, "infocmp.exe").exists()) {
-                        infocmp = new File(p, "infocmp.exe").getAbsolutePath();
-                    }
-                    if (test == null && new File(p, "test.exe").exists()) {
-                        test = new File(p, "test.exe").getAbsolutePath();
-                    }
+        boolean cygwinOrMsys = OSUtils.IS_CYGWIN || OSUtils.IS_MSYSTEM;
+        String suffix = cygwinOrMsys ? ".exe" : "";
+        String tty = null;
+        String stty = null;
+        String sttyfopt = null;
+        String infocmp = null;
+        String test = null;
+        String path = System.getenv("PATH");
+        if (path != null) {
+            String[] paths = path.split(File.pathSeparator);
+            for (String p : paths) {
+                File ttyFile = new File(p, "tty" + suffix);
+                if (tty == null && ttyFile.canExecute()) {
+                    tty = ttyFile.getAbsolutePath();
+                }
+                File sttyFile = new File(p, "stty" + suffix);
+                if (stty == null && sttyFile.canExecute()) {
+                    stty = sttyFile.getAbsolutePath();
+                }
+                File infocmpFile = new File(p, "infocmp" + suffix);
+                if (infocmp == null && infocmpFile.canExecute()) {
+                    infocmp = infocmpFile.getAbsolutePath();
+                }
+                File testFile = new File(p, "test" + suffix);
+                if (test == null && testFile.canExecute()) {
+                    test = testFile.getAbsolutePath();
                 }
             }
-            if (tty == null) {
-                tty = "tty.exe";
-            }
-            if (stty == null) {
-                stty = "stty.exe";
-            }
-            if (infocmp == null) {
-                infocmp = "infocmp.exe";
-            }
-            if (test == null) {
-                test = "test.exe";
-            }
-        } else {
-            tty = "tty";
-            stty = IS_OSX ? "/bin/stty" : "stty";
-            sttyfopt = IS_OSX ? "-f" : "-F";
-            infocmp = "infocmp";
-            test = "/bin/test";
         }
+        if (tty == null) {
+            tty = "tty" + suffix;
+        }
+        if (stty == null) {
+            stty = "stty" + suffix;
+        }
+        if (infocmp == null) {
+            infocmp = "infocmp" + suffix;
+        }
+        if (test == null) {
+            test = "test" + suffix;
+        }
+        sttyfopt = IS_OSX ? "-f" : "-F";
         TTY_COMMAND = tty;
         STTY_COMMAND = stty;
         STTY_F_OPTION = sttyfopt;


### PR DESCRIPTION
- Use Objects.hashCode instead of Objects.hash to avoid vararg array creation (fixes #849)
- Fix TerminalProvider sorting
- Fix shell output going to stderr rather than stdout (fixes #845)
- Fix detection of utilities (fixes #839)
- Add a warning when using the ExecTerminalProvider on recent JDKs
