### PR TITLE
Fix jline/jline3#1185, use a better fallback classloader

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -54,7 +54,7 @@ public interface TerminalProvider {
     static TerminalProvider load(String name) throws IOException {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         if (cl == null) {
-            cl = ClassLoader.getSystemClassLoader();
+            cl = TerminalProvider.class.getClassLoader();
         }
         InputStream is = cl.getResourceAsStream("META-INF/services/org/jline/terminal/provider/" + name);
         if (is != null) {


### PR DESCRIPTION
This fixed issue #1185
Please consider a backport ro jline-3.26.x for java-17 users.