### PR TITLE
Fix cursor position after Status.update()

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -257,6 +257,9 @@ public class Status {
             super.update(newLines, targetCursorPos, flush);
             if (cursorPos != -1) {
                 terminal.puts(Capability.restore_cursor);
+                if (flush) {
+                    terminal.flush();
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #1212 by adding a terminal.flush() call after terminal.puts(Capability.restore_cursor) when the flush parameter is true. This ensures that the cursor position is correctly restored in terminals like Putty and MobaXterm.