### PR TITLE
In maven-wrapper.properties, sync maven version with pom.xml

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.3/apache-maven-3.5.3-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip


### PR DESCRIPTION
.mvn/wrapper/maven-wrapper.properties had a older maven version than pom.xml. This caused a build failure in a system with no preinstalled maven.

Updating the distribution url to the same version as that mentioned in pom.xml makes the build succeed.
