### PR TITLE
Corrected the maven central link

### DIFF
--- a/console-ui/README.md
+++ b/console-ui/README.md
@@ -36,7 +36,7 @@ Console UI uses JLine for the dirty console things.
 
 # Maven artefact
 
-ConsoleUI releases are available at Maven Central [org.jline.console-ui » console-ui](https://search.maven.org/artifact/org.jline.console-ui/console-ui)
+ConsoleUI releases are available at Maven Central [org.jline » jline-console-ui](https://search.maven.org/artifact/org.jline/jline-console-ui)
 
 # Test Run
 


### PR DESCRIPTION
Based on the pom.xml, it should be `org.jline:jline-console-ui` instead of `org.jline.console-ui:console-ui`