### PR TITLE
fix: ensure proper cleanup of pump threads in terminal implementations

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
@@ -112,8 +112,10 @@ public class ExternalTerminal extends LineDisciplineTerminal {
 
     @Override
     public void pause() {
-        synchronized (lock) {
-            paused = true;
+        try {
+            pause(false);
+        } catch (InterruptedException e) {
+            // nah
         }
     }
 
@@ -126,7 +128,9 @@ public class ExternalTerminal extends LineDisciplineTerminal {
         }
         if (p != null) {
             p.interrupt();
-            p.join();
+            if (wait) {
+                p.join();
+            }
         }
     }
 

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -110,8 +110,10 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
 
     @Override
     public void pause() {
-        synchronized (lock) {
-            paused = true;
+        try {
+            pause(false);
+        } catch (InterruptedException e) {
+            // nah
         }
     }
 
@@ -129,11 +131,13 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
         if (p2 != null) {
             p2.interrupt();
         }
-        if (p1 != null) {
-            p1.join();
-        }
-        if (p2 != null) {
-            p2.join();
+        if (wait) {
+            if (p1 != null) {
+                p1.join();
+            }
+            if (p2 != null) {
+                p2.join();
+            }
         }
     }
 


### PR DESCRIPTION
This commit fixes a bug where pump threads were not being properly closed in 
terminal implementations. The issue occurred in both ExternalTerminal and 
PosixPtyTerminal classes where the pause() method was directly setting the 
paused flag without properly handling thread interruption.

Changes:
- Modified pause() in ExternalTerminal and PosixPtyTerminal to call pause(false)
  instead of directly setting the paused flag
- Updated pause(boolean wait) to only join threads when wait=true
- Added proper exception handling for InterruptedException

This fix prevents potential thread leaks where pump threads might continue 
running in the background after they're no longer needed, ensuring proper 
resource cleanup.