### PR TITLE
fix: Improve JLineNativeLoader documentation and references

### DIFF
--- a/native/src/main/java/org/jline/nativ/JLineLibrary.java
+++ b/native/src/main/java/org/jline/nativ/JLineLibrary.java
@@ -11,9 +11,23 @@ package org.jline.nativ;
 import java.io.FileDescriptor;
 
 /**
- * Interface to access some low level.
+ * Native interface for JLine's low-level system operations.
+ * <p>
+ * This class provides access to native methods that are implemented in the JLine native library.
+ * It automatically initializes the native library using {@link JLineNativeLoader#initialize()}
+ * when the class is loaded.
+ * <p>
+ * The native methods in this class provide functionality that is not available through standard
+ * Java APIs, such as creating file descriptors and process redirects directly from file descriptors.
+ * <p>
+ * This class is primarily used internally by JLine's terminal implementations, particularly
+ * those that require direct access to native system calls. Users of JLine typically do not need
+ * to interact with this class directly.
+ * <p>
+ * If the native library cannot be loaded, attempts to use methods in this class will result
+ * in {@link UnsatisfiedLinkError} exceptions.
  *
- * @see    JLineNativeLoader
+ * @see JLineNativeLoader For details on how the native library is loaded and configured
  */
 @SuppressWarnings("unused")
 public class JLineLibrary {

--- a/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
+++ b/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
@@ -44,14 +44,71 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Set the system properties, library.jline.path, library.jline.name,
- * appropriately so that jline can find *.dll, *.jnilib and
- * *.so files, according to the current OS (win, linux, mac).
+ * Manages the loading of JLine's native libraries (*.dll, *.jnilib, *.so) according to the current
+ * operating system (Windows, Linux, macOS) and architecture.
  * <p>
- * The library files are automatically extracted from this project's package
- * (JAR).
+ * This class handles the discovery, extraction, and loading of the appropriate native library
+ * for the current platform. The native libraries are essential for certain terminal operations
+ * that require direct system calls.
  * <p>
- * usage: call {@link #initialize()} before using jline.
+ * <h2>Usage</h2>
+ * Call {@link #initialize()} before using JLine features that require native support:
+ * <pre>
+ * JLineNativeLoader.initialize();
+ * </pre>
+ *
+ * <h2>Library Loading Process</h2>
+ * The loader attempts to find and load the native library in the following order:
+ * <ol>
+ *   <li>From the path specified by the {@code library.jline.path} system property</li>
+ *   <li>From the JAR file's embedded native libraries</li>
+ *   <li>From the Java library path ({@code java.library.path})</li>
+ * </ol>
+ *
+ * <h2>Configuration Options</h2>
+ * The following system properties can be used to configure the native library loading:
+ * <ul>
+ *   <li>{@code library.jline.path} - Custom directory path where native libraries are located.
+ *       The loader will check both {@code [library.jline.path]/[os]/[arch]} and
+ *       {@code [library.jline.path]} directly.</li>
+ *   <li>{@code library.jline.name} - Custom name for the native library file. If not specified,
+ *       the default name will be used (e.g., "jlinenative.dll" on Windows).</li>
+ *   <li>{@code jline.tmpdir} - Custom temporary directory for extracting native libraries.
+ *       If not specified, {@code java.io.tmpdir} will be used.</li>
+ *   <li>{@code java.library.path} - Standard Java property for native library search paths,
+ *       used as a last resort.</li>
+ * </ul>
+ *
+ * <h2>Platform Detection</h2>
+ * The loader automatically detects the current operating system and architecture using
+ * {@link OSInfo} to determine which native library to load. Supported platforms include:
+ * <ul>
+ *   <li>Operating Systems: Windows, macOS (Darwin), Linux, AIX</li>
+ *   <li>Architectures: x86, x86_64 (amd64), ARM (various versions), PowerPC, and others</li>
+ * </ul>
+ *
+ * <h2>Temporary Files</h2>
+ * When loading from the JAR file, the native library is extracted to a temporary location.
+ * These temporary files:
+ * <ul>
+ *   <li>Include version and UUID in the filename to avoid conflicts</li>
+ *   <li>Are automatically cleaned up on JVM exit</li>
+ *   <li>Old unused libraries from previous runs are cleaned up</li>
+ * </ul>
+ *
+ * <h2>Troubleshooting</h2>
+ * If the library fails to load, an exception is thrown with details about:
+ * <ul>
+ *   <li>The detected OS and architecture</li>
+ *   <li>All paths that were searched</li>
+ *   <li>The specific error that occurred</li>
+ * </ul>
+ *
+ * <h2>Java Module System (JPMS) Considerations</h2>
+ * When using JLine with the Java Module System, you may need to add the
+ * {@code --enable-native-access=ALL-UNNAMED} JVM option to allow the native library loading.
+ *
+ * @see OSInfo For details on platform detection
  */
 public class JLineNativeLoader {
 
@@ -61,10 +118,32 @@ public class JLineNativeLoader {
     private static String nativeLibrarySourceUrl;
 
     /**
-     * Loads jline native library.
+     * Loads the JLine native library for the current platform.
+     * <p>
+     * This method should be called before using any JLine features that require native support.
+     * It handles the discovery, extraction, and loading of the appropriate native library.
+     * <p>
+     * The method is thread-safe and idempotent - calling it multiple times has no additional effect
+     * after the first successful call. A background thread is started to clean up old native library
+     * files from previous runs.
+     * <p>
+     * If the library cannot be loaded, a {@link RuntimeException} is thrown with detailed information
+     * about the failure, including the OS, architecture, and paths that were searched.
+     * <p>
+     * Example usage:
+     * <pre>
+     * try {
+     *     JLineNativeLoader.initialize();
+     *     // JLine features that require native support can be used here
+     * } catch (RuntimeException e) {
+     *     // Handle the case where native library cannot be loaded
+     *     System.err.println("JLine native support not available: " + e.getMessage());
+     * }
+     * </pre>
      *
-     * @return True if jline native library is successfully loaded; false
-     *         otherwise.
+     * @return True if the JLine native library is successfully loaded; this will always
+     *         be true if the method returns normally, as it throws an exception on failure.
+     * @throws RuntimeException If the native library cannot be loaded for any reason.
      */
     public static synchronized boolean initialize() {
         // only cleanup before the first extract
@@ -82,21 +161,67 @@ public class JLineNativeLoader {
         return loaded;
     }
 
+    /**
+     * Returns the absolute path to the loaded native library file.
+     * <p>
+     * This method can be used to determine which specific native library file was successfully loaded.
+     * It's particularly useful for debugging and logging purposes.
+     * <p>
+     * Note: This method will return null if called before {@link #initialize()} or if the library
+     * failed to load.
+     *
+     * @return The absolute path to the loaded native library file, or null if the library hasn't been loaded.
+     */
     public static String getNativeLibraryPath() {
         return nativeLibraryPath;
     }
 
+    /**
+     * Returns the source URL from which the native library was loaded.
+     * <p>
+     * This is typically a jar:file: URL pointing to the location within the JAR file
+     * from which the native library was extracted. This information can be useful for
+     * debugging and logging purposes.
+     * <p>
+     * Note: This method will return null if called before {@link #initialize()} or if the library
+     * failed to load, or if the library was loaded from the filesystem rather than extracted from a JAR.
+     *
+     * @return The source URL of the loaded native library, or null if not applicable or if the library hasn't been loaded.
+     */
     public static String getNativeLibrarySourceUrl() {
         return nativeLibrarySourceUrl;
     }
 
+    /**
+     * Returns the temporary directory used for extracting native libraries.
+     * <p>
+     * The directory is determined by checking the following system properties in order:
+     * <ol>
+     *   <li>{@code jline.tmpdir} - Custom JLine-specific temporary directory</li>
+     *   <li>{@code java.io.tmpdir} - Standard Java temporary directory</li>
+     * </ol>
+     *
+     * @return A File object representing the temporary directory.
+     */
     private static File getTempDir() {
         return new File(System.getProperty("jline.tmpdir", System.getProperty("java.io.tmpdir")));
     }
 
     /**
-     * Deleted old native libraries e.g. on Windows the DLL file is not removed
-     * on VM-Exit (bug #80)
+     * Cleans up old native library files from previous runs.
+     * <p>
+     * This method is called automatically by {@link #initialize()} to remove old native library files
+     * that might have been left behind, particularly on Windows where DLL files are not always
+     * properly removed on JVM exit (see bug #80).
+     * <p>
+     * The cleanup process:
+     * <ol>
+     *   <li>Scans the temporary directory for files matching the pattern "jlinenative-[version]*"</li>
+     *   <li>Checks if each file has an associated lock file (.lck extension)</li>
+     *   <li>Deletes files that don't have an associated lock file, as they are from previous runs</li>
+     * </ol>
+     * <p>
+     * This method is run in a low-priority daemon thread to avoid impacting application startup time.
      */
     static void cleanup() {
         String tempFolder = getTempDir().getAbsolutePath();
@@ -166,12 +291,28 @@ public class JLineNativeLoader {
     }
 
     /**
-     * Extracts and loads the specified library file to the target folder
+     * Extracts a native library from the JAR file and loads it.
+     * <p>
+     * This method handles the process of extracting a native library from within the JAR file
+     * to a temporary location on the filesystem, and then loading it using {@link System#load(String)}.
+     * <p>
+     * The extraction process includes several important steps:
+     * <ol>
+     *   <li>Creating a unique filename for the extracted library to avoid conflicts</li>
+     *   <li>Creating a lock file to indicate that the library is in use</li>
+     *   <li>Extracting the library content from the JAR to the temporary file</li>
+     *   <li>Setting appropriate file permissions (readable, writable, executable)</li>
+     *   <li>Verifying that the extraction was successful by comparing file contents</li>
+     *   <li>Loading the extracted library using {@link System#load(String)}</li>
+     * </ol>
+     * <p>
+     * The extracted files are marked for deletion on JVM exit using {@link File#deleteOnExit()},
+     * but on some platforms (particularly Windows), this may not always work reliably.
      *
-     * @param  libFolderForCurrentOS Library path.
-     * @param  libraryFileName       Library name.
-     * @param  targetFolder          Target folder.
-     * @return
+     * @param  libFolderForCurrentOS The path within the JAR file to the native library for the current OS/architecture.
+     * @param  libraryFileName       The filename of the native library.
+     * @param  targetFolder          The target folder where the library will be extracted.
+     * @return                       True if the library was successfully extracted and loaded; false otherwise.
      */
     private static boolean extractAndLoadLibraryFile(
             String libFolderForCurrentOS, String libraryFileName, String targetFolder) {
@@ -242,10 +383,21 @@ public class JLineNativeLoader {
     }
 
     /**
-     * Loads native library using the given path and name of the library.
+     * Loads a native library from a specific file path.
+     * <p>
+     * This method attempts to load a native library using {@link System#load(String)}, which
+     * requires an absolute path to the library file. If successful, it sets the
+     * {@link #nativeLibraryPath} field to the absolute path of the loaded library.
+     * <p>
+     * The method handles the following cases:
+     * <ul>
+     *   <li>If the file doesn't exist, it returns false without attempting to load</li>
+     *   <li>If loading fails with an {@link UnsatisfiedLinkError}, it logs the error and returns false</li>
+     *   <li>If loading succeeds, it sets the path and returns true</li>
+     * </ul>
      *
-     * @param  libPath Path of the native library.
-     * @return         True for successfully loading; false otherwise.
+     * @param  libPath A File object representing the absolute path to the native library file.
+     * @return         True if the library was successfully loaded; false otherwise.
      */
     private static boolean loadNativeLibrary(File libPath) {
         if (libPath.exists()) {
@@ -270,9 +422,28 @@ public class JLineNativeLoader {
     }
 
     /**
-     * Loads jline library using given path and name of the library.
+     * Core method that handles the JLine native library loading process.
+     * <p>
+     * This method implements the library loading strategy, attempting to load the native library
+     * from various locations in a specific order. It's called by {@link #initialize()} and should
+     * not be called directly.
+     * <p>
+     * The loading process follows this sequence:
+     * <ol>
+     *   <li>If the library is already loaded, return immediately</li>
+     *   <li>Try loading from the custom path specified by {@code library.jline.path} system property:
+     *     <ul>
+     *       <li>First check {@code [library.jline.path]/[os]/[arch]/[library.name]}</li>
+     *       <li>Then check {@code [library.jline.path]/[library.name]}</li>
+     *     </ul>
+     *   </li>
+     *   <li>Try extracting and loading from the JAR file's embedded native libraries</li>
+     *   <li>Try loading from each path in the {@code java.library.path} system property</li>
+     *   <li>If all attempts fail, throw an exception with detailed information</li>
+     * </ol>
      *
-     * @throws
+     * @throws Exception If the native library cannot be loaded from any location.
+     *                   The exception includes details about the OS, architecture, and paths searched.
      */
     private static void loadJLineNativeLibrary() throws Exception {
         if (loaded) {
@@ -350,7 +521,16 @@ public class JLineNativeLoader {
     }
 
     /**
-     * @return The major version of the jline library.
+     * Returns the major version number of the JLine library.
+     * <p>
+     * This method extracts the major version number from the full version string.
+     * For example, if the version is "3.21.0", this method returns 3.
+     * <p>
+     * The version information is read from the Maven POM properties file in the JAR.
+     * If the version cannot be determined, 1 is returned as a default value.
+     *
+     * @return The major version number of the JLine library, or 1 if it cannot be determined.
+     * @see #getVersion()
      */
     public static int getMajorVersion() {
         String[] c = getVersion().split("\\.");
@@ -358,7 +538,16 @@ public class JLineNativeLoader {
     }
 
     /**
-     * @return The minor version of the jline library.
+     * Returns the minor version number of the JLine library.
+     * <p>
+     * This method extracts the minor version number from the full version string.
+     * For example, if the version is "3.21.0", this method returns 21.
+     * <p>
+     * The version information is read from the Maven POM properties file in the JAR.
+     * If the version cannot be determined or doesn't have a minor component, 0 is returned as a default value.
+     *
+     * @return The minor version number of the JLine library, or 0 if it cannot be determined.
+     * @see #getVersion()
      */
     public static int getMinorVersion() {
         String[] c = getVersion().split("\\.");
@@ -366,7 +555,19 @@ public class JLineNativeLoader {
     }
 
     /**
-     * @return The version of the jline library.
+     * Returns the full version string of the JLine library.
+     * <p>
+     * This method retrieves the version information from the Maven POM properties file
+     * in the JAR at "/META-INF/maven/org.jline/jline-native/pom.properties".
+     * <p>
+     * The version string is cleaned to include only numeric values and dots (e.g., "3.21.0").
+     * If the version information cannot be determined (e.g., the properties file is missing
+     * or cannot be read), "unknown" is returned.
+     * <p>
+     * This version information is used in the naming of temporary native library files to
+     * ensure proper versioning and avoid conflicts between different JLine versions.
+     *
+     * @return The version string of the JLine library, or "unknown" if it cannot be determined.
      */
     public static String getVersion() {
         URL versionFile = JLineNativeLoader.class.getResource("/META-INF/maven/org.jline/jline-native/pom.properties");

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
@@ -30,7 +30,43 @@ import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.Log;
 import org.jline.utils.OSUtils;
 
+/**
+ * Terminal provider implementation that uses JNI (Java Native Interface) to access
+ * native terminal functionality.
+ * <p>
+ * This provider requires the JLine native library to be loaded, which is handled by
+ * {@link org.jline.nativ.JLineNativeLoader}. The native library provides access to
+ * low-level terminal operations that are not available through standard Java APIs.
+ * <p>
+ * The native library is automatically loaded when this provider is used. If the library
+ * cannot be loaded, the provider will not be available and JLine will fall back to other
+ * available providers.
+ * <p>
+ * The native library loading can be configured using system properties as documented in
+ * {@link org.jline.nativ.JLineNativeLoader}.
+ *
+ * @see org.jline.nativ.JLineNativeLoader
+ * @see org.jline.terminal.TerminalBuilder
+ */
 public class JniTerminalProvider implements TerminalProvider {
+
+    /**
+     * Creates a new JNI terminal provider instance and ensures the native library is loaded.
+     * <p>
+     * The constructor initializes the JLine native library using {@link org.jline.nativ.JLineNativeLoader#initialize()}.
+     * If the native library cannot be loaded, methods in this provider may throw exceptions when used.
+     */
+    public JniTerminalProvider() {
+        try {
+            // Ensure the native library is loaded
+            org.jline.nativ.JLineNativeLoader.initialize();
+        } catch (Exception e) {
+            // Log the error but don't throw - this allows the provider to be instantiated
+            // even if the native library can't be loaded. TerminalBuilder will handle this
+            // by trying other providers.
+            Log.debug("Failed to load JLine native library: " + e.getMessage(), e);
+        }
+    }
 
     @Override
     public String name() {

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -42,6 +42,18 @@ import org.jline.utils.OSUtils;
 
 /**
  * Builder class to create terminals.
+ * <p>
+ * This builder provides a flexible way to create terminal instances with various configurations.
+ * It supports multiple terminal provider implementations, including those that require native libraries.
+ * <p>
+ * When using providers that require native libraries (such as JNI, JNA, or Jansi), the appropriate
+ * native library will be loaded automatically. The loading of these libraries is handled by
+ * {@link org.jline.nativ.JLineNativeLoader} for the JNI provider.
+ * <p>
+ * The native library loading can be configured using system properties as documented in
+ * {@link org.jline.nativ.JLineNativeLoader}.
+ *
+ * @see org.jline.nativ.JLineNativeLoader
  */
 public final class TerminalBuilder {
 
@@ -253,8 +265,20 @@ public final class TerminalBuilder {
 
     /**
      * Enables or disables the {@link #PROP_PROVIDER_JNI}/{@code jni} terminal provider.
+     * <p>
+     * The JNI provider uses the JLine native library loaded by {@link org.jline.nativ.JLineNativeLoader}
+     * to access low-level terminal functionality. This provider generally offers the best performance
+     * and most complete terminal support.
+     * <p>
      * If not specified, the system property {@link #PROP_JNI} will be used if set.
-     * If not specified, the provider will be checked.
+     * If not specified, the provider will be checked for availability.
+     * <p>
+     * The native library loading can be configured using system properties as documented in
+     * {@link org.jline.nativ.JLineNativeLoader}.
+     *
+     * @param jni true to enable the JNI provider, false to disable it
+     * @return this builder
+     * @see org.jline.nativ.JLineNativeLoader
      */
     public TerminalBuilder jni(boolean jni) {
         this.jni = jni;


### PR DESCRIPTION
This PR thoroughly documents JLineNativeLoader and adds references to it in related classes:

- Add comprehensive JavaDoc to JLineNativeLoader explaining how native libraries are loaded
- Add references to JLineNativeLoader in JniTerminalProvider with explicit initialization
- Add references to JLineNativeLoader in TerminalBuilder documentation
- Improve JLineLibrary documentation to explain its relationship with JLineNativeLoader

This improves the documentation of how native libraries are loaded and configured, making it easier for users to understand and troubleshoot native library loading issues.

Fixes #1087