### PR TITLE
Correcting invocation of ScrollConsoleScreenBufferW - using pointers instead of values.

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java
@@ -235,8 +235,8 @@ final class Kernel32 {
             CHAR_INFO lpFill) {
         MethodHandle mh$ = requireNonNull(ScrollConsoleScreenBufferW$MH, "ScrollConsoleScreenBuffer");
         try {
-            return (int)
-                    mh$.invokeExact(hConsoleOutput, lpScrollRectangle, lpClipRectangle, dwDestinationOrigin, lpFill);
+            return (int) mh$.invokeExact(
+                    hConsoleOutput, lpScrollRectangle.seg, lpClipRectangle.seg, dwDestinationOrigin.seg, lpFill.seg);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }


### PR DESCRIPTION
As described in OpenJDK bug:
https://bugs.openjdk.org/browse/JDK-8336375

the invocation of `ScrollConsoleScreenBufferW` in the FFM implementation of `Kernel32` may crash. I believe the reason is that the lookup/"declared" parameters are pointers:
https://github.com/jline/jline3/blob/9489e1b15bd1ee9dd87393aeec7fc5489fbc8a09/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java#L406
but the provided/actual invocation parameters are values:
https://github.com/jline/jline3/blob/9489e1b15bd1ee9dd87393aeec7fc5489fbc8a09/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java#L239

In OpenJDK, I proposed to change the code to use `.seg`, which is consistent with other similar invocations in `Kernel32`, and should ensure a pointer is sent to the native function:
https://github.com/openjdk/jdk/pull/20182

The patch herein is basically the same as the OpenJDK patch.

(I am not aware of a way to automatically test this.)
