### PR TITLE
jdk21

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Completers.java
+++ b/builtins/src/main/java/org/jline/builtins/Completers.java
@@ -446,6 +446,7 @@ public class Completers {
             this(Arrays.asList(nodes));
         }
 
+        @SuppressWarnings("this-escape")
         public TreeCompleter(List<Node> nodes) {
             StringBuilder sb = new StringBuilder();
             addRoots(sb, nodes);

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -1551,6 +1551,7 @@ public class Nano implements Editor {
         this(terminal, root, opts, null);
     }
 
+    @SuppressWarnings("this-escape")
     public Nano(Terminal terminal, Path root, Options opts, ConfigurationPath configPath) {
         this.terminal = terminal;
         this.windowsTerminal = terminal.getClass().getSimpleName().endsWith("WinSysTerminal");

--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -428,6 +428,7 @@ public class Tmux {
         }
     }
 
+    @SuppressWarnings("this-escape")
     public Tmux(Terminal terminal, PrintStream err, Consumer<Terminal> runner) throws IOException {
         this.terminal = terminal;
         this.err = err;

--- a/console/src/main/java/org/jline/console/impl/Builtins.java
+++ b/console/src/main/java/org/jline/console/impl/Builtins.java
@@ -74,6 +74,7 @@ public class Builtins extends JlineCommandRegistry implements CommandRegistry {
         this(null, workDir, configPath, widgetCreator);
     }
 
+    @SuppressWarnings("this-escape")
     public Builtins(
             Set<Command> commands,
             Supplier<Path> workDir,

--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -87,7 +87,7 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
         this(null, engine, printer, workDir, configPath);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "this-escape"})
     public ConsoleEngineImpl(
             Set<Command> commands,
             ScriptEngine engine,

--- a/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
+++ b/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
@@ -81,6 +81,7 @@ public class SystemRegistryImpl implements SystemRegistry {
     private boolean commandGroups = true;
     private Function<CmdLine, CmdDesc> scriptDescription;
 
+    @SuppressWarnings("this-escape")
     public SystemRegistryImpl(Parser parser, Terminal terminal, Supplier<Path> workDir, ConfigurationPath configPath) {
         this.parser = parser;
         this.workDir = workDir;

--- a/console/src/main/java/org/jline/widget/AutopairWidgets.java
+++ b/console/src/main/java/org/jline/widget/AutopairWidgets.java
@@ -68,6 +68,7 @@ public class AutopairWidgets extends Widgets {
         this(reader, false);
     }
 
+    @SuppressWarnings("this-escape")
     public AutopairWidgets(LineReader reader, boolean addCurlyBrackets) {
         super(reader);
         if (existsWidget(AP_INSERT)) {

--- a/console/src/main/java/org/jline/widget/AutosuggestionWidgets.java
+++ b/console/src/main/java/org/jline/widget/AutosuggestionWidgets.java
@@ -22,6 +22,7 @@ import org.jline.reader.impl.BufferImpl;
 public class AutosuggestionWidgets extends Widgets {
     private boolean enabled = false;
 
+    @SuppressWarnings("this-escape")
     public AutosuggestionWidgets(LineReader reader) {
         super(reader);
         if (existsWidget("_autosuggest-forward-char")) {

--- a/console/src/main/java/org/jline/widget/TailTipWidgets.java
+++ b/console/src/main/java/org/jline/widget/TailTipWidgets.java
@@ -124,6 +124,7 @@ public class TailTipWidgets extends Widgets {
         this(reader, null, descriptionSize, tipType, descFun);
     }
 
+    @SuppressWarnings("this-escape")
     private TailTipWidgets(
             LineReader reader,
             Map<String, CmdDesc> tailTips,

--- a/groovy/src/main/java/org/jline/script/GroovyCommand.java
+++ b/groovy/src/main/java/org/jline/script/GroovyCommand.java
@@ -51,6 +51,7 @@ public class GroovyCommand extends AbstractCommandRegistry implements CommandReg
         this(null, engine, printer);
     }
 
+    @SuppressWarnings("this-escape")
     public GroovyCommand(Set<Command> commands, GroovyEngine engine, Printer printer) {
         this.engine = engine;
         this.printer = printer;

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <gogo.jline.version>1.1.8</gogo.jline.version>
         <slf4j.version>2.0.6</slf4j.version>
         <findbugs.version>3.0.2</findbugs.version>
-        <groovy.version>4.0.7</groovy.version>
+        <groovy.version>4.0.13</groovy.version>
         <ivy.version>2.5.1</ivy.version>
         <graal.version>22.3.0</graal.version>
         <graal.plugin.version>21.2.0</graal.plugin.version>
@@ -522,7 +522,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>2.28.0</version>
+                    <version>2.37.0</version>
                     <configuration>
                         <java>
                             <toggleOffOn />
@@ -684,11 +684,6 @@
                 <groupId>org.graalvm.nativeimage</groupId>
                 <artifactId>native-image-maven-plugin</artifactId>
             </plugin>
-
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 
@@ -759,6 +754,21 @@
                         <configuration>
                             <release>8</release>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>java11</id>
+            <activation>
+                <jdk>[11,21)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.diffplug.spotless</groupId>
+                        <artifactId>spotless-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/reader/src/main/java/org/jline/reader/Candidate.java
+++ b/reader/src/main/java/org/jline/reader/Candidate.java
@@ -188,7 +188,7 @@ public class Candidate implements Comparable<Candidate> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hashCode(value);
     }
 
     @Override

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -232,7 +232,7 @@ public class LineReaderImpl implements LineReader, Flushable {
 
     protected KillRing killRing = new KillRing();
 
-    protected UndoTree<Buffer> undo = new UndoTree<>(this::setBuffer);
+    protected UndoTree<Buffer> undo;
     protected boolean isUndo;
 
     /**
@@ -291,6 +291,7 @@ public class LineReaderImpl implements LineReader, Flushable {
         this(terminal, appName, null);
     }
 
+    @SuppressWarnings("this-escape")
     public LineReaderImpl(Terminal terminal, String appName, Map<String, Object> variables) {
         Objects.requireNonNull(terminal, "terminal can not be null");
         this.terminal = terminal;
@@ -309,6 +310,7 @@ public class LineReaderImpl implements LineReader, Flushable {
             this.alternateOut = Curses.tputs(terminal.getStringCapability(Capability.exit_alt_charset_mode));
         }
 
+        undo = new UndoTree<>(this::setBuffer);
         builtinWidgets = builtinWidgets();
         widgets = new HashMap<>(builtinWidgets);
         bindingReader = new BindingReader(terminal.reader());

--- a/reader/src/main/java/org/jline/reader/impl/UndoTree.java
+++ b/reader/src/main/java/org/jline/reader/impl/UndoTree.java
@@ -20,6 +20,7 @@ public class UndoTree<T> {
     private final Node parent;
     private Node current;
 
+    @SuppressWarnings("this-escape")
     public UndoTree(Consumer<T> s) {
         state = s;
         parent = new Node(null);

--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -43,6 +43,7 @@ public class DefaultHistory implements History {
 
     public DefaultHistory() {}
 
+    @SuppressWarnings("this-escape")
     public DefaultHistory(LineReader reader) {
         attach(reader);
     }

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionData.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionData.java
@@ -81,6 +81,7 @@ public class ConnectionData {
      * @param sock Socket of the inbound connection.
      * @param cm the connection manager
      */
+    @SuppressWarnings("this-escape")
     public ConnectionData(Socket sock, ConnectionManager cm) {
         socket = sock;
         connectionManager = cm;

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
@@ -74,6 +74,7 @@ public abstract class ConnectionManager implements Runnable {
     private boolean lineMode = false;
     private boolean stopping = false;
 
+    @SuppressWarnings("this-escape")
     public ConnectionManager() {
         threadGroup = new ThreadGroup(toString() + "Connections");
         closedConnections = new Stack<Connection>();

--- a/terminal/src/main/java/org/jline/terminal/Attributes.java
+++ b/terminal/src/main/java/org/jline/terminal/Attributes.java
@@ -137,6 +137,7 @@ public class Attributes {
 
     public Attributes() {}
 
+    @SuppressWarnings("this-escape")
     public Attributes(Attributes attr) {
         copy(attr);
     }

--- a/terminal/src/main/java/org/jline/terminal/Size.java
+++ b/terminal/src/main/java/org/jline/terminal/Size.java
@@ -15,6 +15,7 @@ public class Size {
 
     public Size() {}
 
+    @SuppressWarnings("this-escape")
     public Size(int columns, int rows) {
         this();
         setColumns(columns);

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -404,7 +404,7 @@ public final class TerminalBuilder {
         List<String> order = Arrays.asList(
                 System.getProperty(PROP_PROVIDERS, PROP_PROVIDERS_DEFAULT).split(","));
         providers.sort(Comparator.comparing(l -> {
-            int idx = order.indexOf(l);
+            int idx = order.indexOf(l.name());
             return idx >= 0 ? idx : Integer.MAX_VALUE;
         }));
 

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -559,7 +559,7 @@ public final class TerminalBuilder {
                         color ? Terminal.TYPE_DUMB_COLOR : Terminal.TYPE_DUMB,
                         new FileInputStream(FileDescriptor.in),
                         new FileOutputStream(
-                                console == TerminalProvider.Stream.Output ? FileDescriptor.out : FileDescriptor.err),
+                                console == TerminalProvider.Stream.Error ? FileDescriptor.err : FileDescriptor.out),
                         encoding,
                         signalHandler);
             }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -44,7 +44,7 @@ public abstract class AbstractTerminal implements Terminal {
     protected final Set<Capability> bools = new HashSet<>();
     protected final Map<Capability, Integer> ints = new HashMap<>();
     protected final Map<Capability, String> strings = new HashMap<>();
-    protected final ColorPalette palette = new ColorPalette(this);
+    protected final ColorPalette palette;
     protected Status status;
     protected Runnable onClose;
 
@@ -52,11 +52,13 @@ public abstract class AbstractTerminal implements Terminal {
         this(name, type, null, SignalHandler.SIG_DFL);
     }
 
+    @SuppressWarnings("this-escape")
     public AbstractTerminal(String name, String type, Charset encoding, SignalHandler signalHandler)
             throws IOException {
         this.name = name;
         this.type = type != null ? type : "ansi";
         this.encoding = encoding != null ? encoding : Charset.defaultCharset();
+        this.palette = new ColorPalette(this);
         for (Signal signal : Signal.values()) {
             handlers.put(signal, signalHandler);
         }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -82,6 +82,7 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
     protected boolean focusTracking = false;
     private volatile boolean closing;
 
+    @SuppressWarnings("this-escape")
     public AbstractWindowsTerminal(
             Writer writer,
             String name,

--- a/terminal/src/main/java/org/jline/terminal/impl/DumbTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DumbTerminal.java
@@ -40,6 +40,7 @@ public class DumbTerminal extends AbstractTerminal {
         this(name, type, in, out, encoding, SignalHandler.SIG_DFL);
     }
 
+    @SuppressWarnings("this-escape")
     public DumbTerminal(
             String name, String type, InputStream in, OutputStream out, Charset encoding, SignalHandler signalHandler)
             throws IOException {

--- a/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
@@ -67,6 +67,7 @@ public class ExternalTerminal extends LineDisciplineTerminal {
         this(name, type, masterInput, masterOutput, encoding, signalHandler, paused, null, null);
     }
 
+    @SuppressWarnings("this-escape")
     public ExternalTerminal(
             String name,
             String type,

--- a/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
@@ -91,6 +91,7 @@ public class LineDisciplineTerminal extends AbstractTerminal {
         this(name, type, masterOutput, encoding, SignalHandler.SIG_DFL);
     }
 
+    @SuppressWarnings("this-escape")
     public LineDisciplineTerminal(
             String name, String type, OutputStream masterOutput, Charset encoding, SignalHandler signalHandler)
             throws IOException {

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -55,6 +55,7 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
         this(name, type, pty, in, out, encoding, signalHandler, false);
     }
 
+    @SuppressWarnings("this-escape")
     public PosixPtyTerminal(
             String name,
             String type,

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -34,6 +34,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
     protected final Map<Signal, Object> nativeHandlers = new HashMap<>();
     protected final Task closer;
 
+    @SuppressWarnings("this-escape")
     public PosixSysTerminal(
             String name, String type, Pty pty, Charset encoding, boolean nativeSignals, SignalHandler signalHandler)
             throws IOException {

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -25,9 +25,12 @@ import org.jline.terminal.impl.PosixSysTerminal;
 import org.jline.terminal.spi.Pty;
 import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.ExecHelper;
+import org.jline.utils.Log;
 import org.jline.utils.OSUtils;
 
 public class ExecTerminalProvider implements TerminalProvider {
+
+    private static boolean warned;
 
     public String name() {
         return "exec";
@@ -142,11 +145,21 @@ public class ExecTerminalProvider implements TerminalProvider {
                 return result.trim();
             }
         } catch (Throwable t) {
+            if ("java.lang.reflect.InaccessibleObjectException"
+                            .equals(t.getClass().getName())
+                    && !warned) {
+                Log.warn(
+                        "The ExecTerminalProvider requires the JVM options: '--add-opens java.base/java.lang=ALL-UNNAMED'");
+                warned = true;
+            }
             // ignore
         }
         return null;
     }
 
+    /**
+     * This requires --add-opens java.base/java.lang=ALL-UNNAMED
+     */
     private ProcessBuilder.Redirect getRedirect(FileDescriptor fd) throws ReflectiveOperationException {
         // This is not really allowed, but this is the only way to redirect the output or error stream
         // to the input.  This is definitely not something you'd usually want to do, but in the case of

--- a/terminal/src/main/java/org/jline/utils/ColorPalette.java
+++ b/terminal/src/main/java/org/jline/utils/ColorPalette.java
@@ -42,6 +42,7 @@ public class ColorPalette {
         this(terminal, null);
     }
 
+    @SuppressWarnings("this-escape")
     public ColorPalette(Terminal terminal, String distance) throws IOException {
         this.terminal = terminal;
         this.distanceName = distance;

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -41,6 +41,7 @@ public class Display {
     protected final boolean delayedWrapAtEol;
     protected final boolean cursorDownIsNewLine;
 
+    @SuppressWarnings("this-escape")
     public Display(Terminal terminal, boolean fullscreen) {
         this.terminal = terminal;
         this.fullScreen = fullscreen;

--- a/terminal/src/main/java/org/jline/utils/OSUtils.java
+++ b/terminal/src/main/java/org/jline/utils/OSUtils.java
@@ -46,54 +46,48 @@ public class OSUtils {
     public static String TEST_COMMAND;
 
     static {
-        String tty;
-        String stty;
-        String sttyfopt;
-        String infocmp;
-        String test;
-        if (OSUtils.IS_CYGWIN || OSUtils.IS_MSYSTEM) {
-            tty = null;
-            stty = null;
-            sttyfopt = null;
-            infocmp = null;
-            test = null;
-            String path = System.getenv("PATH");
-            if (path != null) {
-                String[] paths = path.split(";");
-                for (String p : paths) {
-                    if (tty == null && new File(p, "tty.exe").exists()) {
-                        tty = new File(p, "tty.exe").getAbsolutePath();
-                    }
-                    if (stty == null && new File(p, "stty.exe").exists()) {
-                        stty = new File(p, "stty.exe").getAbsolutePath();
-                    }
-                    if (infocmp == null && new File(p, "infocmp.exe").exists()) {
-                        infocmp = new File(p, "infocmp.exe").getAbsolutePath();
-                    }
-                    if (test == null && new File(p, "test.exe").exists()) {
-                        test = new File(p, "test.exe").getAbsolutePath();
-                    }
+        boolean cygwinOrMsys = OSUtils.IS_CYGWIN || OSUtils.IS_MSYSTEM;
+        String suffix = cygwinOrMsys ? ".exe" : "";
+        String tty = null;
+        String stty = null;
+        String sttyfopt = null;
+        String infocmp = null;
+        String test = null;
+        String path = System.getenv("PATH");
+        if (path != null) {
+            String[] paths = path.split(File.pathSeparator);
+            for (String p : paths) {
+                File ttyFile = new File(p, "tty" + suffix);
+                if (tty == null && ttyFile.canExecute()) {
+                    tty = ttyFile.getAbsolutePath();
+                }
+                File sttyFile = new File(p, "stty" + suffix);
+                if (stty == null && sttyFile.canExecute()) {
+                    stty = sttyFile.getAbsolutePath();
+                }
+                File infocmpFile = new File(p, "infocmp" + suffix);
+                if (infocmp == null && infocmpFile.canExecute()) {
+                    infocmp = infocmpFile.getAbsolutePath();
+                }
+                File testFile = new File(p, "test" + suffix);
+                if (test == null && testFile.canExecute()) {
+                    test = testFile.getAbsolutePath();
                 }
             }
-            if (tty == null) {
-                tty = "tty.exe";
-            }
-            if (stty == null) {
-                stty = "stty.exe";
-            }
-            if (infocmp == null) {
-                infocmp = "infocmp.exe";
-            }
-            if (test == null) {
-                test = "test.exe";
-            }
-        } else {
-            tty = "tty";
-            stty = IS_OSX ? "/bin/stty" : "stty";
-            sttyfopt = IS_OSX ? "-f" : "-F";
-            infocmp = "infocmp";
-            test = "/bin/test";
         }
+        if (tty == null) {
+            tty = "tty" + suffix;
+        }
+        if (stty == null) {
+            stty = "stty" + suffix;
+        }
+        if (infocmp == null) {
+            infocmp = "infocmp" + suffix;
+        }
+        if (test == null) {
+            test = "test" + suffix;
+        }
+        sttyfopt = IS_OSX ? "-f" : "-F";
         TTY_COMMAND = tty;
         STTY_COMMAND = stty;
         STTY_F_OPTION = sttyfopt;

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -39,6 +39,7 @@ public class Status {
         return terminal instanceof AbstractTerminal ? ((AbstractTerminal) terminal).getStatus(create) : null;
     }
 
+    @SuppressWarnings("this-escape")
     public Status(AbstractTerminal terminal) {
         this.terminal = Objects.requireNonNull(terminal, "terminal can not be null");
         this.supported = terminal.getStringCapability(Capability.change_scroll_region) != null


### PR DESCRIPTION
- Use Objects.hashCode instead of Objects.hash to avoid vararg array creation (fixes #849)
- Fix TerminalProvider sorting
- Fix shell output going to stderr rather than stdout (fixes #845)
- Fix detection of utilities (fixes #839)
- Add a warning when using the ExecTerminalProvider on recent JDKs
- Upgrade spotless-maven-plugin to 2.37.0
- Fix build on JDK21
