### PR TITLE
Add overloaded no-arg compile method

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/completer/SystemCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/SystemCompleter.java
@@ -126,6 +126,10 @@ public class SystemCompleter implements Completer {
         return aliasCommand;
     }
 
+    public void compile() {
+        compile(s -> new Candidate(AttributedString.stripAnsi(s), s, null, null, null, null, true));
+    }
+
     public void compile(Function<String, Candidate> candidateBuilder) {
         if (compiled) {
             return;


### PR DESCRIPTION
Before #1120, SystemCompleter had a no-arg compile method that just called the StringsCompleter constructor with a Set<String>. The StringsCompleter constructor then just created a Candidate for each string after stripping out any ANSI characters.

This change adds a no-arg compile method does exactly the same thing. This should make it easier for people to upgrade.