### PR TITLE
Disable Quick Edit Mode with mouse support

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -62,6 +62,7 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
     protected static final int ENABLE_MOUSE_INPUT = 0x0010;
     protected static final int ENABLE_INSERT_MODE = 0x0020;
     protected static final int ENABLE_QUICK_EDIT_MODE = 0x0040;
+    protected static final int ENABLE_EXTENDED_FLAGS = 0x0080;
 
     protected final Writer slaveInputPipe;
     protected final NonBlockingInputStream input;
@@ -201,6 +202,9 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
         }
         if (tracking != MouseTracking.Off) {
             mode |= ENABLE_MOUSE_INPUT;
+            // mouse events not send with quick edit mode
+            // to disable ENABLE_QUICK_EDIT_MODE just set extended flag
+            mode |= ENABLE_EXTENDED_FLAGS;
         }
         setConsoleMode(inConsole, mode);
     }


### PR DESCRIPTION
- On windows disable quick edit mode if mouse support is requested which allows mouse events to get propagated automatically.
- There's no explicit revert for this as it seems to get done automatically.
- Without this user would need to know that quick edit needs to be disabled which is awkward in conhost and even more difficult with new windows terminal which doesn't even directly expose these settings in the UI.
- Fixes #964