### PR TITLE
Improve status bar drawing mechanism (fixes #939)

### DIFF
--- a/console/src/main/java/org/jline/widget/TailTipWidgets.java
+++ b/console/src/main/java/org/jline/widget/TailTipWidgets.java
@@ -9,6 +9,7 @@
 package org.jline.widget;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,7 +157,7 @@ public class TailTipWidgets extends Widgets {
 
     public void setDescriptionSize(int descriptionSize) {
         this.descriptionSize = descriptionSize;
-        initDescription(descriptionSize);
+        initDescription();
     }
 
     public int getDescriptionSize() {
@@ -393,22 +394,33 @@ public class TailTipWidgets extends Widgets {
         if (descriptionSize == 0 || !descriptionEnabled) {
             return;
         }
-        if (desc.isEmpty()) {
-            clearDescription();
-        } else if (desc.size() == descriptionSize) {
-            addDescription(desc);
-        } else if (desc.size() > descriptionSize) {
+        List<AttributedString> list = desc;
+        if (list.size() > descriptionSize) {
             AttributedStringBuilder asb = new AttributedStringBuilder();
-            asb.append(desc.get(descriptionSize - 1)).append("...", new AttributedStyle(AttributedStyle.INVERSE));
-            List<AttributedString> mod = new ArrayList<>(desc.subList(0, descriptionSize - 1));
+            asb.append(list.get(descriptionSize - 1)).append("…", new AttributedStyle(AttributedStyle.INVERSE));
+            List<AttributedString> mod = new ArrayList<>(list.subList(0, descriptionSize - 1));
             mod.add(asb.toAttributedString());
-            addDescription(mod);
-        } else {
-            while (desc.size() != descriptionSize) {
-                desc.add(new AttributedString(""));
+            list = mod;
+        } else if (list.size() < descriptionSize) {
+            List<AttributedString> mod = new ArrayList<>(list);
+            while (mod.size() != descriptionSize) {
+                mod.add(new AttributedString(""));
             }
-            addDescription(desc);
+            list = mod;
         }
+        setDescription(list);
+    }
+
+    /**
+     * Initialize terminal status bar
+     */
+    public void initDescription() {
+        Status.getStatus(reader.getTerminal()).setBorder(true);
+        clearDescription();
+    }
+
+    public void clearDescription() {
+        doDescription(Collections.emptyList());
     }
 
     private boolean autopairEnabled() {
@@ -419,7 +431,7 @@ public class TailTipWidgets extends Widgets {
     public boolean toggleWindow() {
         descriptionEnabled = !descriptionEnabled;
         if (descriptionEnabled) {
-            initDescription(descriptionSize);
+            initDescription();
         } else {
             destroyDescription();
         }
@@ -435,7 +447,7 @@ public class TailTipWidgets extends Widgets {
         } else {
             customBindings();
             if (descriptionEnabled) {
-                initDescription(descriptionSize);
+                initDescription();
             }
             readerErrors = reader.getVariable(LineReader.ERRORS);
             reader.setVariable(LineReader.ERRORS, 0);

--- a/console/src/main/java/org/jline/widget/Widgets.java
+++ b/console/src/main/java/org/jline/widget/Widgets.java
@@ -9,7 +9,7 @@
 package org.jline.widget;
 
 import java.security.InvalidParameterException;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -265,10 +265,10 @@ public abstract class Widgets {
     }
 
     /**
-     * Add description text to the terminal status bar
+     * Set description text to the terminal status bar
      * @param desc description text
      */
-    public void addDescription(List<AttributedString> desc) {
+    public void setDescription(List<AttributedString> desc) {
         Status.getStatus(reader.getTerminal()).update(desc);
     }
 
@@ -276,38 +276,13 @@ public abstract class Widgets {
      *  Clears terminal status bar
      */
     public void clearDescription() {
-        initDescription(0);
-    }
-
-    /**
-     * Initialize terminal status bar
-     * @param size Terminal status bar size in rows
-     */
-    public void initDescription(int size) {
-        Status status = Status.getStatus(reader.getTerminal(), false);
-        if (size > 0) {
-            if (status == null) {
-                status = Status.getStatus(reader.getTerminal());
-            }
-            status.setBorder(true);
-            List<AttributedString> as = new ArrayList<>();
-            for (int i = 0; i < size; i++) {
-                as.add(new AttributedString(""));
-            }
-            addDescription(as);
-        } else if (status != null) {
-            if (size < 0) {
-                status.update(null);
-            } else {
-                status.clear();
-            }
-        }
+        setDescription(Collections.emptyList());
     }
 
     /**
      *  Remove terminal status bar
      */
     public void destroyDescription() {
-        initDescription(-1);
+        Status.getExistingStatus(reader.getTerminal()).ifPresent(Status::hide);
     }
 }

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1197,14 +1197,13 @@ public class LineReaderImpl implements LineReader, Flushable {
     protected void handleSignal(Signal signal) {
         doAutosuggestion = false;
         if (signal == Signal.WINCH) {
-            Status status = Status.getStatus(terminal, false);
-            if (status != null) {
-                status.hardReset();
-            }
             size.copy(terminal.getBufferSize());
             display.resize(size.getRows(), size.getColumns());
-            // restores prompt but also prevents scrolling in consoleZ, see #492
-            // redrawLine();
+            Status status = Status.getStatus(terminal, false);
+            if (status != null) {
+                status.resize(size);
+            }
+            redrawLine();
             redisplay();
         } else if (signal == Signal.CONT) {
             terminal.enterRawMode();
@@ -3874,9 +3873,6 @@ public class LineReaderImpl implements LineReader, Flushable {
 
             Status status = Status.getStatus(terminal, false);
             if (status != null) {
-                if (terminal.getType().startsWith(AbstractWindowsTerminal.TYPE_WINDOWS)) {
-                    status.resize();
-                }
                 status.redraw();
             }
 

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1202,6 +1202,7 @@ public class LineReaderImpl implements LineReader, Flushable {
             Status status = Status.getStatus(terminal, false);
             if (status != null) {
                 status.resize(size);
+                status.reset();
             }
             terminal.puts(Capability.carriage_return);
             terminal.puts(Capability.clr_eos);

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1194,7 +1194,7 @@ public class LineReaderImpl implements LineReader, Flushable {
         return str;
     }
 
-    protected void handleSignal(Signal signal) {
+    protected synchronized void handleSignal(Signal signal) {
         doAutosuggestion = false;
         if (signal == Signal.WINCH) {
             size.copy(terminal.getBufferSize());
@@ -1203,6 +1203,8 @@ public class LineReaderImpl implements LineReader, Flushable {
             if (status != null) {
                 status.resize(size);
             }
+            terminal.puts(Capability.carriage_return);
+            terminal.puts(Capability.clr_eos);
             redrawLine();
             redisplay();
         } else if (signal == Signal.CONT) {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -88,11 +88,12 @@ public abstract class AbstractTerminal implements TerminalExt {
     public void raise(Signal signal) {
         Objects.requireNonNull(signal);
         SignalHandler handler = handlers.get(signal);
-        if (handler != SignalHandler.SIG_DFL && handler != SignalHandler.SIG_IGN) {
+        if (handler == SignalHandler.SIG_DFL) {
+            if (status != null && signal == Signal.WINCH) {
+                status.resize();
+            }
+        } else if (handler != SignalHandler.SIG_IGN) {
             handler.handle(signal);
-        }
-        if (status != null && signal == Signal.WINCH) {
-            status.resize();
         }
     }
 
@@ -108,8 +109,7 @@ public abstract class AbstractTerminal implements TerminalExt {
 
     protected void doClose() throws IOException {
         if (status != null) {
-            status.update(null);
-            flush();
+            status.close();
         }
     }
 

--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -108,6 +108,14 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return append(Character.toString(c));
     }
 
+    public AttributedStringBuilder append(char c, int repeat) {
+        AttributedString s = new AttributedString(Character.toString(c), current);
+        while (repeat-- > 0) {
+            append(s);
+        }
+        return this;
+    }
+
     public AttributedStringBuilder append(CharSequence csq, AttributedStyle style) {
         return append(new AttributedString(csq, style));
     }

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -29,8 +29,8 @@ public class Display {
     protected final boolean fullScreen;
     protected List<AttributedString> oldLines = Collections.emptyList();
     protected int cursorPos;
-    private int columns;
-    private int columns1; // columns+1
+    protected int columns;
+    protected int columns1; // columns+1
     protected int rows;
     protected boolean reset;
     protected boolean delayLineWrap;

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -80,6 +80,8 @@ public class Status {
     public void reset() {
         if (supported) {
             display.reset();
+            scrollRegion = display.rows;
+            terminal.puts(Capability.change_scroll_region, 0, scrollRegion);
         }
     }
 

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
@@ -22,17 +23,19 @@ public class Status {
 
     protected final Terminal terminal;
     protected final boolean supported;
-    protected List<AttributedString> oldLines = Collections.emptyList();
-    protected List<AttributedString> linesToRestore = Collections.emptyList();
-    protected int rows;
-    protected int columns;
-    protected boolean force;
     protected boolean suspended = false;
     protected AttributedString borderString;
     protected int border = 0;
+    protected Display display;
+    protected List<AttributedString> lines = Collections.emptyList();
+    protected int scrollRegion;
 
     public static Status getStatus(Terminal terminal) {
         return getStatus(terminal, true);
+    }
+
+    public static Optional<Status> getExistingStatus(Terminal terminal) {
+        return Optional.ofNullable(getStatus(terminal, false));
     }
 
     public static Status getStatus(Terminal terminal, boolean create) {
@@ -47,14 +50,19 @@ public class Status {
                 && terminal.getStringCapability(Capability.restore_cursor) != null
                 && terminal.getStringCapability(Capability.cursor_address) != null;
         if (supported) {
-            char borderChar = '─';
-            AttributedStringBuilder bb = new AttributedStringBuilder();
-            for (int i = 0; i < 200; i++) {
-                bb.append(borderChar);
-            }
-            borderString = bb.toAttributedString();
+            display = new MovingCursorDisplay(terminal);
             resize();
+            display.reset();
+            scrollRegion = display.rows - 1;
         }
+    }
+
+    public void close() {
+        terminal.puts(Capability.save_cursor);
+        clear();
+        terminal.puts(Capability.change_scroll_region, 0, display.rows - 1);
+        terminal.puts(Capability.restore_cursor);
+        terminal.flush();
     }
 
     public void setBorder(boolean border) {
@@ -62,137 +70,215 @@ public class Status {
     }
 
     public void resize() {
-        Size size = terminal.getSize();
-        this.rows = size.getRows();
-        this.columns = size.getColumns();
-        this.force = true;
+        resize(terminal.getSize());
+    }
+
+    public void resize(Size size) {
+        display.resize(size.getRows(), size.getColumns());
     }
 
     public void reset() {
-        this.force = true;
-    }
-
-    public void hardReset() {
-        if (suspended) {
-            return;
+        if (supported) {
+            display.reset();
         }
-        List<AttributedString> lines = new ArrayList<>(oldLines);
-        int b = border;
-        update(null);
-        border = b;
-        update(lines);
     }
 
     public void redraw() {
         if (suspended) {
             return;
         }
-        update(oldLines);
+        update(lines);
     }
 
+    /**
+     * Clear the status bar lines (but not the border).
+     */
     public void clear() {
-        privateClear(oldLines.size());
+        clear(false);
     }
 
-    private void clearAll() {
-        int b = border;
-        border = 0;
-        privateClear(oldLines.size() + b);
-    }
+    /**
+     * Clear the status bar lines eventually including the border.
+     */
+    private void clear(boolean clearBorder) {}
 
-    private void privateClear(int statusSize) {
-        List<AttributedString> as = new ArrayList<>();
-        for (int i = 0; i < statusSize; i++) {
-            as.add(new AttributedString(""));
-        }
-        if (!as.isEmpty()) {
-            update(as);
-        }
+    public void hide() {
+        update(Collections.emptyList());
     }
 
     public void update(List<AttributedString> lines) {
+        update(lines, true);
+    }
+
+    private final AttributedString ellipsis =
+            new AttributedStringBuilder().append("…", AttributedStyle.INVERSE).toAttributedString();
+
+    /**
+     * Returns <code>true</code> if the cursor may be misplaced and should
+     * be updated.
+     */
+    public void update(List<AttributedString> lines, boolean flush) {
         if (!supported) {
             return;
         }
-        if (lines == null) {
-            lines = Collections.emptyList();
-        }
+        this.lines = new ArrayList<>(lines);
         if (suspended) {
-            linesToRestore = new ArrayList<>(lines);
             return;
         }
-        if (lines.isEmpty()) {
-            clearAll();
+
+        lines = new ArrayList<>(lines);
+        // add border
+        int columns = display.columns;
+        if (border == 1 && !lines.isEmpty()) {
+            lines.add(0, getBorderString(columns));
         }
-        if (oldLines.equals(lines) && !force) {
-            return;
+        // trim or complete lines to the full width
+        for (int i = 0; i < lines.size(); i++) {
+            AttributedString str = lines.get(i);
+            if (str.columnLength() > columns) {
+                str = new AttributedStringBuilder(columns)
+                        .append(lines.get(i).columnSubSequence(0, columns - ellipsis.columnLength()))
+                        .append(ellipsis)
+                        .toAttributedString();
+            } else if (str.columnLength() < columns) {
+                str = new AttributedStringBuilder(columns)
+                        .append(str)
+                        .append(' ', columns - str.columnLength())
+                        .toAttributedString();
+            }
+            lines.set(i, str);
         }
-        int statusSize = lines.size() + (lines.isEmpty() ? 0 : border);
-        int nb = statusSize - oldLines.size() - (oldLines.isEmpty() ? 0 : border);
-        if (nb > 0) {
-            for (int i = 0; i < nb; i++) {
+
+        List<AttributedString> oldLines = this.display.oldLines;
+
+        int newScrollRegion = display.rows - 1 - lines.size();
+        // Update the scroll region if needed.
+        // Note that settings the scroll region usually moves the cursor, so we need to get ready for that.
+        if (newScrollRegion < scrollRegion) {
+            // We need to scroll up to grow the status bar
+            terminal.puts(Capability.save_cursor);
+            for (int i = newScrollRegion; i < scrollRegion; i++) {
                 terminal.puts(Capability.cursor_down);
             }
-            for (int i = 0; i < nb; i++) {
+            terminal.puts(Capability.change_scroll_region, 0, newScrollRegion);
+            terminal.puts(Capability.restore_cursor);
+            for (int i = newScrollRegion; i < scrollRegion; i++) {
                 terminal.puts(Capability.cursor_up);
             }
+            scrollRegion = newScrollRegion;
+        } else if (newScrollRegion > scrollRegion) {
+            terminal.puts(Capability.save_cursor);
+            terminal.puts(Capability.change_scroll_region, 0, newScrollRegion);
+            terminal.puts(Capability.restore_cursor);
+            scrollRegion = newScrollRegion;
         }
-        terminal.puts(Capability.save_cursor);
-        terminal.puts(Capability.cursor_address, rows - statusSize, 0);
-        if (!terminal.puts(Capability.clr_eos)) {
-            for (int i = rows - statusSize; i < rows; i++) {
-                terminal.puts(Capability.cursor_address, i, 0);
+
+        // if the display has more lines, we need to add empty ones to make sure they will be erased
+        List<AttributedString> toDraw = new ArrayList<>(lines);
+        int nbToDraw = toDraw.size();
+        int nbOldLines = oldLines.size();
+        if (nbOldLines > nbToDraw) {
+            terminal.puts(Capability.save_cursor);
+            terminal.puts(Capability.cursor_address, display.rows - nbOldLines, 0);
+            for (int i = 0; i < nbOldLines - nbToDraw; i++) {
                 terminal.puts(Capability.clr_eol);
+                if (i < nbOldLines - nbToDraw - 1) {
+                    terminal.puts(Capability.cursor_down);
+                }
+                oldLines.remove(0);
             }
+            terminal.puts(Capability.restore_cursor);
         }
-        if (border == 1 && !lines.isEmpty()) {
-            terminal.puts(Capability.cursor_address, rows - statusSize, 0);
-            borderString.columnSubSequence(0, columns).print(terminal);
-        }
-        for (int i = 0; i < lines.size(); i++) {
-            terminal.puts(Capability.cursor_address, rows - lines.size() + i, 0);
-            if (lines.get(i).length() > columns) {
-                AttributedStringBuilder asb = new AttributedStringBuilder();
-                asb.append(lines.get(i).substring(0, columns - 3))
-                        .append("...", new AttributedStyle(AttributedStyle.INVERSE));
-                asb.toAttributedString().columnSubSequence(0, columns).print(terminal);
-            } else {
-                lines.get(i).columnSubSequence(0, columns).print(terminal);
-            }
-        }
-        terminal.puts(Capability.change_scroll_region, 0, rows - 1 - statusSize);
-        terminal.puts(Capability.restore_cursor);
-        terminal.flush();
-        oldLines = new ArrayList<>(lines);
-        force = false;
+        // update display
+        display.update(lines, -1, flush);
     }
 
+    private AttributedString getBorderString(int columns) {
+        if (borderString == null || borderString.length() != columns) {
+            char borderChar = '─';
+            AttributedStringBuilder bb = new AttributedStringBuilder();
+            for (int i = 0; i < columns; i++) {
+                bb.append(borderChar);
+            }
+            borderString = bb.toAttributedString();
+        }
+        return borderString;
+    }
+
+    /**
+     * The {@code suspend} method is used when a full-screen.
+     * If the status was not already suspended, the lines
+     * used by the status are cleared during this call.
+     */
     public void suspend() {
-        if (suspended) {
-            return;
+        if (!suspended) {
+            suspended = true;
+            clear(true);
         }
-        linesToRestore = new ArrayList<>(oldLines);
-        int b = border;
-        update(null);
-        border = b;
-        suspended = true;
     }
 
+    /**
+     * The {@code restore()} call is the opposite of {@code suspend()} and
+     * will make the status bar be updated again.
+     * If the status was suspended, the lines
+     * used by the status will be drawn during this call.
+     */
     public void restore() {
-        if (!suspended) {
-            return;
+        if (suspended) {
+            suspended = false;
+            update(this.lines);
         }
-        suspended = false;
-        update(linesToRestore);
-        linesToRestore = Collections.emptyList();
     }
 
     public int size() {
-        return oldLines.size() + border;
+        return size(this.lines);
+    }
+
+    private int size(List<?> lines) {
+        int l = lines.size();
+        return l > 0 ? l + border : 0;
     }
 
     @Override
     public String toString() {
         return "Status[" + "supported=" + supported + ']';
+    }
+
+    static class MovingCursorDisplay extends Display {
+        protected int firstLine;
+
+        public MovingCursorDisplay(Terminal terminal) {
+            super(terminal, false);
+        }
+
+        @Override
+        public void update(List<AttributedString> newLines, int targetCursorPos, boolean flush) {
+            cursorPos = -1;
+            firstLine = rows - newLines.size();
+            super.update(newLines, targetCursorPos, flush);
+            if (cursorPos != -1) {
+                terminal.puts(Capability.restore_cursor);
+            }
+        }
+
+        @Override
+        protected void moveVisualCursorTo(int targetPos, List<AttributedString> newLines) {
+            initCursor();
+            super.moveVisualCursorTo(targetPos, newLines);
+        }
+
+        @Override
+        protected int moveVisualCursorTo(int i1) {
+            initCursor();
+            return super.moveVisualCursorTo(i1);
+        }
+
+        void initCursor() {
+            if (cursorPos == -1) {
+                terminal.puts(Capability.save_cursor);
+                terminal.puts(Capability.cursor_address, firstLine, 0);
+                cursorPos = 0;
+            }
+        }
     }
 }

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -59,7 +59,6 @@ public class Status {
 
     public void close() {
         terminal.puts(Capability.save_cursor);
-        clear();
         terminal.puts(Capability.change_scroll_region, 0, display.rows - 1);
         terminal.puts(Capability.restore_cursor);
         terminal.flush();
@@ -91,18 +90,6 @@ public class Status {
         }
         update(lines);
     }
-
-    /**
-     * Clear the status bar lines (but not the border).
-     */
-    public void clear() {
-        clear(false);
-    }
-
-    /**
-     * Clear the status bar lines eventually including the border.
-     */
-    private void clear(boolean clearBorder) {}
 
     public void hide() {
         update(Collections.emptyList());
@@ -215,7 +202,6 @@ public class Status {
     public void suspend() {
         if (!suspended) {
             suspended = true;
-            clear(true);
         }
     }
 


### PR DESCRIPTION
This is an attempt to improve the situation for #939.

Correctly supporting resize is hard, and with the status bar, even harder.
The reason is that resizing seems quite well supported with the [display heuristic](https://github.com/jline/jline3/blob/master/terminal/src/main/java/org/jline/utils/Display.java#L75-L79).  Such a heuristic is required because the terminal is completely messed up when resizing.  It's getting worse with the status bar because this causes the terminal to scroll up when the width is reduced.   
