### PR TITLE
Fix OutOfMemoryError when using TailTipWidget (fixes #974)

### DIFF
--- a/console/src/test/java/org/jline/widget/TailTipWidgetsTest.java
+++ b/console/src/test/java/org/jline/widget/TailTipWidgetsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.widget;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.impl.LineReaderImpl;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.DumbTerminal;
+import org.jline.utils.InfoCmp.Capability;
+import org.jline.utils.Status;
+import org.jline.widget.TailTipWidgets.TipType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class TailTipWidgetsTest {
+
+    /** A simple extension of {@link DumbTerminal} doing the minimal amount of work so that a {@link Status} constructed
+     * from it is "supported". */
+    private static final class SupportedDumbTerminal extends DumbTerminal {
+        private SupportedDumbTerminal() throws IOException {
+            super(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream());
+            strings.put(Capability.change_scroll_region, "");
+            strings.put(Capability.save_cursor, "");
+            strings.put(Capability.restore_cursor, "");
+            strings.put(Capability.cursor_address, "");
+        }
+    }
+
+    /** Subclass of {@link Status} exposing the {@code supported} field. For testing only. */
+    private static final class TestStatus extends Status {
+        private TestStatus(Terminal terminal) {
+            super(terminal);
+        }
+
+        private boolean isSupported() {
+            return supported;
+        }
+    }
+
+    /** A dummy {@link LineReader} that's immediately resized to 0x0. */
+    private static final class ZeroSizeLineReader extends LineReaderImpl {
+        private ZeroSizeLineReader(Terminal terminal) throws IOException {
+            super(terminal);
+            display.resize(0, 0);
+        }
+    }
+
+    @Test
+    public void enableTest() throws Exception {
+        Terminal terminal = new SupportedDumbTerminal();
+        assertTrue(new TestStatus(terminal).isSupported());
+        LineReader reader = new ZeroSizeLineReader(terminal);
+        new TailTipWidgets(reader, __ -> null, 1, TipType.COMBINED).enable();
+    }
+}

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -68,7 +68,7 @@ public class Display {
 
     public void resize(int rows, int columns) {
         if (rows == 0 || columns == 0) {
-            columns = Integer.MAX_VALUE - 1;
+            columns = 1;
             rows = 1;
         }
         if (this.rows != rows || this.columns != columns) {

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -117,8 +117,9 @@ public class Status {
 
         lines = new ArrayList<>(lines);
         // add border
+        int rows = display.rows;
         int columns = display.columns;
-        if (border == 1 && !lines.isEmpty()) {
+        if (border == 1 && !lines.isEmpty() && rows > 1) {
             lines.add(0, getBorderString(columns));
         }
         // trim or complete lines to the full width


### PR DESCRIPTION
Issue #974 (`OutOfMemoryError` when enabling a `TailTipWidget` in a terminal of size `0x0`) is caused by the new `Status.getBorderString` method, which tries to create a string that's `'─'` repeated `2_147_483_646` times.

The underlying reason why we even get into that situation is `Display.resize`, which interprets a size of `0x0` (which happens e.g. in a detached container) as `1x(Integer.MAX_VALUE-1)`. I understand that zero values might be problematic, and an old issue that is linked to that change mentions some arithmetic exception due to a division by zero. I'm not sure, however, why `Integer.MAX_VALUE - 1` was chosen. My guess is that a value of `1` (same as for the rows) is safer, and some unsystematic tests using existing applications didn't reveal any issues (e.g. when resizing).

I also added an additional check in `Status.update` to check if we have more than one row before even starting to draw anything. If there is only one row, there is no space for a border and text below it. This change in and of itself would already be sufficient, I believe. So if that `Integer.MAX_VALUE - 1` serves a function, it can be restored.

Finally, I added a small unit test reproducing the problem in issue #974, which passes now with the added fixes.