### PR TITLE
Jansi improvements (fixes #904)

### DIFF
--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinConsoleWriter.java
@@ -10,10 +10,10 @@ package org.jline.terminal.impl.jansi.win;
 
 import java.io.IOException;
 
-import org.fusesource.jansi.internal.Kernel32;
 import org.jline.terminal.impl.AbstractWindowsConsoleWriter;
 
 import static org.fusesource.jansi.internal.Kernel32.WriteConsoleW;
+import static org.jline.terminal.impl.jansi.win.WindowsSupport.getLastErrorMessage;
 
 class JansiWinConsoleWriter extends AbstractWindowsConsoleWriter {
 
@@ -27,7 +27,7 @@ class JansiWinConsoleWriter extends AbstractWindowsConsoleWriter {
     @Override
     protected void writeConsole(char[] text, int len) throws IOException {
         if (WriteConsoleW(console, text, len, writtenChars, 0) == 0) {
-            throw new IOException("Failed to write to console: " + Kernel32.getLastErrorMessage());
+            throw new IOException("Failed to write to console: " + getLastErrorMessage());
         }
     }
 }

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/JansiWinSysTerminal.java
@@ -13,7 +13,6 @@ import java.io.IOError;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.function.IntConsumer;
 
 import org.fusesource.jansi.internal.Kernel32;
@@ -28,10 +27,7 @@ import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.InfoCmp;
 import org.jline.utils.OSUtils;
 
-import static org.fusesource.jansi.internal.Kernel32.FORMAT_MESSAGE_FROM_SYSTEM;
-import static org.fusesource.jansi.internal.Kernel32.FormatMessageW;
 import static org.fusesource.jansi.internal.Kernel32.GetConsoleScreenBufferInfo;
-import static org.fusesource.jansi.internal.Kernel32.GetLastError;
 import static org.fusesource.jansi.internal.Kernel32.GetStdHandle;
 import static org.fusesource.jansi.internal.Kernel32.INVALID_HANDLE_VALUE;
 import static org.fusesource.jansi.internal.Kernel32.STD_ERROR_HANDLE;
@@ -39,6 +35,7 @@ import static org.fusesource.jansi.internal.Kernel32.STD_INPUT_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.STD_OUTPUT_HANDLE;
 import static org.fusesource.jansi.internal.Kernel32.WaitForSingleObject;
 import static org.fusesource.jansi.internal.Kernel32.readConsoleInputHelper;
+import static org.jline.terminal.impl.jansi.win.WindowsSupport.getLastErrorMessage;
 
 public class JansiWinSysTerminal extends AbstractWindowsTerminal<Long> {
 
@@ -293,17 +290,5 @@ public class JansiWinSysTerminal extends AbstractWindowsTerminal<Long> {
         strings.remove(InfoCmp.Capability.parm_insert_line);
         strings.remove(InfoCmp.Capability.delete_line);
         strings.remove(InfoCmp.Capability.parm_delete_line);
-    }
-
-    static String getLastErrorMessage() {
-        int errorCode = GetLastError();
-        return getErrorMessage(errorCode);
-    }
-
-    static String getErrorMessage(int errorCode) {
-        int bufferSize = 160;
-        byte[] data = new byte[bufferSize];
-        FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, 0, errorCode, 0, data, bufferSize, null);
-        return new String(data, StandardCharsets.UTF_16LE).trim();
     }
 }

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/WindowsAnsiWriter.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/WindowsAnsiWriter.java
@@ -11,11 +11,11 @@ package org.jline.terminal.impl.jansi.win;
 import java.io.IOException;
 import java.io.Writer;
 
-import org.fusesource.jansi.internal.Kernel32;
 import org.jline.utils.AnsiWriter;
 import org.jline.utils.Colors;
 
 import static org.fusesource.jansi.internal.Kernel32.*;
+import static org.jline.terminal.impl.jansi.win.WindowsSupport.getLastErrorMessage;
 
 /**
  * A Windows ANSI escape processor, that uses JNA to access native platform
@@ -81,7 +81,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
     private void getConsoleInfo() throws IOException {
         out.flush();
         if (GetConsoleScreenBufferInfo(console, info) == 0) {
-            throw new IOException("Could not get the screen info: " + Kernel32.getLastErrorMessage());
+            throw new IOException("Could not get the screen info: " + getLastErrorMessage());
         }
         if (negative) {
             info.attributes = invertAttributeColors(info.attributes);
@@ -103,7 +103,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
             attributes = invertAttributeColors(attributes);
         }
         if (SetConsoleTextAttribute(console, attributes) == 0) {
-            throw new IOException(Kernel32.getLastErrorMessage());
+            throw new IOException(getLastErrorMessage());
         }
     }
 
@@ -121,7 +121,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
         info.cursorPosition.x = (short) Math.max(0, Math.min(info.size.x - 1, info.cursorPosition.x));
         info.cursorPosition.y = (short) Math.max(0, Math.min(info.size.y - 1, info.cursorPosition.y));
         if (SetConsoleCursorPosition(console, info.cursorPosition.copy()) == 0) {
-            throw new IOException(Kernel32.getLastErrorMessage());
+            throw new IOException(getLastErrorMessage());
         }
     }
 
@@ -359,7 +359,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
         info.attributes = originalColors;
         info.unicodeChar = ' ';
         if (ScrollConsoleScreenBuffer(console, scroll, scroll, org, info) == 0) {
-            throw new IOException(Kernel32.getLastErrorMessage());
+            throw new IOException(getLastErrorMessage());
         }
     }
 
@@ -375,7 +375,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
         info.attributes = originalColors;
         info.unicodeChar = ' ';
         if (ScrollConsoleScreenBuffer(console, scroll, scroll, org, info) == 0) {
-            throw new IOException(Kernel32.getLastErrorMessage());
+            throw new IOException(getLastErrorMessage());
         }
     }
 

--- a/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/WindowsSupport.java
+++ b/terminal-jansi/src/main/java/org/jline/terminal/impl/jansi/win/WindowsSupport.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl.jansi.win;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.fusesource.jansi.internal.Kernel32.FORMAT_MESSAGE_FROM_SYSTEM;
+import static org.fusesource.jansi.internal.Kernel32.FormatMessageW;
+import static org.fusesource.jansi.internal.Kernel32.GetLastError;
+
+class WindowsSupport {
+
+    public static String getLastErrorMessage() {
+        int errorCode = GetLastError();
+        int bufferSize = 160;
+        byte[] data = new byte[bufferSize];
+        FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, 0, errorCode, 0, data, bufferSize, null);
+        return new String(data, StandardCharsets.UTF_16LE).trim();
+    }
+}

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/JnaNativePty.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/JnaNativePty.java
@@ -190,6 +190,9 @@ public abstract class JnaNativePty extends AbstractPty implements Pty {
 
     private static boolean isatty(int fd) {
         if (Platform.isMac()) {
+            if (Platform.is64Bit() && Platform.isARM()) {
+                throw new UnsupportedOperationException("Unsupported platform mac-aarch64");
+            }
             return OsXNativePty.isatty(fd) == 1;
         } else if (Platform.isLinux()) {
             return LinuxNativePty.isatty(fd) == 1;
@@ -204,6 +207,9 @@ public abstract class JnaNativePty extends AbstractPty implements Pty {
 
     private static String ttyname(int fd) {
         if (Platform.isMac()) {
+            if (Platform.is64Bit() && Platform.isARM()) {
+                throw new UnsupportedOperationException("Unsupported platform mac-aarch64");
+            }
             return OsXNativePty.ttyname(fd);
         } else if (Platform.isLinux()) {
             return LinuxNativePty.ttyname(fd);

--- a/terminal-jna/src/main/java/org/jline/terminal/impl/jna/JnaTerminalProvider.java
+++ b/terminal-jna/src/main/java/org/jline/terminal/impl/jna/JnaTerminalProvider.java
@@ -26,6 +26,11 @@ import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.OSUtils;
 
 public class JnaTerminalProvider implements TerminalProvider {
+
+    public JnaTerminalProvider() {
+        checkSystemStream(SystemStream.Output);
+    }
+
     @Override
     public String name() {
         return TerminalBuilder.PROP_PROVIDER_JNA;
@@ -106,22 +111,18 @@ public class JnaTerminalProvider implements TerminalProvider {
     @Override
     public boolean isSystemStream(SystemStream stream) {
         try {
-            if (OSUtils.IS_WINDOWS) {
-                return isWindowsSystemStream(stream);
-            } else {
-                return isPosixSystemStream(stream);
-            }
+            return checkSystemStream(stream);
         } catch (Throwable t) {
             return false;
         }
     }
 
-    public boolean isWindowsSystemStream(SystemStream stream) {
-        return JnaWinSysTerminal.isWindowsSystemStream(stream);
-    }
-
-    public boolean isPosixSystemStream(SystemStream stream) {
-        return JnaNativePty.isPosixSystemStream(stream);
+    private boolean checkSystemStream(SystemStream stream) {
+        if (OSUtils.IS_WINDOWS) {
+            return JnaWinSysTerminal.isWindowsSystemStream(stream);
+        } else {
+            return JnaNativePty.isPosixSystemStream(stream);
+        }
     }
 
     @Override


### PR DESCRIPTION
Improve the message when a provider cannot be used by doing an early check and restore compatibility with Jansi 1.17.
