### PR TITLE
org.jline.util.PumpReader signed byte problem

### DIFF
--- a/terminal/src/main/java/org/jline/utils/PumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/PumpReader.java
@@ -413,7 +413,7 @@ public class PumpReader extends Reader {
                 return EOF;
             }
 
-            return buffer.get();
+            return buffer.get() & 0xFF;
         }
 
         private boolean readUsingBuffer() throws IOException {

--- a/terminal/src/test/java/org/jline/utils/PumpReaderTest.java
+++ b/terminal/src/test/java/org/jline/utils/PumpReaderTest.java
@@ -101,10 +101,10 @@ public class PumpReaderTest {
         InputStream inputStream = pump.createInputStream(StandardCharsets.UTF_8);
         byte[] expectedEncoded = "\uD83D\uDE0A".getBytes(StandardCharsets.UTF_8);
         assertEquals(4, expectedEncoded.length); // verify that test is correctly implemented
-        assertEquals(expectedEncoded[0], inputStream.read());
-        assertEquals(expectedEncoded[1], inputStream.read());
-        assertEquals(expectedEncoded[2], inputStream.read());
-        assertEquals(expectedEncoded[3], inputStream.read());
+        assertEquals(expectedEncoded[0] & 0xff, inputStream.read());
+        assertEquals(expectedEncoded[1] & 0xff, inputStream.read());
+        assertEquals(expectedEncoded[2] & 0xff, inputStream.read());
+        assertEquals(expectedEncoded[3] & 0xff, inputStream.read());
         assertEquals(-1, inputStream.read());
     }
 


### PR DESCRIPTION
Fixed problem found in JDK - https://bugs.openjdk.org/browse/JDK-8312475