### PR TITLE
Use default sort order when custom sort order is identical

### DIFF
--- a/reader/src/test/java/org/jline/reader/impl/CandidateCustomSortTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CandidateCustomSortTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jline.reader.Candidate;
+import org.jline.reader.LineReader.Option;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -79,5 +80,29 @@ public class CandidateCustomSortTest extends ReaderTestSupport {
             candidates.add(new Candidate("zoo", "zoo", null, null, null, null, true, 2));
         });
         assertBuffer("foo", new TestBuffer("").tab().tab());
+    }
+
+    @Test
+    public void testCustomSortIdenticalSortValueGroups() {
+        List<Candidate> candidates = Arrays.asList(
+                new Candidate("foo", "foo", null, null, null, null, true, 1),
+                new Candidate("bar", "bar", null, null, null, null, true, 1),
+                new Candidate("zoo", "zoo", null, null, null, null, true, 1),
+                new Candidate("zzz", "zzz", null, null, null, null, true, 0));
+        reader.setOpt(Option.GROUP);
+        String postResult = reader.computePost(candidates, null, null, "").post.toString();
+        assertEquals("zzz   bar   foo   zoo", postResult);
+    }
+
+    @Test
+    public void testCustomSortIdenticalSortValue() {
+        List<Candidate> candidates = Arrays.asList(
+                new Candidate("foo", "foo", null, null, null, null, true, 1),
+                new Candidate("bar", "bar", null, null, null, null, true, 1),
+                new Candidate("zoo", "zoo", null, null, null, null, true, 1),
+                new Candidate("zzz", "zzz", null, null, null, null, true, 0));
+        reader.unsetOpt(Option.GROUP);
+        String postResult = reader.computePost(candidates, null, null, "").post.toString();
+        assertEquals("zzz   bar   foo   zoo", postResult);
     }
 }


### PR DESCRIPTION
This fixes https://github.com/jline/jline3/issues/956
It seems that using a map for sorting is unnecessary since the `Candidate.compareTo` already uses proper comparison of sort order and if they are equal, uses values for sorting candidates.
Sorting the candidates directly will also use the custom sorting basing on overriding the `compareTo` method.