### PR TITLE
Remove execute permission on native .so file

### DIFF
--- a/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
+++ b/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
@@ -200,10 +200,8 @@ public class JLineNativeLoader {
                 extractedLckFile.deleteOnExit();
             }
 
-            // Set executable (x) flag to enable Java to load the native library
             extractedLibFile.setReadable(true);
             extractedLibFile.setWritable(true);
-            extractedLibFile.setExecutable(true);
 
             // Check whether the contents are properly copied from the resource folder
             try (InputStream nativeIn = JLineNativeLoader.class.getResourceAsStream(nativeLibraryFilePath)) {


### PR DESCRIPTION
Removes the execute permission on the `.so` native library file created in the java tmp directory.
This permission is not required for java to load the library file successfully.

JLine creates two files in a temp directory location when being used in an interactive application. 
```
-rwx------. jlinenative-3.27.0-862111cc4ad0a980-libjlinenative.so
-rw-------.  jlinenative-3.27.0-862111cc4ad0a980-libjlinenative.so.lck
```
The `.so` file has read, write, and execute permissions set on it.

The temp directory path set by `java.io.tmpdir` which is typically /tmp or /var/tmp. 
However, these directories are commonly set with the `noexec` flag to conform with security best practices.
example: https://www.stigviewer.com/stig/red_hat_enterprise_linux_8/2023-12-01/finding/V-230513

When the `noexec` flag is set, JLine is prevented from creating the native lib file and functioning correctly. 
However, doing local testing with the permission removed, the native library file was able to be loaded successfully without issue. 