### PR TITLE
Fix NPE in Status#resize when supported is false (fixes #1191)

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -63,10 +63,12 @@ public class Status {
     }
 
     public void close() {
-        terminal.puts(Capability.save_cursor);
-        terminal.puts(Capability.change_scroll_region, 0, display.rows - 1);
-        terminal.puts(Capability.restore_cursor);
-        terminal.flush();
+        if (supported) {
+            terminal.puts(Capability.save_cursor);
+            terminal.puts(Capability.change_scroll_region, 0, display.rows - 1);
+            terminal.puts(Capability.restore_cursor);
+            terminal.flush();
+        }
     }
 
     public void setBorder(boolean border) {
@@ -78,7 +80,9 @@ public class Status {
     }
 
     public void resize(Size size) {
-        display.resize(size.getRows(), size.getColumns());
+        if (supported) {
+            display.resize(size.getRows(), size.getColumns());
+        }
     }
 
     public void reset() {


### PR DESCRIPTION
This PR fixes a NullPointerException that occurs in Status#resize when the 'supported' flag is false. In this case, the 'display' field is not initialized, but methods like resize() and close() were trying to use it without checking if it's null.\n\nThe fix adds appropriate checks for the 'supported' flag before accessing the display object in these methods.