### PR TITLE
Various upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <automatic.module.name />
 
         <jna.version>5.13.0</jna.version>
-        <jansi.version>2.4.0</jansi.version>
+        <jansi.version>2.4.1</jansi.version>
         <juniversalchardet.version>1.0.3</juniversalchardet.version>
         <sshd.version>2.9.2</sshd.version>
         <easymock.version>5.1.0</easymock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -384,12 +384,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>4.0.0-M9</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
@@ -438,7 +438,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>4.2</version>
+                    <version>4.3</version>
                     <configuration>
                         <encoding>UTF-8</encoding>
                         <strictCheck>true</strictCheck>
@@ -529,7 +529,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                 </plugin>
 
                 <plugin>
@@ -541,7 +541,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>2.39.0</version>
+                    <version>2.40.0</version>
                     <configuration>
                         <java>
                             <toggleOffOn />
@@ -751,7 +751,7 @@
                             <dependency>
                                 <groupId>org.apache.commons</groupId>
                                 <artifactId>commons-lang3</artifactId>
-                                <version>3.12.0</version>
+                                <version>3.13.0</version>
                             </dependency>
                         </dependencies>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <slf4j.version>2.0.9</slf4j.version>
         <findbugs.version>3.0.2</findbugs.version>
         <groovy.version>4.0.13</groovy.version>
-        <ivy.version>2.5.1</ivy.version>
+        <ivy.version>2.5.2</ivy.version>
         <graal.version>23.1.1</graal.version>
         <graal.plugin.version>21.2.0</graal.plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <jansi.version>2.4.1</jansi.version>
         <juniversalchardet.version>1.0.3</juniversalchardet.version>
         <sshd.version>2.11.0</sshd.version>
-        <easymock.version>5.1.0</easymock.version>
+        <easymock.version>5.2.0</easymock.version>
         <junit.version>5.10.0</junit.version>
         <gogo.runtime.version>1.1.6</gogo.runtime.version>
         <gogo.jline.version>1.1.8</gogo.jline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <junit.version>5.10.0</junit.version>
         <gogo.runtime.version>1.1.6</gogo.runtime.version>
         <gogo.jline.version>1.1.8</gogo.jline.version>
-        <slf4j.version>2.0.6</slf4j.version>
+        <slf4j.version>2.0.9</slf4j.version>
         <findbugs.version>3.0.2</findbugs.version>
         <groovy.version>4.0.13</groovy.version>
         <ivy.version>2.5.1</ivy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <findbugs.version>3.0.2</findbugs.version>
         <groovy.version>4.0.13</groovy.version>
         <ivy.version>2.5.1</ivy.version>
-        <graal.version>22.3.0</graal.version>
+        <graal.version>23.1.1</graal.version>
         <graal.plugin.version>21.2.0</graal.plugin.version>
 
         <surefire.argLine>--add-opens java.base/java.io=ALL-UNNAMED</surefire.argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <jna.version>5.13.0</jna.version>
         <jansi.version>2.4.1</jansi.version>
         <juniversalchardet.version>1.0.3</juniversalchardet.version>
-        <sshd.version>2.9.2</sshd.version>
+        <sshd.version>2.11.0</sshd.version>
         <easymock.version>5.1.0</easymock.version>
         <junit.version>5.10.0</junit.version>
         <gogo.runtime.version>1.1.6</gogo.runtime.version>

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
@@ -10,7 +10,7 @@ package org.jline.terminal.impl.jansi.win;
 
 import java.io.IOException;
 
-import org.fusesource.jansi.WindowsSupport;
+import org.fusesource.jansi.internal.Kernel32;
 import org.jline.terminal.impl.AbstractWindowsConsoleWriter;
 
 import static org.fusesource.jansi.internal.Kernel32.WriteConsoleW;
@@ -27,7 +27,7 @@ class JansiWinConsoleWriter extends AbstractWindowsConsoleWriter {
     @Override
     protected void writeConsole(char[] text, int len) throws IOException {
         if (WriteConsoleW(console, text, len, writtenChars, 0) == 0) {
-            throw new IOException("Failed to write to console: " + WindowsSupport.getLastErrorMessage());
+            throw new IOException("Failed to write to console: " + Kernel32.getLastErrorMessage());
         }
     }
 }

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/WindowsAnsiWriter.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/WindowsAnsiWriter.java
@@ -11,8 +11,7 @@ package org.jline.terminal.impl.jansi.win;
 import java.io.IOException;
 import java.io.Writer;
 
-import org.fusesource.jansi.WindowsSupport;
-import org.fusesource.jansi.internal.Kernel32.*;
+import org.fusesource.jansi.internal.Kernel32;
 import org.jline.utils.AnsiWriter;
 import org.jline.utils.Colors;
 
@@ -82,7 +81,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
     private void getConsoleInfo() throws IOException {
         out.flush();
         if (GetConsoleScreenBufferInfo(console, info) == 0) {
-            throw new IOException("Could not get the screen info: " + WindowsSupport.getLastErrorMessage());
+            throw new IOException("Could not get the screen info: " + Kernel32.getLastErrorMessage());
         }
         if (negative) {
             info.attributes = invertAttributeColors(info.attributes);
@@ -104,7 +103,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
             attributes = invertAttributeColors(attributes);
         }
         if (SetConsoleTextAttribute(console, attributes) == 0) {
-            throw new IOException(WindowsSupport.getLastErrorMessage());
+            throw new IOException(Kernel32.getLastErrorMessage());
         }
     }
 
@@ -122,7 +121,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
         info.cursorPosition.x = (short) Math.max(0, Math.min(info.size.x - 1, info.cursorPosition.x));
         info.cursorPosition.y = (short) Math.max(0, Math.min(info.size.y - 1, info.cursorPosition.y));
         if (SetConsoleCursorPosition(console, info.cursorPosition.copy()) == 0) {
-            throw new IOException(WindowsSupport.getLastErrorMessage());
+            throw new IOException(Kernel32.getLastErrorMessage());
         }
     }
 
@@ -360,7 +359,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
         info.attributes = originalColors;
         info.unicodeChar = ' ';
         if (ScrollConsoleScreenBuffer(console, scroll, scroll, org, info) == 0) {
-            throw new IOException(WindowsSupport.getLastErrorMessage());
+            throw new IOException(Kernel32.getLastErrorMessage());
         }
     }
 
@@ -376,7 +375,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
         info.attributes = originalColors;
         info.unicodeChar = ' ';
         if (ScrollConsoleScreenBuffer(console, scroll, scroll, org, info) == 0) {
-            throw new IOException(WindowsSupport.getLastErrorMessage());
+            throw new IOException(Kernel32.getLastErrorMessage());
         }
     }
 


### PR DESCRIPTION
- Upgrade jansi from 2.4.0 to 2.4.1
- Upgrade sshd from 2.9.2 to 2.11.0
- Upgrade easymock from 5.1.0 to 5.2.0
- Upgrade slf4j from 2.0.6 to 2.0.9
- Upgrade graal from 22.3.0 to 23.1.1
- Upgrade ivy from 2.5.1 to 2.5.2
- Upgrade various plugins
