### PR TITLE
bug: Obey terminal if set

### DIFF
--- a/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
@@ -247,7 +247,10 @@ public class AnsiConsole {
             width = terminal::getWidth;
             type = terminal instanceof DumbTerminal ? AnsiType.Unsupported : AnsiType.Native;
         } else {
-            out = new FastBufferedOutputStream(new FileOutputStream(stdout ? FileDescriptor.out : FileDescriptor.err));
+            out = terminal != null
+                    ? terminal.output()
+                    : new FastBufferedOutputStream(
+                            new FileOutputStream(stdout ? FileDescriptor.out : FileDescriptor.err));
             width = new AnsiOutputStream.ZeroWidthSupplier();
             type = ((TerminalExt) terminal).getSystemStream() != null ? AnsiType.Redirected : AnsiType.Unsupported;
         }


### PR DESCRIPTION
Currently, if terminal is set, but is not "tty" (ie. is dumb), AnsiConsole will grab the process stdout/stderr instead to obey the set terminal output.

Fixes #1160