### PR TITLE
Replace `Path.toFile()`

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
+++ b/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
@@ -9,6 +9,7 @@
 package org.jline.builtins;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class ConfigurationPath {
@@ -33,9 +34,9 @@ public class ConfigurationPath {
      */
     public Path getConfig(String name) {
         Path out = null;
-        if (userConfig != null && userConfig.resolve(name).toFile().exists()) {
+        if (userConfig != null && Files.exists(userConfig.resolve(name))) {
             out = userConfig.resolve(name);
-        } else if (appConfig != null && appConfig.resolve(name).toFile().exists()) {
+        } else if (appConfig != null && Files.exists(appConfig.resolve(name))) {
             out = appConfig.resolve(name);
         }
         return out;
@@ -62,10 +63,10 @@ public class ConfigurationPath {
     public Path getUserConfig(String name, boolean create) throws IOException {
         Path out = null;
         if (userConfig != null) {
-            if (!userConfig.resolve(name).toFile().exists() && create) {
-                userConfig.resolve(name).toFile().createNewFile();
+            if (!Files.exists(userConfig.resolve(name)) && create) {
+                Files.createFile(userConfig.resolve(name));
             }
-            if (userConfig.resolve(name).toFile().exists()) {
+            if (Files.exists(userConfig.resolve(name))) {
                 out = userConfig.resolve(name);
             }
         }

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -2105,7 +2105,7 @@ public class Nano implements Editor {
                 return false;
             }
         } else if (!Files.exists(newPath)) {
-            newPath.toFile().createNewFile();
+            Files.createFile(newPath);
         }
         Path t = Files.createTempFile("jline-", ".temp");
         try (OutputStream os = Files.newOutputStream(

--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -245,7 +245,7 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
                 }
             }
             for (Path p : scripts) {
-                String name = p.toFile().getName();
+                String name = p.getFileName().toString();
                 int idx = name.lastIndexOf(".");
                 out.put(name.substring(0, idx), name.substring(idx + 1).equals(scriptExtension));
             }
@@ -395,7 +395,7 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
                         for (String e : scriptExtensions()) {
                             String file = command + "." + e;
                             Path path = Paths.get(p, file);
-                            if (path.toFile().exists()) {
+                            if (Files.exists(path)) {
                                 script = path;
                                 scriptExtension(command);
                                 found = true;
@@ -959,7 +959,7 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
                         : engine.getSerializationFormats().get(0);
                 try {
                     Path path = Paths.get(arg);
-                    if (path.toFile().exists()) {
+                    if (Files.exists(path)) {
                         if (!format.equals(SLURP_FORMAT_TEXT)) {
                             out = slurp(path, encoding, format);
                         } else {

--- a/groovy/src/main/groovy/org/jline/groovy/Utils.groovy
+++ b/groovy/src/main/groovy/org/jline/groovy/Utils.groovy
@@ -11,6 +11,7 @@ package org.jline.groovy
 import org.codehaus.groovy.runtime.HandleMetaClass
 import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 
+import java.nio.file.Files
 import java.nio.file.Path
 import org.jline.script.GroovyEngine.Format
 import groovy.json.JsonOutput
@@ -62,9 +63,9 @@ class Utils {
 
     static void persist(Path file, Object object, Format format) {
         if (format == Format.JSON) {
-            file.toFile().write(JsonOutput.toJson(object))
+            Files.writeString(file, JsonOutput.toJson(object))
         } else if (format == Format.NONE) {
-            file.toFile().write(toString(object))
+            Files.writeString(file, toString(object))
         } else {
             throw new IllegalArgumentException()
         }

--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -200,7 +200,7 @@ public class DefaultHistory implements History {
     public void write(Path file, boolean incremental) throws IOException {
         Path path = file != null ? file : getPath();
         if (path != null && Files.exists(path)) {
-            path.toFile().delete();
+            Files.deleteIfExists(path);
         }
         internalWrite(path, incremental ? getLastLoaded(path) : 0);
     }


### PR DESCRIPTION
In some use cases it's preferable to have for example the nanorc configs inside a jar. Although a lot of the code base use `java.nio.file.Path`, a couple of places still call `Path.toFile()`, which isn't supported for NIO's ZIP file system, which can be created for a `jar:` URL, so that the contents of the jar can be used as a (read only) file system.

This PR replaces occurences of `Path.toFile()` and replaces the `File` operations with NIO's `Files`.