### PR TITLE
Fixing the FfmTerminal to run on JDK 22 and on Linux.

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, ubuntu-20.04, windows-latest, macos-latest ]
-        java: [ '21' ]
+        java: [ '22' ]
     steps:
       - uses: actions/checkout@v2
 

--- a/jline/pom.xml
+++ b/jline/pom.xml
@@ -400,7 +400,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>jdk21</id>
+                        <id>jdk22</id>
                         <goals>
                             <goal>compile</goal>
                         </goals>
@@ -408,11 +408,10 @@
                             <includes>
                                 <include>**/ffm/*.java</include>
                             </includes>
-                            <release>21</release>
+                            <release>22</release>
                             <compilerArgs>
-                                <arg>-Xlint:all,-options,-preview</arg>
+                                <arg>-Xlint:all,-options</arg>
                                 <arg>-Werror</arg>
-                                <arg>--enable-preview</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2024-01-23T12:21:59Z</project.build.outputTimestamp>
 
-        <java.build.version>21</java.build.version>
+        <java.build.version>22</java.build.version>
         <java.release.version>8</java.release.version>
         <maven.version>3.6.3</maven.version>
 

--- a/terminal-ffm/pom.xml
+++ b/terminal-ffm/pom.xml
@@ -23,7 +23,7 @@
     <name>JLine FFM Terminal</name>
 
     <properties>
-        <java.release.version>21</java.release.version>
+        <java.release.version>22</java.release.version>
         <automatic.module.name>org.jline.terminal.ffm</automatic.module.name>
     </properties>
 
@@ -56,24 +56,21 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>21</release>
-                    <compilerArgs>
-                        <arg>--enable-preview</arg>
-                    </compilerArgs>
+                    <release>${java.release.version}</release>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>--enable-preview --enable-native-access=ALL-UNNAMED</argLine>
+                    <argLine>--enable-native-access=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <additionalOptions>--enable-preview --release ${java.release.version}</additionalOptions>
+                    <additionalOptions>--release ${java.release.version}</additionalOptions>
                 </configuration>
             </plugin>
         </plugins>

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -248,14 +248,18 @@ class CLibrary {
             c_cc[VINTR] = (byte) t.getControlChar(Attributes.ControlChar.VINTR);
             c_cc[VQUIT] = (byte) t.getControlChar(Attributes.ControlChar.VQUIT);
             c_cc[VSUSP] = (byte) t.getControlChar(Attributes.ControlChar.VSUSP);
-            c_cc[VDSUSP] = (byte) t.getControlChar(Attributes.ControlChar.VDSUSP);
+            if (VDSUSP != (-1)) {
+                c_cc[VDSUSP] = (byte) t.getControlChar(Attributes.ControlChar.VDSUSP);
+            }
             c_cc[VSTART] = (byte) t.getControlChar(Attributes.ControlChar.VSTART);
             c_cc[VSTOP] = (byte) t.getControlChar(Attributes.ControlChar.VSTOP);
             c_cc[VLNEXT] = (byte) t.getControlChar(Attributes.ControlChar.VLNEXT);
             c_cc[VDISCARD] = (byte) t.getControlChar(Attributes.ControlChar.VDISCARD);
             c_cc[VMIN] = (byte) t.getControlChar(Attributes.ControlChar.VMIN);
             c_cc[VTIME] = (byte) t.getControlChar(Attributes.ControlChar.VTIME);
-            c_cc[VSTATUS] = (byte) t.getControlChar(Attributes.ControlChar.VSTATUS);
+            if (VSTATUS != (-1)) {
+                c_cc[VSTATUS] = (byte) t.getControlChar(Attributes.ControlChar.VSTATUS);
+            }
             c_cc().copyFrom(java.lang.foreign.MemorySegment.ofArray(c_cc));
         }
 
@@ -414,14 +418,18 @@ class CLibrary {
             cc.put(Attributes.ControlChar.VINTR, (int) c_cc[VINTR]);
             cc.put(Attributes.ControlChar.VQUIT, (int) c_cc[VQUIT]);
             cc.put(Attributes.ControlChar.VSUSP, (int) c_cc[VSUSP]);
-            cc.put(Attributes.ControlChar.VDSUSP, (int) c_cc[VDSUSP]);
+            if (VDSUSP != (-1)) {
+                cc.put(Attributes.ControlChar.VDSUSP, (int) c_cc[VDSUSP]);
+            }
             cc.put(Attributes.ControlChar.VSTART, (int) c_cc[VSTART]);
             cc.put(Attributes.ControlChar.VSTOP, (int) c_cc[VSTOP]);
             cc.put(Attributes.ControlChar.VLNEXT, (int) c_cc[VLNEXT]);
             cc.put(Attributes.ControlChar.VDISCARD, (int) c_cc[VDISCARD]);
             cc.put(Attributes.ControlChar.VMIN, (int) c_cc[VMIN]);
             cc.put(Attributes.ControlChar.VTIME, (int) c_cc[VTIME]);
-            cc.put(Attributes.ControlChar.VSTATUS, (int) c_cc[VSTATUS]);
+            if (VSTATUS != (-1)) {
+                cc.put(Attributes.ControlChar.VSTATUS, (int) c_cc[VSTATUS]);
+            }
             // Return
             return attr;
         }
@@ -667,19 +675,19 @@ class CLibrary {
     private static final int VWERASE;
     private static final int VKILL;
     private static final int VREPRINT;
-    private static int VERASE2;
+    private static final int VERASE2;
     private static final int VINTR;
     private static final int VQUIT;
     private static final int VSUSP;
-    private static int VDSUSP;
+    private static final int VDSUSP;
     private static final int VSTART;
     private static final int VSTOP;
     private static final int VLNEXT;
     private static final int VDISCARD;
     private static final int VMIN;
-    private static int VSWTC;
+    private static final int VSWTC;
     private static final int VTIME;
-    private static int VSTATUS;
+    private static final int VSTATUS;
 
     private static final int IGNBRK;
     private static final int BRKINT;
@@ -821,6 +829,9 @@ class CLibrary {
             VWERASE = 14;
             VLNEXT = 15;
             VEOL2 = 16;
+            VERASE2 = -1;
+            VDSUSP = -1;
+            VSTATUS = -1;
 
             IGNBRK = 0x0000001;
             BRKINT = 0x0000002;
@@ -943,6 +954,9 @@ class CLibrary {
             VWERASE = 14;
             VLNEXT = 15;
             VEOL2 = 16;
+            VERASE2 = -1;
+            VDSUSP = -1;
+            VSTATUS = -1;
 
             IGNBRK = 0x0000001;
             BRKINT = 0x0000002;
@@ -1063,6 +1077,8 @@ class CLibrary {
             VMIN = 16;
             VTIME = 17;
             VSTATUS = 18;
+            VERASE2 = -1;
+            VSWTC = -1;
 
             IGNBRK = 0x00000001;
             BRKINT = 0x00000002;
@@ -1156,6 +1172,7 @@ class CLibrary {
             VMIN = 16;
             VTIME = 17;
             VSTATUS = 18;
+            VSWTC = -1;
 
             IGNBRK = 0x0000001;
             BRKINT = 0x0000002;

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
@@ -12,6 +12,10 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.nio.charset.Charset;
 
 import org.jline.terminal.Attributes;
@@ -114,5 +118,14 @@ public class FfmTerminalProvider implements TerminalProvider {
     @Override
     public String toString() {
         return "TerminalProvider[" + name() + "]";
+    }
+
+    static VarHandle lookupVarHandle(MemoryLayout layout, PathElement... element) {
+        VarHandle h = layout.varHandle(element);
+
+        // the last parameter of the VarHandle is additional offset, hardcode zero:
+        h = MethodHandles.insertCoordinates(h, 1, 0L);
+
+        return h;
     }
 }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
@@ -124,7 +124,7 @@ public class FfmTerminalProvider implements TerminalProvider {
         VarHandle h = layout.varHandle(element);
 
         // the last parameter of the VarHandle is additional offset, hardcode zero:
-        h = MethodHandles.insertCoordinates(h, 1, 0L);
+        h = MethodHandles.insertCoordinates(h, h.coordinateTypes().size() - 1, 0L);
 
         return h;
     }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java
@@ -14,7 +14,7 @@ import java.lang.invoke.VarHandle;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-@SuppressWarnings({"unused", "preview"})
+@SuppressWarnings({"unused", "restricted"})
 final class Kernel32 {
 
     public static final int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
@@ -277,8 +277,8 @@ final class Kernel32 {
     public static INPUT_RECORD[] readConsoleInputHelper(
             java.lang.foreign.Arena arena, java.lang.foreign.MemorySegment handle, int count, boolean peek)
             throws IOException {
-        java.lang.foreign.MemorySegment inputRecordPtr = arena.allocateArray(INPUT_RECORD.LAYOUT, count);
-        java.lang.foreign.MemorySegment length = arena.allocate(java.lang.foreign.ValueLayout.JAVA_INT, 0);
+        java.lang.foreign.MemorySegment inputRecordPtr = arena.allocate(INPUT_RECORD.LAYOUT, count);
+        java.lang.foreign.MemorySegment length = arena.allocate(java.lang.foreign.ValueLayout.JAVA_INT, 1);
         int res = peek
                 ? PeekConsoleInputW(handle, inputRecordPtr, count, length)
                 : ReadConsoleInputW(handle, inputRecordPtr, count, length);
@@ -910,11 +910,13 @@ final class Kernel32 {
     }
 
     static VarHandle varHandle(java.lang.foreign.MemoryLayout layout, String name) {
-        return layout.varHandle(java.lang.foreign.MemoryLayout.PathElement.groupElement(name));
+        return FfmTerminalProvider.lookupVarHandle(
+                layout, java.lang.foreign.MemoryLayout.PathElement.groupElement(name));
     }
 
     static VarHandle varHandle(java.lang.foreign.MemoryLayout layout, String e1, String name) {
-        return layout.varHandle(
+        return FfmTerminalProvider.lookupVarHandle(
+                layout,
                 java.lang.foreign.MemoryLayout.PathElement.groupElement(e1),
                 java.lang.foreign.MemoryLayout.PathElement.groupElement(name));
     }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinConsoleWriter.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinConsoleWriter.java
@@ -19,7 +19,6 @@ import static org.jline.terminal.impl.ffm.Kernel32.STD_OUTPUT_HANDLE;
 import static org.jline.terminal.impl.ffm.Kernel32.WriteConsoleW;
 import static org.jline.terminal.impl.ffm.Kernel32.getLastErrorMessage;
 
-@SuppressWarnings("preview")
 class NativeWinConsoleWriter extends AbstractWindowsConsoleWriter {
 
     private final java.lang.foreign.MemorySegment console = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -27,7 +26,7 @@ class NativeWinConsoleWriter extends AbstractWindowsConsoleWriter {
     @Override
     protected void writeConsole(char[] text, int len) throws IOException {
         try (java.lang.foreign.Arena arena = java.lang.foreign.Arena.ofConfined()) {
-            java.lang.foreign.MemorySegment txt = arena.allocateArray(ValueLayout.JAVA_CHAR, text);
+            java.lang.foreign.MemorySegment txt = arena.allocateFrom(ValueLayout.JAVA_CHAR, text);
             if (WriteConsoleW(console, txt, len, MemorySegment.NULL, MemorySegment.NULL) == 0) {
                 throw new IOException("Failed to write to console: " + getLastErrorMessage());
             }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
@@ -38,7 +38,6 @@ import static org.jline.terminal.impl.ffm.Kernel32.WaitForSingleObject;
 import static org.jline.terminal.impl.ffm.Kernel32.getLastErrorMessage;
 import static org.jline.terminal.impl.ffm.Kernel32.readConsoleInputHelper;
 
-@SuppressWarnings("preview")
 public class NativeWinSysTerminal extends AbstractWindowsTerminal<java.lang.foreign.MemorySegment> {
 
     public static NativeWinSysTerminal createTerminal(

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/WindowsAnsiWriter.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/WindowsAnsiWriter.java
@@ -37,7 +37,6 @@ import static org.jline.terminal.impl.ffm.Kernel32.SetConsoleTextAttribute;
 import static org.jline.terminal.impl.ffm.Kernel32.SetConsoleTitleW;
 import static org.jline.terminal.impl.ffm.Kernel32.getLastErrorMessage;
 
-@SuppressWarnings("preview")
 class WindowsAnsiWriter extends AnsiWriter {
 
     private static final java.lang.foreign.MemorySegment console = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -401,7 +400,7 @@ class WindowsAnsiWriter extends AnsiWriter {
     @Override
     protected void processChangeWindowTitle(String title) {
         try (java.lang.foreign.Arena session = java.lang.foreign.Arena.ofConfined()) {
-            java.lang.foreign.MemorySegment str = session.allocateUtf8String(title);
+            java.lang.foreign.MemorySegment str = session.allocateFrom(title);
             SetConsoleTitleW(str);
         }
     }


### PR DESCRIPTION
(As a foreword, I assume this PR will need some discussion and/or changes, as it changes the required JDK for build to JDK 22.)

I am working on an upgrade of the JLine inside the OpenJDK, and since JLine now has a Foreign Function and Memory (FFM) Terminal implementation, I would ideally want like to use that instead of the custom native code OpenJDK uses now.

Note the FFM was a preview API in JDK 21, and is final in JDK 22.

But, when I tried to use the FFM-base Terminal, there were some problems:
- the API changed slightly:
  - a few methods (`allocateArray`, `allocateUtf8String`) got changed,
  - the `VarHandle`s returned from `MemoryLayout.varHandle(...)` now accept one more "offset" parameter
- the `termios` structure has a different layout and types than on Mac OS/X. The layout in JLine was the Mac OS/X layout, and this lead to some very weird behavior.

The changes proposed in this patch are:
- the `allocateArray`, `allocateUtf8String` methods are changed to what I believe are their new versions
- when creating the `VarHandle`s, there's a utility that will inject offset `0L`, to keep the handles easy to use
- adding separate layouts for `termios` on Mac and on Linux. The provider will fail on other platforms, as I don't know what are the layout there - can be improved by someone who has access to other platforms.
- in addition to the previous, on Linux, the `VarHandle`s for `termios` are adapted from `int` to `long`, so they appear the same as on Mac to other code.
- removed suppress warnings for "preview", and added suppress warnings for "restricted", which is a new javac warning in JDK 22.
- in Kernel32, there was `java.lang.foreign.MemorySegment length = arena.allocate(java.lang.foreign.ValueLayout.JAVA_INT, 0);`, which is, as far as I can tell, used to store how many characters were read from the input. The `0` there does not make much sense to me, and it didn't work for me. Using `1` in this patch (effectively allocating an array of `JAVA_INT` of size 1, at least per my understanding).
- adjusting the build to require and run using JDK 22. I assume this will need some discussion and/or changes.

Please let me know what you think! Thanks.