### PR TITLE
Undeprecate ConsolePrompt methods et al

### DIFF
--- a/console-ui/src/test/java/org/jline/consoleui/Issue1025.java
+++ b/console-ui/src/test/java/org/jline/consoleui/Issue1025.java
@@ -13,7 +13,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -88,109 +87,107 @@ public class Issue1025 {
         // If you are not using Completers you do not need to create LineReader.
         //
         LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
-        Map<String, PromptResultItemIF> result = new HashMap<>();
-        try (ConsolePrompt prompt = new ConsolePrompt(reader, terminal, config)) {
-            PromptBuilder promptBuilder = prompt.getPromptBuilder();
+        ConsolePrompt prompt = new ConsolePrompt(reader, terminal, config);
+        PromptBuilder promptBuilder = prompt.getPromptBuilder();
 
-            promptBuilder
-                    .createInputPrompt()
-                    .name("name")
-                    .message("Please enter your name")
-                    .defaultValue("John Doe")
-                    // .mask('*')
-                    .addCompleter(
-                            // new Completers.FilesCompleter(() -> Paths.get(System.getProperty("user.dir"))))
-                            new StringsCompleter("Jim", "Jack", "John", "Donald", "Dock"))
-                    .addPrompt();
+        promptBuilder
+                .createInputPrompt()
+                .name("name")
+                .message("Please enter your name")
+                .defaultValue("John Doe")
+                // .mask('*')
+                .addCompleter(
+                        // new Completers.FilesCompleter(() -> Paths.get(System.getProperty("user.dir"))))
+                        new StringsCompleter("Jim", "Jack", "John", "Donald", "Dock"))
+                .addPrompt();
 
-            promptBuilder
-                    .createListPrompt()
-                    .name("pizzatype")
-                    .message("Which pizza do you want?")
-                    .newItem()
-                    .text("Margherita")
-                    .add() // without name (name defaults to text)
-                    .newItem("veneziana")
-                    .text("Veneziana")
-                    .add()
-                    .newItem("hawai")
-                    .text("Hawai")
-                    .add()
-                    .newItem("quattro")
-                    .text("Quattro Stagioni")
-                    .add()
-                    .addPrompt();
+        promptBuilder
+                .createListPrompt()
+                .name("pizzatype")
+                .message("Which pizza do you want?")
+                .newItem()
+                .text("Margherita")
+                .add() // without name (name defaults to text)
+                .newItem("veneziana")
+                .text("Veneziana")
+                .add()
+                .newItem("hawai")
+                .text("Hawai")
+                .add()
+                .newItem("quattro")
+                .text("Quattro Stagioni")
+                .add()
+                .addPrompt();
 
-            promptBuilder
-                    .createCheckboxPrompt()
-                    .name("topping")
-                    .message("Please select additional toppings:")
-                    .newSeparator("standard toppings")
-                    .add()
-                    .newItem()
-                    .name("cheese")
-                    .text("Cheese")
-                    .add()
-                    .newItem("bacon")
-                    .text("Bacon")
-                    .add()
-                    .newItem("onions")
-                    .text("Onions")
-                    .disabledText("Sorry. Out of stock.")
-                    .add()
-                    .newSeparator()
-                    .text("special toppings")
-                    .add()
-                    .newItem("salami")
-                    .text("Very hot salami")
-                    .check()
-                    .add()
-                    .newItem("salmon")
-                    .text("Smoked Salmon")
-                    .add()
-                    .newSeparator("and our speciality...")
-                    .add()
-                    .newItem("special")
-                    .text("Anchovies, and olives")
-                    .checked(true)
-                    .add()
-                    .addPrompt();
+        promptBuilder
+                .createCheckboxPrompt()
+                .name("topping")
+                .message("Please select additional toppings:")
+                .newSeparator("standard toppings")
+                .add()
+                .newItem()
+                .name("cheese")
+                .text("Cheese")
+                .add()
+                .newItem("bacon")
+                .text("Bacon")
+                .add()
+                .newItem("onions")
+                .text("Onions")
+                .disabledText("Sorry. Out of stock.")
+                .add()
+                .newSeparator()
+                .text("special toppings")
+                .add()
+                .newItem("salami")
+                .text("Very hot salami")
+                .check()
+                .add()
+                .newItem("salmon")
+                .text("Smoked Salmon")
+                .add()
+                .newSeparator("and our speciality...")
+                .add()
+                .newItem("special")
+                .text("Anchovies, and olives")
+                .checked(true)
+                .add()
+                .addPrompt();
 
-            promptBuilder
-                    .createChoicePrompt()
-                    .name("payment")
-                    .message("How do you want to pay?")
-                    .newItem()
-                    .name("cash")
-                    .message("Cash")
-                    .key('c')
-                    .asDefault()
-                    .add()
-                    .newItem("visa")
-                    .message("Visa Card")
-                    .key('v')
-                    .add()
-                    .newItem("master")
-                    .message("Master Card")
-                    .key('m')
-                    .add()
-                    .newSeparator("online payment")
-                    .add()
-                    .newItem("paypal")
-                    .message("Paypal")
-                    .key('p')
-                    .add()
-                    .addPrompt();
+        promptBuilder
+                .createChoicePrompt()
+                .name("payment")
+                .message("How do you want to pay?")
+                .newItem()
+                .name("cash")
+                .message("Cash")
+                .key('c')
+                .asDefault()
+                .add()
+                .newItem("visa")
+                .message("Visa Card")
+                .key('v')
+                .add()
+                .newItem("master")
+                .message("Master Card")
+                .key('m')
+                .add()
+                .newSeparator("online payment")
+                .add()
+                .newItem("paypal")
+                .message("Paypal")
+                .key('p')
+                .add()
+                .addPrompt();
 
-            promptBuilder
-                    .createConfirmPromp()
-                    .name("delivery")
-                    .message("Is this pizza for delivery?")
-                    .defaultValue(ConfirmChoice.ConfirmationValue.YES)
-                    .addPrompt();
+        promptBuilder
+                .createConfirmPromp()
+                .name("delivery")
+                .message("Is this pizza for delivery?")
+                .defaultValue(ConfirmChoice.ConfirmationValue.YES)
+                .addPrompt();
 
-            prompt.prompt(header, promptBuilder.build(), result);
-        }
+        Map<String, ? extends PromptResultItemIF> result = prompt.prompt(header, promptBuilder.build());
         System.out.println("result = " + result);
 
         ConfirmResult delivery = (ConfirmResult) result.get("delivery");

--- a/console-ui/src/test/java/org/jline/consoleui/examples/Basic.java
+++ b/console-ui/src/test/java/org/jline/consoleui/examples/Basic.java
@@ -9,7 +9,6 @@
 package org.jline.consoleui.examples;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -67,110 +66,107 @@ public class Basic {
             // If you are not using Completers you do not need to create LineReader.
             //
             LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
-            Map<String, PromptResultItemIF> result = new HashMap<>();
+            ConsolePrompt prompt = new ConsolePrompt(reader, terminal, config);
+            PromptBuilder promptBuilder = prompt.getPromptBuilder();
 
-            try (ConsolePrompt prompt = new ConsolePrompt(reader, terminal, config)) {
-                PromptBuilder promptBuilder = prompt.getPromptBuilder();
+            promptBuilder
+                    .createInputPrompt()
+                    .name("name")
+                    .message("Please enter your name")
+                    .defaultValue("John Doe")
+                    // .mask('*')
+                    .addCompleter(
+                            // new Completers.FilesCompleter(() -> Paths.get(System.getProperty("user.dir"))))
+                            new StringsCompleter("Jim", "Jack", "John", "Donald", "Dock"))
+                    .addPrompt();
 
-                promptBuilder
-                        .createInputPrompt()
-                        .name("name")
-                        .message("Please enter your name")
-                        .defaultValue("John Doe")
-                        // .mask('*')
-                        .addCompleter(
-                                // new Completers.FilesCompleter(() -> Paths.get(System.getProperty("user.dir"))))
-                                new StringsCompleter("Jim", "Jack", "John", "Donald", "Dock"))
-                        .addPrompt();
+            promptBuilder
+                    .createListPrompt()
+                    .name("pizzatype")
+                    .message("Which pizza do you want?")
+                    .newItem()
+                    .text("Margherita")
+                    .add() // without name (name defaults to text)
+                    .newItem("veneziana")
+                    .text("Veneziana")
+                    .add()
+                    .newItem("hawai")
+                    .text("Hawai")
+                    .add()
+                    .newItem("quattro")
+                    .text("Quattro Stagioni")
+                    .add()
+                    .addPrompt();
 
-                promptBuilder
-                        .createListPrompt()
-                        .name("pizzatype")
-                        .message("Which pizza do you want?")
-                        .newItem()
-                        .text("Margherita")
-                        .add() // without name (name defaults to text)
-                        .newItem("veneziana")
-                        .text("Veneziana")
-                        .add()
-                        .newItem("hawai")
-                        .text("Hawai")
-                        .add()
-                        .newItem("quattro")
-                        .text("Quattro Stagioni")
-                        .add()
-                        .addPrompt();
+            promptBuilder
+                    .createCheckboxPrompt()
+                    .name("topping")
+                    .message("Please select additional toppings:")
+                    .newSeparator("standard toppings")
+                    .add()
+                    .newItem()
+                    .name("cheese")
+                    .text("Cheese")
+                    .add()
+                    .newItem("bacon")
+                    .text("Bacon")
+                    .add()
+                    .newItem("onions")
+                    .text("Onions")
+                    .disabledText("Sorry. Out of stock.")
+                    .add()
+                    .newSeparator()
+                    .text("special toppings")
+                    .add()
+                    .newItem("salami")
+                    .text("Very hot salami")
+                    .check()
+                    .add()
+                    .newItem("salmon")
+                    .text("Smoked Salmon")
+                    .add()
+                    .newSeparator("and our speciality...")
+                    .add()
+                    .newItem("special")
+                    .text("Anchovies, and olives")
+                    .checked(true)
+                    .add()
+                    .addPrompt();
 
-                promptBuilder
-                        .createCheckboxPrompt()
-                        .name("topping")
-                        .message("Please select additional toppings:")
-                        .newSeparator("standard toppings")
-                        .add()
-                        .newItem()
-                        .name("cheese")
-                        .text("Cheese")
-                        .add()
-                        .newItem("bacon")
-                        .text("Bacon")
-                        .add()
-                        .newItem("onions")
-                        .text("Onions")
-                        .disabledText("Sorry. Out of stock.")
-                        .add()
-                        .newSeparator()
-                        .text("special toppings")
-                        .add()
-                        .newItem("salami")
-                        .text("Very hot salami")
-                        .check()
-                        .add()
-                        .newItem("salmon")
-                        .text("Smoked Salmon")
-                        .add()
-                        .newSeparator("and our speciality...")
-                        .add()
-                        .newItem("special")
-                        .text("Anchovies, and olives")
-                        .checked(true)
-                        .add()
-                        .addPrompt();
+            promptBuilder
+                    .createChoicePrompt()
+                    .name("payment")
+                    .message("How do you want to pay?")
+                    .newItem()
+                    .name("cash")
+                    .message("Cash")
+                    .key('c')
+                    .asDefault()
+                    .add()
+                    .newItem("visa")
+                    .message("Visa Card")
+                    .key('v')
+                    .add()
+                    .newItem("master")
+                    .message("Master Card")
+                    .key('m')
+                    .add()
+                    .newSeparator("online payment")
+                    .add()
+                    .newItem("paypal")
+                    .message("Paypal")
+                    .key('p')
+                    .add()
+                    .addPrompt();
 
-                promptBuilder
-                        .createChoicePrompt()
-                        .name("payment")
-                        .message("How do you want to pay?")
-                        .newItem()
-                        .name("cash")
-                        .message("Cash")
-                        .key('c')
-                        .asDefault()
-                        .add()
-                        .newItem("visa")
-                        .message("Visa Card")
-                        .key('v')
-                        .add()
-                        .newItem("master")
-                        .message("Master Card")
-                        .key('m')
-                        .add()
-                        .newSeparator("online payment")
-                        .add()
-                        .newItem("paypal")
-                        .message("Paypal")
-                        .key('p')
-                        .add()
-                        .addPrompt();
+            promptBuilder
+                    .createConfirmPromp()
+                    .name("delivery")
+                    .message("Is this pizza for delivery?")
+                    .defaultValue(ConfirmChoice.ConfirmationValue.YES)
+                    .addPrompt();
 
-                promptBuilder
-                        .createConfirmPromp()
-                        .name("delivery")
-                        .message("Is this pizza for delivery?")
-                        .defaultValue(ConfirmChoice.ConfirmationValue.YES)
-                        .addPrompt();
-
-                prompt.prompt(header, promptBuilder.build(), result);
-            }
+            Map<String, ? extends PromptResultItemIF> result = prompt.prompt(header, promptBuilder.build());
             System.out.println("result = " + result);
 
             ConfirmResult delivery = (ConfirmResult) result.get("delivery");

--- a/console-ui/src/test/java/org/jline/consoleui/examples/BasicDynamic.java
+++ b/console-ui/src/test/java/org/jline/consoleui/examples/BasicDynamic.java
@@ -72,36 +72,34 @@ public class BasicDynamic {
             // LineReader is needed only if you are adding JLine Completers in your prompts.
             // If you are not using Completers you do not need to create LineReader.
             //
-            Map<String, PromptResultItemIF> result;
             LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
-            try (ConsolePrompt prompt = new ConsolePrompt(reader, terminal, config)) {
-                result = prompt.prompt(header, results -> {
-                    if (results.isEmpty()) {
-                        // No results yet, so we start with the first list of questions
-                        return pizzaOrHamburgerPrompt(prompt);
+            ConsolePrompt prompt = new ConsolePrompt(reader, terminal, config);
+            Map<String, PromptResultItemIF> result = prompt.prompt(header, results -> {
+                if (results.isEmpty()) {
+                    // No results yet, so we start with the first list of questions
+                    return pizzaOrHamburgerPrompt(prompt);
+                }
+                // We have some results, so we know that the user chose a "product",
+                // so we can return the next list of questions based on that choice
+                if ("Pizza".equals(results.get("product").getResult())) {
+                    // Check if the pizza questions were already answered
+                    if (!results.containsKey("pizzatype")) {
+                        // No, so let's return the pizza questions
+                        return pizzaPrompt(prompt);
                     }
-                    // We have some results, so we know that the user chose a "product",
-                    // so we can return the next list of questions based on that choice
-                    if ("Pizza".equals(results.get("product").getResult())) {
-                        // Check if the pizza questions were already answered
-                        if (!results.containsKey("pizzatype")) {
-                            // No, so let's return the pizza questions
-                            return pizzaPrompt(prompt);
-                        }
-                    } else {
-                        // Check if the hamburger questions were already answered
-                        if (!results.containsKey("hamburgertype")) {
-                            // No, so let's return the hamburger questions
-                            return hamburgerPrompt(prompt);
-                        }
+                } else {
+                    // Check if the hamburger questions were already answered
+                    if (!results.containsKey("hamburgertype")) {
+                        // No, so let's return the hamburger questions
+                        return hamburgerPrompt(prompt);
                     }
-                    // Check if the final questions were already answered
-                    if (!results.containsKey("payment")) {
-                        return finalPrompt(prompt);
-                    }
-                    return null;
-                });
-            }
+                }
+                // Check if the final questions were already answered
+                if (!results.containsKey("payment")) {
+                    return finalPrompt(prompt);
+                }
+                return null;
+            });
             System.out.println("result = " + result);
             if (result.isEmpty()) {
                 System.out.println("User cancelled order.");

--- a/console-ui/src/test/java/org/jline/consoleui/examples/LongList.java
+++ b/console-ui/src/test/java/org/jline/consoleui/examples/LongList.java
@@ -10,7 +10,6 @@ package org.jline.consoleui.examples;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -38,35 +37,29 @@ public class LongList {
 
         try (Terminal terminal = TerminalBuilder.builder().build()) {
             ConsolePrompt.UiConfig config = new ConsolePrompt.UiConfig(">", "( )", "(x)", "( )");
-            Map<String, PromptResultItemIF> result = new HashMap<>();
+            ConsolePrompt prompt = new ConsolePrompt(terminal, config);
+            PromptBuilder promptBuilder = prompt.getPromptBuilder();
 
-            try (ConsolePrompt prompt = new ConsolePrompt(terminal, config)) {
-                PromptBuilder promptBuilder = prompt.getPromptBuilder();
+            ListPromptBuilder listPrompt = promptBuilder.createListPrompt();
+            listPrompt.name("longlist").message("What's your favourite Letter?").relativePageSize(66);
 
-                ListPromptBuilder listPrompt = promptBuilder.createListPrompt();
-                listPrompt
-                        .name("longlist")
-                        .message("What's your favourite Letter?")
-                        .relativePageSize(66);
+            for (char letter = 'A'; letter <= 'C'; letter++)
+                for (char letter2 = 'A'; letter2 <= 'Z'; letter2++)
+                    listPrompt.newItem().text("" + letter + letter2).add();
+            listPrompt.addPrompt();
 
-                for (char letter = 'A'; letter <= 'C'; letter++)
-                    for (char letter2 = 'A'; letter2 <= 'Z'; letter2++)
-                        listPrompt.newItem().text("" + letter + letter2).add();
-                listPrompt.addPrompt();
+            CheckboxPromptBuilder checkboxPrompt = promptBuilder.createCheckboxPrompt();
+            checkboxPrompt
+                    .name("longcheckbox")
+                    .message("What's your favourite Letter? Select all you want...")
+                    .relativePageSize(66);
 
-                CheckboxPromptBuilder checkboxPrompt = promptBuilder.createCheckboxPrompt();
-                checkboxPrompt
-                        .name("longcheckbox")
-                        .message("What's your favourite Letter? Select all you want...")
-                        .relativePageSize(66);
+            for (char letter = 'A'; letter <= 'C'; letter++)
+                for (char letter2 = 'A'; letter2 <= 'Z'; letter2++)
+                    checkboxPrompt.newItem().text("" + letter + letter2).add();
+            checkboxPrompt.addPrompt();
 
-                for (char letter = 'A'; letter <= 'C'; letter++)
-                    for (char letter2 = 'A'; letter2 <= 'Z'; letter2++)
-                        checkboxPrompt.newItem().text("" + letter + letter2).add();
-                checkboxPrompt.addPrompt();
-
-                prompt.prompt(header, promptBuilder.build(), result);
-            }
+            Map<String, PromptResultItemIF> result = prompt.prompt(header, promptBuilder.build());
             System.out.println("result = " + result);
         } catch (IOException e) {
             e.printStackTrace();

--- a/console-ui/src/test/java/org/jline/consoleui/examples/SimpleExample.java
+++ b/console-ui/src/test/java/org/jline/consoleui/examples/SimpleExample.java
@@ -10,7 +10,6 @@ package org.jline.consoleui.examples;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,30 +28,28 @@ public class SimpleExample {
         header.add(new AttributedStringBuilder().append("Simple list example:").toAttributedString());
 
         try (Terminal terminal = TerminalBuilder.builder().build()) {
-            Map<String, PromptResultItemIF> result = new HashMap<>();
-            try (ConsolePrompt prompt = new ConsolePrompt(terminal)) {
-                PromptBuilder promptBuilder = prompt.getPromptBuilder();
+            ConsolePrompt prompt = new ConsolePrompt(terminal);
+            PromptBuilder promptBuilder = prompt.getPromptBuilder();
 
-                promptBuilder
-                        .createListPrompt()
-                        .name("pizzatype")
-                        .message("Which pizza do you want?")
-                        .newItem()
-                        .text("Margherita")
-                        .add() // without name (name defaults to text)
-                        .newItem("veneziana")
-                        .text("Veneziana")
-                        .add()
-                        .newItem("hawai")
-                        .text("Hawai")
-                        .add()
-                        .newItem("quattro")
-                        .text("Quattro Stagioni")
-                        .add()
-                        .addPrompt();
+            promptBuilder
+                    .createListPrompt()
+                    .name("pizzatype")
+                    .message("Which pizza do you want?")
+                    .newItem()
+                    .text("Margherita")
+                    .add() // without name (name defaults to text)
+                    .newItem("veneziana")
+                    .text("Veneziana")
+                    .add()
+                    .newItem("hawai")
+                    .text("Hawai")
+                    .add()
+                    .newItem("quattro")
+                    .text("Quattro Stagioni")
+                    .add()
+                    .addPrompt();
 
-                prompt.prompt(header, promptBuilder.build(), result);
-            }
+            Map<String, PromptResultItemIF> result = prompt.prompt(header, promptBuilder.build());
             System.out.println("result = " + result);
         } catch (IOException e) {
             e.printStackTrace();

--- a/console-ui/src/test/java/org/jline/consoleui/prompt/PromptBuilderTest.java
+++ b/console-ui/src/test/java/org/jline/consoleui/prompt/PromptBuilderTest.java
@@ -23,109 +23,108 @@ public class PromptBuilderTest {
 
     @Test
     public void testBuilder() throws IOException {
-        try (ConsolePrompt prompt = new ConsolePrompt(TerminalBuilder.builder().build())) {
-            PromptBuilder promptBuilder = prompt.getPromptBuilder();
+        ConsolePrompt prompt = new ConsolePrompt(TerminalBuilder.builder().build());
+        PromptBuilder promptBuilder = prompt.getPromptBuilder();
 
-            promptBuilder
-                    .createConfirmPromp()
-                    .name("wantapizza")
-                    .message("Do you want to order a pizza?")
-                    .defaultValue(ConfirmChoice.ConfirmationValue.YES)
-                    .addPrompt();
+        promptBuilder
+                .createConfirmPromp()
+                .name("wantapizza")
+                .message("Do you want to order a pizza?")
+                .defaultValue(ConfirmChoice.ConfirmationValue.YES)
+                .addPrompt();
 
-            promptBuilder
-                    .createInputPrompt()
-                    .name("name")
-                    .message("Please enter your name")
-                    .defaultValue("John Doe")
-                    .addPrompt();
+        promptBuilder
+                .createInputPrompt()
+                .name("name")
+                .message("Please enter your name")
+                .defaultValue("John Doe")
+                .addPrompt();
 
-            promptBuilder
-                    .createListPrompt()
-                    .name("pizzatype")
-                    .message("Which pizza do you want?")
-                    .newItem()
-                    .text("Margherita")
-                    .add() // without name (name defaults to text)
-                    .newItem("veneziana")
-                    .text("Veneziana")
-                    .add()
-                    .newItem("hawai")
-                    .text("Hawai")
-                    .add()
-                    .newItem("quattro")
-                    .text("Quattro Stagioni")
-                    .add()
-                    .addPrompt();
+        promptBuilder
+                .createListPrompt()
+                .name("pizzatype")
+                .message("Which pizza do you want?")
+                .newItem()
+                .text("Margherita")
+                .add() // without name (name defaults to text)
+                .newItem("veneziana")
+                .text("Veneziana")
+                .add()
+                .newItem("hawai")
+                .text("Hawai")
+                .add()
+                .newItem("quattro")
+                .text("Quattro Stagioni")
+                .add()
+                .addPrompt();
 
-            promptBuilder
-                    .createCheckboxPrompt()
-                    .name("topping")
-                    .message("Please select additional toppings:")
-                    .newSeparator("standard toppings")
-                    .add()
-                    .newItem()
-                    .name("cheese")
-                    .text("Cheese")
-                    .add()
-                    .newItem("bacon")
-                    .text("Bacon")
-                    .add()
-                    .newItem("onions")
-                    .text("Onions")
-                    .disabledText("Sorry. Out of stock.")
-                    .add()
-                    .newSeparator()
-                    .text("special toppings")
-                    .add()
-                    .newItem("salami")
-                    .text("Very hot salami")
-                    .check()
-                    .add()
-                    .newItem("salmon")
-                    .text("Smoked Salmon")
-                    .add()
-                    .newSeparator("and our speciality...")
-                    .add()
-                    .newItem("special")
-                    .text("Anchovies, and olives")
-                    .checked(true)
-                    .add()
-                    .addPrompt();
+        promptBuilder
+                .createCheckboxPrompt()
+                .name("topping")
+                .message("Please select additional toppings:")
+                .newSeparator("standard toppings")
+                .add()
+                .newItem()
+                .name("cheese")
+                .text("Cheese")
+                .add()
+                .newItem("bacon")
+                .text("Bacon")
+                .add()
+                .newItem("onions")
+                .text("Onions")
+                .disabledText("Sorry. Out of stock.")
+                .add()
+                .newSeparator()
+                .text("special toppings")
+                .add()
+                .newItem("salami")
+                .text("Very hot salami")
+                .check()
+                .add()
+                .newItem("salmon")
+                .text("Smoked Salmon")
+                .add()
+                .newSeparator("and our speciality...")
+                .add()
+                .newItem("special")
+                .text("Anchovies, and olives")
+                .checked(true)
+                .add()
+                .addPrompt();
 
-            assertNotNull(promptBuilder);
-            promptBuilder
-                    .createChoicePrompt()
-                    .name("payment")
-                    .message("How do you want to pay?")
-                    .newItem()
-                    .name("cash")
-                    .message("Cash")
-                    .key('c')
-                    .asDefault()
-                    .add()
-                    .newItem("visa")
-                    .message("Visa Card")
-                    .key('v')
-                    .add()
-                    .newItem("master")
-                    .message("Master Card")
-                    .key('m')
-                    .add()
-                    .newSeparator("online payment")
-                    .add()
-                    .newItem("paypal")
-                    .message("Paypal")
-                    .key('p')
-                    .add()
-                    .addPrompt();
+        assertNotNull(promptBuilder);
+        promptBuilder
+                .createChoicePrompt()
+                .name("payment")
+                .message("How do you want to pay?")
+                .newItem()
+                .name("cash")
+                .message("Cash")
+                .key('c')
+                .asDefault()
+                .add()
+                .newItem("visa")
+                .message("Visa Card")
+                .key('v')
+                .add()
+                .newItem("master")
+                .message("Master Card")
+                .key('m')
+                .add()
+                .newSeparator("online payment")
+                .add()
+                .newItem("paypal")
+                .message("Paypal")
+                .key('p')
+                .add()
+                .addPrompt();
 
-            List<PromptableElementIF> promptableElementList = promptBuilder.build();
+        List<PromptableElementIF> promptableElementList = promptBuilder.build();
 
-            // only for test. reset the default reader to a test reader to automate the input
-            // promptableElementList.get(0)
+        // only for test. reset the default reader to a test reader to automate the input
+        // promptableElementList.get(0)
 
-            // HashMap<String, Object> result = prompt.prompt(promptableElementList);
-        }
+        // HashMap<String, Object> result = prompt.prompt(promptableElementList);
     }
 }


### PR DESCRIPTION
Implemented:

- open()/close() methods for ConsolePrompt
- calling open()/close() in prompt() methods that return Maps
- removed `@Deprecated` annotations
- removed new and unused (non Map returning) `prompt()` method
- made new (non Map returning) prompt() method `protected`
- fixed examples
- made sure all ConsolePrompt fields are `protected`

Fixes #1141
