### PR TITLE
fix history trim for non-timestamped files

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -247,12 +247,16 @@ public class DefaultHistory implements History {
         Log.trace("Trimming history path: ", path);
         // Load all history entries
         LinkedList<Entry> allItems = new LinkedList<>();
-        try (BufferedReader reader = Files.newBufferedReader(path)) {
-            reader.lines().forEach(l -> {
-                int idx = l.indexOf(':');
-                Instant time = Instant.ofEpochMilli(Long.parseLong(l.substring(0, idx)));
-                String line = unescape(l.substring(idx + 1));
-                allItems.add(createEntry(allItems.size(), time, line));
+        try (BufferedReader historyFileReader = Files.newBufferedReader(path)) {
+            historyFileReader.lines().forEach(l -> {
+                if (reader.isSet(LineReader.Option.HISTORY_TIMESTAMPED)) {
+                    int idx = l.indexOf(':');
+                    Instant time = Instant.ofEpochMilli(Long.parseLong(l.substring(0, idx)));
+                    String line = unescape(l.substring(idx + 1));
+                    allItems.add(createEntry(allItems.size(), time, line));
+                } else {
+                    allItems.add(createEntry(allItems.size(), Instant.now(), unescape(l)));
+                }
             });
         }
         // Remove duplicates


### PR DESCRIPTION
I've got a report today from a user that there is an issue saving the console history. This is due to the fact that the console history can be timestamped (format `<timestamp>:<line>`) but also just the raw line (format `<line>`). The trim process tries to find the delimiter char `:` everytime, and errors out if the console history is not timestamped:
![image](https://github.com/jline/jline3/assets/40468651/d73de554-ce78-4b71-957c-6396ca6ef429)

I've changed the trim process in a way that it checks if the history is timestamped, and if not there is no split applied and the line is just parsed raw. The time is not used in the further trim steps.