### PR TITLE
Fix Ctrl+Space handling on Windows terminals

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -282,7 +282,7 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
                     if (isAlt) {
                         processInputChar('\033');
                     }
-                    if (isCtrl && ch != ' ' && ch != '\n' && ch != 0x7f) {
+                    if (isCtrl && ch != '\n' && ch != 0x7f) {
                         processInputChar((char) (ch == '?' ? 0x7f : Character.toUpperCase(ch) & 0x1f));
                     } else {
                         processInputChar(ch);


### PR DESCRIPTION
This PR fixes issue #1188 by removing the special case handling for Ctrl+Space in AbstractWindowsTerminal.java. 

On Windows, when Ctrl+Space is pressed, it was being treated as a regular space character (0x20) instead of being converted to the NUL character (0x00) like other Ctrl+key combinations. This prevented Ctrl+Space from working correctly in applications like the Nano editor.

The fix is simple: remove the  condition from the if statement that handles control characters, allowing Ctrl+Space to be properly converted to the NUL character.