### PR TITLE
Release on Java 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ on:
       java-version:
         description: The java version to use
         required: false
-        default: 22
+        default: 21
       distribution:
         description: The java distribution to use.
         required: false


### PR DESCRIPTION
Please release on at least Java 21, it's the newest LTS release, still quite fresh. jline publised on Java 22 causes issues in our CI pipeline.
Thank you :bow:
