### PR TITLE
Don't attempt line break at last line

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -308,8 +308,10 @@ public class Display {
                 }
             } else if (atRight) {
                 if (this.wrapAtEol) {
-                    terminal.writer().write(" \b");
-                    cursorPos++;
+                    if (!fullScreen || (fullScreen && lineIndex < numLines)) {
+                        terminal.writer().write(" \b");
+                        cursorPos++;
+                    }
                 } else {
                     terminal.puts(Capability.carriage_return); // CR / not newline.
                     cursorPos = curCol;


### PR DESCRIPTION
- This fixes issue in Display which should not do a line break on fullscreen mode for a last line causing scrolling and making screen of by one line.
- Fixes #963