### PR TITLE
Return early from LineReaderImpl.doList if no possibilities or rows (fixes #941)

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -5006,10 +5006,13 @@ public class LineReaderImpl implements LineReader, Flushable {
         PostResult postResult = computePost(possible, null, null, completed);
         int lines = postResult.lines;
         int listMax = getInt(LIST_MAX, DEFAULT_LIST_MAX);
-        if (listMax > 0 && possible.size() >= listMax || lines >= size.getRows() - promptLines) {
+        int rows = size.getRows();
+        int possibleSize = possible.size();
+        if (possibleSize == 0 || rows == 0) return false;
+        if (listMax > 0 && possibleSize >= listMax || lines >= rows - promptLines) {
             if (!forSuggestion) {
                 // prompt
-                post = () -> new AttributedString(getAppName() + ": do you wish to see all " + possible.size()
+                post = () -> new AttributedString(getAppName() + ": do you wish to see all " + possibleSize
                         + " possibilities (" + lines + " lines)?");
                 redisplay(true);
                 int c = readCharacter();

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -5006,10 +5006,11 @@ public class LineReaderImpl implements LineReader, Flushable {
         PostResult postResult = computePost(possible, null, null, completed);
         int lines = postResult.lines;
         int listMax = getInt(LIST_MAX, DEFAULT_LIST_MAX);
-        int rows = size.getRows();
         int possibleSize = possible.size();
-        if (possibleSize == 0 || rows == 0) return false;
-        if (listMax > 0 && possibleSize >= listMax || lines >= rows - promptLines) {
+        if (possibleSize == 0 || size.getRows() == 0) {
+            return false;
+        }
+        if (listMax > 0 && possibleSize >= listMax || lines >= size.getRows() - promptLines) {
             if (!forSuggestion) {
                 // prompt
                 post = () -> new AttributedString(getAppName() + ": do you wish to see all " + possibleSize

--- a/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
@@ -189,7 +189,7 @@ public class CompletionTest extends ReaderTestSupport {
         reader.setCompleter(new StringsCompleter(
                 Arrays.asList("ae_helloWorld", "ad_helloWorld", "ac_helloWorld", "ab_helloWorld", "aa_helloWorld")));
 
-        assertLine("a", new TestBuffer("a\t\n\n"));
+        assertLine("a", new TestBuffer("a\t\n"));
     }
 
     @Test

--- a/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
@@ -193,6 +193,17 @@ public class CompletionTest extends ReaderTestSupport {
     }
 
     @Test
+    public void testTerminalNoSizeComplete() {
+        terminal.setSize(new Size());
+        reader.doAutosuggestion = true;
+        reader.autosuggestion = LineReader.SuggestionType.COMPLETER;
+        reader.setCompleter(new StringsCompleter(
+                Arrays.asList("ae_helloWorld", "ad_helloWorld", "ac_helloWorld", "ab_helloWorld", "aa_helloWorld")));
+
+        assertLine("a", new TestBuffer("a\t\n"));
+    }
+
+    @Test
     public void testParserEofOnEscapedNewLine() {
         DefaultParser parser = new DefaultParser();
         parser.setEofOnEscapedNewLine(true);


### PR DESCRIPTION
Calling `LineReaderImpl.redisplay` when running in a container started via compose can trigger infinite recursion, eventually throwing a `StackOverflowError`.