### PR TITLE
The readLine() call should exit when the thread is interrupted

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -651,7 +651,7 @@ public class LineReaderImpl implements LineReader, Flushable {
                 lock.unlock();
             }
 
-            while (true) {
+            while (!Thread.interrupted()) {
 
                 KeyMap<Binding> local = null;
                 if (isInViCmdMode() && regionActive != RegionType.NONE) {


### PR DESCRIPTION
Refactored the readLine() to exit on thread interruption