### PR TITLE
docs: Add comprehensive Javadoc to JLine Terminal and Reader

### DIFF
--- a/reader/pom.xml
+++ b/reader/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2020, the original author or authors.
+    Copyright (c) 2002-2025, the original author or authors.
 
     This software is distributable under the BSD license. See the terms of the
     BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/keymap/KeyMap.java
+++ b/reader/src/main/java/org/jline/keymap/KeyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -19,14 +19,42 @@ import org.jline.utils.Curses;
 import org.jline.utils.InfoCmp.Capability;
 
 /**
- * The KeyMap class contains all bindings from keys to operations.
+ * The KeyMap class maps keyboard input sequences to operations or actions.
+ * <p>
+ * KeyMap is a core component of JLine's input handling system, providing the ability
+ * to bind specific key sequences (like Ctrl+A, Alt+F, or multi-key sequences) to
+ * arbitrary operations represented by objects of type T.
+ * <p>
+ * Key features include:
+ * <ul>
+ *   <li>Support for single-key and multi-key sequences</li>
+ *   <li>Special handling for Unicode characters not explicitly bound</li>
+ *   <li>Timeout handling for ambiguous bindings (e.g., Escape key vs. Alt combinations)</li>
+ *   <li>Utility methods for creating common key sequences (Ctrl, Alt, etc.)</li>
+ * </ul>
+ * <p>
+ * This class is used extensively by the {@link org.jline.reader.LineReader} to implement
+ * customizable key bindings for line editing operations.
  *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * @param <T> the type of objects to which key sequences are bound
  * @since 2.6
  */
 public class KeyMap<T> {
 
+    /**
+     * The size of the direct mapping array for ASCII characters.
+     * Characters with code points below this value are mapped directly.
+     */
     public static final int KEYMAP_LENGTH = 128;
+
+    /**
+     * Default timeout in milliseconds for ambiguous bindings.
+     * <p>
+     * This is used when a prefix of a multi-character binding is also bound to an action.
+     * For example, if both Escape and Escape+[A are bound, the reader will wait this
+     * amount of time after receiving Escape to determine if it's a standalone Escape
+     * or the beginning of the Escape+[A sequence.
+     */
     public static final long DEFAULT_AMBIGUOUS_TIMEOUT = 1000L;
 
     private Object[] mapping = new Object[KEYMAP_LENGTH];
@@ -35,6 +63,16 @@ public class KeyMap<T> {
     private T nomatch;
     private long ambiguousTimeout = DEFAULT_AMBIGUOUS_TIMEOUT;
 
+    /**
+     * Converts a key sequence to a displayable string representation.
+     * <p>
+     * This method formats control characters, escape sequences, and other special
+     * characters in a readable way, similar to how they might be represented in
+     * configuration files.
+     *
+     * @param key the key sequence to display
+     * @return a readable string representation of the key sequence
+     */
     public static String display(String key) {
         StringBuilder sb = new StringBuilder();
         sb.append("\"");
@@ -57,6 +95,15 @@ public class KeyMap<T> {
         return sb.toString();
     }
 
+    /**
+     * Translates a string containing special escape sequences into the actual key sequence.
+     * <p>
+     * This method handles escape sequences like ^A (Ctrl+A), \e (Escape), \C-a (Ctrl+A),
+     * \M-a (Alt+A), etc., converting them to the actual character sequences they represent.
+     *
+     * @param str the string with escape sequences to translate
+     * @return the translated key sequence
+     */
     public static String translate(String str) {
         int i;
         if (!str.isEmpty()) {
@@ -185,6 +232,15 @@ public class KeyMap<T> {
         return keySeq.toString();
     }
 
+    /**
+     * Generates a collection of key sequences from a range specification.
+     * <p>
+     * This method takes a range specification like "a-z" or "\C-a-\C-z" and
+     * returns a collection of all key sequences in that range.
+     *
+     * @param range the range specification
+     * @return a collection of key sequences in the specified range, or null if the range is invalid
+     */
     public static Collection<String> range(String range) {
         String[] keys = range.split("-");
         if (keys.length != 2) {
@@ -216,30 +272,83 @@ public class KeyMap<T> {
         return seqs;
     }
 
+    /**
+     * Returns the escape character as a string.
+     *
+     * @return the escape character ("\033")
+     */
     public static String esc() {
         return "\033";
     }
 
+    /**
+     * Creates an Alt+key sequence for a single character.
+     * <p>
+     * This is equivalent to pressing the Alt key and a character key simultaneously.
+     * Internally, this is represented as the escape character followed by the character.
+     *
+     * @param c the character to combine with Alt
+     * @return the Alt+character key sequence
+     */
     public static String alt(char c) {
         return "\033" + c;
     }
 
+    /**
+     * Creates an Alt+key sequence for a string.
+     * <p>
+     * This is equivalent to pressing the Alt key and typing a sequence of characters.
+     * Internally, this is represented as the escape character followed by the string.
+     *
+     * @param c the string to combine with Alt
+     * @return the Alt+string key sequence
+     */
     public static String alt(String c) {
         return "\033" + c;
     }
 
+    /**
+     * Returns the delete character as a string.
+     *
+     * @return the delete character ("\177")
+     */
     public static String del() {
         return "\177";
     }
 
+    /**
+     * Creates a Ctrl+key sequence for a character.
+     * <p>
+     * This is equivalent to pressing the Ctrl key and a character key simultaneously.
+     * For example, Ctrl+A is represented as the character with code point 1.
+     *
+     * @param key the character to combine with Ctrl
+     * @return the Ctrl+key sequence
+     */
     public static String ctrl(char key) {
         return key == '?' ? del() : Character.toString((char) (Character.toUpperCase(key) & 0x1f));
     }
 
+    /**
+     * Returns the escape sequence for a terminal capability.
+     * <p>
+     * This method retrieves the escape sequence for special keys like arrow keys,
+     * function keys, etc., based on the terminal's capabilities.
+     *
+     * @param terminal the terminal to query
+     * @param capability the capability to retrieve
+     * @return the escape sequence for the specified capability
+     */
     public static String key(Terminal terminal, Capability capability) {
         return Curses.tputs(terminal.getStringCapability(capability));
     }
 
+    /**
+     * Comparator for sorting key sequences.
+     * <p>
+     * This comparator sorts key sequences first by length, then lexicographically.
+     * It's useful for ensuring that longer key sequences are checked before their prefixes.
+     */
     public static final Comparator<String> KEYSEQ_COMPARATOR = (s1, s2) -> {
         int len1 = s1.length();
         int len2 = s2.length();
@@ -261,34 +370,92 @@ public class KeyMap<T> {
     // Methods
     //
 
+    /**
+     * Gets the binding for Unicode characters that don't have explicit bindings.
+     * <p>
+     * This is used as a fallback for characters that don't have specific bindings
+     * in the keymap. Typically, this might be set to a function that inserts the
+     * character into the line buffer.
+     *
+     * @return the binding for Unicode characters
+     */
     public T getUnicode() {
         return unicode;
     }
 
+    /**
+     * Sets the binding for Unicode characters that don't have explicit bindings.
+     *
+     * @param unicode the binding for Unicode characters
+     */
     public void setUnicode(T unicode) {
         this.unicode = unicode;
     }
 
+    /**
+     * Gets the binding for input sequences that don't match any known binding.
+     * <p>
+     * This is used as a fallback when an input sequence doesn't match any binding
+     * in the keymap.
+     *
+     * @return the binding for non-matching sequences
+     */
     public T getNomatch() {
         return nomatch;
     }
 
+    /**
+     * Sets the binding for input sequences that don't match any known binding.
+     *
+     * @param nomatch the binding for non-matching sequences
+     */
     public void setNomatch(T nomatch) {
         this.nomatch = nomatch;
     }
 
+    /**
+     * Gets the timeout for ambiguous key bindings in milliseconds.
+     * <p>
+     * This timeout is used when a prefix of a multi-character binding is also bound
+     * to an action. The reader will wait this amount of time after receiving the prefix
+     * to determine if more characters are coming.
+     *
+     * @return the ambiguous binding timeout in milliseconds
+     */
     public long getAmbiguousTimeout() {
         return ambiguousTimeout;
     }
 
+    /**
+     * Sets the timeout for ambiguous key bindings in milliseconds.
+     *
+     * @param ambiguousTimeout the ambiguous binding timeout in milliseconds
+     */
     public void setAmbiguousTimeout(long ambiguousTimeout) {
         this.ambiguousTimeout = ambiguousTimeout;
     }
 
+    /**
+     * Gets the binding for the "another key" action.
+     * <p>
+     * This binding is returned when a key sequence doesn't match any binding
+     * but is a prefix of a longer binding. It's typically used to implement
+     * incremental search or other features that need to process each character
+     * as it's typed.
+     *
+     * @return the "another key" binding
+     */
     public T getAnotherKey() {
         return anotherKey;
     }
 
+    /**
+     * Returns a map of all bound key sequences and their associated bindings.
+     * <p>
+     * The map is sorted by key sequence using the {@link #KEYSEQ_COMPARATOR}.
+     *
+     * @return a map of bound key sequences to their bindings
+     */
     public Map<String, T> getBoundKeys() {
         Map<String, T> bound = new TreeMap<>(KEYSEQ_COMPARATOR);
         doGetBoundKeys(this, "", bound);
@@ -309,6 +476,22 @@ public class KeyMap<T> {
         }
     }
 
+    /**
+     * Gets the binding for a key sequence, with information about remaining characters.
+     * <p>
+     * This method returns the binding for the given key sequence, if one exists.
+     * It also provides information about how much of the key sequence was consumed
+     * in the {@code remaining} parameter:
+     * <ul>
+     *   <li>If remaining[0] is -1, the entire sequence was consumed</li>
+     *   <li>If remaining[0] is positive, that many characters at the end were not consumed</li>
+     *   <li>If remaining[0] is 0, the sequence was consumed but no binding was found</li>
+     * </ul>
+     *
+     * @param keySeq the key sequence to look up
+     * @param remaining array of length at least 1 to receive information about remaining characters
+     * @return the binding for the key sequence, or null if no binding was found
+     */
     @SuppressWarnings("unchecked")
     public T getBound(CharSequence keySeq, int[] remaining) {
         remaining[0] = -1;
@@ -334,30 +517,75 @@ public class KeyMap<T> {
         }
     }
 
+    /**
+     * Gets the binding for a key sequence.
+     * <p>
+     * This method returns the binding for the given key sequence only if the entire
+     * sequence is consumed. If the sequence is a prefix of a longer binding or doesn't
+     * match any binding, null is returned.
+     *
+     * @param keySeq the key sequence to look up
+     * @return the binding for the key sequence, or null if no binding was found or the sequence is a prefix
+     */
     public T getBound(CharSequence keySeq) {
         int[] remaining = new int[1];
         T res = getBound(keySeq, remaining);
         return remaining[0] <= 0 ? res : null;
     }
 
+    /**
+     * Binds a function to a key sequence only if the key sequence is not already bound.
+     * <p>
+     * This method is useful for setting up default bindings that should not override
+     * user-defined bindings.
+     *
+     * @param function the function to bind
+     * @param keySeq the key sequence to bind to
+     */
     public void bindIfNotBound(T function, CharSequence keySeq) {
         if (function != null && keySeq != null) {
             bind(this, keySeq, function, true);
         }
     }
 
+    /**
+     * Binds a function to multiple key sequences.
+     * <p>
+     * This is a convenience method that calls {@link #bind(Object, CharSequence)}
+     * for each key sequence.
+     *
+     * @param function the function to bind
+     * @param keySeqs the key sequences to bind to
+     */
     public void bind(T function, CharSequence... keySeqs) {
         for (CharSequence keySeq : keySeqs) {
             bind(function, keySeq);
         }
     }
 
+    /**
+     * Binds a function to multiple key sequences.
+     * <p>
+     * This is a convenience method that calls {@link #bind(Object, CharSequence)}
+     * for each key sequence in the iterable.
+     *
+     * @param function the function to bind
+     * @param keySeqs the key sequences to bind to
+     */
     public void bind(T function, Iterable<? extends CharSequence> keySeqs) {
         for (CharSequence keySeq : keySeqs) {
             bind(function, keySeq);
         }
     }
 
+    /**
+     * Binds a function to a key sequence.
+     * <p>
+     * If the function is null, the key sequence is unbound.
+     *
+     * @param function the function to bind, or null to unbind
+     * @param keySeq the key sequence to bind to
+     */
     public void bind(T function, CharSequence keySeq) {
         if (keySeq != null) {
             if (function == null) {
@@ -374,6 +602,13 @@ public class KeyMap<T> {
         }
     }
 
+    /**
+     * Unbinds a key sequence.
+     * <p>
+     * This removes any binding associated with the given key sequence.
+     *
+     * @param keySeq the key sequence to unbind
+     */
     public void unbind(CharSequence keySeq) {
         if (keySeq != null) {
             unbind(this, keySeq);

--- a/reader/src/main/java/org/jline/keymap/package-info.java
+++ b/reader/src/main/java/org/jline/keymap/package-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2025, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+/**
+ * JLine 3 Keymap Package - Components for handling keyboard input and key bindings.
+ * <p>
+ * This package provides the fundamental classes for mapping keyboard input sequences
+ * to actions in interactive terminal applications. It enables the creation of
+ * customizable key bindings similar to those found in editors like Emacs and Vi.
+ * <p>
+ * Key components in this package include:
+ * <ul>
+ *   <li>{@link org.jline.keymap.KeyMap} - Maps key sequences to actions or commands</li>
+ *   <li>{@link org.jline.keymap.BindingReader} - Reads input and translates it to bound actions</li>
+ * </ul>
+ * <p>
+ * The keymap system supports:
+ * <ul>
+ *   <li>Multi-character key sequences (e.g., Escape followed by other keys)</li>
+ *   <li>Special keys like function keys, arrow keys, etc.</li>
+ *   <li>Control key combinations</li>
+ *   <li>Alt/Meta key combinations</li>
+ *   <li>Unicode character input</li>
+ * </ul>
+ * <p>
+ * This package is used extensively by the {@link org.jline.reader.LineReader} to implement
+ * customizable editing capabilities.
+ *
+ * @since 3.0
+ */
+package org.jline.keymap;

--- a/reader/src/main/java/org/jline/reader/Binding.java
+++ b/reader/src/main/java/org/jline/reader/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -9,13 +9,28 @@
 package org.jline.reader;
 
 /**
- * Marker interface for objects bound to key sequences.
+ * Marker interface for objects that can be bound to key sequences in a KeyMap.
+ * <p>
+ * The Binding interface serves as a common type for different kinds of actions
+ * that can be triggered by key sequences in the line editor. JLine supports
+ * three main types of bindings:
+ * <ul>
+ *   <li>{@link Widget} - Executes a specific editing function</li>
+ *   <li>{@link Macro} - Executes a sequence of keystrokes</li>
+ *   <li>{@link Reference} - References another widget by name</li>
+ * </ul>
+ * <p>
+ * Key bindings are managed through KeyMaps, which map key sequences to Binding
+ * objects. When a user presses a key sequence, the LineReader looks up the
+ * corresponding Binding in the current KeyMap and executes it.
+ * <p>
+ * This interface doesn't define any methods; it's used purely as a marker
+ * to identify objects that can be bound to key sequences.
  *
  * @see Macro
  * @see Reference
  * @see Widget
  * @see org.jline.keymap.KeyMap
- *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * @see LineReader#getKeyMaps()
  */
 public interface Binding {}

--- a/reader/src/main/java/org/jline/reader/Buffer.java
+++ b/reader/src/main/java/org/jline/reader/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -8,36 +8,116 @@
  */
 package org.jline.reader;
 
+/**
+ * Represents the editable text buffer in the LineReader.
+ * <p>
+ * The Buffer interface provides methods for manipulating the text that the user
+ * is currently editing in the LineReader. It supports operations such as cursor
+ * movement, text insertion and deletion, and content retrieval.
+ * <p>
+ * The buffer maintains a current cursor position that indicates where text will
+ * be inserted or deleted. Many of the methods in this interface operate relative
+ * to this cursor position.
+ * <p>
+ * The default implementation is {@link org.jline.reader.impl.BufferImpl}.
+ *
+ * @see LineReader#getBuffer()
+ * @see org.jline.reader.impl.BufferImpl
+ */
 public interface Buffer {
 
     /*
      * Read access
      */
 
+    /**
+     * Returns the current cursor position in the buffer.
+     *
+     * @return the current cursor position (0-based index)
+     */
     int cursor();
 
+    /**
+     * Returns the character at the specified position in the buffer.
+     *
+     * @param i the position to check
+     * @return the character at the specified position, or -1 if the position is invalid
+     */
     int atChar(int i);
 
+    /**
+     * Returns the length of the buffer.
+     *
+     * @return the number of characters in the buffer
+     */
     int length();
 
+    /**
+     * Returns the character at the current cursor position.
+     *
+     * @return the character at the cursor position, or -1 if the cursor is at the end of the buffer
+     */
     int currChar();
 
+    /**
+     * Returns the character before the current cursor position.
+     *
+     * @return the character before the cursor position, or -1 if the cursor is at the beginning of the buffer
+     */
     int prevChar();
 
+    /**
+     * Returns the character after the current cursor position.
+     *
+     * @return the character after the cursor position, or -1 if the cursor is at the end of the buffer
+     */
     int nextChar();
 
     /*
      * Movement
      */
 
+    /**
+     * Moves the cursor to the specified position.
+     *
+     * @param position the position to move the cursor to
+     * @return true if the cursor was moved, false if the position was invalid
+     */
     boolean cursor(int position);
 
+    /**
+     * Moves the cursor by the specified number of characters.
+     * Positive values move right, negative values move left.
+     *
+     * @param num the number of characters to move
+     * @return the number of positions actually moved
+     */
     int move(int num);
 
+    /**
+     * Moves the cursor up one line while maintaining the same column position if possible.
+     * This is used for multi-line editing.
+     *
+     * @return true if the cursor was moved, false if it was already at the first line
+     */
     boolean up();
 
+    /**
+     * Moves the cursor down one line while maintaining the same column position if possible.
+     * This is used for multi-line editing.
+     *
+     * @return true if the cursor was moved, false if it was already at the last line
+     */
     boolean down();
 
+    /**
+     * Moves the cursor by the specified number of columns and rows.
+     * This is used for multi-line editing.
+     *
+     * @param dx the number of columns to move (positive for right, negative for left)
+     * @param dy the number of rows to move (positive for down, negative for up)
+     * @return true if the cursor was moved, false otherwise
+     */
     boolean moveXY(int dx, int dy);
 
     /*

--- a/reader/src/main/java/org/jline/reader/Candidate.java
+++ b/reader/src/main/java/org/jline/reader/Candidate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2019, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,9 +11,30 @@ package org.jline.reader;
 import java.util.Objects;
 
 /**
- * A completion candidate.
+ * Represents a completion candidate for tab completion.
+ * <p>
+ * A Candidate encapsulates all the information needed to display and apply a
+ * completion suggestion. This includes the actual text to be inserted, how it
+ * should be displayed to the user, grouping information, descriptions, and
+ * other metadata that controls how the candidate behaves when selected.
+ * <p>
+ * Candidates are created by {@link Completer} implementations and passed to the
+ * LineReader, which then filters, sorts, and displays them to the user when
+ * tab completion is requested.
+ * <p>
+ * Each candidate has several properties:
+ * <ul>
+ *   <li>value - The actual text to be inserted when the candidate is selected</li>
+ *   <li>display - How the candidate should be displayed to the user (may include ANSI styling)</li>
+ *   <li>group - Optional grouping category for organizing related candidates</li>
+ *   <li>description - Optional help text explaining the candidate</li>
+ *   <li>suffix - Optional text to append when the candidate is selected</li>
+ *   <li>complete - Whether the candidate is a complete word or may be further expanded</li>
+ * </ul>
  *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * @see Completer
+ * @see LineReader.Option#AUTO_GROUP
+ * @see LineReader.Option#GROUP
  */
 public class Candidate implements Comparable<Candidate> {
 

--- a/reader/src/main/java/org/jline/reader/Completer.java
+++ b/reader/src/main/java/org/jline/reader/Completer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -12,26 +12,51 @@ import java.util.List;
 
 /**
  * A completer is the mechanism by which tab-completion candidates will be resolved.
+ * <p>
+ * Completers are used to provide context-sensitive suggestions when the user presses
+ * the tab key while typing a command. They analyze the current input line and generate
+ * a list of possible completions based on the context.
+ * <p>
+ * JLine provides several built-in completers in the {@code org.jline.reader.impl.completer}
+ * package, including:
+ * <ul>
+ *   <li>{@code ArgumentCompleter} - Completes commands based on position of arguments</li>
+ *   <li>{@code FileNameCompleter} - Completes file and directory names</li>
+ *   <li>{@code StringsCompleter} - Completes from a predefined set of strings</li>
+ *   <li>{@code SystemCompleter} - Aggregates multiple completers for different commands</li>
+ * </ul>
+ * <p>
+ * Completers can be combined and nested to create sophisticated completion behavior.
+ * They are typically registered with a {@link LineReader} using the
+ * {@link LineReaderBuilder#completer(Completer)} method.
  *
- * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
  * @since 2.3
+ * @see Candidate
+ * @see LineReaderBuilder#completer(Completer)
  */
 public interface Completer {
     /**
      * Populates <i>candidates</i> with a list of possible completions for the <i>command line</i>.
-     *
+     * <p>
      * The list of candidates will be sorted and filtered by the LineReader, so that
      * the list of candidates displayed to the user will usually be smaller than
-     * the list given by the completer.  Thus it is not necessary for the completer
-     * to do any matching based on the current buffer.  On the contrary, in order
+     * the list given by the completer. Thus it is not necessary for the completer
+     * to do any matching based on the current buffer. On the contrary, in order
      * for the typo matcher to work, all possible candidates for the word being
      * completed should be returned.
+     * <p>
+     * Implementations should add {@link Candidate} objects to the candidates list.
+     * Each candidate can include additional information such as descriptions, groups,
+     * and display attributes that will be used when presenting completion options
+     * to the user.
+     * <p>
+     * This method is called by the LineReader when the user requests completion,
+     * typically by pressing the Tab key.
      *
-     * @param reader        The line reader
-     * @param line          The parsed command line
-     * @param candidates    The {@link List} of candidates to populate
+     * @param reader        The line reader instance that is requesting completion
+     * @param line          The parsed command line containing the current input state
+     * @param candidates    The {@link List} of candidates to populate with completion options
+     * @see Candidate
      */
     void complete(LineReader reader, ParsedLine line, List<Candidate> candidates);
 }

--- a/reader/src/main/java/org/jline/reader/CompletingParsedLine.java
+++ b/reader/src/main/java/org/jline/reader/CompletingParsedLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -12,14 +12,51 @@ package org.jline.reader;
  * An extension of {@link ParsedLine} that, being aware of the quoting and escaping rules
  * of the {@link org.jline.reader.Parser} that produced it, knows if and how a completion candidate
  * should be escaped/quoted.
+ * <p>
+ * This interface adds methods to handle the raw (unprocessed) form of words, including
+ * any quotes and escape characters that may be present in the original input. It also
+ * provides functionality to properly escape completion candidates according to the
+ * parser's syntax rules.
+ * <p>
+ * Implementations of this interface are crucial for proper tab completion in shells
+ * that support complex quoting and escaping mechanisms, ensuring that completed text
+ * is properly formatted according to the shell's syntax.
  *
- * @author Eric Bottard
+ * @see ParsedLine
+ * @see Parser
  */
 public interface CompletingParsedLine extends ParsedLine {
 
+    /**
+     * Escapes a completion candidate according to the parser's quoting and escaping rules.
+     * <p>
+     * This method ensures that special characters in the candidate are properly escaped
+     * or quoted according to the syntax rules of the parser, maintaining consistency with
+     * the current input line's quoting style.
+     *
+     * @param candidate the completion candidate that may need escaping
+     * @param complete true if this is a complete word, false if it's a partial completion
+     * @return the properly escaped/quoted candidate ready for insertion
+     */
     CharSequence escape(CharSequence candidate, boolean complete);
 
+    /**
+     * Returns the cursor position within the raw (unprocessed) current word.
+     * <p>
+     * Unlike {@link ParsedLine#wordCursor()}, this method returns the cursor position
+     * in the original word text, including any quotes and escape characters.
+     *
+     * @return the cursor position within the raw current word
+     */
     int rawWordCursor();
 
+    /**
+     * Returns the length of the raw (unprocessed) current word.
+     * <p>
+     * This is the length of the original word text, including any quotes and
+     * escape characters that may have been removed during parsing.
+     *
+     * @return the length of the raw current word
+     */
     int rawWordLength();
 }

--- a/reader/src/main/java/org/jline/reader/CompletionMatcher.java
+++ b/reader/src/main/java/org/jline/reader/CompletionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,17 +11,46 @@ package org.jline.reader;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Interface for matching and filtering completion candidates.
+ * <p>
+ * The CompletionMatcher is responsible for determining which completion candidates
+ * should be presented to the user based on what they've typed so far. It implements
+ * the logic for matching candidates against the input, handling case sensitivity,
+ * typo tolerance, and other matching strategies.
+ * <p>
+ * This interface allows for different matching algorithms to be used, such as:
+ * <ul>
+ *   <li>Prefix matching - candidates that start with the input text</li>
+ *   <li>Substring matching - candidates that contain the input text</li>
+ *   <li>Fuzzy matching - candidates that approximately match the input text</li>
+ *   <li>Camel case matching - matching based on camel case patterns</li>
+ * </ul>
+ * <p>
+ * The default implementation is {@link org.jline.reader.impl.CompletionMatcherImpl}.
+ *
+ * @see org.jline.reader.impl.CompletionMatcherImpl
+ * @see LineReader.Option#COMPLETE_MATCHER_TYPO
+ * @see LineReader.Option#COMPLETE_MATCHER_CAMELCASE
+ */
 public interface CompletionMatcher {
 
     /**
-     * Compiles completion matcher functions
+     * Initializes the matcher with the current completion context.
+     * <p>
+     * This method is called before any matching operations to set up the matcher
+     * with the current completion context, including the line being completed,
+     * reader options, and other parameters that affect how matching should be performed.
+     * <p>
+     * The matcher uses this information to compile its internal matching functions
+     * that will be used to filter candidates.
      *
-     * @param options LineReader options
-     * @param prefix invoked by complete-prefix or expand-or-complete-prefix widget
-     * @param line The parsed line within which completion has been requested
-     * @param caseInsensitive if completion is case insensitive or not
-     * @param errors number of errors accepted in matching
-     * @param originalGroupName value of JLineReader variable original-group-name
+     * @param options LineReader options that may affect matching behavior
+     * @param prefix true if invoked by complete-prefix or expand-or-complete-prefix widget
+     * @param line the parsed line within which completion has been requested
+     * @param caseInsensitive true if completion should be case insensitive
+     * @param errors number of typo errors accepted in matching (for fuzzy matching)
+     * @param originalGroupName value of the LineReader variable original-group-name
      */
     void compile(
             Map<LineReader.Option, Boolean> options,
@@ -32,21 +61,37 @@ public interface CompletionMatcher {
             String originalGroupName);
 
     /**
+     * Filters the provided candidates based on the current matching criteria.
+     * <p>
+     * This method applies the matching algorithm to the list of candidates and
+     * returns only those that match the current input according to the configured
+     * matching rules. The returned list may be sorted based on match quality.
      *
-     * @param candidates list of candidates
-     * @return a list of candidates that completion matcher matches
+     * @param candidates the list of candidates to filter
+     * @return a list of candidates that match the current input
      */
     List<Candidate> matches(List<Candidate> candidates);
 
     /**
+     * Returns a candidate that exactly matches the current input, if any.
+     * <p>
+     * An exact match typically means the candidate's value is identical to what
+     * the user has typed, possibly ignoring case depending on the matcher configuration.
+     * This is used to determine if the completion should be accepted immediately
+     * without showing a list of options.
      *
-     * @return a candidate that have exact match, null if no exact match found
+     * @return a candidate that exactly matches the current input, or null if no exact match is found
      */
     Candidate exactMatch();
 
     /**
+     * Returns the longest common prefix shared by all matched candidates.
+     * <p>
+     * This is used to implement tab completion behavior where pressing tab will
+     * automatically complete as much of the input as can be unambiguously determined
+     * from the available candidates.
      *
-     * @return a common prefix of matched candidates
+     * @return the longest common prefix of all matched candidates, or an empty string if none
      */
     String getCommonPrefix();
 }

--- a/reader/src/main/java/org/jline/reader/EOFError.java
+++ b/reader/src/main/java/org/jline/reader/EOFError.java
@@ -8,6 +8,24 @@
  */
 package org.jline.reader;
 
+/**
+ * Exception thrown when parsing is incomplete due to unexpected end of input.
+ * <p>
+ * EOFError is a specialized type of {@link SyntaxError} that indicates the input
+ * is incomplete rather than invalid. This typically occurs when the user has entered
+ * an incomplete construct, such as an unclosed quote, parenthesis, or bracket.
+ * <p>
+ * This exception provides additional information about what is missing to complete
+ * the input, which can be used by the LineReader to provide appropriate feedback
+ * to the user, such as a continuation prompt that indicates what needs to be closed.
+ * <p>
+ * The name "EOFError" refers to "End Of File Error", indicating that the parser
+ * reached the end of the input before the syntax was complete.
+ *
+ * @see SyntaxError
+ * @see Parser
+ * @see Parser.ParseContext#SECONDARY_PROMPT
+ */
 public class EOFError extends SyntaxError {
 
     private static final long serialVersionUID = 1L;
@@ -31,14 +49,38 @@ public class EOFError extends SyntaxError {
         this.nextClosingBracket = nextClosingBracket;
     }
 
+    /**
+     * Returns the string that is missing to complete the input.
+     * <p>
+     * This is typically a closing delimiter such as a quote, parenthesis, or bracket
+     * that would complete the current syntactic construct.
+     *
+     * @return the missing string, or null if not applicable
+     */
     public String getMissing() {
         return missing;
     }
 
+    /**
+     * Returns the number of unclosed brackets in the input.
+     * <p>
+     * This count can be used to determine how many closing brackets are needed
+     * to complete the input.
+     *
+     * @return the number of unclosed brackets
+     */
     public int getOpenBrackets() {
         return openBrackets;
     }
 
+    /**
+     * Returns the next closing bracket that is expected.
+     * <p>
+     * This indicates the specific type of bracket (e.g., ')', ']', or '}') that
+     * is expected next to continue closing the open brackets.
+     *
+     * @return the next expected closing bracket, or null if not applicable
+     */
     public String getNextClosingBracket() {
         return nextClosingBracket;
     }

--- a/reader/src/main/java/org/jline/reader/Editor.java
+++ b/reader/src/main/java/org/jline/reader/Editor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2019, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,10 +11,57 @@ package org.jline.reader;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Interface for launching external editors from within a JLine application.
+ * <p>
+ * The Editor interface provides functionality for opening and editing files in
+ * an external text editor. This allows JLine applications to offer users the
+ * ability to edit content in their preferred editor rather than being limited
+ * to the line editing capabilities of the terminal.
+ * <p>
+ * Typical use cases include:
+ * <ul>
+ *   <li>Editing configuration files</li>
+ *   <li>Writing or modifying scripts</li>
+ *   <li>Composing long text content</li>
+ * </ul>
+ * <p>
+ * Implementations of this interface handle the details of launching the external
+ * editor process, waiting for it to complete, and potentially reading back the
+ * edited content.
+ *
+ * @see LineReader#editAndAddInBuffer(java.nio.file.Path)
+ */
 public interface Editor {
+    /**
+     * Opens the specified files in the external editor.
+     * <p>
+     * This method launches the external editor with the given files as arguments.
+     * The behavior depends on the specific editor implementation and configuration.
+     *
+     * @param files the list of files to open in the editor
+     * @throws IOException if an I/O error occurs while launching the editor
+     */
     public void open(List<String> files) throws IOException;
 
+    /**
+     * Runs the editor process.
+     * <p>
+     * This method starts the editor process and typically waits for it to complete.
+     * The specific behavior depends on the editor implementation.
+     *
+     * @throws IOException if an I/O error occurs while running the editor
+     */
     public void run() throws IOException;
 
+    /**
+     * Sets whether the editor should run in restricted mode.
+     * <p>
+     * In restricted mode, the editor may have limited functionality or access
+     * to certain features or files. This is typically used for security reasons
+     * when the application needs to limit what the user can do in the editor.
+     *
+     * @param restricted true to enable restricted mode, false otherwise
+     */
     public void setRestricted(boolean restricted);
 }

--- a/reader/src/main/java/org/jline/reader/EndOfFileException.java
+++ b/reader/src/main/java/org/jline/reader/EndOfFileException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Expander.java
+++ b/reader/src/main/java/org/jline/reader/Expander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -8,9 +8,50 @@
  */
 package org.jline.reader;
 
+/**
+ * The Expander interface provides functionality for expanding special syntax in command lines.
+ * <p>
+ * Expanders are responsible for processing and expanding various types of expressions
+ * in the input line before it is executed. This includes:
+ * <ul>
+ *   <li>History expansions (e.g., !! to repeat the last command)</li>
+ *   <li>Variable expansions (e.g., $HOME or ${HOME})</li>
+ *   <li>Other shell-like expansions</li>
+ * </ul>
+ * <p>
+ * The expander is called by the LineReader after the user has accepted a line but before
+ * it is executed or added to the history. This allows the user to see the unexpanded form
+ * while editing, but ensures that the expanded form is what gets executed and stored in history.
+ * <p>
+ * The default implementation is {@link org.jline.reader.impl.DefaultExpander}.
+ *
+ * @see org.jline.reader.impl.DefaultExpander
+ * @see LineReader#getExpander()
+ * @see LineReaderBuilder#expander(Expander)
+ */
 public interface Expander {
 
+    /**
+     * Expands history references in the input line.
+     * <p>
+     * This method processes history designators such as !!, !$, !n, etc., replacing
+     * them with the corresponding entries from the command history.
+     *
+     * @param history the command history to use for expansion
+     * @param line the input line containing history references
+     * @return the line with history references expanded
+     */
     String expandHistory(History history, String line);
 
+    /**
+     * Expands variables in the input word.
+     * <p>
+     * This method processes variable references such as $VAR or ${VAR}, replacing
+     * them with their values. The specific syntax and behavior depends on the
+     * implementation.
+     *
+     * @param word the word containing variable references
+     * @return the word with variables expanded
+     */
     String expandVar(String word);
 }

--- a/reader/src/main/java/org/jline/reader/Highlighter.java
+++ b/reader/src/main/java/org/jline/reader/Highlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -12,30 +12,69 @@ import java.util.regex.Pattern;
 
 import org.jline.utils.AttributedString;
 
+/**
+ * The Highlighter interface provides syntax highlighting functionality for the LineReader.
+ * <p>
+ * Highlighters are responsible for applying visual styling to the command line text as
+ * the user types. This can include syntax highlighting for programming languages,
+ * highlighting matching brackets, marking errors, or any other visual cues that help
+ * users understand the structure and validity of their input.
+ * <p>
+ * Implementations convert plain text into {@link AttributedString} instances that contain
+ * both the text and its visual styling information. The LineReader will then render
+ * these styled strings to the terminal with the appropriate colors and text attributes.
+ * <p>
+ * The default implementation is {@link org.jline.reader.impl.DefaultHighlighter}.
+ *
+ * @see org.jline.utils.AttributedString
+ * @see org.jline.reader.impl.DefaultHighlighter
+ * @see LineReaderBuilder#highlighter(Highlighter)
+ */
 public interface Highlighter {
 
     /**
-     * Highlight buffer
-     * @param reader LineReader
-     * @param buffer the buffer to be highlighted
-     * @return highlighted buffer
+     * Highlights the provided text buffer with appropriate styling.
+     * <p>
+     * This method is called by the LineReader to apply syntax highlighting to the
+     * current input line. It should analyze the buffer content and return an
+     * AttributedString with appropriate styling applied based on the content's
+     * syntax, structure, or other relevant characteristics.
+     *
+     * @param reader The LineReader instance requesting highlighting
+     * @param buffer The text buffer to be highlighted
+     * @return An AttributedString containing the highlighted buffer with styling applied
      */
     AttributedString highlight(LineReader reader, String buffer);
 
     /**
-     * Refresh highlight configuration
+     * Refreshes the highlighter's configuration.
+     * <p>
+     * This method is called when the highlighter should reload or refresh its
+     * configuration, such as when color schemes change or when syntax rules are updated.
+     * The default implementation does nothing.
+     *
+     * @param reader The LineReader instance associated with this highlighter
      */
     default void refresh(LineReader reader) {}
 
     /**
-     * Set error pattern to be highlighted
-     * @param errorPattern error pattern to be highlighted
+     * Sets a regular expression pattern that identifies errors to be highlighted.
+     * <p>
+     * Text matching this pattern will typically be highlighted with error styling
+     * (often red or with a distinctive background color) to indicate problematic input.
+     *
+     * @param errorPattern A regular expression pattern that matches text to be highlighted as errors
      */
     void setErrorPattern(Pattern errorPattern);
 
     /**
-     * Set error index to be highlighted
-     * @param errorIndex error index to be highlighted
+     * Sets a specific character position in the buffer to be highlighted as an error.
+     * <p>
+     * This is typically used to indicate the exact position of a syntax error or
+     * other issue in the input line. The highlighter will apply error styling at
+     * this position.
+     *
+     * @param errorIndex The character index in the buffer to be highlighted as an error
      */
     void setErrorIndex(int errorIndex);
 }

--- a/reader/src/main/java/org/jline/reader/History.java
+++ b/reader/src/main/java/org/jline/reader/History.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -15,11 +15,29 @@ import java.util.Iterator;
 import java.util.ListIterator;
 
 /**
- * Console history.
+ * Console command history management interface.
+ * <p>
+ * The History interface provides functionality for storing, retrieving, and navigating
+ * through previously entered commands. It allows users to recall and reuse commands
+ * they've typed before, which is a fundamental feature of interactive command-line
+ * interfaces.
+ * <p>
+ * History implementations typically support:
+ * <ul>
+ *   <li>Adding new entries as commands are executed</li>
+ *   <li>Navigating backward and forward through history</li>
+ *   <li>Persisting history to a file for use across sessions</li>
+ *   <li>Filtering or ignoring certain commands based on patterns</li>
+ * </ul>
+ * <p>
+ * Each history entry contains the command text along with metadata such as the
+ * timestamp when it was executed.
+ * <p>
+ * The default implementation is {@link org.jline.reader.impl.history.DefaultHistory}.
  *
- * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  * @since 2.3
+ * @see LineReader#getHistory()
+ * @see LineReaderBuilder#history(History)
  */
 public interface History extends Iterable<History.Entry> {
 
@@ -108,11 +126,32 @@ public interface History extends Iterable<History.Entry> {
     // Entries
     //
 
+    /**
+     * Represents a single history entry containing a command line and its metadata.
+     * <p>
+     * Each entry in the history has an index position, a timestamp indicating when
+     * it was added, and the actual command line text.
+     */
     interface Entry {
+        /**
+         * Returns the index of this entry in the history.
+         *
+         * @return the index position of this entry
+         */
         int index();
 
+        /**
+         * Returns the timestamp when this entry was added to the history.
+         *
+         * @return the timestamp of this entry
+         */
         Instant time();
 
+        /**
+         * Returns the command line text of this entry.
+         *
+         * @return the command line text
+         */
         String line();
     }
 

--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -417,6 +417,14 @@ public interface LineReader {
      */
     String SYSTEM_PROPERTY_PREFIX = "system-property-prefix";
 
+    /**
+     * Returns the default key maps used by the LineReader.
+     * <p>
+     * These key maps define the standard key bindings for different editing modes
+     * such as Emacs mode, Vi command mode, Vi insert mode, etc.
+     *
+     * @return a map of key map names to key maps
+     */
     Map<String, KeyMap<Binding>> defaultKeyMaps();
 
     enum Option {
@@ -690,32 +698,151 @@ public interface LineReader {
     // Chainable setters
     //
 
+    /**
+     * Sets a variable in the LineReader and returns the LineReader for method chaining.
+     * <p>
+     * Variables control various aspects of the LineReader's behavior. See the
+     * various variable constants defined in this interface for available options.
+     *
+     * @param name the variable name
+     * @param value the variable value
+     * @return this LineReader
+     */
     LineReader variable(String name, Object value);
 
+    /**
+     * Sets an option in the LineReader and returns the LineReader for method chaining.
+     * <p>
+     * Options control various aspects of the LineReader's behavior. See the
+     * {@link Option} enum for available options.
+     *
+     * @param option the option to set
+     * @param value the option value
+     * @return this LineReader
+     */
     LineReader option(Option option, boolean value);
 
+    /**
+     * Calls a widget by name.
+     * <p>
+     * Widgets are functions that perform editing operations. This method allows
+     * invoking a widget programmatically rather than through a key binding.
+     *
+     * @param name the name of the widget to call
+     */
     void callWidget(String name);
 
+    /**
+     * Returns a map of all variables set in the LineReader.
+     * <p>
+     * Variables control various aspects of the LineReader's behavior. See the
+     * various variable constants defined in this interface for available options.
+     *
+     * @return a map of variable names to their values
+     */
     Map<String, Object> getVariables();
 
+    /**
+     * Returns the value of a variable.
+     * <p>
+     * Variables control various aspects of the LineReader's behavior. See the
+     * various variable constants defined in this interface for available options.
+     *
+     * @param name the variable name
+     * @return the variable value, or null if the variable is not set
+     */
     Object getVariable(String name);
 
+    /**
+     * Sets a variable in the LineReader.
+     * <p>
+     * Variables control various aspects of the LineReader's behavior. See the
+     * various variable constants defined in this interface for available options.
+     *
+     * @param name the variable name
+     * @param value the variable value
+     */
     void setVariable(String name, Object value);
 
+    /**
+     * Checks if an option is set.
+     * <p>
+     * Options control various aspects of the LineReader's behavior. See the
+     * {@link Option} enum for available options.
+     *
+     * @param option the option to check
+     * @return true if the option is set, false otherwise
+     */
     boolean isSet(Option option);
 
+    /**
+     * Sets an option to true.
+     * <p>
+     * Options control various aspects of the LineReader's behavior. See the
+     * {@link Option} enum for available options.
+     *
+     * @param option the option to set
+     */
     void setOpt(Option option);
 
+    /**
+     * Sets an option to false.
+     * <p>
+     * Options control various aspects of the LineReader's behavior. See the
+     * {@link Option} enum for available options.
+     *
+     * @param option the option to unset
+     */
     void unsetOpt(Option option);
 
+    /**
+     * Returns the terminal associated with this LineReader.
+     * <p>
+     * The terminal is used for input/output operations and provides information
+     * about the terminal capabilities and size.
+     *
+     * @return the terminal
+     */
     Terminal getTerminal();
 
+    /**
+     * Returns a map of all widgets registered with this LineReader.
+     * <p>
+     * Widgets are functions that perform editing operations and can be bound
+     * to key sequences.
+     *
+     * @return a map of widget names to widgets
+     */
     Map<String, Widget> getWidgets();
 
+    /**
+     * Returns a map of all built-in widgets provided by the LineReader.
+     * <p>
+     * Built-in widgets implement standard editing operations like cursor movement,
+     * text deletion, history navigation, etc.
+     *
+     * @return a map of built-in widget names to widgets
+     */
     Map<String, Widget> getBuiltinWidgets();
 
+    /**
+     * Returns the current line buffer.
+     * <p>
+     * The buffer contains the text that the user is currently editing.
+     * It provides methods for manipulating the text and cursor position.
+     *
+     * @return the current line buffer
+     */
     Buffer getBuffer();
 
+    /**
+     * Returns the application name associated with this LineReader.
+     * <p>
+     * The application name is used for various purposes, such as naming
+     * history files and identifying the application in terminal titles.
+     *
+     * @return the application name
+     */
     String getAppName();
 
     /**
@@ -741,50 +868,218 @@ public interface LineReader {
      */
     MouseEvent readMouseEvent();
 
+    /**
+     * Returns the history associated with this LineReader.
+     * <p>
+     * The history stores previously entered command lines and provides
+     * methods for navigating, searching, and managing history entries.
+     *
+     * @return the command history
+     */
     History getHistory();
 
+    /**
+     * Returns the parser associated with this LineReader.
+     * <p>
+     * The parser is responsible for breaking command lines into tokens
+     * according to the syntax rules of the shell or application.
+     *
+     * @return the parser
+     */
     Parser getParser();
 
+    /**
+     * Returns the highlighter associated with this LineReader.
+     * <p>
+     * The highlighter is responsible for applying syntax highlighting
+     * to the command line as the user types.
+     *
+     * @return the highlighter
+     */
     Highlighter getHighlighter();
 
+    /**
+     * Returns the expander associated with this LineReader.
+     * <p>
+     * The expander is responsible for expanding special syntax in the command line,
+     * such as history references (e.g., !!, !$) and variables (e.g., $HOME).
+     *
+     * @return the expander
+     */
     Expander getExpander();
 
+    /**
+     * Returns all key maps registered with this LineReader.
+     * <p>
+     * Key maps define the mappings from key sequences to actions for different
+     * editing modes (e.g., Emacs mode, Vi command mode, Vi insert mode).
+     *
+     * @return a map of key map names to key maps
+     */
     Map<String, KeyMap<Binding>> getKeyMaps();
 
+    /**
+     * Returns the name of the currently active key map.
+     * <p>
+     * The active key map determines how key presses are interpreted and
+     * which actions they trigger.
+     *
+     * @return the name of the active key map
+     */
     String getKeyMap();
 
+    /**
+     * Sets the active key map by name.
+     * <p>
+     * The active key map determines how key presses are interpreted and
+     * which actions they trigger.
+     *
+     * @param name the name of the key map to activate
+     * @return true if the key map was successfully set, false if the key map does not exist
+     */
     boolean setKeyMap(String name);
 
+    /**
+     * Returns the currently active key map.
+     * <p>
+     * The active key map determines how key presses are interpreted and
+     * which actions they trigger.
+     *
+     * @return the active key map
+     */
     KeyMap<Binding> getKeys();
 
+    /**
+     * Returns the parsed representation of the current line.
+     * <p>
+     * The parsed line contains the tokenized form of the current input line,
+     * broken down according to the syntax rules of the parser.
+     *
+     * @return the parsed line, or null if the line has not been parsed yet
+     */
     ParsedLine getParsedLine();
 
+    /**
+     * Returns the current search term when in history search mode.
+     * <p>
+     * This is the string that the user is searching for in the command history.
+     *
+     * @return the current search term, or null if not in search mode
+     */
     String getSearchTerm();
 
+    /**
+     * Returns the type of the currently active region selection.
+     * <p>
+     * The region is a selected portion of text in the buffer, similar to
+     * a selection in a text editor.
+     *
+     * @return the type of the active region, or {@link RegionType#NONE} if no region is active
+     */
     RegionType getRegionActive();
 
+    /**
+     * Returns the mark position of the currently active region.
+     * <p>
+     * The mark is one endpoint of the selected region, with the cursor
+     * being the other endpoint.
+     *
+     * @return the position of the mark, or -1 if no region is active
+     */
     int getRegionMark();
 
+    /**
+     * Adds a collection of commands to the input buffer for execution.
+     * <p>
+     * These commands will be executed one by one when the user accepts the current line.
+     * This is useful for implementing features like command scripts or macros.
+     *
+     * @param commands the commands to add to the buffer
+     */
     void addCommandsInBuffer(Collection<String> commands);
 
+    /**
+     * Opens a file in an external editor and adds its contents to the input buffer.
+     * <p>
+     * This method allows the user to edit a file in their preferred text editor
+     * and then have its contents added to the input buffer for execution.
+     *
+     * @param file the file to edit, or null to create a temporary file
+     * @throws Exception if an error occurs while editing the file
+     * @see #editAndAddInBuffer(Path)
+     */
     default void editAndAddInBuffer(File file) throws Exception {
         editAndAddInBuffer(file != null ? file.toPath() : null);
     }
 
+    /**
+     * Opens a file in an external editor and adds its contents to the input buffer.
+     * <p>
+     * This method allows the user to edit a file in their preferred text editor
+     * and then have its contents added to the input buffer for execution.
+     *
+     * @param file the file to edit, or null to create a temporary file
+     * @throws Exception if an error occurs while editing the file
+     */
     void editAndAddInBuffer(Path file) throws Exception;
 
+    /**
+     * Returns the last key binding that was processed.
+     * <p>
+     * This is the string representation of the last key sequence that
+     * triggered an action.
+     *
+     * @return the last key binding, or null if no binding has been processed
+     */
     String getLastBinding();
 
+    /**
+     * Returns the current tail tip text.
+     * <p>
+     * The tail tip is a hint or suggestion displayed at the end of the current line,
+     * typically showing command syntax or parameter information.
+     *
+     * @return the current tail tip text, or null if no tail tip is set
+     */
     String getTailTip();
 
+    /**
+     * Sets the tail tip text.
+     * <p>
+     * The tail tip is a hint or suggestion displayed at the end of the current line,
+     * typically showing command syntax or parameter information.
+     *
+     * @param tailTip the tail tip text to display, or null to clear the tail tip
+     */
     void setTailTip(String tailTip);
 
+    /**
+     * Sets the type of auto-suggestion to use.
+     * <p>
+     * Auto-suggestions provide inline completion suggestions as the user types,
+     * based on history, completers, or other sources.
+     *
+     * @param type the type of auto-suggestion to use
+     */
     void setAutosuggestion(SuggestionType type);
 
+    /**
+     * Returns the current auto-suggestion type.
+     * <p>
+     * Auto-suggestions provide inline completion suggestions as the user types,
+     * based on history, completers, or other sources.
+     *
+     * @return the current auto-suggestion type
+     */
     SuggestionType getAutosuggestion();
 
     /**
-     * Clear any internal buffers.
+     * Clears any internal buffers and sensitive data.
+     * <p>
+     * This method is used to ensure that sensitive information, such as passwords
+     * or other confidential data, is removed from memory when it's no longer needed.
+     * It should be called when the LineReader is no longer in use or before reading
+     * sensitive information.
      */
     void zeroOut();
 }

--- a/reader/src/main/java/org/jline/reader/LineReaderBuilder.java
+++ b/reader/src/main/java/org/jline/reader/LineReaderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -20,8 +20,39 @@ import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.Log;
 
+/**
+ * A builder for creating and configuring {@link LineReader} instances.
+ * <p>
+ * This builder provides a fluent API for constructing LineReader objects with
+ * various configuration options. It simplifies the process of creating a properly
+ * configured LineReader by providing methods for setting all the necessary components
+ * and options.
+ * <p>
+ * Example usage:
+ * <pre>
+ * LineReader reader = LineReaderBuilder.builder()
+ *     .terminal(terminal)
+ *     .completer(completer)
+ *     .parser(parser)
+ *     .highlighter(highlighter)
+ *     .variable(LineReader.HISTORY_FILE, historyFile)
+ *     .option(LineReader.Option.AUTO_LIST, true)
+ *     .build();
+ * </pre>
+ * <p>
+ * If no terminal is provided, the builder will attempt to create a default terminal
+ * using {@link TerminalBuilder#terminal()}.
+ *
+ * @see LineReader
+ * @see Terminal
+ */
 public final class LineReaderBuilder {
 
+    /**
+     * Creates a new LineReaderBuilder instance.
+     *
+     * @return a new LineReaderBuilder
+     */
     public static LineReaderBuilder builder() {
         return new LineReaderBuilder();
     }
@@ -40,6 +71,14 @@ public final class LineReaderBuilder {
 
     private LineReaderBuilder() {}
 
+    /**
+     * Sets the terminal to be used by the LineReader.
+     * <p>
+     * If not specified, a default terminal will be created when building the LineReader.
+     *
+     * @param terminal the terminal to use
+     * @return this builder
+     */
     public LineReaderBuilder terminal(Terminal terminal) {
         this.terminal = terminal;
         return this;
@@ -72,16 +111,49 @@ public final class LineReaderBuilder {
         return this;
     }
 
+    /**
+     * Sets the completer to be used for tab completion.
+     * <p>
+     * The completer provides completion candidates when the user presses the tab key.
+     *
+     * @param completer the completer to use
+     * @return this builder
+     * @see Completer
+     */
     public LineReaderBuilder completer(Completer completer) {
         this.completer = completer;
         return this;
     }
 
+    /**
+     * Sets the highlighter to be used for syntax highlighting.
+     * <p>
+     * The highlighter applies styling to the input text as the user types.
+     *
+     * @param highlighter the highlighter to use
+     * @return this builder
+     * @see Highlighter
+     */
     public LineReaderBuilder highlighter(Highlighter highlighter) {
         this.highlighter = highlighter;
         return this;
     }
 
+    /**
+     * Sets the parser to be used for parsing command lines.
+     * <p>
+     * The parser breaks the input line into tokens according to specific syntax rules.
+     * It is used during tab completion and when accepting a line of input.
+     * <p>
+     * This method will log a warning if the provided parser does not support the
+     * {@link CompletingParsedLine} interface, as this may cause issues with completion
+     * of escaped or quoted words.
+     *
+     * @param parser the parser to use
+     * @return this builder
+     * @see Parser
+     * @see CompletingParsedLine
+     */
     public LineReaderBuilder parser(Parser parser) {
         if (parser != null) {
             try {
@@ -109,6 +181,25 @@ public final class LineReaderBuilder {
         return this;
     }
 
+    /**
+     * Builds and returns a LineReader instance with the configured options.
+     * <p>
+     * This method creates a new LineReader with all the components and options that
+     * have been set on this builder. If no terminal has been provided, a default
+     * terminal will be created.
+     * <p>
+     * The resulting LineReader will have the following components set:
+     * <ul>
+     *   <li>Terminal - either the provided terminal or a default one</li>
+     *   <li>Application name - either the provided name or the terminal name</li>
+     *   <li>History - either the provided history or a new DefaultHistory</li>
+     *   <li>Completer, Highlighter, Parser, Expander - if provided</li>
+     *   <li>Options - any options that were set using option()</li>
+     * </ul>
+     *
+     * @return a new LineReader instance
+     * @throws IOError if there is an error creating the default terminal
+     */
     public LineReader build() {
         Terminal terminal = this.terminal;
         if (terminal == null) {

--- a/reader/src/main/java/org/jline/reader/Macro.java
+++ b/reader/src/main/java/org/jline/reader/Macro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -8,6 +8,28 @@
  */
 package org.jline.reader;
 
+/**
+ * A macro that executes a sequence of keystrokes when invoked.
+ * <p>
+ * The Macro class is a type of {@link Binding} that represents a sequence of keystrokes
+ * to be executed when a key sequence bound to this macro is pressed. When triggered,
+ * the LineReader will process each keystroke in the macro's sequence as if they were
+ * typed by the user.
+ * <p>
+ * Macros are useful for automating repetitive sequences of editing operations by
+ * binding them to a single key combination. They can include any valid key sequence,
+ * including control characters and escape sequences.
+ * <p>
+ * For example, a macro might be used to:
+ * <ul>
+ *   <li>Move the cursor to the beginning of the line and insert a specific prefix</li>
+ *   <li>Delete a word and replace it with another string</li>
+ *   <li>Execute a series of editing commands in sequence</li>
+ * </ul>
+ *
+ * @see Binding
+ * @see LineReader#runMacro(String)
+ */
 public class Macro implements Binding {
 
     private final String sequence;
@@ -16,6 +38,11 @@ public class Macro implements Binding {
         this.sequence = sequence;
     }
 
+    /**
+     * Returns the keystroke sequence that this macro will execute.
+     *
+     * @return the keystroke sequence
+     */
     public String getSequence() {
         return sequence;
     }

--- a/reader/src/main/java/org/jline/reader/MaskingCallback.java
+++ b/reader/src/main/java/org/jline/reader/MaskingCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -9,26 +9,57 @@
 package org.jline.reader;
 
 /**
- * Callback used to mask parts of the line
+ * Callback used to mask parts of the line for sensitive input like passwords.
+ * <p>
+ * The MaskingCallback interface provides methods to transform the input line
+ * both for display purposes and for history storage. This allows applications
+ * to implement custom masking strategies for sensitive information, such as
+ * passwords, API keys, or other confidential data.
+ * <p>
+ * When a MaskingCallback is provided to the LineReader, it will be used to:
+ * <ul>
+ *   <li>Transform the line before displaying it to the user (e.g., replacing password characters with asterisks)</li>
+ *   <li>Transform the line before storing it in the history (e.g., removing sensitive information)</li>
+ * </ul>
+ * <p>
+ * A simple implementation is provided in {@link org.jline.reader.impl.SimpleMaskingCallback},
+ * which replaces all characters with a single mask character.
+ *
+ * @see org.jline.reader.impl.SimpleMaskingCallback
+ * @see LineReader#readLine(String, String, MaskingCallback, String)
  */
 public interface MaskingCallback {
 
     /**
-     * Transforms the line before it is displayed so that
-     * some parts can be hidden.
+     * Transforms the line before it is displayed so that sensitive parts can be hidden.
+     * <p>
+     * This method is called by the LineReader whenever the display needs to be updated.
+     * It allows the implementation to replace sensitive information with mask characters
+     * or other visual indicators while preserving the actual input for processing.
+     * <p>
+     * For example, a password masking implementation might replace each character with
+     * an asterisk (*) or hide the input entirely.
      *
-     * @param line the current line being edited
-     * @return the modified line to display
+     * @param line the current line being edited (contains the actual input)
+     * @return the modified line to display (with sensitive parts masked)
      */
     String display(String line);
 
     /**
-     * Transforms the line before storing in the history.
-     * If the return value is empty or null, it will not be saved
-     * in the history.
+     * Transforms the line before storing it in the history.
+     * <p>
+     * This method is called by the LineReader when a line is about to be added to
+     * the command history. It allows the implementation to remove or redact sensitive
+     * information before it is persisted.
+     * <p>
+     * If the return value is empty or null, the line will not be saved in the history at all,
+     * which is often appropriate for commands containing passwords or other sensitive data.
+     * <p>
+     * For example, a command like "login --password=secret" might be transformed to
+     * "login --password=****" or simply "login" before being stored in history.
      *
-     * @param line the line to be added to history
-     * @return the modified line
+     * @param line the line to be added to history (contains the actual input)
+     * @return the modified line for history storage, or null/empty to prevent history storage
      */
     String history(String line);
 }

--- a/reader/src/main/java/org/jline/reader/ParsedLine.java
+++ b/reader/src/main/java/org/jline/reader/ParsedLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -13,12 +13,23 @@ import java.util.List;
 /**
  * <code>ParsedLine</code> objects are returned by the {@link Parser}
  * during completion or when accepting the line.
- *
+ * <p>
+ * This interface represents a command line that has been tokenized into words
+ * according to the syntax rules of the parser. It provides access to the individual
+ * words, the current word being completed, cursor positions, and the original
+ * unparsed line.
+ * <p>
+ * ParsedLine objects are used extensively during tab completion to determine
+ * what the user is trying to complete and to provide the appropriate context
+ * to {@link Completer} implementations.
+ * <p>
  * The instances should implement the {@link CompletingParsedLine}
- * interface so that escape chars and quotes can be correctly handled.
+ * interface so that escape chars and quotes can be correctly handled during
+ * completion.
  *
  * @see Parser
  * @see CompletingParsedLine
+ * @see Completer
  */
 public interface ParsedLine {
 

--- a/reader/src/main/java/org/jline/reader/Parser.java
+++ b/reader/src/main/java/org/jline/reader/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,6 +11,23 @@ package org.jline.reader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * The Parser interface is responsible for parsing command lines into tokens.
+ * <p>
+ * Parsers analyze input strings and break them into words/tokens according to
+ * specific syntax rules. They handle features such as quoting, escaping special
+ * characters, and comments. The parser is used by the LineReader during tab
+ * completion and when accepting a line of input.
+ * <p>
+ * Implementations should ideally return {@link CompletingParsedLine} objects
+ * to properly support completion with escaped or quoted words.
+ * <p>
+ * The default implementation is {@link org.jline.reader.impl.DefaultParser}.
+ *
+ * @see ParsedLine
+ * @see CompletingParsedLine
+ * @see org.jline.reader.impl.DefaultParser
+ */
 public interface Parser {
     String REGEX_VARIABLE = "[a-zA-Z_]+[a-zA-Z0-9_-]*";
     String REGEX_COMMAND = "[:]?[a-zA-Z]+[a-zA-Z0-9_-]*";

--- a/reader/src/main/java/org/jline/reader/PrintAboveWriter.java
+++ b/reader/src/main/java/org/jline/reader/PrintAboveWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Reference.java
+++ b/reader/src/main/java/org/jline/reader/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -9,7 +9,24 @@
 package org.jline.reader;
 
 /**
- * A reference to a {@link Widget}.
+ * A reference to a {@link Widget} by name.
+ * <p>
+ * The Reference class is a type of {@link Binding} that refers to a widget by its name
+ * rather than directly holding the widget implementation. When a key sequence bound to
+ * a Reference is pressed, the LineReader will look up the referenced widget by name
+ * and execute it.
+ * <p>
+ * This indirection allows for more flexible key bindings, as it enables binding keys
+ * to widgets that might be defined or redefined after the key binding is established.
+ * It also allows multiple key sequences to reference the same widget without duplicating
+ * the widget implementation.
+ * <p>
+ * References are particularly useful in configuration files where widgets are referred
+ * to by name rather than by direct object references.
+ *
+ * @see Widget
+ * @see Binding
+ * @see LineReader#callWidget(String)
  */
 public class Reference implements Binding {
 
@@ -19,6 +36,11 @@ public class Reference implements Binding {
         this.name = name;
     }
 
+    /**
+     * Returns the name of the referenced widget.
+     *
+     * @return the widget name
+     */
     public String name() {
         return name;
     }

--- a/reader/src/main/java/org/jline/reader/SyntaxError.java
+++ b/reader/src/main/java/org/jline/reader/SyntaxError.java
@@ -8,6 +8,24 @@
  */
 package org.jline.reader;
 
+/**
+ * Exception thrown when a syntax error is encountered during parsing.
+ * <p>
+ * SyntaxError is thrown by the {@link Parser} when it encounters invalid syntax
+ * in the input line. It provides information about the location of the error
+ * (line and column) and a descriptive message about the nature of the error.
+ * <p>
+ * This exception is typically caught by the LineReader, which may then display
+ * an error message to the user or take other appropriate action based on the
+ * parsing context.
+ * <p>
+ * The {@link EOFError} subclass is used specifically for incomplete input errors,
+ * such as unclosed quotes or brackets, which might be completed by additional input.
+ *
+ * @see Parser
+ * @see EOFError
+ * @see Parser.ParseContext
+ */
 public class SyntaxError extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
@@ -21,10 +39,20 @@ public class SyntaxError extends RuntimeException {
         this.column = column;
     }
 
+    /**
+     * Returns the column position where the syntax error occurred.
+     *
+     * @return the column position (0-based index)
+     */
     public int column() {
         return column;
     }
 
+    /**
+     * Returns the line number where the syntax error occurred.
+     *
+     * @return the line number (0-based index)
+     */
     public int line() {
         return line;
     }

--- a/reader/src/main/java/org/jline/reader/UserInterruptException.java
+++ b/reader/src/main/java/org/jline/reader/UserInterruptException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Widget.java
+++ b/reader/src/main/java/org/jline/reader/Widget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -9,10 +9,38 @@
 package org.jline.reader;
 
 /**
+ * A Widget represents an action that can be bound to a key sequence in the LineReader.
+ * <p>
+ * Widgets are the fundamental building blocks of the line editor's functionality.
+ * Each widget implements a specific editing action or command that can be invoked
+ * by the user through key bindings. Examples include moving the cursor, deleting
+ * characters, searching history, and completing words.
+ * <p>
+ * Widgets can be bound to key sequences using the LineReader's key maps. When the
+ * user presses a key sequence that is bound to a widget, the widget's {@link #apply()}
+ * method is called to perform the associated action.
+ * <p>
+ * JLine provides a set of built-in widgets that implement common editing functions,
+ * and applications can define custom widgets to extend the editor's functionality.
+ * <p>
+ * This interface is designed as a functional interface, making it easy to implement
+ * widgets using lambda expressions.
  *
+ * @see LineReader#getWidgets()
+ * @see LineReader#getBuiltinWidgets()
+ * @see LineReader#callWidget(String)
+ * @see Binding
  */
 @FunctionalInterface
 public interface Widget extends Binding {
 
+    /**
+     * Executes the action associated with this widget.
+     * <p>
+     * This method is called when the key sequence bound to this widget is pressed.
+     * It should perform the widget's specific editing action or command.
+     *
+     * @return true if the widget was successfully applied, false otherwise
+     */
     boolean apply();
 }

--- a/reader/src/main/java/org/jline/reader/impl/BufferImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/BufferImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -14,11 +14,27 @@ import java.util.Objects;
 import org.jline.reader.Buffer;
 
 /**
- * A holder for a {@link StringBuilder} that also contains the current cursor position.
+ * Default implementation of the {@link Buffer} interface.
+ * <p>
+ * This class provides a mutable buffer for storing and manipulating the text being
+ * edited in the LineReader. It maintains the text content and the current cursor
+ * position, and provides methods for text insertion, deletion, and cursor movement.
+ * <p>
+ * Key features include:
+ * <ul>
+ *   <li>Efficient text insertion and deletion with a gap buffer implementation</li>
+ *   <li>Support for Unicode characters beyond the Basic Multilingual Plane</li>
+ *   <li>Cursor movement in both character and line coordinates</li>
+ *   <li>Copy and paste operations</li>
+ *   <li>Secure clearing of buffer contents</li>
+ * </ul>
+ * <p>
+ * The buffer uses a gap buffer data structure for efficient editing operations,
+ * which provides good performance for the typical editing patterns in a line editor.
  *
- * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  * @since 2.0
+ * @see Buffer
+ * @see LineReader#getBuffer()
  */
 public class BufferImpl implements Buffer {
     private int cursor = 0;

--- a/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -20,6 +20,30 @@ import org.jline.reader.CompletionMatcher;
 import org.jline.reader.LineReader;
 import org.jline.utils.AttributedString;
 
+/**
+ * Default implementation of the {@link CompletionMatcher} interface.
+ * <p>
+ * This matcher provides sophisticated algorithms for matching completion candidates
+ * against user input, with support for:
+ * <ul>
+ *   <li>Prefix matching - candidates that start with the input text</li>
+ *   <li>Substring matching - candidates that contain the input text</li>
+ *   <li>Camel case matching - matching based on camel case patterns</li>
+ *   <li>Fuzzy matching - candidates that approximately match with allowed typos</li>
+ * </ul>
+ * <p>
+ * The matcher uses a chain of matching strategies, trying each one in sequence until
+ * matches are found. This allows for a graceful fallback from exact matches to more
+ * approximate matches.
+ * <p>
+ * The behavior of the matcher can be controlled through LineReader options such as
+ * {@link LineReader.Option#COMPLETE_MATCHER_TYPO} and
+ * {@link LineReader.Option#COMPLETE_MATCHER_CAMELCASE}.
+ *
+ * @see CompletionMatcher
+ * @see LineReader.Option#COMPLETE_MATCHER_TYPO
+ * @see LineReader.Option#COMPLETE_MATCHER_CAMELCASE
+ */
 public class CompletionMatcherImpl implements CompletionMatcher {
     protected Predicate<String> exact;
     protected List<Function<Map<String, List<Candidate>>, Map<String, List<Candidate>>>> matchers;

--- a/reader/src/main/java/org/jline/reader/impl/DefaultExpander.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -14,6 +14,26 @@ import org.jline.reader.Expander;
 import org.jline.reader.History;
 import org.jline.reader.History.Entry;
 
+/**
+ * Default implementation of the {@link Expander} interface.
+ * <p>
+ * This expander provides functionality for expanding special syntax in command lines,
+ * including:
+ * <ul>
+ *   <li>History expansions (e.g., !!, !$, !n, etc.)</li>
+ *   <li>Variable expansions (e.g., $HOME, ${PATH})</li>
+ * </ul>
+ * <p>
+ * The history expansion syntax is similar to that used in Bash and other shells,
+ * allowing users to reference and reuse previous commands or parts of commands.
+ * <p>
+ * The expander is used by the LineReader to process the command line after the user
+ * has accepted it but before it is executed or added to the history.
+ *
+ * @see Expander
+ * @see LineReader#getExpander()
+ * @see LineReader#setExpander(Expander)
+ */
 public class DefaultExpander implements Expander {
 
     /**

--- a/reader/src/main/java/org/jline/reader/impl/DefaultHighlighter.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -18,6 +18,27 @@ import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
 import org.jline.utils.WCWidth;
 
+/**
+ * Default implementation of the {@link Highlighter} interface.
+ * <p>
+ * This highlighter provides basic syntax highlighting capabilities for the LineReader,
+ * including:
+ * <ul>
+ *   <li>Highlighting of search matches</li>
+ *   <li>Highlighting of errors based on patterns or indices</li>
+ *   <li>Highlighting of selected regions</li>
+ * </ul>
+ * <p>
+ * The highlighting is applied using {@link AttributedStyle} to change the appearance
+ * of text in the terminal, such as colors, bold, underline, etc.
+ * <p>
+ * Applications can customize the highlighting behavior by extending this class
+ * and overriding the {@link #highlight(LineReader, String)} method.
+ *
+ * @see Highlighter
+ * @see AttributedStyle
+ * @see LineReader#setHighlighter(Highlighter)
+ */
 public class DefaultHighlighter implements Highlighter {
     protected Pattern errorPattern;
     protected int errorIndex = -1;

--- a/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -18,6 +18,29 @@ import org.jline.reader.EOFError;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.Parser;
 
+/**
+ * Default implementation of the {@link Parser} interface.
+ * <p>
+ * This parser provides a flexible implementation for parsing command lines into tokens,
+ * with support for:
+ * <ul>
+ *   <li>Quoted strings with customizable quote characters</li>
+ *   <li>Escaped characters with customizable escape characters</li>
+ *   <li>Bracket matching with customizable bracket pairs</li>
+ *   <li>Line and block comments with customizable delimiters</li>
+ *   <li>Command and variable name validation with customizable regex patterns</li>
+ * </ul>
+ * <p>
+ * The parser is highly configurable through its chainable setter methods, allowing
+ * applications to customize its behavior to match their specific syntax requirements.
+ * <p>
+ * The parser also implements the {@link CompletingParsedLine} interface, which provides
+ * additional methods for handling completion with proper escaping of special characters.
+ *
+ * @see Parser
+ * @see CompletingParsedLine
+ * @see LineReader#setParser(Parser)
+ */
 public class DefaultParser implements Parser {
 
     public enum Bracket {
@@ -655,8 +678,6 @@ public class DefaultParser implements Parser {
 
     /**
      * The result of a delimited buffer.
-     *
-     * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
      */
     public class ArgumentList implements ParsedLine, CompletingParsedLine {
         private final String line;

--- a/reader/src/main/java/org/jline/reader/impl/InputRC.java
+++ b/reader/src/main/java/org/jline/reader/impl/InputRC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -24,20 +24,72 @@ import org.jline.reader.Reference;
 import org.jline.terminal.Terminal;
 import org.jline.utils.Log;
 
+/**
+ * Handles inputrc configuration files for JLine.
+ * <p>
+ * This class provides functionality for parsing and applying inputrc configuration
+ * files, which are used to customize key bindings and other behavior of the
+ * LineReader. The format is compatible with GNU Readline's inputrc files.
+ * <p>
+ * Key features include:
+ * <ul>
+ *   <li>Binding keys to functions or macros</li>
+ *   <li>Setting variables that control LineReader behavior</li>
+ *   <li>Conditional configuration based on terminal type</li>
+ * </ul>
+ * <p>
+ * The configuration is typically loaded from a file specified by the
+ * {@link org.jline.reader.LineReader#INPUT_RC_FILE_NAME} variable, but can also
+ * be loaded from any input stream.
+ *
+ * @see org.jline.reader.LineReader#INPUT_RC_FILE_NAME
+ * @see org.jline.reader.LineReader#getKeyMaps()
+ */
 public final class InputRC {
 
+    /**
+     * Configures a LineReader from an inputrc file at the specified URL.
+     * <p>
+     * This method opens the URL and passes the resulting input stream to
+     * {@link #configure(LineReader, InputStream)}.
+     *
+     * @param reader the LineReader to configure
+     * @param url the URL of the inputrc file
+     * @throws IOException if an I/O error occurs while reading the configuration
+     */
     public static void configure(LineReader reader, URL url) throws IOException {
         try (InputStream is = url.openStream()) {
             configure(reader, is);
         }
     }
 
+    /**
+     * Configures a LineReader from an inputrc file.
+     * <p>
+     * This method reads configuration commands from the provided input stream
+     * and passes them to {@link #configure(LineReader, Reader)}.
+     *
+     * @param reader the LineReader to configure
+     * @param is the input stream containing the configuration
+     * @throws IOException if an I/O error occurs while reading the configuration
+     */
     public static void configure(LineReader reader, InputStream is) throws IOException {
         try (InputStreamReader r = new InputStreamReader(is)) {
             configure(reader, r);
         }
     }
 
+    /**
+     * Configures a LineReader from an inputrc file.
+     * <p>
+     * This method reads configuration commands from the provided reader
+     * and applies them to the LineReader. The format of the input is compatible
+     * with GNU Readline's inputrc files.
+     *
+     * @param reader the LineReader to configure
+     * @param r the reader containing the configuration
+     * @throws IOException if an I/O error occurs while reading the configuration
+     */
     public static void configure(LineReader reader, Reader r) throws IOException {
         BufferedReader br;
         if (r instanceof BufferedReader) {
@@ -372,6 +424,16 @@ public final class InputRC {
         }
     }
 
+    /**
+     * Sets a variable in the LineReader.
+     * <p>
+     * This method handles special cases for certain variables, such as the keymap,
+     * and options that can be turned on or off.
+     *
+     * @param reader the LineReader to modify
+     * @param key the name of the variable to set
+     * @param val the value to set
+     */
     static void setVar(LineReader reader, String key, String val) {
         if (LineReader.KEYMAP.equalsIgnoreCase(key)) {
             reader.setKeyMap(val);

--- a/reader/src/main/java/org/jline/reader/impl/KillRing.java
+++ b/reader/src/main/java/org/jline/reader/impl/KillRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -61,12 +61,32 @@ import static org.jline.keymap.KeyMap.translate;
 import static org.jline.terminal.TerminalBuilder.PROP_DISABLE_ALTERNATE_CHARSET;
 
 /**
- * A reader for terminal applications. It supports custom tab-completion,
- * saveable command history, and command line editing.
+ * The default implementation of the {@link LineReader} interface.
+ * <p>
+ * This class provides a comprehensive implementation of line editing capabilities
+ * for interactive terminal applications, including:
+ * <ul>
+ *   <li>Command history navigation and management</li>
+ *   <li>Tab completion with customizable completion strategies</li>
+ *   <li>Syntax highlighting</li>
+ *   <li>Emacs and Vi editing modes</li>
+ *   <li>Key binding customization</li>
+ *   <li>Cut and paste with kill ring</li>
+ *   <li>Undo/redo functionality</li>
+ *   <li>Search through history</li>
+ *   <li>Multi-line editing</li>
+ *   <li>Character masking for password input</li>
+ * </ul>
+ * <p>
+ * This implementation is highly configurable through options and variables that
+ * control various aspects of its behavior. It also provides a rich set of widgets
+ * (editing functions) that can be bound to key sequences.
+ * <p>
+ * Most applications should not create instances of this class directly, but instead
+ * use the {@link LineReaderBuilder} to create properly configured instances.
  *
- * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * @see LineReader
+ * @see LineReaderBuilder
  */
 @SuppressWarnings("StatementWithEmptyBody")
 public class LineReaderImpl implements LineReader, Flushable {

--- a/reader/src/main/java/org/jline/reader/impl/ReaderUtils.java
+++ b/reader/src/main/java/org/jline/reader/impl/ReaderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,19 +11,67 @@ package org.jline.reader.impl;
 import org.jline.reader.LineReader;
 import org.jline.utils.Levenshtein;
 
+/**
+ * Utility methods for LineReader implementations.
+ * <p>
+ * This class provides helper methods for working with LineReader variables and options.
+ * It includes methods for retrieving variables of different types (string, boolean, integer,
+ * long) with default values, checking if options are set, and calculating string distances
+ * for completion matching.
+ * <p>
+ * These utilities are primarily used by the LineReader implementation classes to access
+ * configuration values in a consistent way, with proper type conversion and default handling.
+ *
+ * @see LineReader#getVariable(String)
+ * @see LineReader#isSet(LineReader.Option)
+ */
 public class ReaderUtils {
 
     private ReaderUtils() {}
 
+    /**
+     * Checks if a LineReader option is set.
+     * <p>
+     * This method safely handles null readers by returning false.
+     *
+     * @param reader the LineReader to check, may be null
+     * @param option the option to check
+     * @return true if the reader is not null and the option is set, false otherwise
+     */
     public static boolean isSet(LineReader reader, LineReader.Option option) {
         return reader != null && reader.isSet(option);
     }
 
+    /**
+     * Gets a string variable from a LineReader with a default value.
+     * <p>
+     * This method safely handles null readers by returning the default value.
+     *
+     * @param reader the LineReader to get the variable from, may be null
+     * @param name the name of the variable to get
+     * @param def the default value to return if the variable is not set or the reader is null
+     * @return the variable value as a string, or the default value
+     */
     public static String getString(LineReader reader, String name, String def) {
         Object v = reader != null ? reader.getVariable(name) : null;
         return v != null ? v.toString() : def;
     }
 
+    /**
+     * Gets a boolean variable from a LineReader with a default value.
+     * <p>
+     * This method safely handles null readers by returning the default value.
+     * String values are converted to boolean according to these rules:
+     * <ul>
+     *   <li>Empty string, "on", "1", and "true" (case-insensitive) are considered true</li>
+     *   <li>All other strings are considered false</li>
+     * </ul>
+     *
+     * @param reader the LineReader to get the variable from, may be null
+     * @param name the name of the variable to get
+     * @param def the default value to return if the variable is not set or the reader is null
+     * @return the variable value as a boolean, or the default value
+     */
     public static boolean getBoolean(LineReader reader, String name, boolean def) {
         Object v = reader != null ? reader.getVariable(name) : null;
         if (v instanceof Boolean) {
@@ -35,6 +83,17 @@ public class ReaderUtils {
         return def;
     }
 
+    /**
+     * Gets an integer variable from a LineReader with a default value.
+     * <p>
+     * This method safely handles null readers by returning the default value.
+     * String values are parsed as integers, with a fallback to 0 if parsing fails.
+     *
+     * @param reader the LineReader to get the variable from, may be null
+     * @param name the name of the variable to get
+     * @param def the default value to return if the variable is not set or the reader is null
+     * @return the variable value as an integer, or the default value
+     */
     public static int getInt(LineReader reader, String name, int def) {
         int nb = def;
         Object v = reader != null ? reader.getVariable(name) : null;
@@ -51,6 +110,17 @@ public class ReaderUtils {
         return nb;
     }
 
+    /**
+     * Gets a long variable from a LineReader with a default value.
+     * <p>
+     * This method safely handles null readers by returning the default value.
+     * String values are parsed as longs, with a fallback to 0 if parsing fails.
+     *
+     * @param reader the LineReader to get the variable from, may be null
+     * @param name the name of the variable to get
+     * @param def the default value to return if the variable is not set or the reader is null
+     * @return the variable value as a long, or the default value
+     */
     public static long getLong(LineReader reader, String name, long def) {
         long nb = def;
         Object v = reader != null ? reader.getVariable(name) : null;
@@ -67,6 +137,17 @@ public class ReaderUtils {
         return nb;
     }
 
+    /**
+     * Calculates the edit distance between a word and a candidate string.
+     * <p>
+     * This method is used for fuzzy matching in completion. It uses the Levenshtein
+     * distance algorithm to determine how similar two strings are, with special handling
+     * for candidates that are longer than the word being matched.
+     *
+     * @param word the word to match against
+     * @param cand the candidate string to check
+     * @return the edit distance between the strings (lower values indicate closer matches)
+     */
     public static int distance(String word, String cand) {
         if (word.length() < cand.length()) {
             int d1 = Levenshtein.distance(word, cand.substring(0, Math.min(cand.length(), word.length())));

--- a/reader/src/main/java/org/jline/reader/impl/SimpleMaskingCallback.java
+++ b/reader/src/main/java/org/jline/reader/impl/SimpleMaskingCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/UndoTree.java
+++ b/reader/src/main/java/org/jline/reader/impl/UndoTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,8 +11,22 @@ package org.jline.reader.impl;
 import java.util.function.Consumer;
 
 /**
- * Simple undo tree.
- * Note that the first added state can't be undone
+ * Provides undo/redo functionality for the LineReader.
+ * <p>
+ * This class implements a simple undo tree that allows tracking and restoring
+ * previous states of an object (typically the line buffer). It maintains a linear
+ * history of states that can be navigated with undo and redo operations.
+ * <p>
+ * Key features:
+ * <ul>
+ *   <li>Tracks a sequence of states that can be undone and redone</li>
+ *   <li>Uses a consumer to apply state changes when undoing or redoing</li>
+ *   <li>Maintains the current position in the undo history</li>
+ * </ul>
+ * <p>
+ * Note that the first added state (the initial state) cannot be undone.
+ *
+ * @param <T> the type of state object being tracked
  */
 public class UndoTree<T> {
 

--- a/reader/src/main/java/org/jline/reader/impl/completer/AggregateCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/AggregateCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -21,7 +21,6 @@ import org.jline.reader.ParsedLine;
 /**
  * Completer which contains multiple completers and aggregates them together.
  *
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  * @since 2.3
  */
 public class AggregateCompleter implements Completer {

--- a/reader/src/main/java/org/jline/reader/impl/completer/ArgumentCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/ArgumentCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2019, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -25,8 +25,6 @@ import org.jline.reader.ParsedLine;
  * A {@link Completer} implementation that invokes a child completer using the appropriate <i>separator</i> argument.
  * This can be used instead of the individual completers having to know about argument parsing semantics.
  *
- * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  * @since 2.3
  */
 public class ArgumentCompleter implements Completer {

--- a/reader/src/main/java/org/jline/reader/impl/completer/EnumCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/EnumCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -16,7 +16,6 @@ import org.jline.reader.Completer;
 /**
  * {@link Completer} for {@link Enum} names.
  *
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  * @since 2.3
  */
 public class EnumCompleter extends StringsCompleter {

--- a/reader/src/main/java/org/jline/reader/impl/completer/FileNameCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/FileNameCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -39,8 +39,6 @@ import org.jline.utils.AttributedStyle;
  * not provide any way of determining that easily</li>
  * </ul>
  *
- * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  * @since 2.3
  * @deprecated use <code>org.jline.builtins.Completers$FileNameCompleter</code> instead
  */

--- a/reader/src/main/java/org/jline/reader/impl/completer/NullCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/NullCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -18,8 +18,6 @@ import org.jline.reader.ParsedLine;
 /**
  * Null completer.
  *
- * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  * @since 2.3
  */
 public final class NullCompleter implements Completer {

--- a/reader/src/main/java/org/jline/reader/impl/completer/StringsCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/StringsCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2019, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -24,7 +24,6 @@ import org.jline.utils.AttributedString;
 /**
  * Completer for a set of strings.
  *
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
  * @since 2.3
  */
 public class StringsCompleter implements Completer {

--- a/reader/src/main/java/org/jline/reader/impl/completer/SystemCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/SystemCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -20,8 +20,6 @@ import org.jline.utils.AttributedString;
 
 /**
  * Completer which contains multiple completers and aggregates them together.
- *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public class SystemCompleter implements Completer {
     private Map<String, List<Completer>> completers = new HashMap<>();

--- a/reader/src/main/java/org/jline/reader/impl/completer/package-info.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author or authors.
+ * Copyright (c) 2002-2025, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -7,8 +7,28 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 /**
- * JLine 3.
+ * JLine 3 Completer Implementations.
+ * <p>
+ * This package provides various implementations of the {@link org.jline.reader.Completer}
+ * interface for different completion scenarios. These completers can be used individually
+ * or combined to create sophisticated tab completion behavior.
+ * <p>
+ * Key completer implementations include:
+ * <ul>
+ *   <li>{@link org.jline.reader.impl.completer.ArgumentCompleter} - Completes commands based on argument position</li>
+ *   <li>{@link org.jline.reader.impl.completer.FileNameCompleter} - Completes file and directory names</li>
+ *   <li>{@link org.jline.reader.impl.completer.StringsCompleter} - Completes from a predefined set of strings</li>
+ *   <li>{@link org.jline.reader.impl.completer.SystemCompleter} - Aggregates multiple completers for different commands</li>
+ *   <li>{@link org.jline.reader.impl.completer.AggregateCompleter} - Combines multiple completers</li>
+ *   <li>{@link org.jline.reader.impl.completer.NullCompleter} - A no-op completer that provides no completions</li>
+ * </ul>
+ * <p>
+ * These completers can be registered with a {@link org.jline.reader.LineReader} using
+ * the {@link org.jline.reader.LineReaderBuilder#completer(org.jline.reader.Completer)}
+ * method.
  *
  * @since 3.0
+ * @see org.jline.reader.Completer
+ * @see org.jline.reader.LineReaderBuilder#completer(org.jline.reader.Completer)
  */
 package org.jline.reader.impl.completer;

--- a/reader/src/main/java/org/jline/reader/impl/history/package-info.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author or authors.
+ * Copyright (c) 2002-2025, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -7,8 +7,27 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 /**
- * JLine 3.
+ * JLine 3 History Implementation Package.
+ * <p>
+ * This package provides implementations of the {@link org.jline.reader.History} interface
+ * for managing command history in interactive applications. Command history allows users
+ * to recall, edit, and reuse previously entered commands.
+ * <p>
+ * Key features of the history implementation include:
+ * <ul>
+ *   <li>Persistent storage of command history in files</li>
+ *   <li>Configurable history size limits for memory and file storage</li>
+ *   <li>Support for timestamped history entries</li>
+ *   <li>Filtering of history entries based on patterns</li>
+ *   <li>Duplicate entry handling (ignore, reduce blanks, etc.)</li>
+ *   <li>Navigation through history (previous/next, first/last, etc.)</li>
+ * </ul>
+ * <p>
+ * The main implementation class is {@link org.jline.reader.impl.history.DefaultHistory},
+ * which provides a file-backed history implementation with various configuration options.
  *
  * @since 3.0
+ * @see org.jline.reader.History
+ * @see org.jline.reader.impl.history.DefaultHistory
  */
 package org.jline.reader.impl.history;

--- a/reader/src/main/java/org/jline/reader/impl/package-info.java
+++ b/reader/src/main/java/org/jline/reader/impl/package-info.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2025, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+/**
+ * JLine 3 Reader Implementation Package.
+ * <p>
+ * This package provides the core implementations of the interfaces defined in the
+ * {@link org.jline.reader} package. These implementations form the foundation of
+ * JLine's line editing and command processing capabilities.
+ * <p>
+ * Key implementation classes include:
+ * <ul>
+ *   <li>{@link org.jline.reader.impl.LineReaderImpl} - The main implementation of the
+ *       {@link org.jline.reader.LineReader} interface, providing line editing, history
+ *       navigation, completion, and other interactive features</li>
+ *   <li>{@link org.jline.reader.impl.DefaultParser} - Implementation of the
+ *       {@link org.jline.reader.Parser} interface for tokenizing command lines</li>
+ *   <li>{@link org.jline.reader.impl.DefaultHighlighter} - Implementation of the
+ *       {@link org.jline.reader.Highlighter} interface for syntax highlighting</li>
+ *   <li>{@link org.jline.reader.impl.DefaultExpander} - Implementation of the
+ *       {@link org.jline.reader.Expander} interface for expanding history references and variables</li>
+ *   <li>{@link org.jline.reader.impl.CompletionMatcherImpl} - Implementation of the
+ *       {@link org.jline.reader.CompletionMatcher} interface for matching completion candidates</li>
+ *   <li>{@link org.jline.reader.impl.BufferImpl} - Implementation of the
+ *       {@link org.jline.reader.Buffer} interface for managing the line buffer</li>
+ * </ul>
+ * <p>
+ * This package also contains utility classes that support the main implementations:
+ * <ul>
+ *   <li>{@link org.jline.reader.impl.ReaderUtils} - Utility methods for LineReader implementations</li>
+ *   <li>{@link org.jline.reader.impl.UndoTree} - Provides undo/redo functionality</li>
+ *   <li>{@link org.jline.reader.impl.KillRing} - Implements a kill ring for cut/paste operations</li>
+ *   <li>{@link org.jline.reader.impl.InputRC} - Handles inputrc configuration files</li>
+ * </ul>
+ * <p>
+ * Most users will not need to interact directly with these implementation classes,
+ * but instead should use the {@link org.jline.reader.LineReaderBuilder} to create
+ * properly configured instances.
+ *
+ * @since 3.0
+ * @see org.jline.reader
+ * @see org.jline.reader.LineReaderBuilder
+ */
+package org.jline.reader.impl;

--- a/reader/src/main/java/org/jline/reader/package-info.java
+++ b/reader/src/main/java/org/jline/reader/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author or authors.
+ * Copyright (c) 2002-2025, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -7,7 +7,33 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 /**
- * JLine 3.
+ * JLine 3 Reader Package - Core components for building interactive command-line interfaces.
+ * <p>
+ * This package provides the fundamental interfaces and classes for creating interactive
+ * command-line applications with features such as:
+ * <ul>
+ *   <li>Line editing with customizable key bindings</li>
+ *   <li>Command history navigation</li>
+ *   <li>Tab completion with pluggable completion strategies</li>
+ *   <li>Customizable syntax highlighting</li>
+ *   <li>Password masking</li>
+ *   <li>Custom prompt rendering</li>
+ *   <li>Command parsing and tokenization</li>
+ * </ul>
+ * <p>
+ * The main entry point is the {@link org.jline.reader.LineReader} interface, which can be
+ * instantiated using the {@link org.jline.reader.LineReaderBuilder}. The LineReader provides
+ * methods to read input from the user with various customization options.
+ * <p>
+ * Key components in this package include:
+ * <ul>
+ *   <li>{@link org.jline.reader.LineReader} - The main interface for reading lines from the console</li>
+ *   <li>{@link org.jline.reader.LineReaderBuilder} - Builder for creating LineReader instances</li>
+ *   <li>{@link org.jline.reader.Parser} - Interface for parsing command lines into tokens</li>
+ *   <li>{@link org.jline.reader.Completer} - Interface for providing tab-completion candidates</li>
+ *   <li>{@link org.jline.reader.Highlighter} - Interface for syntax highlighting</li>
+ *   <li>{@link org.jline.reader.History} - Interface for command history management</li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/reader/src/test/java/org/jline/keymap/BindingReaderTest.java
+++ b/reader/src/test/java/org/jline/keymap/BindingReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/keymap/KeyMapTest.java
+++ b/reader/src/test/java/org/jline/keymap/KeyMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/completer/ArgumentCompleterTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/ArgumentCompleterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/completer/NullCompleterTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/NullCompleterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/completer/StringsCompleterTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/StringsCompleterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/BufferTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/BufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/ColonCommandCompletionTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/ColonCommandCompletionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/CompletionMatcherTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/CompletionWithCustomMatcherTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionWithCustomMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/CompletionWithParserTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionWithParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/DefaultParserTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/DefaultParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/DigitArgumentTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/DigitArgumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/EditLineTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/EditLineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/KillRingTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/KillRingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/MultiByteCharTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/MultiByteCharTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/ReaderTestSupport.java
+++ b/reader/src/test/java/org/jline/reader/impl/ReaderTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/ViMoveModeTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/ViMoveModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/WidgetTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/WidgetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/history/HistoryReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/HistoryReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/history/HistoryTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/HistoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
+++ b/reader/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/terminal/impl/ExternalTerminalTest.java
+++ b/reader/src/test/java/org/jline/terminal/impl/ExternalTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/Attributes.java
+++ b/terminal/src/main/java/org/jline/terminal/Attributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -13,34 +13,152 @@ import java.util.EnumSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * Encapsulates terminal attributes and settings that control terminal behavior.
+ *
+ * <p>
+ * The Attributes class represents the terminal settings similar to the POSIX termios structure,
+ * providing control over terminal input/output behavior, control characters, and various flags.
+ * These attributes determine how the terminal processes input and output, handles special characters,
+ * and behaves in response to various conditions.
+ * </p>
+ *
+ * <p>
+ * Terminal attributes are organized into several categories:
+ * </p>
+ * <ul>
+ *   <li><b>Input Flags</b> - Control input processing (e.g., character mapping, parity checking)</li>
+ *   <li><b>Output Flags</b> - Control output processing (e.g., newline translation)</li>
+ *   <li><b>Control Flags</b> - Control hardware settings (e.g., baud rate, character size)</li>
+ *   <li><b>Local Flags</b> - Control various terminal behaviors (e.g., echo, canonical mode)</li>
+ *   <li><b>Control Characters</b> - Define special characters (e.g., EOF, interrupt, erase)</li>
+ * </ul>
+ *
+ * <p>
+ * Attributes objects are typically obtained from a {@link Terminal} using {@link Terminal#getAttributes()},
+ * modified as needed, and then applied back to the terminal using {@link Terminal#setAttributes(Attributes)}.
+ * </p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * Terminal terminal = TerminalBuilder.terminal();
+ *
+ * // Get current attributes
+ * Attributes attrs = terminal.getAttributes();
+ *
+ * // Modify attributes
+ * attrs.setLocalFlag(LocalFlag.ECHO, false);  // Disable echo
+ * attrs.setInputFlag(InputFlag.ICRNL, false); // Disable CR to NL mapping
+ * attrs.setControlChar(ControlChar.VMIN, 1);   // Set minimum input to 1 character
+ *
+ * // Apply modified attributes
+ * terminal.setAttributes(attrs);
+ * </pre>
+ *
+ * @see Terminal#getAttributes()
+ * @see Terminal#setAttributes(Attributes)
+ */
 public class Attributes {
 
     /**
-     * Control characters
+     * Control characters used for special terminal functions.
+     *
+     * <p>
+     * Control characters are special characters that trigger specific terminal behaviors
+     * when encountered in the input stream. These characters control various aspects of
+     * terminal operation, such as signaling end-of-file, interrupting processes, or
+     * erasing characters.
+     * </p>
+     *
+     * <p>
+     * The most commonly used control characters include:
+     * </p>
+     * <ul>
+     *   <li>{@link #VEOF} - End-of-file character (typically Ctrl+D)</li>
+     *   <li>{@link #VINTR} - Interrupt character (typically Ctrl+C)</li>
+     *   <li>{@link #VQUIT} - Quit character (typically Ctrl+\)</li>
+     *   <li>{@link #VERASE} - Erase character (typically Backspace)</li>
+     *   <li>{@link #VKILL} - Kill line character (typically Ctrl+U)</li>
+     *   <li>{@link #VMIN} - Minimum number of characters for non-canonical read</li>
+     *   <li>{@link #VTIME} - Timeout in deciseconds for non-canonical read</li>
+     * </ul>
+     *
+     * <p>
+     * Control characters can be accessed and modified using {@link #getControlChar(ControlChar)}
+     * and {@link #setControlChar(ControlChar, int)}.
+     * </p>
+     *
+     * @see #getControlChar(ControlChar)
+     * @see #setControlChar(ControlChar, int)
      */
     public enum ControlChar {
+        /** End-of-file character (typically Ctrl+D) */
         VEOF,
+        /** End-of-line character */
         VEOL,
+        /** Secondary end-of-line character */
         VEOL2,
+        /** Erase character (typically Backspace) */
         VERASE,
+        /** Word erase character (typically Ctrl+W) */
         VWERASE,
+        /** Kill line character (typically Ctrl+U) */
         VKILL,
+        /** Reprint line character (typically Ctrl+R) */
         VREPRINT,
+        /** Interrupt character (typically Ctrl+C) */
         VINTR,
+        /** Quit character (typically Ctrl+\) */
         VQUIT,
+        /** Suspend character (typically Ctrl+Z) */
         VSUSP,
+        /** Delayed suspend character */
         VDSUSP,
+        /** Start output character (typically Ctrl+Q) */
         VSTART,
+        /** Stop output character (typically Ctrl+S) */
         VSTOP,
+        /** Literal next character (typically Ctrl+V) */
         VLNEXT,
+        /** Discard output character (typically Ctrl+O) */
         VDISCARD,
+        /** Minimum number of characters for non-canonical read */
         VMIN,
+        /** Timeout in deciseconds for non-canonical read */
         VTIME,
+        /** Status request character (typically Ctrl+T) */
         VSTATUS
     }
 
     /**
-     * Input flags - software input processing
+     * Input flags that control how terminal input is processed.
+     *
+     * <p>
+     * Input flags determine how the terminal processes input characters before they are
+     * made available to the application. These flags control aspects such as character
+     * mapping, parity checking, and flow control for input.
+     * </p>
+     *
+     * <p>
+     * Common input flags include:
+     * </p>
+     * <ul>
+     *   <li>{@link #ICRNL} - Map CR to NL on input (convert carriage returns to newlines)</li>
+     *   <li>{@link #INLCR} - Map NL to CR on input (convert newlines to carriage returns)</li>
+     *   <li>{@link #IGNCR} - Ignore carriage returns on input</li>
+     *   <li>{@link #IXON} - Enable XON/XOFF flow control on output</li>
+     *   <li>{@link #IXOFF} - Enable XON/XOFF flow control on input</li>
+     * </ul>
+     *
+     * <p>
+     * Input flags can be accessed and modified using methods like {@link #getInputFlag(InputFlag)},
+     * {@link #setInputFlag(InputFlag, boolean)}, and {@link #setInputFlags(EnumSet)}.
+     * </p>
+     *
+     * @see #getInputFlag(InputFlag)
+     * @see #setInputFlag(InputFlag, boolean)
+     * @see #getInputFlags()
+     * @see #setInputFlags(EnumSet)
      */
     public enum InputFlag {
         IGNBRK, /* ignore BREAK condition */
@@ -61,8 +179,34 @@ public class Attributes {
         INORMEOL /* normalize end-of-line */
     }
 
-    /*
-     * Output flags - software output processing
+    /**
+     * Output flags that control how terminal output is processed.
+     *
+     * <p>
+     * Output flags determine how the terminal processes output characters before they are
+     * sent to the terminal device. These flags control aspects such as newline translation,
+     * tab expansion, and other output processing features.
+     * </p>
+     *
+     * <p>
+     * Common output flags include:
+     * </p>
+     * <ul>
+     *   <li>{@link #OPOST} - Enable output processing (required for other output flags to take effect)</li>
+     *   <li>{@link #ONLCR} - Map NL to CR-NL on output (convert newlines to carriage return + newline)</li>
+     *   <li>{@link #OCRNL} - Map CR to NL on output (convert carriage returns to newlines)</li>
+     *   <li>{@link #OXTABS} - Expand tabs to spaces on output</li>
+     * </ul>
+     *
+     * <p>
+     * Output flags can be accessed and modified using methods like {@link #getOutputFlag(OutputFlag)},
+     * {@link #setOutputFlag(OutputFlag, boolean)}, and {@link #setOutputFlags(EnumSet)}.
+     * </p>
+     *
+     * @see #getOutputFlag(OutputFlag)
+     * @see #setOutputFlag(OutputFlag, boolean)
+     * @see #getOutputFlags()
+     * @see #setOutputFlags(EnumSet)
      */
     public enum OutputFlag {
         OPOST, /* enable following output processing */
@@ -82,8 +226,34 @@ public class Attributes {
         OFDEL /* fill is DEL, else NUL */
     }
 
-    /*
-     * Control flags - hardware control of terminal
+    /**
+     * Control flags that manage hardware aspects of the terminal.
+     *
+     * <p>
+     * Control flags determine how the terminal hardware operates. These flags control
+     * aspects such as baud rate, character size, parity, and hardware flow control.
+     * </p>
+     *
+     * <p>
+     * Common control flags include:
+     * </p>
+     * <ul>
+     *   <li>{@link #CS5}, {@link #CS6}, {@link #CS7}, {@link #CS8} - Character size (5-8 bits)</li>
+     *   <li>{@link #CSTOPB} - Use two stop bits instead of one</li>
+     *   <li>{@link #PARENB} - Enable parity generation and detection</li>
+     *   <li>{@link #PARODD} - Use odd parity instead of even</li>
+     *   <li>{@link #CLOCAL} - Ignore modem control lines</li>
+     * </ul>
+     *
+     * <p>
+     * Control flags can be accessed and modified using methods like {@link #getControlFlag(ControlFlag)},
+     * {@link #setControlFlag(ControlFlag, boolean)}, and {@link #setControlFlags(EnumSet)}.
+     * </p>
+     *
+     * @see #getControlFlag(ControlFlag)
+     * @see #setControlFlag(ControlFlag, boolean)
+     * @see #getControlFlags()
+     * @see #setControlFlags(EnumSet)
      */
     public enum ControlFlag {
         CIGNORE, /* ignore control flags */
@@ -104,12 +274,40 @@ public class Attributes {
         CCAR_OFLOW /* DCD flow control of output */
     }
 
-    /*
-     * "Local" flags - dumping ground for other state
+    /**
+     * Local flags that control various terminal behaviors.
      *
-     * Warning: some flags in this structure begin with
-     * the letter "I" and look like they belong in the
-     * input flag.
+     * <p>
+     * Local flags control a variety of terminal behaviors that don't fit into the other
+     * flag categories. These include echo control, canonical mode, signal generation,
+     * and special character processing.
+     * </p>
+     *
+     * <p>
+     * Common local flags include:
+     * </p>
+     * <ul>
+     *   <li>{@link #ECHO} - Echo input characters</li>
+     *   <li>{@link #ICANON} - Enable canonical mode (line-by-line input)</li>
+     *   <li>{@link #ISIG} - Enable signal generation (INTR, QUIT, SUSP)</li>
+     *   <li>{@link #IEXTEN} - Enable extended input processing</li>
+     *   <li>{@link #ECHOCTL} - Echo control characters as ^X</li>
+     * </ul>
+     *
+     * <p>
+     * Note: Some flags in this category begin with the letter "I" and might appear to
+     * belong in the input flags category, but they are historically part of the local flags.
+     * </p>
+     *
+     * <p>
+     * Local flags can be accessed and modified using methods like {@link #getLocalFlag(LocalFlag)},
+     * {@link #setLocalFlag(LocalFlag, boolean)}, and {@link #setLocalFlags(EnumSet)}.
+     * </p>
+     *
+     * @see #getLocalFlag(LocalFlag)
+     * @see #setLocalFlag(LocalFlag, boolean)
+     * @see #getLocalFlags()
+     * @see #setLocalFlags(EnumSet)
      */
     public enum LocalFlag {
         ECHOKE, /* visual erase for line kill */
@@ -137,8 +335,29 @@ public class Attributes {
     final EnumSet<LocalFlag> lflag = EnumSet.noneOf(LocalFlag.class);
     final EnumMap<ControlChar, Integer> cchars = new EnumMap<>(ControlChar.class);
 
+    /**
+     * Creates a new Attributes instance with default settings.
+     *
+     * <p>
+     * This constructor creates an Attributes object with all flags unset and
+     * all control characters undefined. The attributes can be modified using
+     * the various setter methods.
+     * </p>
+     */
     public Attributes() {}
 
+    /**
+     * Creates a new Attributes instance by copying another Attributes object.
+     *
+     * <p>
+     * This constructor creates a new Attributes object with the same settings
+     * as the specified Attributes object. All flags and control characters are
+     * copied from the source object.
+     * </p>
+     *
+     * @param attr the Attributes object to copy
+     * @see #copy(Attributes)
+     */
     @SuppressWarnings("this-escape")
     public Attributes(Attributes attr) {
         copy(attr);
@@ -148,19 +367,70 @@ public class Attributes {
     // Input flags
     //
 
+    /**
+     * Returns the set of input flags currently enabled.
+     *
+     * <p>
+     * This method returns a reference to the internal set of input flags.
+     * Changes to the returned set will directly affect this Attributes object.
+     * </p>
+     *
+     * @return the set of enabled input flags
+     * @see InputFlag
+     * @see #setInputFlags(EnumSet)
+     */
     public EnumSet<InputFlag> getInputFlags() {
         return iflag;
     }
 
+    /**
+     * Sets the input flags to the specified set of flags.
+     *
+     * <p>
+     * This method replaces all current input flags with the specified set.
+     * Any previously enabled flags not in the new set will be disabled.
+     * </p>
+     *
+     * @param flags the set of input flags to enable
+     * @see InputFlag
+     * @see #getInputFlags()
+     */
     public void setInputFlags(EnumSet<InputFlag> flags) {
         iflag.clear();
         iflag.addAll(flags);
     }
 
+    /**
+     * Checks if a specific input flag is enabled.
+     *
+     * <p>
+     * This method returns whether the specified input flag is currently enabled
+     * in this Attributes object.
+     * </p>
+     *
+     * @param flag the input flag to check
+     * @return {@code true} if the flag is enabled, {@code false} otherwise
+     * @see InputFlag
+     * @see #setInputFlag(InputFlag, boolean)
+     */
     public boolean getInputFlag(InputFlag flag) {
         return iflag.contains(flag);
     }
 
+    /**
+     * Sets multiple input flags to the same value.
+     *
+     * <p>
+     * This method enables or disables all the specified input flags based on the
+     * value parameter. If value is true, all flags in the set will be enabled.
+     * If value is false, all flags in the set will be disabled.
+     * </p>
+     *
+     * @param flags the set of input flags to modify
+     * @param value {@code true} to enable the flags, {@code false} to disable them
+     * @see InputFlag
+     * @see #setInputFlag(InputFlag, boolean)
+     */
     public void setInputFlags(EnumSet<InputFlag> flags, boolean value) {
         if (value) {
             iflag.addAll(flags);
@@ -169,6 +439,19 @@ public class Attributes {
         }
     }
 
+    /**
+     * Sets a specific input flag to the specified value.
+     *
+     * <p>
+     * This method enables or disables a single input flag based on the value parameter.
+     * If value is true, the flag will be enabled. If value is false, the flag will be disabled.
+     * </p>
+     *
+     * @param flag the input flag to modify
+     * @param value {@code true} to enable the flag, {@code false} to disable it
+     * @see InputFlag
+     * @see #getInputFlag(InputFlag)
+     */
     public void setInputFlag(InputFlag flag, boolean value) {
         if (value) {
             iflag.add(flag);
@@ -280,20 +563,86 @@ public class Attributes {
     // Control chars
     //
 
+    /**
+     * Returns the map of control characters and their values.
+     *
+     * <p>
+     * This method returns a reference to the internal map of control characters.
+     * Changes to the returned map will directly affect this Attributes object.
+     * </p>
+     *
+     * @return the map of control characters to their values
+     * @see ControlChar
+     * @see #setControlChars(EnumMap)
+     */
     public EnumMap<ControlChar, Integer> getControlChars() {
         return cchars;
     }
 
+    /**
+     * Sets the control characters to the specified map of values.
+     *
+     * <p>
+     * This method replaces all current control character settings with the
+     * specified map. Any previously set control characters not in the new map
+     * will be unset.
+     * </p>
+     *
+     * @param chars the map of control characters to their values
+     * @see ControlChar
+     * @see #getControlChars()
+     */
     public void setControlChars(EnumMap<ControlChar, Integer> chars) {
         cchars.clear();
         cchars.putAll(chars);
     }
 
+    /**
+     * Returns the value of a specific control character.
+     *
+     * <p>
+     * This method returns the current value of the specified control character,
+     * or -1 if the control character is not defined.
+     * </p>
+     *
+     * <p>
+     * For most control characters, the value represents the ASCII code of the
+     * character. For {@link ControlChar#VMIN} and {@link ControlChar#VTIME},
+     * the values have special meanings related to non-canonical input mode.
+     * </p>
+     *
+     * @param c the control character to retrieve
+     * @return the value of the control character, or -1 if not defined
+     * @see ControlChar
+     * @see #setControlChar(ControlChar, int)
+     */
     public int getControlChar(ControlChar c) {
         Integer v = cchars.get(c);
         return v != null ? v : -1;
     }
 
+    /**
+     * Sets a specific control character to the specified value.
+     *
+     * <p>
+     * This method sets the value of the specified control character.
+     * </p>
+     *
+     * <p>
+     * For most control characters, the value should be the ASCII code of the
+     * character. For {@link ControlChar#VMIN} and {@link ControlChar#VTIME},
+     * the values have special meanings:
+     * </p>
+     * <ul>
+     *   <li>VMIN - Minimum number of characters for non-canonical read</li>
+     *   <li>VTIME - Timeout in deciseconds for non-canonical read</li>
+     * </ul>
+     *
+     * @param c the control character to set
+     * @param value the value to set for the control character
+     * @see ControlChar
+     * @see #getControlChar(ControlChar)
+     */
     public void setControlChar(ControlChar c, int value) {
         cchars.put(c, value);
     }
@@ -302,6 +651,17 @@ public class Attributes {
     // Miscellaneous methods
     //
 
+    /**
+     * Copies all settings from another Attributes object to this one.
+     *
+     * <p>
+     * This method copies all flags and control characters from the specified
+     * Attributes object to this object. Any previous settings in this object
+     * will be overwritten.
+     * </p>
+     *
+     * @param attributes the Attributes object to copy from
+     */
     public void copy(Attributes attributes) {
         setControlFlags(attributes.getControlFlags());
         setInputFlags(attributes.getInputFlags());

--- a/terminal/src/main/java/org/jline/terminal/Cursor.java
+++ b/terminal/src/main/java/org/jline/terminal/Cursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -9,7 +9,45 @@
 package org.jline.terminal;
 
 /**
- * Class holding the cursor position.
+ * Represents the position of the cursor within a terminal.
+ *
+ * <p>
+ * The Cursor class encapsulates the coordinates of the cursor in a terminal, providing
+ * access to its X (column) and Y (row) position. Cursor positions are used for various
+ * terminal operations such as text insertion, deletion, and formatting.
+ * </p>
+ *
+ * <p>
+ * In terminal coordinates:
+ * </p>
+ * <ul>
+ *   <li><b>X coordinate</b> - Represents the column position (horizontal), typically 0-based</li>
+ *   <li><b>Y coordinate</b> - Represents the row position (vertical), typically 0-based</li>
+ * </ul>
+ *
+ * <p>
+ * Cursor objects are typically obtained from a {@link Terminal} using the
+ * {@link Terminal#getCursorPosition(java.util.function.IntConsumer)} method, which queries
+ * the terminal for its current cursor position. This information can be used to determine
+ * where text will be inserted or to calculate relative positions for cursor movement.
+ * </p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * Terminal terminal = TerminalBuilder.terminal();
+ *
+ * // Get current cursor position
+ * Cursor cursor = terminal.getCursorPosition(c -> {});
+ * if (cursor != null) {
+ *     System.out.println("Cursor position: column=" + cursor.getX() + ", row=" + cursor.getY());
+ * }
+ * </pre>
+ *
+ * <p>
+ * Note that not all terminals support cursor position reporting. The
+ * {@link Terminal#getCursorPosition(java.util.function.IntConsumer)} method may return
+ * {@code null} if cursor position reporting is not supported.
+ * </p>
  *
  * @see Terminal#getCursorPosition(java.util.function.IntConsumer)
  */
@@ -18,19 +56,63 @@ public class Cursor {
     private final int x;
     private final int y;
 
+    /**
+     * Creates a new Cursor instance at the specified coordinates.
+     *
+     * <p>
+     * This constructor creates a Cursor object representing a position in the terminal
+     * at the given column (x) and row (y) coordinates. In terminal coordinates, the
+     * origin (0,0) is typically at the top-left corner of the screen.
+     * </p>
+     *
+     * @param x the column position (horizontal coordinate)
+     * @param y the row position (vertical coordinate)
+     */
     public Cursor(int x, int y) {
         this.x = x;
         this.y = y;
     }
 
+    /**
+     * Returns the column position (horizontal coordinate) of this cursor.
+     *
+     * <p>
+     * The X coordinate represents the horizontal position of the cursor in the terminal,
+     * measured in character cells from the left edge of the terminal. The leftmost column
+     * is typically position 0.
+     * </p>
+     *
+     * @return the column position (X coordinate)
+     */
     public int getX() {
         return x;
     }
 
+    /**
+     * Returns the row position (vertical coordinate) of this cursor.
+     *
+     * <p>
+     * The Y coordinate represents the vertical position of the cursor in the terminal,
+     * measured in character cells from the top edge of the terminal. The topmost row
+     * is typically position 0.
+     * </p>
+     *
+     * @return the row position (Y coordinate)
+     */
     public int getY() {
         return y;
     }
 
+    /**
+     * Compares this Cursor object with another object for equality.
+     *
+     * <p>
+     * Two Cursor objects are considered equal if they have the same X and Y coordinates.
+     * </p>
+     *
+     * @param o the object to compare with
+     * @return {@code true} if the objects are equal, {@code false} otherwise
+     */
     @Override
     public boolean equals(Object o) {
         if (o instanceof Cursor) {
@@ -41,11 +123,29 @@ public class Cursor {
         }
     }
 
+    /**
+     * Returns a hash code for this Cursor object.
+     *
+     * <p>
+     * The hash code is computed based on the X and Y coordinates.
+     * </p>
+     *
+     * @return a hash code value for this object
+     */
     @Override
     public int hashCode() {
         return x * 31 + y;
     }
 
+    /**
+     * Returns a string representation of this Cursor object.
+     *
+     * <p>
+     * The string representation includes the X and Y coordinates.
+     * </p>
+     *
+     * @return a string representation of this object
+     */
     @Override
     public String toString() {
         return "Cursor[" + "x=" + x + ", y=" + y + ']';

--- a/terminal/src/main/java/org/jline/terminal/MouseEvent.java
+++ b/terminal/src/main/java/org/jline/terminal/MouseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -10,28 +10,136 @@ package org.jline.terminal;
 
 import java.util.EnumSet;
 
+/**
+ * Represents a mouse event in a terminal that supports mouse tracking.
+ *
+ * <p>
+ * The MouseEvent class encapsulates information about mouse actions in a terminal,
+ * including the type of event (press, release, move, etc.), which button was involved,
+ * any modifier keys that were pressed, and the coordinates where the event occurred.
+ * </p>
+ *
+ * <p>
+ * Mouse events are only available in terminals that support mouse tracking, which can be
+ * enabled using {@link Terminal#trackMouse(Terminal.MouseTracking)}. Once mouse tracking
+ * is enabled, mouse events can be read using {@link Terminal#readMouseEvent()}.
+ * </p>
+ *
+ * <p>
+ * Mouse events include:
+ * </p>
+ * <ul>
+ *   <li><b>Pressed</b> - A mouse button was pressed</li>
+ *   <li><b>Released</b> - A mouse button was released</li>
+ *   <li><b>Moved</b> - The mouse was moved without any buttons pressed</li>
+ *   <li><b>Dragged</b> - The mouse was moved with a button pressed</li>
+ *   <li><b>Wheel</b> - The mouse wheel was scrolled</li>
+ * </ul>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * Terminal terminal = TerminalBuilder.terminal();
+ *
+ * // Enable mouse tracking
+ * if (terminal.hasMouseSupport()) {
+ *     terminal.trackMouse(Terminal.MouseTracking.Normal);
+ *
+ *     // Read mouse events
+ *     MouseEvent event = terminal.readMouseEvent();
+ *     System.out.println("Mouse event: type=" + event.getType() +
+ *                        ", button=" + event.getButton() +
+ *                        ", position=" + event.getX() + "," + event.getY());
+ * }
+ * </pre>
+ *
+ * @see Terminal#hasMouseSupport()
+ * @see Terminal#trackMouse(Terminal.MouseTracking)
+ * @see Terminal#readMouseEvent()
+ */
 public class MouseEvent {
 
+    /**
+     * Defines the types of mouse events that can occur.
+     */
     public enum Type {
+        /**
+         * A mouse button was released.
+         */
         Released,
+
+        /**
+         * A mouse button was pressed.
+         */
         Pressed,
+
+        /**
+         * The mouse wheel was scrolled.
+         */
         Wheel,
+
+        /**
+         * The mouse was moved without any buttons pressed.
+         */
         Moved,
+
+        /**
+         * The mouse was moved with a button pressed (drag operation).
+         */
         Dragged
     }
 
+    /**
+     * Defines the mouse buttons that can be involved in a mouse event.
+     */
     public enum Button {
+        /**
+         * No specific button is involved (used for move events).
+         */
         NoButton,
+
+        /**
+         * The primary mouse button (usually the left button).
+         */
         Button1,
+
+        /**
+         * The middle mouse button.
+         */
         Button2,
+
+        /**
+         * The secondary mouse button (usually the right button).
+         */
         Button3,
+
+        /**
+         * The mouse wheel was scrolled upward.
+         */
         WheelUp,
+
+        /**
+         * The mouse wheel was scrolled downward.
+         */
         WheelDown
     }
 
+    /**
+     * Defines the modifier keys that can be pressed during a mouse event.
+     */
     public enum Modifier {
+        /**
+         * The Shift key was pressed during the mouse event.
+         */
         Shift,
+
+        /**
+         * The Alt key was pressed during the mouse event.
+         */
         Alt,
+
+        /**
+         * The Control key was pressed during the mouse event.
+         */
         Control
     }
 
@@ -41,6 +149,15 @@ public class MouseEvent {
     private final int x;
     private final int y;
 
+    /**
+     * Creates a new MouseEvent with the specified parameters.
+     *
+     * @param type      the type of mouse event (press, release, etc.)
+     * @param button    the button involved in the event
+     * @param modifiers the modifier keys pressed during the event
+     * @param x         the column (horizontal) position of the event
+     * @param y         the row (vertical) position of the event
+     */
     public MouseEvent(Type type, Button button, EnumSet<Modifier> modifiers, int x, int y) {
         this.type = type;
         this.button = button;
@@ -49,26 +166,66 @@ public class MouseEvent {
         this.y = y;
     }
 
+    /**
+     * Returns the type of this mouse event.
+     *
+     * @return the event type (press, release, move, etc.)
+     */
     public Type getType() {
         return type;
     }
 
+    /**
+     * Returns the button involved in this mouse event.
+     *
+     * @return the mouse button
+     */
     public Button getButton() {
         return button;
     }
 
+    /**
+     * Returns the set of modifier keys pressed during this mouse event.
+     *
+     * @return the set of modifier keys (Shift, Alt, Control)
+     */
     public EnumSet<Modifier> getModifiers() {
         return modifiers;
     }
 
+    /**
+     * Returns the column (horizontal) position of this mouse event.
+     *
+     * @return the X coordinate (column)
+     */
     public int getX() {
         return x;
     }
 
+    /**
+     * Returns the row (vertical) position of this mouse event.
+     *
+     * @return the Y coordinate (row)
+     */
     public int getY() {
         return y;
     }
 
+    /**
+     * Returns a string representation of this MouseEvent object.
+     *
+     * <p>
+     * The string representation includes all properties of the mouse event:
+     * the event type, button, modifier keys, and coordinates.
+     * </p>
+     *
+     * <p>Example output:</p>
+     * <pre>
+     * MouseEvent[type=Pressed, button=Button1, modifiers=[Shift], x=10, y=20]
+     * </pre>
+     *
+     * @return a string representation of this object
+     */
     @Override
     public String toString() {
         return "MouseEvent[" + "type="

--- a/terminal/src/main/java/org/jline/terminal/Size.java
+++ b/terminal/src/main/java/org/jline/terminal/Size.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -8,13 +8,70 @@
  */
 package org.jline.terminal;
 
+/**
+ * Represents the dimensions of a terminal in terms of rows and columns.
+ *
+ * <p>
+ * The Size class encapsulates the dimensions of a terminal screen, providing methods to get and set
+ * the number of rows and columns. Terminal dimensions are used for various operations such as
+ * cursor positioning, screen clearing, and text layout calculations.
+ * </p>
+ *
+ * <p>
+ * Terminal dimensions are typically measured in character cells, where:
+ * </p>
+ * <ul>
+ *   <li><b>Columns</b> - The number of character cells in each row (width)</li>
+ *   <li><b>Rows</b> - The number of character cells in each column (height)</li>
+ * </ul>
+ *
+ * <p>
+ * Size objects are typically obtained from a {@link Terminal} using {@link Terminal#getSize()},
+ * and can be used to adjust display formatting or to set the terminal size using
+ * {@link Terminal#setSize(Size)}.
+ * </p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * Terminal terminal = TerminalBuilder.terminal();
+ *
+ * // Get current terminal size
+ * Size size = terminal.getSize();
+ * System.out.println("Terminal dimensions: " + size.getColumns() + "x" + size.getRows());
+ *
+ * // Create a new size and set it
+ * Size newSize = new Size(80, 24);
+ * terminal.setSize(newSize);
+ * </pre>
+ *
+ * @see Terminal#getSize()
+ * @see Terminal#setSize(Size)
+ */
 public class Size {
 
     private int rows;
     private int cols;
 
+    /**
+     * Creates a new Size instance with default dimensions (0 rows and 0 columns).
+     *
+     * <p>
+     * This constructor creates a Size object with zero dimensions. The dimensions
+     * can be set later using {@link #setRows(int)} and {@link #setColumns(int)}.
+     * </p>
+     */
     public Size() {}
 
+    /**
+     * Creates a new Size instance with the specified dimensions.
+     *
+     * <p>
+     * This constructor creates a Size object with the specified number of columns and rows.
+     * </p>
+     *
+     * @param columns the number of columns (width)
+     * @param rows the number of rows (height)
+     */
     @SuppressWarnings("this-escape")
     public Size(int columns, int rows) {
         this();
@@ -22,18 +79,58 @@ public class Size {
         setRows(rows);
     }
 
+    /**
+     * Returns the number of columns (width) in this terminal size.
+     *
+     * <p>
+     * The number of columns represents the width of the terminal in character cells.
+     * </p>
+     *
+     * @return the number of columns
+     * @see #setColumns(int)
+     */
     public int getColumns() {
         return cols;
     }
 
+    /**
+     * Sets the number of columns (width) for this terminal size.
+     *
+     * <p>
+     * The number of columns represents the width of the terminal in character cells.
+     * </p>
+     *
+     * @param columns the number of columns to set
+     * @see #getColumns()
+     */
     public void setColumns(int columns) {
         cols = (short) columns;
     }
 
+    /**
+     * Returns the number of rows (height) in this terminal size.
+     *
+     * <p>
+     * The number of rows represents the height of the terminal in character cells.
+     * </p>
+     *
+     * @return the number of rows
+     * @see #setRows(int)
+     */
     public int getRows() {
         return rows;
     }
 
+    /**
+     * Sets the number of rows (height) for this terminal size.
+     *
+     * <p>
+     * The number of rows represents the height of the terminal in character cells.
+     * </p>
+     *
+     * @param rows the number of rows to set
+     * @see #getRows()
+     */
     public void setRows(int rows) {
         this.rows = (short) rows;
     }
@@ -53,11 +150,32 @@ public class Size {
         return row * (cols + 1) + col;
     }
 
+    /**
+     * Copies the dimensions from another Size object to this one.
+     *
+     * <p>
+     * This method updates this Size object to have the same dimensions
+     * (rows and columns) as the specified Size object.
+     * </p>
+     *
+     * @param size the Size object to copy dimensions from
+     */
     public void copy(Size size) {
         setColumns(size.getColumns());
         setRows(size.getRows());
     }
 
+    /**
+     * Compares this Size object with another object for equality.
+     *
+     * <p>
+     * Two Size objects are considered equal if they have the same number of
+     * rows and columns.
+     * </p>
+     *
+     * @param o the object to compare with
+     * @return {@code true} if the objects are equal, {@code false} otherwise
+     */
     @Override
     public boolean equals(Object o) {
         if (o instanceof Size) {
@@ -68,11 +186,29 @@ public class Size {
         }
     }
 
+    /**
+     * Returns a hash code for this Size object.
+     *
+     * <p>
+     * The hash code is computed based on the rows and columns values.
+     * </p>
+     *
+     * @return a hash code value for this object
+     */
     @Override
     public int hashCode() {
         return rows * 31 + cols;
     }
 
+    /**
+     * Returns a string representation of this Size object.
+     *
+     * <p>
+     * The string representation includes the number of columns and rows.
+     * </p>
+     *
+     * @return a string representation of this object
+     */
     @Override
     public String toString() {
         return "Size[" + "cols=" + cols + ", rows=" + rows + ']';

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -25,84 +25,341 @@ import org.jline.utils.NonBlockingReader;
 /**
  * A terminal representing a virtual terminal on the computer.
  *
- * Terminals should be closed by calling the {@link #close()} method
- * in order to restore their original state.
+ * <p>The Terminal interface is the central abstraction in JLine, providing access to the terminal's
+ * capabilities, input/output streams, and control functions. It abstracts the differences between
+ * various terminal types and operating systems, allowing applications to work consistently across
+ * environments.</p>
+ *
+ * <h2>Terminal Capabilities</h2>
+ * <p>Terminals provide access to their capabilities through the {@link #getStringCapability(Capability)},
+ * {@link #getBooleanCapability(Capability)}, and {@link #getNumericCapability(Capability)} methods.
+ * These capabilities represent the terminal's features and are defined in the terminfo database.</p>
+ *
+ * <h2>Input and Output</h2>
+ * <p>Terminal input can be read using the {@link #reader()} method, which returns a non-blocking reader.
+ * Output can be written using the {@link #writer()} method, which returns a print writer. For raw access
+ * to the underlying streams, use {@link #input()} and {@link #output()}.</p>
+ *
+ * <h2>Terminal Attributes</h2>
+ * <p>Terminal attributes control the behavior of the terminal, such as echo mode, canonical mode, etc.
+ * These can be accessed and modified using {@link #getAttributes()} and {@link #setAttributes(Attributes)}.</p>
+ *
+ * <h2>Signal Handling</h2>
+ * <p>Terminals can handle various signals, such as CTRL+C (INT), CTRL+\ (QUIT), etc. Signal handlers
+ * can be registered using {@link #handle(Signal, SignalHandler)}.</p>
+ *
+ * <p>Signal handling allows terminal applications to respond appropriately to these events,
+ * such as gracefully terminating when the user presses Ctrl+C, or adjusting the display
+ * when the terminal window is resized.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * Terminal terminal = TerminalBuilder.terminal();
+ *
+ * // Handle interrupt signal (Ctrl+C)
+ * terminal.handle(Signal.INT, signal -> {
+ *     terminal.writer().println("\nInterrupted! Press Enter to exit.");
+ *     terminal.flush();
+ * });
+ * </pre>
+ *
+ * <h2>Mouse Support</h2>
+ * <p>Some terminals support mouse tracking, which can be enabled using {@link #trackMouse(MouseTracking)}.
+ * Mouse events can then be read using {@link #readMouseEvent()}.</p>
+ *
+ * <h2>Lifecycle</h2>
+ * <p>Terminals should be closed by calling the {@link #close()} method when they are no longer needed
+ * in order to restore their original state. Failure to close a terminal may leave the terminal in an
+ * inconsistent state.</p>
+ *
+ * <h2>Creating Terminals</h2>
+ * <p>Terminals are typically created using the {@link TerminalBuilder} class, which provides a fluent API
+ * for configuring and creating terminal instances.</p>
+ *
+ * @see TerminalBuilder
+ * @see Attributes
+ * @see Size
+ * @see Cursor
+ * @see MouseEvent
  */
 public interface Terminal extends Closeable, Flushable {
 
     /**
-     * Type used for dumb terminals.
+     * Type identifier for dumb terminals with minimal capabilities.
+     *
+     * <p>
+     * A dumb terminal has minimal capabilities and typically does not support
+     * cursor movement, colors, or other advanced features. It's often used as
+     * a fallback when a more capable terminal is not available.
+     * </p>
      */
     String TYPE_DUMB = "dumb";
 
+    /**
+     * Type identifier for dumb terminals with basic color support.
+     *
+     * <p>
+     * A dumb-color terminal has minimal capabilities like a dumb terminal,
+     * but does support basic color output. It still lacks support for cursor
+     * movement and other advanced features.
+     * </p>
+     */
     String TYPE_DUMB_COLOR = "dumb-color";
 
+    /**
+     * Returns the name of this terminal.
+     *
+     * <p>
+     * The terminal name is typically a descriptive identifier that can be used for logging
+     * or debugging purposes. It may reflect the terminal type, connection method, or other
+     * distinguishing characteristics.
+     * </p>
+     *
+     * @return the terminal name
+     */
     String getName();
 
-    //
-    // Signal support
-    //
+    /*
+     * Signal support for terminal applications.
+     *
+     * <p>
+     * JLine provides support for handling terminal signals, which are asynchronous notifications
+     * sent to the application in response to certain events or user actions. Common signals include
+     * interrupt (Ctrl+C), quit (Ctrl+\), suspend (Ctrl+Z), and window size changes.
+     * </p>
+     *
+     * <p>
+     */
 
     /**
-     * Types of signals.
+     * Types of signals that can be handled by terminal applications.
+     *
+     * <p>
+     * Signals represent asynchronous notifications that can be sent to the application
+     * in response to certain events or user actions. Each signal type corresponds to a
+     * specific event or key combination:
+     * </p>
+     *
+     * <ul>
+     *   <li>{@link #INT} - Interrupt signal (typically Ctrl+C)</li>
+     *   <li>{@link #QUIT} - Quit signal (typically Ctrl+\)</li>
+     *   <li>{@link #TSTP} - Terminal stop signal (typically Ctrl+Z)</li>
+     *   <li>{@link #CONT} - Continue signal (sent when resuming after TSTP)</li>
+     *   <li>{@link #INFO} - Information signal (typically Ctrl+T on BSD systems)</li>
+     *   <li>{@link #WINCH} - Window change signal (sent when terminal size changes)</li>
+     * </ul>
+     *
+     * <p>
+     * Note that signal handling behavior may vary across different platforms and terminal
+     * implementations. Some signals may not be available or may behave differently on
+     * certain systems.
+     * </p>
+     *
+     * @see #handle(Signal, SignalHandler)
+     * @see #raise(Signal)
      */
     enum Signal {
+        /**
+         * Interrupt signal, typically generated by pressing Ctrl+C.
+         * Used to interrupt or terminate a running process.
+         */
         INT,
+
+        /**
+         * Quit signal, typically generated by pressing Ctrl+\.
+         * Often used to force a core dump or immediate termination.
+         * Note: The JVM does not easily allow catching this signal natively.
+         */
         QUIT,
+
+        /**
+         * Terminal stop signal, typically generated by pressing Ctrl+Z.
+         * Used to suspend the current process.
+         */
         TSTP,
+
+        /**
+         * Continue signal, sent when resuming a process after suspension.
+         * This signal is sent to a process when it's resumed after being stopped by TSTP.
+         */
         CONT,
+
+        /**
+         * Information signal, typically generated by pressing Ctrl+T on BSD systems.
+         * Used to request status information from a running process.
+         */
         INFO,
+
+        /**
+         * Window change signal, sent when the terminal window size changes.
+         * Applications can handle this signal to adjust their display accordingly.
+         */
         WINCH
     }
 
     /**
-     * The SignalHandler defines the interface used to trap signals and perform specific behaviors.
+     * Interface for handling terminal signals.
+     *
+     * <p>
+     * The SignalHandler interface defines the contract for objects that can respond to
+     * terminal signals. When a signal is raised, the corresponding handler's {@link #handle(Signal)}
+     * method is called with the signal that was raised.
+     * </p>
+     *
+     * <p>
+     * JLine provides two predefined signal handlers:
+     * </p>
+     * <ul>
+     *   <li>{@link #SIG_DFL} - Default signal handler that uses the JVM's default behavior</li>
+     *   <li>{@link #SIG_IGN} - Ignores the signal and performs no special processing</li>
+     * </ul>
+     *
+     * <p>Example usage with a custom handler:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Create a custom signal handler
+     * SignalHandler handler = signal -> {
+     *     if (signal == Signal.INT) {
+     *         terminal.writer().println("\nInterrupted!");
+     *         terminal.flush();
+     *     }
+     * };
+     *
+     * // Register the handler for the INT signal
+     * terminal.handle(Signal.INT, handler);
+     * </pre>
+     *
      * @see Terminal.Signal
      * @see Terminal#handle(Signal, SignalHandler)
      */
     interface SignalHandler {
 
         /**
-         * The {@code SIG_DFL} value can be used to specify that the JVM default behavior
-         * should be used to handle this signal.
+         * Default signal handler that uses the JVM's default behavior for the signal.
+         *
+         * <p>
+         * When this handler is registered for a signal, the terminal will use the JVM's
+         * default behavior to handle the signal. For example, the default behavior for
+         * the INT signal (Ctrl+C) is to terminate the JVM.
+         * </p>
+         *
+         * <p>Example usage:</p>
+         * <pre>
+         * // Restore default behavior for INT signal
+         * terminal.handle(Signal.INT, SignalHandler.SIG_DFL);
+         * </pre>
          */
         SignalHandler SIG_DFL = NativeSignalHandler.SIG_DFL;
 
         /**
-         * The {@code SIG_IGN} value can be used to ignore this signal and not perform
-         * any special processing.
+         * Signal handler that ignores the signal and performs no special processing.
+         *
+         * <p>
+         * When this handler is registered for a signal, the terminal will completely
+         * ignore the signal and continue normal operation. This is useful for preventing
+         * signals like INT (Ctrl+C) from terminating the application.
+         * </p>
+         *
+         * <p>Example usage:</p>
+         * <pre>
+         * // Ignore INT signal (Ctrl+C will not terminate the application)
+         * terminal.handle(Signal.INT, SignalHandler.SIG_IGN);
+         * </pre>
          */
         SignalHandler SIG_IGN = NativeSignalHandler.SIG_IGN;
 
         /**
-         * Handle the signal.
-         * @param signal the signal
+         * Handles the specified signal.
+         *
+         * <p>
+         * This method is called when a signal is raised and this handler is registered
+         * for that signal. Implementations should perform any necessary actions in response
+         * to the signal.
+         * </p>
+         *
+         * <p>
+         * Note that signal handlers should generally be short-lived and avoid blocking
+         * operations, as they may be called in contexts where blocking could cause
+         * deadlocks or other issues.
+         * </p>
+         *
+         * @param signal the signal that was raised
          */
         void handle(Signal signal);
     }
 
     /**
      * Registers a handler for the given {@link Signal}.
+     *
      * <p>
-     * Note that the JVM does not easily allow catching the {@link Signal#QUIT} signal, which causes a thread dump
-     * to be displayed.  This signal is mainly used when connecting through an SSH socket to a virtual terminal.
+     * This method allows the application to specify custom behavior when a particular
+     * signal is raised. The handler's {@link SignalHandler#handle(Signal)} method will
+     * be called whenever the specified signal is raised.
+     * </p>
+     *
+     * <p>
+     * Note that the JVM does not easily allow catching the {@link Signal#QUIT} signal (Ctrl+\),
+     * which typically causes a thread dump to be displayed. This signal handling is mainly
+     * effective when connecting through an SSH socket to a virtual terminal.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Handle window resize events
+     * terminal.handle(Signal.WINCH, signal -> {
+     *     Size size = terminal.getSize();
+     *     terminal.writer().println("\nTerminal resized to " +
+     *                              size.getColumns() + "x" + size.getRows());
+     *     terminal.flush();
+     * });
+     *
+     * // Ignore interrupt signal
+     * terminal.handle(Signal.INT, SignalHandler.SIG_IGN);
+     * </pre>
      *
      * @param signal the signal to register a handler for
-     * @param handler the handler
-     * @return the previous signal handler
+     * @param handler the handler to be called when the signal is raised
+     * @return the previous signal handler that was registered for this signal
+     * @see Signal
+     * @see SignalHandler
+     * @see #raise(Signal)
      */
     SignalHandler handle(Signal signal, SignalHandler handler);
 
     /**
-     * Raise the specific signal.
-     * This is not method usually called by non system terminals.
-     * When accessing a terminal through a SSH or Telnet connection, signals may be
-     * conveyed by the protocol and thus need to be raised when reaching the terminal code.
-     * The terminals do that automatically when the terminal input stream has a character
-     * mapped to {@link Attributes.ControlChar#VINTR}, {@link Attributes.ControlChar#VQUIT},
-     * or {@link Attributes.ControlChar#VSUSP}.
+     * Raises the specified signal, triggering any registered handlers.
+     *
+     * <p>
+     * This method manually triggers a signal, causing any registered handler for that
+     * signal to be called. This is typically not a method that application code would
+     * call directly, but is used internally by terminal implementations.
+     * </p>
+     *
+     * <p>
+     * When accessing a terminal through an SSH or Telnet connection, signals may be
+     * conveyed by the protocol and need to be raised when they reach the terminal code.
+     * Terminal implementations automatically raise signals when the input stream receives
+     * characters mapped to special control characters:
+     * </p>
+     * <ul>
+     *   <li>{@link Attributes.ControlChar#VINTR} (typically Ctrl+C) - Raises {@link Signal#INT}</li>
+     *   <li>{@link Attributes.ControlChar#VQUIT} (typically Ctrl+\) - Raises {@link Signal#QUIT}</li>
+     *   <li>{@link Attributes.ControlChar#VSUSP} (typically Ctrl+Z) - Raises {@link Signal#TSTP}</li>
+     * </ul>
+     *
+     * <p>
+     * In some cases, application code might want to programmatically raise signals to
+     * trigger specific behaviors, such as simulating a window resize event by raising
+     * {@link Signal#WINCH}.
+     * </p>
      *
      * @param signal the signal to raise
+     * @see Signal
+     * @see #handle(Signal, SignalHandler)
+     * @see Attributes.ControlChar
      */
     void raise(Signal signal);
 
@@ -174,10 +431,41 @@ public interface Terminal extends Closeable, Flushable {
     boolean canPauseResume();
 
     /**
-     * Stop reading the input stream.
+     * Temporarily stops reading the input stream.
+     *
+     * <p>
+     * This method pauses the terminal's input processing, which can be useful when
+     * transferring control to a subprocess or when the terminal needs to be in a
+     * specific state for certain operations. While paused, the terminal will not
+     * process input or handle signals that would normally be triggered by special
+     * characters in the input stream.
+     * </p>
+     *
+     * <p>
+     * This method returns immediately without waiting for the terminal to actually
+     * pause. To wait until the terminal has fully paused, use {@link #pause(boolean)}
+     * with a value of {@code true}.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Pause terminal input processing before running a subprocess
+     * terminal.pause();
+     *
+     * // Run subprocess that takes control of the terminal
+     * Process process = new ProcessBuilder("vim").inheritIO().start();
+     * process.waitFor();
+     *
+     * // Resume terminal input processing
+     * terminal.resume();
+     * </pre>
      *
      * @see #resume()
+     * @see #pause(boolean)
      * @see #paused()
+     * @see #canPauseResume()
      */
     void pause();
 
@@ -190,10 +478,36 @@ public interface Terminal extends Closeable, Flushable {
     void pause(boolean wait) throws InterruptedException;
 
     /**
-     * Resume reading the input stream.
+     * Resumes reading the input stream after it has been paused.
+     *
+     * <p>
+     * This method restarts the terminal's input processing after it has been
+     * temporarily stopped using {@link #pause()} or {@link #pause(boolean)}.
+     * Once resumed, the terminal will continue to process input and handle signals
+     * triggered by special characters in the input stream.
+     * </p>
+     *
+     * <p>
+     * Calling this method when the terminal is not paused has no effect.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Pause terminal input processing
+     * terminal.pause();
+     *
+     * // Perform operations while terminal input is paused...
+     *
+     * // Resume terminal input processing
+     * terminal.resume();
+     * </pre>
      *
      * @see #pause()
+     * @see #pause(boolean)
      * @see #paused()
+     * @see #canPauseResume()
      */
     void resume();
 
@@ -217,26 +531,176 @@ public interface Terminal extends Closeable, Flushable {
     // Pty settings
     //
 
+    /**
+     * Puts the terminal into raw mode.
+     *
+     * <p>
+     * In raw mode, input is available character by character, terminal-generated signals are disabled,
+     * and special character processing is disabled. This mode is typically used for full-screen
+     * interactive applications like text editors.
+     * </p>
+     *
+     * <p>
+     * This method modifies the terminal attributes to configure raw mode and returns the
+     * original attributes, which can be used to restore the terminal to its previous state.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     * Attributes originalAttributes = terminal.enterRawMode();
+     *
+     * // Use terminal in raw mode...
+     *
+     * // Restore original attributes when done
+     * terminal.setAttributes(originalAttributes);
+     * </pre>
+     *
+     * @return the original terminal attributes before entering raw mode
+     * @see #setAttributes(Attributes)
+     */
     Attributes enterRawMode();
 
+    /**
+     * Returns whether the terminal is currently echoing input characters.
+     *
+     * <p>
+     * When echo is enabled, characters typed by the user are automatically displayed on the screen.
+     * When echo is disabled, input characters are not displayed, which is useful for password input
+     * or other sensitive information.
+     * </p>
+     *
+     * @return {@code true} if echo is enabled, {@code false} otherwise
+     * @see #echo(boolean)
+     */
     boolean echo();
 
+    /**
+     * Enables or disables echoing of input characters.
+     *
+     * <p>
+     * When echo is enabled, characters typed by the user are automatically displayed on the screen.
+     * When echo is disabled, input characters are not displayed, which is useful for password input
+     * or other sensitive information.
+     * </p>
+     *
+     * <p>Example usage for password input:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     * boolean oldEcho = terminal.echo(false); // Disable echo
+     * String password = readPassword(terminal);
+     * terminal.echo(oldEcho); // Restore previous echo state
+     * </pre>
+     *
+     * @param echo {@code true} to enable echo, {@code false} to disable it
+     * @return the previous echo state
+     */
     boolean echo(boolean echo);
 
     /**
-     * Returns the terminal attributes.
-     * The returned object can be safely modified
-     * further used in a call to {@link #setAttributes(Attributes)}.
+     * Returns the current terminal attributes.
      *
-     * @return the terminal attributes.
+     * <p>
+     * Terminal attributes control various aspects of terminal behavior, including:
+     * </p>
+     * <ul>
+     *   <li><b>Input processing</b> - How input characters are processed (e.g., character mapping, parity checking)</li>
+     *   <li><b>Output processing</b> - How output characters are processed (e.g., newline translation)</li>
+     *   <li><b>Control settings</b> - Hardware settings like baud rate and character size</li>
+     *   <li><b>Local settings</b> - Terminal behavior settings like echo, canonical mode, and signal generation</li>
+     *   <li><b>Control characters</b> - Special characters like EOF, interrupt, and erase</li>
+     * </ul>
+     *
+     * <p>
+     * The returned {@link Attributes} object is a copy of the terminal's current attributes
+     * and can be safely modified without affecting the terminal until it is applied using
+     * {@link #setAttributes(Attributes)}. This allows for making multiple changes to the
+     * attributes before applying them all at once.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Get current attributes
+     * Attributes attrs = terminal.getAttributes();
+     *
+     * // Modify attributes
+     * attrs.setLocalFlag(LocalFlag.ECHO, false);      // Disable echo
+     * attrs.setInputFlag(InputFlag.ICRNL, false);     // Disable CR to NL mapping
+     * attrs.setControlChar(ControlChar.VMIN, 1);      // Set minimum input to 1 character
+     * attrs.setControlChar(ControlChar.VTIME, 0);     // Set timeout to 0 deciseconds
+     *
+     * // Apply modified attributes
+     * terminal.setAttributes(attrs);
+     * </pre>
+     *
+     * @return a copy of the terminal's current attributes
+     * @see #setAttributes(Attributes)
+     * @see Attributes
+     * @see #enterRawMode()
      */
     Attributes getAttributes();
 
     /**
-     * Set the terminal attributes.
-     * The terminal will perform a copy of the given attributes.
+     * Sets the terminal attributes to the specified values.
      *
-     * @param attr the new attributes
+     * <p>
+     * This method applies the specified attributes to the terminal, changing its behavior
+     * according to the settings in the {@link Attributes} object. The terminal makes a copy
+     * of the provided attributes, so further modifications to the {@code attr} object will
+     * not affect the terminal until this method is called again.
+     * </p>
+     *
+     * <p>
+     * Terminal attributes control various aspects of terminal behavior, including input and
+     * output processing, control settings, local settings, and special control characters.
+     * Changing these attributes allows for fine-grained control over how the terminal
+     * processes input and output.
+     * </p>
+     *
+     * <p>
+     * Common attribute modifications include:
+     * </p>
+     * <ul>
+     *   <li>Disabling echo for password input</li>
+     *   <li>Enabling/disabling canonical mode for line-by-line or character-by-character input</li>
+     *   <li>Disabling signal generation for custom handling of Ctrl+C and other control sequences</li>
+     *   <li>Changing control characters like the interrupt character or end-of-file character</li>
+     * </ul>
+     *
+     * <p>
+     * For convenience, the {@link #enterRawMode()} method provides a pre-configured set of
+     * attributes suitable for full-screen interactive applications.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Save original attributes for later restoration
+     * Attributes originalAttrs = terminal.getAttributes();
+     *
+     * try {
+     *     // Create and configure new attributes
+     *     Attributes attrs = new Attributes(originalAttrs);
+     *     attrs.setLocalFlag(LocalFlag.ECHO, false);      // Disable echo for password input
+     *     attrs.setLocalFlag(LocalFlag.ICANON, false);    // Disable canonical mode
+     *
+     *     // Apply the new attributes
+     *     terminal.setAttributes(attrs);
+     *
+     *     // Use terminal with modified attributes...
+     * } finally {
+     *     // Restore original attributes
+     *     terminal.setAttributes(originalAttrs);
+     * }
+     * </pre>
+     *
+     * @param attr the attributes to apply to the terminal
+     * @see #getAttributes()
+     * @see Attributes
+     * @see #enterRawMode()
      */
     void setAttributes(Attributes attr);
 
@@ -247,12 +711,50 @@ public interface Terminal extends Closeable, Flushable {
      */
     Size getSize();
 
+    /**
+     * Sets the size of the terminal.
+     *
+     * <p>
+     * This method attempts to resize the terminal to the specified dimensions. Note that
+     * not all terminals support resizing, and the actual size after this operation may
+     * differ from the requested size depending on terminal capabilities and constraints.
+     * </p>
+     *
+     * <p>
+     * For virtual terminals or terminal emulators, this may update the internal size
+     * representation. For physical terminals, this may send appropriate escape sequences
+     * to adjust the viewable area.
+     * </p>
+     *
+     * @param size the new terminal size (columns and rows)
+     * @see #getSize()
+     */
     void setSize(Size size);
 
+    /**
+     * Returns the width (number of columns) of the terminal.
+     *
+     * <p>
+     * This is a convenience method equivalent to {@code getSize().getColumns()}.
+     * </p>
+     *
+     * @return the number of columns in the terminal
+     * @see #getSize()
+     */
     default int getWidth() {
         return getSize().getColumns();
     }
 
+    /**
+     * Returns the height (number of rows) of the terminal.
+     *
+     * <p>
+     * This is a convenience method equivalent to {@code getSize().getRows()}.
+     * </p>
+     *
+     * @return the number of rows in the terminal
+     * @see #getSize()
+     */
     default int getHeight() {
         return getSize().getRows();
     }
@@ -273,20 +775,161 @@ public interface Terminal extends Closeable, Flushable {
         return getSize();
     }
 
+    /**
+     * Flushes any buffered output to the terminal.
+     *
+     * <p>
+     * Terminal implementations may buffer output for efficiency. This method ensures
+     * that any buffered data is written to the terminal immediately. It's important
+     * to call this method when immediate display of output is required, such as when
+     * prompting for user input or updating status information.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     * terminal.writer().print("Enter your name: ");
+     * terminal.flush(); // Ensure the prompt is displayed before reading input
+     * String name = terminal.reader().readLine();
+     * </pre>
+     */
     void flush();
 
     //
     // Infocmp capabilities
     //
 
+    /**
+     * Returns the type of this terminal.
+     *
+     * <p>
+     * The terminal type is a string identifier that describes the terminal's capabilities
+     * and behavior. Common terminal types include "xterm", "vt100", "ansi", and "dumb".
+     * This type is often used to look up terminal capabilities in the terminfo database.
+     * </p>
+     *
+     * <p>
+     * Special terminal types include:
+     * </p>
+     * <ul>
+     *   <li>{@link #TYPE_DUMB} - A terminal with minimal capabilities, typically not supporting
+     *       cursor movement or colors</li>
+     *   <li>{@link #TYPE_DUMB_COLOR} - A dumb terminal that supports basic color output</li>
+     * </ul>
+     *
+     * @return the terminal type identifier
+     * @see #TYPE_DUMB
+     * @see #TYPE_DUMB_COLOR
+     */
     String getType();
 
+    /**
+     * Outputs a terminal control string for the specified capability.
+     *
+     * <p>
+     * This method formats and outputs a control sequence for the specified terminal capability,
+     * with the given parameters. It's used to perform terminal operations such as cursor movement,
+     * screen clearing, color changes, and other terminal-specific functions.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Clear the screen
+     * terminal.puts(Capability.clear_screen);
+     *
+     * // Move cursor to position (10, 20)
+     * terminal.puts(Capability.cursor_address, 20, 10);
+     *
+     * // Set foreground color to red
+     * terminal.puts(Capability.set_a_foreground, 1);
+     * </pre>
+     *
+     * @param capability the terminal capability to use
+     * @param params the parameters for the capability
+     * @return {@code true} if the capability is supported and was output, {@code false} otherwise
+     * @see #getStringCapability(Capability)
+     */
     boolean puts(Capability capability, Object... params);
 
+    /**
+     * Returns whether the terminal supports the specified boolean capability.
+     *
+     * <p>
+     * Boolean capabilities indicate whether the terminal supports specific features,
+     * such as color support, automatic margins, or status line support.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Check if terminal supports colors
+     * if (terminal.getBooleanCapability(Capability.colors)) {
+     *     // Use color output
+     * } else {
+     *     // Use monochrome output
+     * }
+     * </pre>
+     *
+     * @param capability the boolean capability to check
+     * @return {@code true} if the terminal supports the capability, {@code false} otherwise
+     */
     boolean getBooleanCapability(Capability capability);
 
+    /**
+     * Returns the value of the specified numeric capability for this terminal.
+     *
+     * <p>
+     * Numeric capabilities represent terminal properties with numeric values, such as
+     * the maximum number of colors supported, the number of function keys, or timing
+     * parameters for certain operations.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Get the number of colors supported by the terminal
+     * Integer colors = terminal.getNumericCapability(Capability.max_colors);
+     * if (colors != null &amp;&amp; colors >= 256) {
+     *     // Terminal supports 256 colors
+     * }
+     * </pre>
+     *
+     * @param capability the numeric capability to retrieve
+     * @return the value of the capability, or {@code null} if the capability is not supported
+     */
     Integer getNumericCapability(Capability capability);
 
+    /**
+     * Returns the string value of the specified capability for this terminal.
+     *
+     * <p>
+     * String capabilities represent terminal control sequences that can be used to perform
+     * various operations, such as moving the cursor, changing colors, clearing the screen,
+     * or ringing the bell. These sequences can be parameterized using the {@link #puts(Capability, Object...)}
+     * method.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Get the control sequence for clearing the screen
+     * String clearScreen = terminal.getStringCapability(Capability.clear_screen);
+     * if (clearScreen != null) {
+     *     // Use the sequence directly
+     *     terminal.writer().print(clearScreen);
+     *     terminal.flush();
+     * }
+     * </pre>
+     *
+     * @param capability the string capability to retrieve
+     * @return the string value of the capability, or {@code null} if the capability is not supported
+     * @see #puts(Capability, Object...)
+     */
     String getStringCapability(Capability capability);
 
     //
@@ -332,76 +975,347 @@ public interface Terminal extends Closeable, Flushable {
     }
 
     /**
-     * Returns <code>true</code> if the terminal has support for mouse.
-     * @return whether mouse is supported by the terminal
+     * Returns whether the terminal has support for mouse tracking.
+     *
+     * <p>
+     * Mouse support allows the terminal to report mouse events such as clicks, movement,
+     * and wheel scrolling. Not all terminals support mouse tracking, so this method
+     * should be called before attempting to enable mouse tracking with
+     * {@link #trackMouse(MouseTracking)}.
+     * </p>
+     *
+     * <p>
+     * Common terminal emulators that support mouse tracking include xterm, iTerm2,
+     * and modern versions of GNOME Terminal and Konsole. Terminal multiplexers like
+     * tmux and screen may also support mouse tracking depending on their configuration
+     * and the capabilities of the underlying terminal.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * if (terminal.hasMouseSupport()) {
+     *     // Enable mouse tracking
+     *     terminal.trackMouse(MouseTracking.Normal);
+     *
+     *     // Process mouse events
+     *     // ...
+     * } else {
+     *     System.out.println("Mouse tracking not supported by this terminal");
+     * }
+     * </pre>
+     *
+     * @return {@code true} if the terminal supports mouse tracking, {@code false} otherwise
      * @see #trackMouse(MouseTracking)
+     * @see #readMouseEvent()
      */
     boolean hasMouseSupport();
 
     /**
-     * Change the mouse tracking mouse.
-     * To start mouse tracking, this method must be called with a valid mouse tracking mode.
-     * Mouse events will be reported by writing the {@link Capability#key_mouse} to the input stream.
-     * When this character sequence is detected, the {@link #readMouseEvent()} method can be
-     * called to actually read the corresponding mouse event.
+     * Enables or disables mouse tracking with the specified mode.
      *
-     * @param tracking the mouse tracking mode
-     * @return <code>true</code> if mouse tracking is supported
+     * <p>
+     * This method configures the terminal to report mouse events according to the
+     * specified tracking mode. When mouse tracking is enabled, the terminal will
+     * send special escape sequences to the input stream whenever mouse events occur.
+     * These sequences begin with the {@link Capability#key_mouse} sequence, followed
+     * by data that describes the specific mouse event.
+     * </p>
+     *
+     * <p>
+     * The tracking mode determines which mouse events are reported:
+     * </p>
+     * <ul>
+     *   <li>{@link MouseTracking#Off} - Disables mouse tracking</li>
+     *   <li>{@link MouseTracking#Normal} - Reports button press and release events</li>
+     *   <li>{@link MouseTracking#Button} - Reports button press, release, and motion events while buttons are pressed</li>
+     *   <li>{@link MouseTracking#Any} - Reports all mouse events, including movement without buttons pressed</li>
+     * </ul>
+     *
+     * <p>
+     * To process mouse events, applications should:
+     * </p>
+     * <ol>
+     *   <li>Enable mouse tracking by calling this method with the desired mode</li>
+     *   <li>Monitor the input stream for the {@link Capability#key_mouse} sequence</li>
+     *   <li>When this sequence is detected, call {@link #readMouseEvent()} to decode the event</li>
+     *   <li>Process the returned {@link MouseEvent} as needed</li>
+     * </ol>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * if (terminal.hasMouseSupport()) {
+     *     // Enable tracking of all mouse events
+     *     boolean supported = terminal.trackMouse(MouseTracking.Any);
+     *
+     *     if (supported) {
+     *         System.out.println("Mouse tracking enabled");
+     *         // Set up input processing to detect and handle mouse events
+     *     }
+     * }
+     * </pre>
+     *
+     * @param tracking the mouse tracking mode to enable, or {@link MouseTracking#Off} to disable tracking
+     * @return {@code true} if the requested mouse tracking mode is supported, {@code false} otherwise
+     * @see MouseTracking
+     * @see #hasMouseSupport()
+     * @see #readMouseEvent()
      */
     boolean trackMouse(MouseTracking tracking);
 
     /**
-     * Read a MouseEvent from the terminal input stream.
-     * Such an event must have been detected by scanning the terminal's {@link Capability#key_mouse}
-     * in the stream immediately before reading the event.
+     * Reads and decodes a mouse event from the terminal input stream.
      *
-     * @return the decoded mouse event.
+     * <p>
+     * This method should be called after detecting the terminal's {@link Capability#key_mouse}
+     * sequence in the input stream, which indicates that a mouse event has occurred.
+     * The method reads the necessary data from the input stream and decodes it into
+     * a {@link MouseEvent} object containing information about the event type, button,
+     * modifiers, and coordinates.
+     * </p>
+     *
+     * <p>
+     * Before calling this method, mouse tracking must be enabled using
+     * {@link #trackMouse(MouseTracking)} with an appropriate tracking mode.
+     * </p>
+     *
+     * <p>
+     * The typical pattern for handling mouse events is:
+     * </p>
+     * <ol>
+     *   <li>Enable mouse tracking with {@link #trackMouse(MouseTracking)}</li>
+     *   <li>Read input from the terminal</li>
+     *   <li>When the {@link Capability#key_mouse} sequence is detected, call this method</li>
+     *   <li>Process the returned {@link MouseEvent}</li>
+     * </ol>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * if (terminal.hasMouseSupport()) {
+     *     terminal.trackMouse(MouseTracking.Normal);
+     *
+     *     // Read input and look for mouse events
+     *     String keyMouse = terminal.getStringCapability(Capability.key_mouse);
+     *     // When keyMouse sequence is detected in the input:
+     *     MouseEvent event = terminal.readMouseEvent();
+     *     System.out.println("Mouse event: " + event.getType() +
+     *                       " at " + event.getX() + "," + event.getY());
+     * }
+     * </pre>
+     *
+     * @return the decoded mouse event containing event type, button, modifiers, and coordinates
      * @see #trackMouse(MouseTracking)
+     * @see #hasMouseSupport()
+     * @see MouseEvent
      */
     MouseEvent readMouseEvent();
 
     /**
-     * Read a MouseEvent from the given input stream.
+     * Reads and decodes a mouse event using the provided input supplier.
      *
-     * @param reader the input supplier
-     * @return the decoded mouse event
+     * <p>
+     * This method is similar to {@link #readMouseEvent()}, but allows reading mouse event
+     * data from a custom input source rather than the terminal's default input stream.
+     * This can be useful in situations where input is being processed through a different
+     * channel or when implementing custom input handling.
+     * </p>
+     *
+     * <p>
+     * The input supplier should provide the raw bytes of the mouse event data as integers.
+     * The method will read the necessary data from the supplier and decode it into a
+     * {@link MouseEvent} object containing information about the event type, button,
+     * modifiers, and coordinates.
+     * </p>
+     *
+     * <p>
+     * This method is primarily intended for advanced use cases where the standard
+     * {@link #readMouseEvent()} method is not sufficient.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * // Create a custom input supplier
+     * IntSupplier customReader = new IntSupplier() {
+     *     private byte[] data = ...; // Mouse event data
+     *     private int index = 0;
+     *
+     *     public int getAsInt() {
+     *         return (index &lt; data.length) ? data[index++] &amp; 0xFF : -1;
+     *     }
+     * };
+     *
+     * // Read mouse event using the custom supplier
+     * MouseEvent event = terminal.readMouseEvent(customReader);
+     * </pre>
+     *
+     * @param reader the input supplier that provides the raw bytes of the mouse event data
+     * @return the decoded mouse event containing event type, button, modifiers, and coordinates
+     * @see #readMouseEvent()
+     * @see MouseEvent
      */
     MouseEvent readMouseEvent(IntSupplier reader);
 
     /**
-     * Returns <code>true</code> if the terminal has support for focus tracking.
-     * @return whether focus tracking is supported by the terminal
+     * Returns whether the terminal has support for focus tracking.
+     *
+     * <p>
+     * Focus tracking allows the terminal to report when it gains or loses focus.
+     * This can be useful for applications that need to change their behavior or
+     * appearance based on whether they are currently in focus.
+     * </p>
+     *
+     * <p>
+     * Not all terminals support focus tracking, so this method should be called
+     * before attempting to enable focus tracking with {@link #trackFocus(boolean)}.
+     * </p>
+     *
+     * <p>
+     * When focus tracking is enabled and supported, the terminal will send special
+     * escape sequences to the input stream when focus is gained ("\33[I") or
+     * lost ("\33[O"). Applications can detect these sequences to respond to
+     * focus changes.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * if (terminal.hasFocusSupport()) {
+     *     // Enable focus tracking
+     *     terminal.trackFocus(true);
+     *
+     *     // Now the application can detect focus changes
+     *     // by looking for "\33[I" and "\33[O" in the input stream
+     * } else {
+     *     System.out.println("Focus tracking not supported by this terminal");
+     * }
+     * </pre>
+     *
+     * @return {@code true} if the terminal supports focus tracking, {@code false} otherwise
      * @see #trackFocus(boolean)
      */
     boolean hasFocusSupport();
 
     /**
-     * Enable or disable focus tracking mode.
-     * When focus tracking has been activated, each time the terminal grabs the focus,
-     * the string "\33[I" will be sent to the input stream and each time the focus is lost,
-     * the string "\33[O" will be sent to the input stream.
+     * Enables or disables focus tracking mode.
      *
-     * @param tracking whether the focus tracking mode should be enabled or not
-     * @return <code>true</code> if focus tracking is supported
+     * <p>
+     * Focus tracking allows applications to detect when the terminal window gains or loses
+     * focus. When focus tracking is enabled, the terminal will send special escape sequences
+     * to the input stream whenever the focus state changes:
+     * </p>
+     * <ul>
+     *   <li>When the terminal gains focus: "\33[I" (ESC [ I)</li>
+     *   <li>When the terminal loses focus: "\33[O" (ESC [ O)</li>
+     * </ul>
+     *
+     * <p>
+     * Applications can monitor the input stream for these sequences to detect focus changes
+     * and respond accordingly, such as by changing the cursor appearance, pausing animations,
+     * or adjusting the display.
+     * </p>
+     *
+     * <p>
+     * Not all terminals support focus tracking. Use {@link #hasFocusSupport()} to check
+     * whether focus tracking is supported before enabling it.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     *
+     * if (terminal.hasFocusSupport()) {
+     *     // Enable focus tracking
+     *     boolean enabled = terminal.trackFocus(true);
+     *
+     *     if (enabled) {
+     *         System.out.println("Focus tracking enabled");
+     *         // Set up input processing to detect focus change sequences
+     *     }
+     * }
+     * </pre>
+     *
+     * @param tracking {@code true} to enable focus tracking, {@code false} to disable it
+     * @return {@code true} if focus tracking is supported and the operation succeeded, {@code false} otherwise
+     * @see #hasFocusSupport()
      */
     boolean trackFocus(boolean tracking);
 
     /**
-     * Color support
+     * Returns the color palette for this terminal.
+     *
+     * <p>
+     * The color palette provides access to the terminal's color capabilities,
+     * allowing for customization and mapping of colors to terminal-specific values.
+     * This is particularly useful for terminals that support different color modes
+     * (8-color, 256-color, or true color).
+     * </p>
+     *
+     * <p>
+     * The palette allows mapping between color values and their RGB representations,
+     * and provides methods for color conversion and manipulation.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.terminal();
+     * ColorPalette palette = terminal.getPalette();
+     *
+     * // Get RGB values for a specific color
+     * int[] rgb = palette.toRgb(AttributedStyle.RED);
+     * </pre>
+     *
+     * @return the terminal's color palette
+     * @see org.jline.utils.ColorPalette
      */
     ColorPalette getPalette();
 
     /**
-     * Get the terminal's default foreground color.
-     * @return the RGB value of the default foreground color, or -1 if not available
+     * Returns the terminal's default foreground color as an RGB value.
+     *
+     * <p>
+     * This method provides access to the terminal's default text color, which can be
+     * useful for creating color schemes that complement the terminal's default colors.
+     * The color is returned as a packed RGB integer value (0xRRGGBB).
+     * </p>
+     *
+     * <p>
+     * If the terminal does not support color detection or the default color cannot
+     * be determined, this method returns -1.
+     * </p>
+     *
+     * @return the RGB value (0xRRGGBB) of the default foreground color, or -1 if not available
+     * @see #getDefaultBackgroundColor()
+     * @see #getPalette()
      */
     default int getDefaultForegroundColor() {
         return getPalette().getDefaultForeground();
     }
 
     /**
-     * Get the terminal's default background color.
-     * @return the RGB value of the default background color, or -1 if not available
+     * Returns the terminal's default background color as an RGB value.
+     *
+     * <p>
+     * This method provides access to the terminal's default background color, which can be
+     * useful for creating color schemes that complement the terminal's default colors.
+     * The color is returned as a packed RGB integer value (0xRRGGBB).
+     * </p>
+     *
+     * <p>
+     * If the terminal does not support color detection or the default color cannot
+     * be determined, this method returns -1.
+     * </p>
+     *
+     * @return the RGB value (0xRRGGBB) of the default background color, or -1 if not available
+     * @see #getDefaultForegroundColor()
+     * @see #getPalette()
      */
     default int getDefaultBackgroundColor() {
         return getPalette().getDefaultBackground();

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -24,6 +24,42 @@ import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.NonBlockingReader;
 
+/**
+ * Base implementation for terminals on POSIX-compliant systems.
+ *
+ * <p>
+ * The AbstractPosixTerminal class provides a foundation for terminal implementations
+ * on POSIX-compliant systems such as Linux, macOS, and other Unix-like operating
+ * systems. It builds on the AbstractTerminal class and adds POSIX-specific
+ * functionality, particularly related to pseudoterminal (PTY) handling.
+ * </p>
+ *
+ * <p>
+ * This class manages the interaction with the underlying PTY, handling terminal
+ * attributes, size changes, and other POSIX-specific terminal operations. It
+ * provides implementations for many of the abstract methods defined in
+ * AbstractTerminal, leaving only a few methods to be implemented by concrete
+ * subclasses.
+ * </p>
+ *
+ * <p>
+ * Key features provided by this class include:
+ * </p>
+ * <ul>
+ *   <li>PTY management and interaction</li>
+ *   <li>Terminal attribute preservation and restoration</li>
+ *   <li>Size handling and window change signals</li>
+ *   <li>Cursor position detection</li>
+ * </ul>
+ *
+ * <p>
+ * This class is designed to be extended by concrete implementations that target
+ * specific POSIX platforms or environments.
+ * </p>
+ *
+ * @see org.jline.terminal.impl.AbstractTerminal
+ * @see org.jline.terminal.spi.Pty
+ */
 public abstract class AbstractPosixTerminal extends AbstractTerminal {
 
     protected final Pty pty;

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2019, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -30,6 +30,32 @@ import static org.jline.terminal.TerminalBuilder.PROP_FILE_DESCRIPTOR_CREATION_M
 import static org.jline.terminal.TerminalBuilder.PROP_FILE_DESCRIPTOR_CREATION_MODE_REFLECTION;
 import static org.jline.terminal.TerminalBuilder.PROP_NON_BLOCKING_READS;
 
+/**
+ * Base implementation of the Pty interface.
+ *
+ * <p>
+ * The AbstractPty class provides a common foundation for pseudoterminal (PTY)
+ * implementations. It handles common functionality such as system stream management
+ * and provider access, while leaving platform-specific PTY operations to be
+ * implemented by concrete subclasses.
+ * </p>
+ *
+ * <p>
+ * This class serves as the base for various PTY implementations, including:
+ * </p>
+ * <ul>
+ *   <li>Native PTY implementations (JNI, JNA, FFM) for direct access to system PTYs</li>
+ *   <li>Exec PTY implementation that uses external commands</li>
+ * </ul>
+ *
+ * <p>
+ * The AbstractPty maintains information about the associated system stream and
+ * terminal provider, which are common to all PTY implementations regardless of
+ * the underlying mechanism used to interact with the terminal.
+ * </p>
+ *
+ * @see org.jline.terminal.spi.Pty
+ */
 public abstract class AbstractPty implements Pty {
 
     protected final TerminalProvider provider;

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -35,6 +35,38 @@ import org.jline.utils.InfoCmp.Capability;
 import org.jline.utils.Log;
 import org.jline.utils.Status;
 
+/**
+ * Base implementation of the Terminal interface.
+ *
+ * <p>
+ * This abstract class provides a common foundation for terminal implementations,
+ * handling many of the core terminal functions such as signal handling, attribute
+ * management, and capability lookup. It implements most of the methods defined in
+ * the {@link org.jline.terminal.Terminal} interface, leaving only a few abstract
+ * methods to be implemented by concrete subclasses.
+ * </p>
+ *
+ * <p>
+ * Terminal implementations typically extend this class and provide implementations
+ * for the abstract methods related to their specific platform or environment.
+ * This class handles the common functionality, allowing subclasses to focus on
+ * platform-specific details.
+ * </p>
+ *
+ * <p>
+ * Key features provided by this class include:
+ * </p>
+ * <ul>
+ *   <li>Signal handling infrastructure</li>
+ *   <li>Terminal attribute management</li>
+ *   <li>Terminal capability lookup and caching</li>
+ *   <li>Size and cursor position handling</li>
+ *   <li>Mouse and focus tracking support</li>
+ * </ul>
+ *
+ * @see org.jline.terminal.Terminal
+ * @see org.jline.terminal.spi.TerminalExt
+ */
 public abstract class AbstractTerminal implements TerminalExt {
 
     protected final String name;

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsConsoleWriter.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsConsoleWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,10 +11,64 @@ package org.jline.terminal.impl;
 import java.io.IOException;
 import java.io.Writer;
 
+/**
+ * Base class for writing to Windows console.
+ *
+ * <p>
+ * The AbstractWindowsConsoleWriter class provides a foundation for writing text
+ * to the Windows console. It extends the standard Writer class and handles the
+ * common aspects of writing to the console, while leaving the actual console
+ * interaction to be implemented by concrete subclasses.
+ * </p>
+ *
+ * <p>
+ * This class is necessary because standard Java output streams don't work well
+ * with the Windows console, particularly for non-ASCII characters and color output.
+ * Instead of using standard output streams, Windows terminal implementations use
+ * this writer to directly interact with the Windows console API.
+ * </p>
+ *
+ * <p>
+ * Concrete subclasses must implement the {@link #writeConsole(char[], int)} method
+ * to perform the actual writing to the console using platform-specific mechanisms
+ * (e.g., JNI, JNA, or FFM).
+ * </p>
+ *
+ * @see java.io.Writer
+ */
 public abstract class AbstractWindowsConsoleWriter extends Writer {
 
+    /**
+     * Writes text to the Windows console.
+     *
+     * <p>
+     * This method must be implemented by concrete subclasses to perform the actual
+     * writing to the Windows console using platform-specific mechanisms. The
+     * implementation should handle proper encoding and display of characters,
+     * including non-ASCII characters and ANSI escape sequences if supported.
+     * </p>
+     *
+     * @param text the character array containing the text to write
+     * @param len the number of characters to write
+     * @throws IOException if an I/O error occurs
+     */
     protected abstract void writeConsole(char[] text, int len) throws IOException;
 
+    /**
+     * Writes a portion of a character array to the Windows console.
+     *
+     * <p>
+     * This method handles the common logic for writing to the console, including
+     * creating a new character array if the offset is not zero and synchronizing
+     * access to the console. The actual writing is delegated to the
+     * {@link #writeConsole(char[], int)} method implemented by subclasses.
+     * </p>
+     *
+     * @param cbuf the character array containing the text to write
+     * @param off the offset from which to start reading characters
+     * @param len the number of characters to write
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public void write(char[] cbuf, int off, int len) throws IOException {
         char[] text = cbuf;

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -33,16 +33,49 @@ import org.jline.utils.Signals;
 import org.jline.utils.WriterOutputStream;
 
 /**
- * The AbstractWindowsTerminal is used as the base class for windows terminal.
- * Due to windows limitations, mostly the missing support for ansi sequences,
- * the only way to create a correct terminal is to use the windows api to set
- * character attributes, move the cursor, erasing, etc...
+ * Base implementation for terminals on Windows systems.
  *
- * UTF-8 support is also lacking in windows and the code page supposed to
- * emulate UTF-8 is a bit broken. In order to work around this broken
- * code page, windows api WriteConsoleW is used directly.  This means that
- * the writer() becomes the primary output, while the output() is bridged
- * to the writer() using a WriterOutputStream wrapper.
+ * <p>
+ * The AbstractWindowsTerminal class provides a foundation for terminal implementations
+ * on Windows operating systems. It addresses Windows-specific limitations and
+ * peculiarities, particularly related to console handling, character encoding,
+ * and ANSI sequence support.
+ * </p>
+ *
+ * <p>
+ * Due to Windows limitations, particularly the historically limited support for ANSI
+ * sequences, this implementation uses Windows-specific APIs to handle terminal
+ * operations such as setting character attributes, moving the cursor, erasing content,
+ * and other terminal functions. This approach provides better compatibility and
+ * performance compared to emulating ANSI sequences on Windows.
+ * </p>
+ *
+ * <p>
+ * UTF-8 support has also been historically problematic on Windows, with the code page
+ * meant to emulate UTF-8 being somewhat broken. To work around these issues, this
+ * implementation uses the Windows API WriteConsoleW directly. As a result, the
+ * writer() method becomes the primary output mechanism, while the output() stream
+ * is bridged to the writer using a WriterOutputStream wrapper.
+ * </p>
+ *
+ * <p>
+ * Key features provided by this class include:
+ * </p>
+ * <ul>
+ *   <li>Windows console API integration</li>
+ *   <li>Color attribute handling</li>
+ *   <li>Cursor positioning and manipulation</li>
+ *   <li>Proper UTF-8 and Unicode support</li>
+ *   <li>Input processing for Windows console events</li>
+ * </ul>
+ *
+ * <p>
+ * This class is designed to be extended by concrete implementations that use
+ * specific Windows API access mechanisms (e.g., JNA, JNI, FFM).
+ * </p>
+ *
+ * @see org.jline.terminal.impl.AbstractTerminal
+ * @param <Console> the Windows console type used by the specific implementation
  */
 public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal {
 

--- a/terminal/src/main/java/org/jline/terminal/impl/CursorSupport.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/CursorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -19,8 +19,67 @@ import org.jline.terminal.Terminal;
 import org.jline.utils.Curses;
 import org.jline.utils.InfoCmp;
 
+/**
+ * Utility class for cursor position detection in terminals.
+ *
+ * <p>
+ * The CursorSupport class provides functionality for determining the current
+ * cursor position in a terminal. It uses terminal capabilities to request the
+ * cursor position from the terminal and parse the response.
+ * </p>
+ *
+ * <p>
+ * This class is used internally by terminal implementations to implement the
+ * {@link Terminal#getCursorPosition(IntConsumer)} method. It relies on specific
+ * terminal capabilities (user6 and user7) that define the sequence to request
+ * the cursor position and the format of the response.
+ * </p>
+ *
+ * <p>
+ * The cursor position detection works by:
+ * </p>
+ * <ol>
+ *   <li>Sending a special escape sequence to the terminal (defined by user7 capability)</li>
+ *   <li>Reading the terminal's response</li>
+ *   <li>Parsing the response using a pattern derived from the user6 capability</li>
+ *   <li>Extracting the row and column coordinates from the parsed response</li>
+ * </ol>
+ *
+ * <p>
+ * Note that cursor position reporting is not supported by all terminals, and
+ * this method may return null if the terminal does not support this feature
+ * or if an error occurs during the detection process.
+ * </p>
+ *
+ * @see Terminal#getCursorPosition(IntConsumer)
+ * @see Cursor
+ */
 public class CursorSupport {
 
+    /**
+     * Gets the current cursor position from the terminal.
+     *
+     * <p>
+     * This method sends a request to the terminal for its current cursor position
+     * and parses the response to extract the coordinates. It uses the terminal's
+     * user6 and user7 capabilities to determine the request sequence and response
+     * format.
+     * </p>
+     *
+     * <p>
+     * The method reads from the terminal's input stream until it finds a response
+     * that matches the expected pattern. Any characters read that are not part of
+     * the cursor position response can be optionally collected through the
+     * discarded consumer.
+     * </p>
+     *
+     * @param terminal the terminal to get the cursor position from
+     * @param discarded an optional consumer for characters read that are not part
+     *                 of the cursor position response, or null if these characters
+     *                 should be ignored
+     * @return the cursor position, or null if the position could not be determined
+     *         (e.g., if the terminal does not support cursor position reporting)
+     */
     public static Cursor getCursorPosition(Terminal terminal, IntConsumer discarded) {
         try {
             String u6 = terminal.getStringCapability(InfoCmp.Capability.user6);

--- a/terminal/src/main/java/org/jline/terminal/impl/Diag.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/Diag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, the original author(s).
+ * Copyright (c) 2022-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -21,12 +21,63 @@ import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.OSUtils;
 
+/**
+ * Diagnostic utility for JLine terminals.
+ *
+ * <p>
+ * The Diag class provides diagnostic tools for analyzing and troubleshooting
+ * JLine terminal configurations. It can be used to gather information about
+ * the current environment, available terminal providers, system properties,
+ * and other details relevant to terminal operation.
+ * </p>
+ *
+ * <p>
+ * This class can be run as a standalone application to generate a diagnostic
+ * report, which is useful for debugging terminal-related issues. The report
+ * includes information such as:
+ * </p>
+ * <ul>
+ *   <li>Java version and system properties</li>
+ *   <li>Operating system details</li>
+ *   <li>Available terminal providers</li>
+ *   <li>Terminal capabilities and attributes</li>
+ *   <li>Console and TTY information</li>
+ * </ul>
+ *
+ * <p>
+ * The diagnostic information can help identify configuration issues, missing
+ * dependencies, or platform-specific problems that might affect terminal
+ * functionality.
+ * </p>
+ */
 public class Diag {
 
+    /**
+     * Main entry point for running the diagnostic tool.
+     *
+     * <p>
+     * This method runs the diagnostic tool and prints the results to standard output.
+     * If the "--verbose" flag is provided as an argument, additional detailed
+     * information will be included in the output.
+     * </p>
+     *
+     * @param args command-line arguments (use "--verbose" for detailed output)
+     */
     public static void main(String[] args) {
         diag(System.out, Arrays.asList(args).contains("--verbose"));
     }
 
+    /**
+     * Generates a diagnostic report with standard verbosity.
+     *
+     * <p>
+     * This method generates a diagnostic report with standard verbosity and
+     * writes it to the specified PrintStream. This is equivalent to calling
+     * {@link #diag(PrintStream, boolean)} with {@code verbose=false}.
+     * </p>
+     *
+     * @param out the PrintStream to write the diagnostic report to
+     */
     public static void diag(PrintStream out) {
         diag(out, true);
     }

--- a/terminal/src/main/java/org/jline/terminal/impl/DumbTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DumbTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -24,6 +24,41 @@ import org.jline.utils.NonBlocking;
 import org.jline.utils.NonBlockingInputStream;
 import org.jline.utils.NonBlockingReader;
 
+/**
+ * A minimal terminal implementation with limited capabilities.
+ *
+ * <p>
+ * The DumbTerminal class provides a basic terminal implementation that works in
+ * environments where a full-featured terminal is not available or not supported.
+ * It has minimal capabilities and does not support features like cursor movement,
+ * color output, or advanced input processing.
+ * </p>
+ *
+ * <p>
+ * This terminal type is often used as a fallback when more capable terminal
+ * implementations cannot be created, such as in non-interactive environments,
+ * redirected I/O scenarios, or when running inside IDEs or other tools that
+ * don't provide full terminal emulation.
+ * </p>
+ *
+ * <p>
+ * The DumbTerminal supports two variants:
+ * </p>
+ * <ul>
+ *   <li>Standard dumb terminal ({@link org.jline.terminal.Terminal#TYPE_DUMB}) - No color support</li>
+ *   <li>Color dumb terminal ({@link org.jline.terminal.Terminal#TYPE_DUMB_COLOR}) - Basic color support</li>
+ * </ul>
+ *
+ * <p>
+ * While limited in capabilities, the DumbTerminal still provides the core terminal
+ * functionality such as reading input and writing output, making it suitable for
+ * basic console applications that don't require advanced terminal features.
+ * </p>
+ *
+ * @see org.jline.terminal.Terminal#TYPE_DUMB
+ * @see org.jline.terminal.Terminal#TYPE_DUMB_COLOR
+ * @see org.jline.terminal.impl.AbstractTerminal
+ */
 public class DumbTerminal extends AbstractTerminal {
 
     private final TerminalProvider provider;

--- a/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) 2023-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -23,6 +23,34 @@ import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
 
+/**
+ * Terminal provider implementation for dumb terminals.
+ *
+ * <p>
+ * The DumbTerminalProvider class provides a TerminalProvider implementation that
+ * creates DumbTerminal instances. Dumb terminals have minimal capabilities and
+ * are used as a fallback when more capable terminal implementations cannot be
+ * created or when running in environments with limited terminal support.
+ * </p>
+ *
+ * <p>
+ * This provider supports two types of dumb terminals:
+ * </p>
+ * <ul>
+ *   <li>Standard dumb terminal ({@link Terminal#TYPE_DUMB}) - No color support</li>
+ *   <li>Color dumb terminal ({@link Terminal#TYPE_DUMB_COLOR}) - Basic color support</li>
+ * </ul>
+ *
+ * <p>
+ * The provider name is "dumb", which can be specified in the {@code org.jline.terminal.provider}
+ * system property to force the use of this provider. This is useful in environments
+ * where other terminal providers might not work correctly or when terminal capabilities
+ * are not needed.
+ * </p>
+ *
+ * @see org.jline.terminal.spi.TerminalProvider
+ * @see org.jline.terminal.impl.DumbTerminal
+ */
 public class DumbTerminalProvider implements TerminalProvider {
 
     @Override

--- a/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -21,13 +21,39 @@ import org.jline.terminal.Size;
 import org.jline.terminal.spi.TerminalProvider;
 
 /**
- * Console implementation with embedded line disciplined.
+ * Terminal implementation designed for external connections with embedded line discipline.
  *
- * This terminal is well-suited for supporting incoming external
- * connections, such as from the network (through telnet, ssh,
- * or any kind of protocol).
- * The terminal will start consuming the input in a separate thread
- * to generate interruption events.
+ * <p>
+ * The ExternalTerminal class provides a terminal implementation that is well-suited
+ * for supporting incoming external connections, such as those from network sources
+ * (telnet, SSH, or other protocols). It extends the LineDisciplineTerminal class,
+ * inheriting its line discipline functionality while adding features specific to
+ * external connection handling.
+ * </p>
+ *
+ * <p>
+ * This terminal implementation starts consuming input in a separate thread to
+ * generate interruption events promptly, ensuring that signals like Ctrl+C are
+ * processed immediately rather than waiting for the application to read the input.
+ * This is particularly important for network-based terminals where latency could
+ * otherwise affect the responsiveness of signal handling.
+ * </p>
+ *
+ * <p>
+ * Key features of this implementation include:
+ * </p>
+ * <ul>
+ *   <li>Support for external connections over various protocols</li>
+ *   <li>Prompt signal handling through background input processing</li>
+ *   <li>Configurable terminal type and attributes</li>
+ *   <li>Support for dynamic size changes</li>
+ * </ul>
+ *
+ * <p>
+ * This terminal is commonly used in server applications that need to provide
+ * terminal access to remote clients, such as SSH servers, telnet servers, or
+ * custom network protocols that require terminal emulation.
+ * </p>
  *
  * @see LineDisciplineTerminal
  */

--- a/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -45,6 +45,41 @@ import org.jline.utils.NonBlockingReader;
  * has to happen as soon as the user hit the keyboard, and not
  * only when the application running in the terminal processes
  * the input.
+ *
+ * <p>
+ * The LineDisciplineTerminal class provides a terminal implementation that emulates
+ * the line discipline functionality typically provided by the operating system's
+ * terminal driver. Line discipline refers to the processing of input and output
+ * characters according to various modes and settings, such as canonical mode,
+ * echo, and special character handling.
+ * </p>
+ *
+ * <p>
+ * This terminal implementation is particularly useful in environments where:
+ * </p>
+ * <ul>
+ *   <li>The underlying system does not provide native terminal capabilities</li>
+ *   <li>The application needs precise control over terminal behavior</li>
+ *   <li>The terminal is being used in a non-standard environment (e.g., embedded systems)</li>
+ * </ul>
+ *
+ * <p>
+ * Key features of this implementation include:
+ * </p>
+ * <ul>
+ *   <li>Emulation of canonical and non-canonical input modes</li>
+ *   <li>Support for character echoing</li>
+ *   <li>Special character handling (e.g., interrupt, erase, kill)</li>
+ *   <li>Input and output processing according to terminal attributes</li>
+ * </ul>
+ *
+ * <p>
+ * This terminal implementation works with any input and output streams, making it
+ * highly flexible and adaptable to various environments.
+ * </p>
+ *
+ * @see org.jline.terminal.Attributes
+ * @see org.jline.terminal.impl.AbstractTerminal
  */
 public class LineDisciplineTerminal extends AbstractTerminal {
 

--- a/terminal/src/main/java/org/jline/terminal/impl/MouseSupport.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/MouseSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -20,12 +20,81 @@ import org.jline.terminal.Terminal;
 import org.jline.utils.InfoCmp;
 import org.jline.utils.InputStreamReader;
 
+/**
+ * Utility class for mouse support in terminals.
+ *
+ * <p>
+ * The MouseSupport class provides functionality for enabling, disabling, and
+ * processing mouse events in terminals that support mouse tracking. It handles
+ * the details of sending the appropriate escape sequences to the terminal to
+ * enable different mouse tracking modes and parsing the responses to create
+ * MouseEvent objects.
+ * </p>
+ *
+ * <p>
+ * This class is used internally by terminal implementations to implement the
+ * mouse-related methods defined in the Terminal interface, such as
+ * {@link Terminal#hasMouseSupport()}, {@link Terminal#trackMouse(Terminal.MouseTracking)},
+ * and {@link Terminal#readMouseEvent()}.
+ * </p>
+ *
+ * <p>
+ * Mouse tracking in terminals typically works by:
+ * </p>
+ * <ol>
+ *   <li>Sending special escape sequences to enable a specific mouse tracking mode</li>
+ *   <li>Receiving escape sequences from the terminal when mouse events occur</li>
+ *   <li>Parsing these sequences to extract information about the event type, button, modifiers, and coordinates</li>
+ *   <li>Creating MouseEvent objects that represent these events</li>
+ * </ol>
+ *
+ * <p>
+ * Note that mouse support is not available in all terminals, and the methods in
+ * this class may not work correctly if the terminal does not support mouse tracking.
+ * </p>
+ *
+ * @see Terminal#hasMouseSupport()
+ * @see Terminal#trackMouse(Terminal.MouseTracking)
+ * @see Terminal#readMouseEvent()
+ * @see MouseEvent
+ */
 public class MouseSupport {
 
+    /**
+     * Checks if the terminal supports mouse tracking.
+     *
+     * <p>
+     * This method determines whether the terminal supports mouse tracking by
+     * checking if it has the key_mouse capability. This capability is required
+     * for mouse tracking to work correctly.
+     * </p>
+     *
+     * @param terminal the terminal to check
+     * @return {@code true} if the terminal supports mouse tracking, {@code false} otherwise
+     */
     public static boolean hasMouseSupport(Terminal terminal) {
         return terminal.getStringCapability(InfoCmp.Capability.key_mouse) != null;
     }
 
+    /**
+     * Enables or disables mouse tracking in the terminal.
+     *
+     * <p>
+     * This method sends the appropriate escape sequences to the terminal to
+     * enable or disable mouse tracking according to the specified tracking mode.
+     * The available tracking modes are:
+     * </p>
+     * <ul>
+     *   <li>{@link Terminal.MouseTracking#Off} - Disables mouse tracking</li>
+     *   <li>{@link Terminal.MouseTracking#Normal} - Reports button press and release events</li>
+     *   <li>{@link Terminal.MouseTracking#Button} - Reports button press, release, and motion events while buttons are pressed</li>
+     *   <li>{@link Terminal.MouseTracking#Any} - Reports all mouse events, including movement without buttons pressed</li>
+     * </ul>
+     *
+     * @param terminal the terminal to configure
+     * @param tracking the mouse tracking mode to enable
+     * @return {@code true} if mouse tracking is supported and was configured, {@code false} otherwise
+     */
     public static boolean trackMouse(Terminal terminal, Terminal.MouseTracking tracking) {
         if (hasMouseSupport(terminal)) {
             switch (tracking) {
@@ -49,10 +118,44 @@ public class MouseSupport {
         }
     }
 
+    /**
+     * Reads a mouse event from the terminal.
+     *
+     * <p>
+     * This method reads a mouse event from the terminal's input stream and
+     * converts it into a MouseEvent object. It uses the previous mouse event
+     * to determine the type of the new event (e.g., to distinguish between
+     * press, drag, and release events).
+     * </p>
+     *
+     * @param terminal the terminal to read from
+     * @param last the previous mouse event, used to determine the type of the new event
+     * @return the mouse event that was read
+     */
     public static MouseEvent readMouse(Terminal terminal, MouseEvent last) {
         return readMouse(() -> readExt(terminal), last);
     }
 
+    /**
+     * Reads a mouse event using the provided input supplier.
+     *
+     * <p>
+     * This method reads a mouse event using the provided input supplier and
+     * converts it into a MouseEvent object. It uses the previous mouse event
+     * to determine the type of the new event (e.g., to distinguish between
+     * press, drag, and release events).
+     * </p>
+     *
+     * <p>
+     * The input supplier should provide the raw bytes of the mouse event data.
+     * This method expects the data to be in the format used by xterm-compatible
+     * terminals for mouse reporting.
+     * </p>
+     *
+     * @param reader the input supplier to read from
+     * @param last the previous mouse event, used to determine the type of the new event
+     * @return the mouse event that was read
+     */
     public static MouseEvent readMouse(IntSupplier reader, MouseEvent last) {
         int cb = reader.getAsInt() - ' ';
         int cx = reader.getAsInt() - ' ' - 1;
@@ -119,6 +222,20 @@ public class MouseSupport {
         return new MouseEvent(type, button, modifiers, cx, cy);
     }
 
+    /**
+     * Reads a single character from the terminal's input stream.
+     *
+     * <p>
+     * This method reads a single character from the terminal's input stream,
+     * handling the case where the terminal's encoding is not UTF-8. Mouse events
+     * are encoded in UTF-8, so if the terminal is using a different encoding,
+     * this method creates a temporary UTF-8 reader to read the character.
+     * </p>
+     *
+     * @param terminal the terminal to read from
+     * @return the character that was read
+     * @throws IOError if an I/O error occurs while reading
+     */
     private static int readExt(Terminal terminal) {
         try {
             // The coordinates are encoded in UTF-8, so if that's not the input encoding,

--- a/terminal/src/main/java/org/jline/terminal/impl/NativeSignalHandler.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/NativeSignalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,14 +11,78 @@ package org.jline.terminal.impl;
 import org.jline.terminal.Terminal.Signal;
 import org.jline.terminal.Terminal.SignalHandler;
 
+/**
+ * Implementation of SignalHandler for native signal handling.
+ *
+ * <p>
+ * The NativeSignalHandler class provides an implementation of the SignalHandler
+ * interface that represents native signal handlers. It defines two special
+ * instances that correspond to the standard POSIX signal dispositions:
+ * </p>
+ * <ul>
+ *   <li>{@link #SIG_DFL} - The default signal handler</li>
+ *   <li>{@link #SIG_IGN} - The signal handler that ignores the signal</li>
+ * </ul>
+ *
+ * <p>
+ * This class is used internally by terminal implementations to represent native
+ * signal handlers. It cannot be instantiated directly, and its {@link #handle(Signal)}
+ * method throws an UnsupportedOperationException because native signal handling
+ * is performed by the underlying platform, not by Java code.
+ * </p>
+ *
+ * @see org.jline.terminal.Terminal.SignalHandler
+ * @see org.jline.terminal.Terminal#handle(Signal, SignalHandler)
+ */
 public final class NativeSignalHandler implements SignalHandler {
 
+    /**
+     * The default signal handler.
+     *
+     * <p>
+     * This constant represents the default signal handler, which corresponds to
+     * the SIG_DFL disposition in POSIX systems. When a signal is handled by the
+     * default handler, the default action for that signal is taken, which varies
+     * depending on the signal (e.g., termination, core dump, ignore, etc.).
+     * </p>
+     */
     public static final NativeSignalHandler SIG_DFL = new NativeSignalHandler();
 
+    /**
+     * The signal handler that ignores signals.
+     *
+     * <p>
+     * This constant represents the signal handler that ignores signals, which
+     * corresponds to the SIG_IGN disposition in POSIX systems. When a signal is
+     * handled by this handler, the signal is ignored and no action is taken.
+     * </p>
+     */
     public static final NativeSignalHandler SIG_IGN = new NativeSignalHandler();
 
+    /**
+     * Private constructor to prevent direct instantiation.
+     *
+     * <p>
+     * This constructor is private because NativeSignalHandler instances should
+     * only be created for the predefined constants SIG_DFL and SIG_IGN.
+     * </p>
+     */
     private NativeSignalHandler() {}
 
+    /**
+     * Handles the specified signal.
+     *
+     * <p>
+     * This method always throws an UnsupportedOperationException because native
+     * signal handling is performed by the underlying platform, not by Java code.
+     * The NativeSignalHandler instances are only used as markers to indicate
+     * which native signal handler should be used.
+     * </p>
+     *
+     * @param signal the signal to handle
+     * @throws UnsupportedOperationException always thrown to indicate that this
+     *                                       method cannot be called directly
+     */
     public void handle(Signal signal) {
         throw new UnsupportedOperationException();
     }

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -22,6 +22,36 @@ import org.jline.utils.NonBlocking;
 import org.jline.utils.NonBlockingInputStream;
 import org.jline.utils.NonBlockingReader;
 
+/**
+ * Terminal implementation for POSIX systems using a pseudoterminal (PTY).
+ *
+ * <p>
+ * The PosixPtyTerminal class provides a terminal implementation for POSIX systems
+ * (Linux, macOS, etc.) that uses a pseudoterminal (PTY) for terminal operations.
+ * It extends the AbstractPosixTerminal class and adds functionality specific to
+ * PTY-based terminals.
+ * </p>
+ *
+ * <p>
+ * This implementation is used when a full terminal emulation is needed, such as
+ * when creating a terminal for an external process or when connecting to a remote
+ * terminal. It provides access to the master and slave sides of the PTY, allowing
+ * for bidirectional communication with the terminal.
+ * </p>
+ *
+ * <p>
+ * Key features of this implementation include:
+ * </p>
+ * <ul>
+ *   <li>Full terminal emulation using a pseudoterminal</li>
+ *   <li>Support for terminal attributes and size changes</li>
+ *   <li>Access to both master and slave sides of the PTY</li>
+ *   <li>Support for non-blocking I/O</li>
+ * </ul>
+ *
+ * @see org.jline.terminal.impl.AbstractPosixTerminal
+ * @see org.jline.terminal.spi.Pty
+ */
 public class PosixPtyTerminal extends AbstractPosixTerminal {
 
     private final InputStream in;

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -26,6 +26,36 @@ import org.jline.utils.ShutdownHooks;
 import org.jline.utils.ShutdownHooks.Task;
 import org.jline.utils.Signals;
 
+/**
+ * Terminal implementation for POSIX systems using system streams.
+ *
+ * <p>
+ * The PosixSysTerminal class provides a terminal implementation for POSIX systems
+ * (Linux, macOS, etc.) that uses the system standard input and output streams.
+ * It extends the AbstractPosixTerminal class and adds functionality specific to
+ * system stream-based terminals.
+ * </p>
+ *
+ * <p>
+ * This implementation is used when connecting to the actual system terminal, such
+ * as when running a console application in a terminal window. It provides access
+ * to the standard input and output streams, allowing for interaction with the
+ * user through the terminal.
+ * </p>
+ *
+ * <p>
+ * Key features of this implementation include:
+ * </p>
+ * <ul>
+ *   <li>Direct access to system standard input and output</li>
+ *   <li>Support for terminal attributes and size changes</li>
+ *   <li>Support for non-blocking I/O</li>
+ *   <li>Automatic restoration of terminal state on shutdown</li>
+ * </ul>
+ *
+ * @see org.jline.terminal.impl.AbstractPosixTerminal
+ * @see org.jline.terminal.spi.Pty
+ */
 public class PosixSysTerminal extends AbstractPosixTerminal {
 
     protected final NonBlockingInputStream input;

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecPty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -34,10 +34,54 @@ import org.jline.utils.OSUtils;
 
 import static org.jline.utils.ExecHelper.exec;
 
+/**
+ * A pseudoterminal implementation that uses external commands to interact with the terminal.
+ *
+ * <p>
+ * The ExecPty class provides a Pty implementation that uses external commands (such as
+ * stty, tput, etc.) to interact with the terminal. This approach allows JLine to work
+ * in environments where native libraries are not available or cannot be used, by relying
+ * on standard command-line utilities that are typically available on Unix-like systems.
+ * </p>
+ *
+ * <p>
+ * This implementation executes external commands to perform operations such as:
+ * </p>
+ * <ul>
+ *   <li>Getting and setting terminal attributes</li>
+ *   <li>Getting and setting terminal size</li>
+ *   <li>Determining the current terminal device</li>
+ * </ul>
+ *
+ * <p>
+ * The ExecPty is typically used as a fallback when more direct methods of terminal
+ * interaction (such as JNI or JNA) are not available. While it provides good compatibility,
+ * it may have higher overhead due to the need to spawn external processes for many operations.
+ * </p>
+ *
+ * @see org.jline.terminal.impl.AbstractPty
+ * @see org.jline.terminal.spi.Pty
+ */
 public class ExecPty extends AbstractPty implements Pty {
 
     private final String name;
 
+    /**
+     * Creates an ExecPty instance for the current terminal.
+     *
+     * <p>
+     * This method creates an ExecPty instance for the current terminal by executing
+     * the 'tty' command to determine the terminal device name. It is used to obtain
+     * a Pty object that can interact with the current terminal using external commands.
+     * </p>
+     *
+     * @param provider the terminal provider that will own this Pty
+     * @param systemStream the system stream (must be Output or Error) associated with this Pty
+     * @return a new ExecPty instance for the current terminal
+     * @throws IOException if the current terminal is not a TTY or if an error occurs
+     *                     while executing the 'tty' command
+     * @throws IllegalArgumentException if systemStream is not Output or Error
+     */
     public static Pty current(TerminalProvider provider, SystemStream systemStream) throws IOException {
         try {
             String result = exec(true, OSUtils.TTY_COMMAND);
@@ -50,14 +94,49 @@ public class ExecPty extends AbstractPty implements Pty {
         }
     }
 
+    /**
+     * Creates a new ExecPty instance.
+     *
+     * <p>
+     * This constructor creates a new ExecPty instance with the specified provider,
+     * system stream, and terminal device name. It is protected because instances should
+     * typically be created using the {@link #current(TerminalProvider, SystemStream)} method.
+     * </p>
+     *
+     * @param provider the terminal provider that will own this Pty
+     * @param systemStream the system stream associated with this Pty
+     * @param name the name of the terminal device (e.g., "/dev/tty")
+     */
     protected ExecPty(TerminalProvider provider, SystemStream systemStream, String name) {
         super(provider, systemStream);
         this.name = name;
     }
 
+    /**
+     * Closes this Pty.
+     *
+     * <p>
+     * This implementation does nothing, as there are no resources to release.
+     * The terminal device is not actually opened by this class, so it does not
+     * need to be closed.
+     * </p>
+     *
+     * @throws IOException if an I/O error occurs (never thrown by this implementation)
+     */
     @Override
     public void close() throws IOException {}
 
+    /**
+     * Returns the name of the terminal device.
+     *
+     * <p>
+     * This method returns the name of the terminal device associated with this Pty,
+     * which was determined when the Pty was created. This is typically a device path
+     * such as "/dev/tty" or "/dev/pts/0".
+     * </p>
+     *
+     * @return the name of the terminal device
+     */
     public String getName() {
         return name;
     }

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, the original author(s).
+ * Copyright (c) 2022-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -36,14 +36,64 @@ import static org.jline.terminal.TerminalBuilder.PROP_REDIRECT_PIPE_CREATION_MOD
 import static org.jline.terminal.TerminalBuilder.PROP_REDIRECT_PIPE_CREATION_MODE_NATIVE;
 import static org.jline.terminal.TerminalBuilder.PROP_REDIRECT_PIPE_CREATION_MODE_REFLECTION;
 
+/**
+ * A terminal provider implementation that uses external commands to interact with the terminal.
+ *
+ * <p>
+ * The ExecTerminalProvider class provides a TerminalProvider implementation that uses
+ * external commands (such as stty, tput, etc.) to interact with the terminal. This approach
+ * allows JLine to work in environments where native libraries are not available or cannot
+ * be used, by relying on standard command-line utilities that are typically available on
+ * Unix-like systems.
+ * </p>
+ *
+ * <p>
+ * This provider is typically used as a fallback when more direct methods of terminal
+ * interaction (such as JNI or JNA) are not available. While it provides good compatibility,
+ * it may have higher overhead due to the need to spawn external processes for many operations.
+ * </p>
+ *
+ * <p>
+ * The provider name is "exec", which can be specified in the {@code org.jline.terminal.provider}
+ * system property to force the use of this provider.
+ * </p>
+ *
+ * @see org.jline.terminal.spi.TerminalProvider
+ * @see org.jline.terminal.impl.exec.ExecPty
+ */
 public class ExecTerminalProvider implements TerminalProvider {
 
     private static boolean warned;
 
+    /**
+     * Returns the name of this terminal provider.
+     *
+     * <p>
+     * This method returns the name of this terminal provider, which is "exec".
+     * This name can be specified in the {@code org.jline.terminal.provider} system
+     * property to force the use of this provider.
+     * </p>
+     *
+     * @return the name of this terminal provider ("exec")
+     */
     public String name() {
         return TerminalBuilder.PROP_PROVIDER_EXEC;
     }
 
+    /**
+     * Creates a Pty for the current terminal.
+     *
+     * <p>
+     * This method creates an ExecPty instance for the current terminal by executing
+     * the 'tty' command to determine the terminal device name. It is used to obtain
+     * a Pty object that can interact with the current terminal using external commands.
+     * </p>
+     *
+     * @param systemStream the system stream to associate with the Pty
+     * @return a new ExecPty instance for the current terminal
+     * @throws IOException if the current terminal is not a TTY or if an error occurs
+     *                     while executing the 'tty' command
+     */
     public Pty current(SystemStream systemStream) throws IOException {
         if (!isSystemStream(systemStream)) {
             throw new IOException("Not a system stream: " + systemStream);
@@ -51,6 +101,26 @@ public class ExecTerminalProvider implements TerminalProvider {
         return ExecPty.current(this, systemStream);
     }
 
+    /**
+     * Creates a terminal connected to a system stream.
+     *
+     * <p>
+     * This method creates a terminal that is connected to one of the standard
+     * system streams (standard input, standard output, or standard error). It uses
+     * the ExecPty implementation to interact with the terminal using external commands.
+     * </p>
+     *
+     * @param name the name of the terminal
+     * @param type the terminal type (e.g., "xterm", "dumb")
+     * @param ansiPassThrough whether to pass through ANSI escape sequences
+     * @param encoding the character encoding to use
+     * @param nativeSignals whether to use native signal handling
+     * @param signalHandler the signal handler to use
+     * @param paused whether the terminal should start in a paused state
+     * @param systemStream the system stream to connect to
+     * @return a new terminal connected to the specified system stream
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public Terminal sysTerminal(
             String name,
@@ -71,6 +141,31 @@ public class ExecTerminalProvider implements TerminalProvider {
         }
     }
 
+    /**
+     * Creates a terminal connected to a system stream on Windows.
+     *
+     * <p>
+     * This method creates a terminal that is connected to one of the standard
+     * system streams on Windows. It uses the ExecPty implementation to interact
+     * with the terminal using external commands.
+     * </p>
+     *
+     * <p>
+     * Note that on Windows, the exec provider has limited functionality and may
+     * not work as well as the native providers (JNI, JNA, etc.).
+     * </p>
+     *
+     * @param name the name of the terminal
+     * @param type the terminal type (e.g., "xterm", "dumb")
+     * @param ansiPassThrough whether to pass through ANSI escape sequences
+     * @param encoding the character encoding to use
+     * @param nativeSignals whether to use native signal handling
+     * @param signalHandler the signal handler to use
+     * @param paused whether the terminal should start in a paused state
+     * @param systemStream the system stream to connect to
+     * @return a new terminal connected to the specified system stream
+     * @throws IOException if an I/O error occurs
+     */
     public Terminal winSysTerminal(
             String name,
             String type,
@@ -89,6 +184,26 @@ public class ExecTerminalProvider implements TerminalProvider {
         }
     }
 
+    /**
+     * Creates a terminal connected to a system stream on POSIX systems.
+     *
+     * <p>
+     * This method creates a terminal that is connected to one of the standard
+     * system streams on POSIX systems (Linux, macOS, etc.). It uses the ExecPty
+     * implementation to interact with the terminal using external commands.
+     * </p>
+     *
+     * @param name the name of the terminal
+     * @param type the terminal type (e.g., "xterm", "dumb")
+     * @param ansiPassThrough whether to pass through ANSI escape sequences
+     * @param encoding the character encoding to use
+     * @param nativeSignals whether to use native signal handling
+     * @param signalHandler the signal handler to use
+     * @param paused whether the terminal should start in a paused state
+     * @param systemStream the system stream to connect to
+     * @return a new terminal connected to the specified system stream
+     * @throws IOException if an I/O error occurs
+     */
     public Terminal posixSysTerminal(
             String name,
             String type,
@@ -103,6 +218,28 @@ public class ExecTerminalProvider implements TerminalProvider {
         return new PosixSysTerminal(name, type, pty, encoding, nativeSignals, signalHandler);
     }
 
+    /**
+     * Creates a new terminal with custom input and output streams.
+     *
+     * <p>
+     * This method creates a terminal that is connected to the specified input and
+     * output streams. It creates an ExternalTerminal that emulates the line
+     * discipline functionality typically provided by the operating system's terminal
+     * driver.
+     * </p>
+     *
+     * @param name the name of the terminal
+     * @param type the terminal type (e.g., "xterm", "dumb")
+     * @param in the input stream to read from
+     * @param out the output stream to write to
+     * @param encoding the character encoding to use
+     * @param signalHandler the signal handler to use
+     * @param paused whether the terminal should start in a paused state
+     * @param attributes the initial terminal attributes
+     * @param size the initial terminal size
+     * @return a new terminal connected to the specified streams
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public Terminal newTerminal(
             String name,
@@ -118,6 +255,18 @@ public class ExecTerminalProvider implements TerminalProvider {
         return new ExternalTerminal(this, name, type, in, out, encoding, signalHandler, paused, attributes, size);
     }
 
+    /**
+     * Checks if the specified system stream is available on this platform.
+     *
+     * <p>
+     * This method determines whether the specified system stream (standard input,
+     * standard output, or standard error) is available for use on the current
+     * platform. It checks both POSIX and Windows system streams.
+     * </p>
+     *
+     * @param stream the system stream to check
+     * @return {@code true} if the system stream is available, {@code false} otherwise
+     */
     @Override
     public boolean isSystemStream(SystemStream stream) {
         try {
@@ -144,6 +293,18 @@ public class ExecTerminalProvider implements TerminalProvider {
         return false;
     }
 
+    /**
+     * Returns the name of the specified system stream on this platform.
+     *
+     * <p>
+     * This method returns a platform-specific name or identifier for the specified
+     * system stream. The name may be used for display purposes or for accessing
+     * the stream through platform-specific APIs.
+     * </p>
+     *
+     * @param stream the system stream
+     * @return the name of the system stream on this platform
+     */
     @Override
     public String systemStreamName(SystemStream stream) {
         try {
@@ -169,6 +330,24 @@ public class ExecTerminalProvider implements TerminalProvider {
         return null;
     }
 
+    /**
+     * Returns the width (number of columns) of the specified system stream.
+     *
+     * <p>
+     * This method determines the width of the terminal associated with the specified
+     * system stream. The width is measured in character cells and represents the
+     * number of columns available for display.
+     * </p>
+     *
+     * <p>
+     * This implementation uses the 'tput cols' command to determine the terminal width.
+     * If the command fails or returns an invalid value, a default width of 80 columns
+     * is returned.
+     * </p>
+     *
+     * @param stream the system stream
+     * @return the width of the system stream in character columns
+     */
     @Override
     public int systemStreamWidth(SystemStream stream) {
         try (ExecPty pty = new ExecPty(this, stream, null)) {

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/package-info.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/package-info.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Implementation of terminal functionality using external command-line utilities.
+ *
+ * <p>
+ * This package provides implementations of terminal-related interfaces that rely on
+ * external command-line utilities (such as stty, tput, etc.) rather than native code
+ * or JNI libraries. This approach allows JLine to work in environments where native
+ * libraries are not available or cannot be used.
+ * </p>
+ *
+ * <p>
+ * The key components in this package are:
+ * </p>
+ *
+ * <ul>
+ *   <li>{@link org.jline.terminal.impl.exec.ExecPty} - A pseudoterminal implementation
+ *       that uses external commands to interact with the terminal. It provides functionality
+ *       for terminal attribute manipulation, size detection, and process control using
+ *       standard Unix utilities.</li>
+ *   <li>{@link org.jline.terminal.impl.exec.ExecTerminalProvider} - A terminal provider
+ *       that creates terminals using the exec-based approach. It serves as a fallback
+ *       when native terminal access is not available.</li>
+ * </ul>
+ *
+ * <p>
+ * This package is particularly useful in the following scenarios:
+ * </p>
+ *
+ * <ul>
+ *   <li>When running on platforms where JLine's native libraries cannot be loaded</li>
+ *   <li>In restricted environments where JNI access is limited or prohibited</li>
+ *   <li>As a fallback mechanism when preferred terminal access methods fail</li>
+ *   <li>For debugging or testing terminal functionality without native dependencies</li>
+ * </ul>
+ *
+ * <p>
+ * The implementations in this package execute external commands to perform operations
+ * such as:
+ * </p>
+ *
+ * <ul>
+ *   <li>Getting and setting terminal attributes (using stty)</li>
+ *   <li>Determining terminal size (using stty or tput)</li>
+ *   <li>Sending signals to processes</li>
+ *   <li>Creating and managing pseudoterminals</li>
+ * </ul>
+ *
+ * <p>
+ * While this approach is more portable than native code, it may have performance
+ * implications due to the overhead of executing external processes. It is typically
+ * used as a fallback when more efficient methods are not available.
+ * </p>
+ *
+ * @see org.jline.terminal.spi.TerminalProvider
+ * @see org.jline.terminal.spi.Pty
+ */
+package org.jline.terminal.impl.exec;

--- a/terminal/src/main/java/org/jline/terminal/impl/package-info.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author or authors.
+ * Copyright (c) 2002-2025, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -7,7 +7,9 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 /**
- * JLine 3.
+ * JLine Terminal implementation classes.
+ *
+ * This package contains the implementation classes for the JLine Terminal API.
  *
  * @since 3.0
  */

--- a/terminal/src/main/java/org/jline/terminal/package-info.java
+++ b/terminal/src/main/java/org/jline/terminal/package-info.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2025, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+/**
+ * JLine Terminal API - Core abstractions for terminal operations across different platforms.
+ *
+ * <p>This package provides a comprehensive API for interacting with terminals in a platform-independent
+ * way. It abstracts the differences between various terminal types and operating systems, allowing
+ * applications to work consistently across environments.</p>
+ *
+ * <h2>Key Components</h2>
+ *
+ * <h3>Terminal Interface</h3>
+ * <p>The {@link org.jline.terminal.Terminal} interface is the central abstraction, representing a virtual
+ * terminal. It provides methods for:</p>
+ * <ul>
+ *   <li>Reading input and writing output</li>
+ *   <li>Managing terminal attributes</li>
+ *   <li>Handling terminal size and cursor positioning</li>
+ *   <li>Processing signals (like CTRL+C)</li>
+ *   <li>Supporting mouse events</li>
+ *   <li>Accessing terminal capabilities</li>
+ * </ul>
+ *
+ * <h3>Terminal Creation</h3>
+ * <p>The {@link org.jline.terminal.TerminalBuilder} class provides a fluent API for creating terminal
+ * instances with specific configurations. It supports various terminal types and providers, allowing
+ * for flexible terminal creation based on the environment and requirements.</p>
+ *
+ * <h3>Terminal Attributes</h3>
+ * <p>The {@link org.jline.terminal.Attributes} class encapsulates terminal settings such as:</p>
+ * <ul>
+ *   <li>Input flags (e.g., character echoing, canonical mode)</li>
+ *   <li>Output flags (e.g., output processing)</li>
+ *   <li>Control flags (e.g., baud rate, character size)</li>
+ *   <li>Local flags (e.g., echo, canonical processing)</li>
+ *   <li>Control characters (e.g., EOF, interrupt, erase)</li>
+ * </ul>
+ *
+ * <h3>Supporting Classes</h3>
+ * <ul>
+ *   <li>{@link org.jline.terminal.Size} - Represents the dimensions of a terminal (rows and columns)</li>
+ *   <li>{@link org.jline.terminal.Cursor} - Represents a cursor position within the terminal</li>
+ *   <li>{@link org.jline.terminal.MouseEvent} - Encapsulates mouse events (clicks, movements) in the terminal</li>
+ * </ul>
+ *
+ * <h2>Usage Example</h2>
+ * <pre>
+ * // Create a terminal
+ * Terminal terminal = TerminalBuilder.builder()
+ *     .system(true)
+ *     .build();
+ *
+ * // Get terminal size
+ * Size size = terminal.getSize();
+ * System.out.println("Terminal size: " + size.getColumns() + "x" + size.getRows());
+ *
+ * // Write to the terminal
+ * terminal.writer().println("Hello, JLine Terminal!");
+ * terminal.flush();
+ *
+ * // Read from the terminal
+ * int c = terminal.reader().read();
+ *
+ * // Close the terminal when done
+ * terminal.close();
+ * </pre>
+ *
+ * <h2>Terminal Implementations</h2>
+ * <p>The actual terminal implementations are provided in the {@code org.jline.terminal.impl} package,
+ * with platform-specific implementations available through various provider modules like:</p>
+ * <ul>
+ *   <li>jline-terminal-jansi - JANSI-based implementation</li>
+ *   <li>jline-terminal-jna - JNA-based implementation</li>
+ *   <li>jline-terminal-jni - JNI-based implementation</li>
+ * </ul>
+ *
+ * <p>The Service Provider Interface (SPI) for terminal implementations is defined in the
+ * {@code org.jline.terminal.spi} package.</p>
+ *
+ * @since 3.0
+ */
+package org.jline.terminal;

--- a/terminal/src/main/java/org/jline/terminal/spi/Pty.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/Pty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -16,25 +16,165 @@ import java.io.OutputStream;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
 
+/**
+ * Represents a pseudoterminal (PTY) that provides terminal emulation.
+ *
+ * <p>
+ * A pseudoterminal (PTY) is a pair of virtual character devices that provide a bidirectional
+ * communication channel. The PTY consists of a master side and a slave side. The slave side
+ * appears as a terminal device to processes, while the master side is used by terminal emulators
+ * to control the slave side.
+ * </p>
+ *
+ * <p>
+ * This interface provides methods to access the input and output streams for both the master
+ * and slave sides of the PTY, as well as methods to get and set terminal attributes and size.
+ * </p>
+ *
+ * <p>
+ * PTY implementations are typically platform-specific and may use different underlying
+ * mechanisms depending on the operating system (e.g., /dev/pts on Unix-like systems).
+ * </p>
+ *
+ * @see java.io.Closeable
+ */
 public interface Pty extends Closeable {
 
+    /**
+     * Returns the input stream for the master side of the PTY.
+     *
+     * <p>
+     * This stream receives data that has been written to the slave's output stream.
+     * Terminal emulators typically read from this stream to get the output from
+     * processes running in the terminal.
+     * </p>
+     *
+     * @return the master's input stream
+     * @throws IOException if an I/O error occurs
+     */
     InputStream getMasterInput() throws IOException;
 
+    /**
+     * Returns the output stream for the master side of the PTY.
+     *
+     * <p>
+     * Data written to this stream will be available for reading from the slave's
+     * input stream. Terminal emulators typically write to this stream to send input
+     * to processes running in the terminal.
+     * </p>
+     *
+     * @return the master's output stream
+     * @throws IOException if an I/O error occurs
+     */
     OutputStream getMasterOutput() throws IOException;
 
+    /**
+     * Returns the input stream for the slave side of the PTY.
+     *
+     * <p>
+     * This stream receives data that has been written to the master's output stream.
+     * Processes running in the terminal read from this stream to get their input.
+     * </p>
+     *
+     * @return the slave's input stream
+     * @throws IOException if an I/O error occurs
+     */
     InputStream getSlaveInput() throws IOException;
 
+    /**
+     * Returns the output stream for the slave side of the PTY.
+     *
+     * <p>
+     * Data written to this stream will be available for reading from the master's
+     * input stream. Processes running in the terminal write to this stream to
+     * produce their output.
+     * </p>
+     *
+     * @return the slave's output stream
+     * @throws IOException if an I/O error occurs
+     */
     OutputStream getSlaveOutput() throws IOException;
 
+    /**
+     * Returns the current terminal attributes for this PTY.
+     *
+     * <p>
+     * Terminal attributes control various aspects of terminal behavior, such as
+     * echo settings, line discipline, and control characters.
+     * </p>
+     *
+     * @return the current terminal attributes
+     * @throws IOException if an I/O error occurs
+     * @see org.jline.terminal.Attributes
+     */
     Attributes getAttr() throws IOException;
 
+    /**
+     * Sets the terminal attributes for this PTY.
+     *
+     * <p>
+     * This method allows changing various aspects of terminal behavior, such as
+     * echo settings, line discipline, and control characters.
+     * </p>
+     *
+     * @param attr the terminal attributes to set
+     * @throws IOException if an I/O error occurs
+     * @see org.jline.terminal.Attributes
+     */
     void setAttr(Attributes attr) throws IOException;
 
+    /**
+     * Returns the current size (dimensions) of this PTY.
+     *
+     * <p>
+     * The size includes the number of rows and columns in the terminal window.
+     * </p>
+     *
+     * @return the current terminal size
+     * @throws IOException if an I/O error occurs
+     * @see org.jline.terminal.Size
+     */
     Size getSize() throws IOException;
 
+    /**
+     * Sets the size (dimensions) of this PTY.
+     *
+     * <p>
+     * This method changes the number of rows and columns in the terminal window.
+     * When the size changes, a SIGWINCH signal is typically sent to processes
+     * running in the terminal.
+     * </p>
+     *
+     * @param size the new terminal size to set
+     * @throws IOException if an I/O error occurs
+     * @see org.jline.terminal.Size
+     */
     void setSize(Size size) throws IOException;
 
+    /**
+     * Returns the system stream associated with this PTY, if any.
+     *
+     * <p>
+     * The system stream indicates whether this PTY is connected to standard input,
+     * standard output, or standard error.
+     * </p>
+     *
+     * @return the associated system stream, or {@code null} if this PTY is not
+     *         associated with a system stream
+     * @see SystemStream
+     */
     SystemStream getSystemStream();
 
+    /**
+     * Returns the terminal provider that created this PTY.
+     *
+     * <p>
+     * The terminal provider is responsible for creating and managing terminal
+     * instances on a specific platform.
+     * </p>
+     *
+     * @return the terminal provider that created this PTY
+     * @see TerminalProvider
+     */
     TerminalProvider getProvider();
 }

--- a/terminal/src/main/java/org/jline/terminal/spi/SystemStream.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/SystemStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) 2023-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -8,8 +8,53 @@
  */
 package org.jline.terminal.spi;
 
+/**
+ * Represents the standard system streams available in a terminal environment.
+ *
+ * <p>
+ * This enum defines the three standard streams that are typically available
+ * in a terminal environment: standard input, standard output, and standard error.
+ * These streams are used for communication between the terminal and the processes
+ * running within it.
+ * </p>
+ *
+ * <p>
+ * Terminal implementations and PTY objects may be associated with one of these
+ * system streams to indicate their role in the terminal environment.
+ * </p>
+ *
+ * @see org.jline.terminal.spi.Pty#getSystemStream()
+ * @see org.jline.terminal.spi.TerminalExt#getSystemStream()
+ */
 public enum SystemStream {
+    /**
+     * Standard input stream (stdin).
+     *
+     * <p>
+     * This stream is used to provide input to processes running in the terminal.
+     * It typically represents keyboard input from the user.
+     * </p>
+     */
     Input,
+
+    /**
+     * Standard output stream (stdout).
+     *
+     * <p>
+     * This stream is used by processes to output normal data. It typically
+     * represents the main display output of the terminal.
+     * </p>
+     */
     Output,
+
+    /**
+     * Standard error stream (stderr).
+     *
+     * <p>
+     * This stream is used by processes to output error messages and diagnostic
+     * information. It may be displayed differently from standard output or
+     * redirected to a separate destination.
+     * </p>
+     */
     Error
 }

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalExt.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) 2023-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,21 +11,63 @@ package org.jline.terminal.spi;
 import org.jline.terminal.Terminal;
 
 /**
- * The {@code TerminalExt} interface is implemented by {@code Terminal}s
- * and provides access to the Terminal's internals.
+ * Extended Terminal interface that provides access to internal implementation details.
+ *
+ * <p>
+ * The {@code TerminalExt} interface extends the standard {@link Terminal} interface
+ * with additional methods that provide access to the terminal's internal implementation
+ * details. These methods are primarily used by terminal providers and other internal
+ * components of the JLine library.
+ * </p>
+ *
+ * <p>
+ * Terminal implementations typically implement this interface to expose information
+ * about their creation and configuration, such as the provider that created them
+ * and the system stream they are associated with.
+ * </p>
+ *
+ * <p>
+ * Application code should generally use the standard {@link Terminal} interface
+ * rather than this extended interface, unless specific access to these internal
+ * details is required.
+ * </p>
+ *
+ * @see Terminal
+ * @see TerminalProvider
+ * @see SystemStream
  */
 public interface TerminalExt extends Terminal {
 
     /**
-     * Returns the {@code TerminalProvider} that created this terminal
-     * or {@code null} if the terminal was created with no provider.
+     * Returns the terminal provider that created this terminal.
+     *
+     * <p>
+     * The terminal provider is responsible for creating and managing terminal
+     * instances on a specific platform. This method allows access to the provider
+     * that created this terminal, which can be useful for accessing provider-specific
+     * functionality or for creating additional terminals with the same provider.
+     * </p>
+     *
+     * @return the {@code TerminalProvider} that created this terminal,
+     *         or {@code null} if the terminal was created with no provider
+     * @see TerminalProvider
      */
     TerminalProvider getProvider();
 
     /**
-     * The underlying system stream, may be {@link SystemStream#Output},
-     * {@link SystemStream#Error}, or {@code null} if this terminal is not bound
-     * to a system stream.
+     * Returns the system stream associated with this terminal, if any.
+     *
+     * <p>
+     * This method indicates whether the terminal is bound to a standard system stream
+     * (standard input, standard output, or standard error). Terminals that are connected
+     * to system streams typically represent the actual terminal window or console that
+     * the application is running in.
+     * </p>
+     *
+     * @return the underlying system stream, which may be {@link SystemStream#Input},
+     *         {@link SystemStream#Output}, {@link SystemStream#Error}, or {@code null}
+     *         if this terminal is not bound to a system stream
+     * @see SystemStream
      */
     SystemStream getSystemStream();
 }

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, the original author(s).
+ * Copyright (c) 2022-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -18,10 +18,72 @@ import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 
+/**
+ * Service provider interface for terminal implementations.
+ *
+ * <p>
+ * The TerminalProvider interface defines the contract for classes that can create
+ * and manage terminal instances on specific platforms. Each provider implements
+ * platform-specific terminal functionality, allowing JLine to work across different
+ * operating systems and environments.
+ * </p>
+ *
+ * <p>
+ * JLine includes several built-in terminal providers:
+ * </p>
+ * <ul>
+ *   <li>FFM - Foreign Function Memory (Java 22+) based implementation</li>
+ *   <li>JNI - Java Native Interface based implementation</li>
+ *   <li>Jansi - Implementation based on the Jansi library</li>
+ *   <li>JNA - Java Native Access based implementation</li>
+ *   <li>Exec - Implementation using external commands</li>
+ *   <li>Dumb - Fallback implementation with limited capabilities</li>
+ * </ul>
+ *
+ * <p>
+ * Terminal providers are loaded dynamically using the {@link #load(String)} method,
+ * which looks up provider implementations in the classpath based on their name.
+ * </p>
+ *
+ * @see Terminal
+ * @see org.jline.terminal.TerminalBuilder
+ */
 public interface TerminalProvider {
 
+    /**
+     * Returns the name of this terminal provider.
+     *
+     * <p>
+     * The provider name is a unique identifier that can be used to request this
+     * specific provider when creating terminals. Common provider names include
+     * "ffm", "jni", "jansi", "jna", "exec", and "dumb".
+     * </p>
+     *
+     * @return the name of this terminal provider
+     */
     String name();
 
+    /**
+     * Creates a terminal connected to a system stream.
+     *
+     * <p>
+     * This method creates a terminal that is connected to one of the standard
+     * system streams (standard input, standard output, or standard error). Such
+     * terminals typically represent the actual terminal window or console that
+     * the application is running in.
+     * </p>
+     *
+     * @param name the name of the terminal
+     * @param type the terminal type (e.g., "xterm", "dumb")
+     * @param ansiPassThrough whether to pass through ANSI escape sequences
+     * @param encoding the character encoding to use
+     * @param nativeSignals whether to use native signal handling
+     * @param signalHandler the signal handler to use
+     * @param paused whether the terminal should start in a paused state
+     * @param systemStream the system stream to connect to
+     * @return a new terminal connected to the specified system stream
+     * @throws IOException if an I/O error occurs
+     */
     Terminal sysTerminal(
             String name,
             String type,
@@ -33,6 +95,28 @@ public interface TerminalProvider {
             SystemStream systemStream)
             throws IOException;
 
+    /**
+     * Creates a new terminal with custom input and output streams.
+     *
+     * <p>
+     * This method creates a terminal that is connected to the specified input and
+     * output streams. Such terminals can be used for various purposes, such as
+     * connecting to remote terminals over network connections or creating virtual
+     * terminals for testing.
+     * </p>
+     *
+     * @param name the name of the terminal
+     * @param type the terminal type (e.g., "xterm", "dumb")
+     * @param masterInput the input stream to read from
+     * @param masterOutput the output stream to write to
+     * @param encoding the character encoding to use
+     * @param signalHandler the signal handler to use
+     * @param paused whether the terminal should start in a paused state
+     * @param attributes the initial terminal attributes
+     * @param size the initial terminal size
+     * @return a new terminal connected to the specified streams
+     * @throws IOException if an I/O error occurs
+     */
     Terminal newTerminal(
             String name,
             String type,
@@ -45,12 +129,68 @@ public interface TerminalProvider {
             Size size)
             throws IOException;
 
+    /**
+     * Checks if the specified system stream is available on this platform.
+     *
+     * <p>
+     * This method determines whether the specified system stream (standard input,
+     * standard output, or standard error) is available for use on the current
+     * platform. Some platforms or environments may restrict access to certain
+     * system streams.
+     * </p>
+     *
+     * @param stream the system stream to check
+     * @return {@code true} if the system stream is available, {@code false} otherwise
+     */
     boolean isSystemStream(SystemStream stream);
 
+    /**
+     * Returns the name of the specified system stream on this platform.
+     *
+     * <p>
+     * This method returns a platform-specific name or identifier for the specified
+     * system stream. The name may be used for display purposes or for accessing
+     * the stream through platform-specific APIs.
+     * </p>
+     *
+     * @param stream the system stream
+     * @return the name of the system stream on this platform
+     */
     String systemStreamName(SystemStream stream);
 
+    /**
+     * Returns the width (number of columns) of the specified system stream.
+     *
+     * <p>
+     * This method determines the width of the terminal associated with the specified
+     * system stream. The width is measured in character cells and represents the
+     * number of columns available for display.
+     * </p>
+     *
+     * @param stream the system stream
+     * @return the width of the system stream in character columns
+     */
     int systemStreamWidth(SystemStream stream);
 
+    /**
+     * Loads a terminal provider with the specified name.
+     *
+     * <p>
+     * This method loads a terminal provider implementation based on its name.
+     * Provider implementations are discovered through the Java ServiceLoader
+     * mechanism, looking for resource files in the classpath at
+     * {@code META-INF/services/org/jline/terminal/provider/[name]}.
+     * </p>
+     *
+     * <p>
+     * Each provider resource file should contain a {@code class} property that
+     * specifies the fully qualified name of the provider implementation class.
+     * </p>
+     *
+     * @param name the name of the provider to load
+     * @return the loaded terminal provider
+     * @throws IOException if the provider cannot be loaded
+     */
     static TerminalProvider load(String name) throws IOException {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         if (cl == null) {

--- a/terminal/src/main/java/org/jline/terminal/spi/package-info.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2002-2025, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+/**
+ * JLine Terminal Service Provider Interface (SPI).
+ *
+ * This package contains interfaces that define the Service Provider Interface (SPI)
+ * for terminal implementations. These interfaces allow for pluggable terminal
+ * implementations across different platforms and environments.
+ *
+ * @since 3.0
+ */
+package org.jline.terminal.spi;

--- a/terminal/src/main/java/org/jline/utils/AnsiWriter.java
+++ b/terminal/src/main/java/org/jline/utils/AnsiWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018, the original author(s).
+ * Copyright (c) 2009-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -15,19 +15,43 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 /**
- * A ANSI writer extracts ANSI escape codes written to
- * a {@link Writer} and calls corresponding <code>process*</code> methods.
+ * A writer that processes ANSI escape sequences.
  *
+ * <p>
+ * The AnsiWriter class extends FilterWriter to intercept and process ANSI escape
+ * sequences written to the underlying writer. It extracts ANSI escape codes and
+ * calls corresponding <code>process*</code> methods for each recognized sequence.
+ * </p>
+ *
+ * <p>
+ * This class just filters out the escape codes so that they are not sent out to
+ * the underlying {@link Writer}: <code>process*</code> methods are empty. Subclasses
+ * should actually perform the ANSI escape behaviors by implementing active code
+ * in <code>process*</code> methods.
+ * </p>
+ *
+ * <p>
+ * This class is useful for implementing terminal emulation, where ANSI escape
+ * sequences need to be interpreted to control cursor movement, text attributes,
+ * colors, and other terminal features.
+ * </p>
+ *
+ * <p>
+ * The class handles various ANSI escape sequences, including:
+ * </p>
+ * <ul>
+ *   <li>Cursor movement (up, down, left, right)</li>
+ *   <li>Cursor positioning (absolute and relative)</li>
+ *   <li>Text attributes (bold, underline, blink, etc.)</li>
+ *   <li>Colors (foreground and background)</li>
+ *   <li>Screen clearing and line manipulation</li>
+ * </ul>
+ *
+ * <p>
  * For more information about ANSI escape codes, see:
- * http://en.wikipedia.org/wiki/ANSI_escape_code
+ * <a href="http://en.wikipedia.org/wiki/ANSI_escape_code">Wikipedia: ANSI escape code</a>
+ * </p>
  *
- * This class just filters out the escape codes so that they are not
- * sent out to the underlying {@link Writer}: <code>process*</code> methods
- * are empty. Subclasses should actually perform the ANSI escape behaviors
- * by implementing active code in <code>process*</code> methods.
- *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
- * @author Joris Kuipers
  * @since 1.0
  */
 public class AnsiWriter extends FilterWriter {

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -37,32 +37,131 @@ import static org.jline.utils.AttributedStyle.F_ITALIC;
 import static org.jline.utils.AttributedStyle.F_UNDERLINE;
 import static org.jline.utils.AttributedStyle.MASK;
 
+/**
+ * A character sequence with ANSI style attributes.
+ *
+ * <p>
+ * The AttributedCharSequence class is an abstract base class for character sequences
+ * that have ANSI style attributes (colors, bold, underline, etc.) associated with
+ * each character. It provides methods for rendering the character sequence with its
+ * attributes to various outputs, such as ANSI terminals, non-ANSI terminals, and
+ * plain text.
+ * </p>
+ *
+ * <p>
+ * This class serves as the foundation for styled text in JLine, allowing for rich
+ * text formatting in terminal applications. It is extended by concrete classes like
+ * {@link AttributedString} and {@link AttributedStringBuilder} that provide specific
+ * implementations for different use cases.
+ * </p>
+ *
+ * <p>
+ * The class provides methods to:
+ * </p>
+ * <ul>
+ *   <li>Convert the sequence to a plain string without attributes</li>
+ *   <li>Render the sequence with ANSI escape codes for compatible terminals</li>
+ *   <li>Render the sequence for terminals with limited attribute support</li>
+ *   <li>Calculate the visible length of the sequence (excluding escape codes)</li>
+ *   <li>Extract substrings while preserving attributes</li>
+ * </ul>
+ */
 public abstract class AttributedCharSequence implements CharSequence {
 
     public static final int TRUE_COLORS = 0x1000000;
     private static final int HIGH_COLORS = 0x7FFF;
 
+    /**
+     * Enum defining color mode forcing options for ANSI rendering.
+     *
+     * <p>
+     * This enum specifies how color rendering should be forced when generating
+     * ANSI escape sequences, regardless of the terminal's reported capabilities.
+     * </p>
+     */
     public enum ForceMode {
+        /**
+         * No forcing; use the terminal's reported color capabilities.
+         */
         None,
+
+        /**
+         * Force the use of 256-color mode (8-bit colors).
+         */
         Force256Colors,
+
+        /**
+         * Force the use of true color mode (24-bit RGB colors).
+         */
         ForceTrueColors
     }
 
     // cache the value here as we can't afford to get it each time
     static final boolean DISABLE_ALTERNATE_CHARSET = Boolean.getBoolean(PROP_DISABLE_ALTERNATE_CHARSET);
 
+    /**
+     * Prints this attributed string to the specified terminal.
+     *
+     * <p>
+     * This method renders the attributed string with appropriate ANSI escape
+     * sequences for the specified terminal and prints it to the terminal's writer.
+     * </p>
+     *
+     * @param terminal the terminal to print to
+     */
     public void print(Terminal terminal) {
         terminal.writer().print(toAnsi(terminal));
     }
 
+    /**
+     * Prints this attributed string to the specified terminal, followed by a line break.
+     *
+     * <p>
+     * This method renders the attributed string with appropriate ANSI escape
+     * sequences for the specified terminal and prints it to the terminal's writer,
+     * followed by a line break.
+     * </p>
+     *
+     * @param terminal the terminal to print to
+     */
     public void println(Terminal terminal) {
         terminal.writer().println(toAnsi(terminal));
     }
 
+    /**
+     * Converts this attributed string to an ANSI escape sequence string.
+     *
+     * <p>
+     * This method renders the attributed string with ANSI escape sequences
+     * to represent the text attributes (colors, bold, underline, etc.).
+     * It uses default color capabilities (256 colors) and no forced color mode.
+     * </p>
+     *
+     * @return a string with ANSI escape sequences representing this attributed string
+     * @see #toAnsi(Terminal)
+     */
     public String toAnsi() {
         return toAnsi(null);
     }
 
+    /**
+     * Converts this attributed string to an ANSI escape sequence string
+     * appropriate for the specified terminal.
+     *
+     * <p>
+     * This method renders the attributed string with ANSI escape sequences
+     * to represent the text attributes (colors, bold, underline, etc.),
+     * taking into account the capabilities of the specified terminal.
+     * </p>
+     *
+     * <p>
+     * If the terminal is a dumb terminal (Terminal.TYPE_DUMB), this method
+     * returns the plain text without any escape sequences.
+     * </p>
+     *
+     * @param terminal the terminal to generate ANSI sequences for, or null to use default capabilities
+     * @return a string with ANSI escape sequences representing this attributed string
+     */
     public String toAnsi(Terminal terminal) {
         if (terminal != null && Terminal.TYPE_DUMB.equals(terminal.getType())) {
             return toString();
@@ -99,14 +198,59 @@ public abstract class AttributedCharSequence implements CharSequence {
         return toAnsi(colors, force256colors ? ForceMode.Force256Colors : ForceMode.None, null, altIn, altOut);
     }
 
+    /**
+     * Converts this attributed string to an ANSI escape sequence string
+     * with the specified color capabilities and force mode.
+     *
+     * <p>
+     * This method renders the attributed string with ANSI escape sequences
+     * using the specified number of colors and force mode.
+     * </p>
+     *
+     * @param colors the number of colors to use (8, 256, or 16777216 for true colors)
+     * @param force the force mode to use for color rendering
+     * @return a string with ANSI escape sequences representing this attributed string
+     */
     public String toAnsi(int colors, ForceMode force) {
         return toAnsi(colors, force, null, null, null);
     }
 
+    /**
+     * Converts this attributed string to an ANSI escape sequence string
+     * with the specified color capabilities, force mode, and color palette.
+     *
+     * <p>
+     * This method renders the attributed string with ANSI escape sequences
+     * using the specified number of colors, force mode, and color palette.
+     * </p>
+     *
+     * @param colors the number of colors to use (8, 256, or 16777216 for true colors)
+     * @param force the force mode to use for color rendering
+     * @param palette the color palette to use for color conversion
+     * @return a string with ANSI escape sequences representing this attributed string
+     */
     public String toAnsi(int colors, ForceMode force, ColorPalette palette) {
         return toAnsi(colors, force, palette, null, null);
     }
 
+    /**
+     * Converts this attributed string to an ANSI escape sequence string
+     * with the specified color capabilities, force mode, color palette,
+     * and alternate character set sequences.
+     *
+     * <p>
+     * This method renders the attributed string with ANSI escape sequences
+     * using the specified number of colors, force mode, color palette, and
+     * alternate character set sequences for box drawing characters.
+     * </p>
+     *
+     * @param colors the number of colors to use (8, 256, or 16777216 for true colors)
+     * @param force the force mode to use for color rendering
+     * @param palette the color palette to use for color conversion, or null for the default palette
+     * @param altIn the sequence to enable the alternate character set, or null to disable
+     * @param altOut the sequence to disable the alternate character set, or null to disable
+     * @return a string with ANSI escape sequences representing this attributed string
+     */
     public String toAnsi(int colors, ForceMode force, ColorPalette palette, String altIn, String altOut) {
         StringBuilder sb = new StringBuilder();
         long style = 0;
@@ -293,16 +437,66 @@ public abstract class AttributedCharSequence implements CharSequence {
         return false;
     }
 
+    /**
+     * Returns the style at the specified index in this attributed string.
+     *
+     * <p>
+     * This method returns the AttributedStyle object associated with the
+     * character at the specified index in this attributed string.
+     * </p>
+     *
+     * @param index the index of the character whose style to return
+     * @return the style at the specified index
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     public abstract AttributedStyle styleAt(int index);
 
+    /**
+     * Returns the style code at the specified index in this attributed string.
+     *
+     * <p>
+     * This method returns the raw style code (as a long value) associated with the
+     * character at the specified index in this attributed string.
+     * </p>
+     *
+     * @param index the index of the character whose style code to return
+     * @return the style code at the specified index
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     long styleCodeAt(int index) {
         return styleAt(index).getStyle();
     }
 
+    /**
+     * Returns whether the character at the specified index is hidden.
+     *
+     * <p>
+     * This method checks if the character at the specified index has the
+     * hidden attribute set, which means it should not be displayed.
+     * </p>
+     *
+     * @param index the index of the character to check
+     * @return true if the character is hidden, false otherwise
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     public boolean isHidden(int index) {
         return (styleCodeAt(index) & F_HIDDEN) != 0;
     }
 
+    /**
+     * Returns the start index of the run of characters with the same style
+     * that includes the character at the specified index.
+     *
+     * <p>
+     * A run is a sequence of consecutive characters that have the same style.
+     * This method finds the first character in the run that includes the
+     * character at the specified index.
+     * </p>
+     *
+     * @param index the index of a character in the run
+     * @return the start index of the run (inclusive)
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     public int runStart(int index) {
         AttributedStyle style = styleAt(index);
         while (index > 0 && styleAt(index - 1).equals(style)) {
@@ -311,6 +505,20 @@ public abstract class AttributedCharSequence implements CharSequence {
         return index;
     }
 
+    /**
+     * Returns the limit index of the run of characters with the same style
+     * that includes the character at the specified index.
+     *
+     * <p>
+     * A run is a sequence of consecutive characters that have the same style.
+     * This method finds the index after the last character in the run that
+     * includes the character at the specified index.
+     * </p>
+     *
+     * @param index the index of a character in the run
+     * @return the limit index of the run (exclusive)
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     public int runLimit(int index) {
         AttributedStyle style = styleAt(index);
         while (index < length() - 1 && styleAt(index + 1).equals(style)) {
@@ -322,6 +530,26 @@ public abstract class AttributedCharSequence implements CharSequence {
     @Override
     public abstract AttributedString subSequence(int start, int end);
 
+    /**
+     * Returns a new AttributedString that is a substring of this attributed string.
+     *
+     * <p>
+     * This method returns a new AttributedString that contains the characters and
+     * styles from this attributed string starting at the specified start index
+     * (inclusive) and ending at the specified end index (exclusive).
+     * </p>
+     *
+     * <p>
+     * This method is equivalent to {@link #subSequence(int, int)} but returns
+     * an AttributedString instead of an AttributedCharSequence.
+     * </p>
+     *
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the specified substring with its attributes
+     * @throws IndexOutOfBoundsException if start or end are negative,
+     *         if end is greater than length(), or if start is greater than end
+     */
     public AttributedString substring(int start, int end) {
         return subSequence(start, end);
     }
@@ -335,10 +563,35 @@ public abstract class AttributedCharSequence implements CharSequence {
         return buffer()[offset() + index];
     }
 
+    /**
+     * Returns the code point at the specified index in this attributed string.
+     *
+     * <p>
+     * This method returns the Unicode code point at the specified index.
+     * If the character at the specified index is a high-surrogate code unit
+     * and the following character is a low-surrogate code unit, then the
+     * supplementary code point is returned; otherwise, the code unit at the
+     * specified index is returned.
+     * </p>
+     *
+     * @param index the index to the code point
+     * @return the code point at the specified index
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     public int codePointAt(int index) {
         return Character.codePointAt(buffer(), index + offset());
     }
 
+    /**
+     * Returns whether this attributed string contains the specified character.
+     *
+     * <p>
+     * This method checks if the specified character appears in this attributed string.
+     * </p>
+     *
+     * @param c the character to search for
+     * @return true if this attributed string contains the specified character, false otherwise
+     */
     public boolean contains(char c) {
         for (int i = 0; i < length(); i++) {
             if (charAt(i) == c) {
@@ -348,14 +601,61 @@ public abstract class AttributedCharSequence implements CharSequence {
         return false;
     }
 
+    /**
+     * Returns the code point before the specified index in this attributed string.
+     *
+     * <p>
+     * This method returns the Unicode code point before the specified index.
+     * If the character before the specified index is a low-surrogate code unit
+     * and the character before that is a high-surrogate code unit, then the
+     * supplementary code point is returned; otherwise, the code unit before the
+     * specified index is returned.
+     * </p>
+     *
+     * @param index the index following the code point that should be returned
+     * @return the Unicode code point value before the specified index
+     * @throws IndexOutOfBoundsException if the index is less than 1 or greater than length()
+     */
     public int codePointBefore(int index) {
         return Character.codePointBefore(buffer(), index + offset());
     }
 
+    /**
+     * Returns the number of Unicode code points in the specified range of this attributed string.
+     *
+     * <p>
+     * This method counts the number of Unicode code points in the range of this
+     * attributed string starting at the specified index (inclusive) and extending
+     * for the specified length. A surrogate pair is counted as one code point.
+     * </p>
+     *
+     * @param index the index to the first character of the range
+     * @param length the length of the range in characters
+     * @return the number of Unicode code points in the specified range
+     * @throws IndexOutOfBoundsException if index is negative, or length is negative,
+     *         or index + length is greater than length()
+     */
     public int codePointCount(int index, int length) {
         return Character.codePointCount(buffer(), index + offset(), length);
     }
 
+    /**
+     * Returns the display width of this attributed string in columns.
+     *
+     * <p>
+     * This method calculates the display width of this attributed string in columns,
+     * taking into account wide characters (such as East Asian characters), zero-width
+     * characters (such as combining marks), and hidden characters. This is useful for
+     * determining how much space the string will occupy when displayed in a terminal.
+     * </p>
+     *
+     * <p>
+     * Hidden characters (those with the hidden attribute set) are not counted in the
+     * column length.
+     * </p>
+     *
+     * @return the display width of this attributed string in columns
+     */
     public int columnLength() {
         int cols = 0;
         int len = length();
@@ -367,6 +667,26 @@ public abstract class AttributedCharSequence implements CharSequence {
         return cols;
     }
 
+    /**
+     * Returns a subsequence of this attributed string based on column positions.
+     *
+     * <p>
+     * This method returns a subsequence of this attributed string that spans from
+     * the specified start column position (inclusive) to the specified stop column
+     * position (exclusive). Column positions are determined by the display width of
+     * characters, taking into account wide characters, zero-width characters, and
+     * hidden characters.
+     * </p>
+     *
+     * <p>
+     * This method is useful for extracting portions of text based on their visual
+     * position in a terminal, rather than their character indices.
+     * </p>
+     *
+     * @param start the starting column position (inclusive)
+     * @param stop the ending column position (exclusive)
+     * @return the subsequence spanning the specified column range
+     */
     public AttributedString columnSubSequence(int start, int stop) {
         int begin = 0;
         int col = 0;
@@ -393,10 +713,44 @@ public abstract class AttributedCharSequence implements CharSequence {
         return subSequence(begin, end);
     }
 
+    /**
+     * Splits this attributed string into multiple lines based on column width.
+     *
+     * <p>
+     * This method splits this attributed string into multiple lines, each with a
+     * maximum width of the specified number of columns. The splitting is done based
+     * on the display width of characters, taking into account wide characters,
+     * zero-width characters, and hidden characters.
+     * </p>
+     *
+     * <p>
+     * This is equivalent to calling {@link #columnSplitLength(int, boolean, boolean)}
+     * with {@code includeNewlines=false} and {@code delayLineWrap=true}.
+     * </p>
+     *
+     * @param columns the maximum width of each line in columns
+     * @return a list of attributed strings, each representing a line
+     */
     public List<AttributedString> columnSplitLength(int columns) {
         return columnSplitLength(columns, false, true);
     }
 
+    /**
+     * Splits this attributed string into multiple lines based on column width,
+     * with options for handling newlines and line wrapping.
+     *
+     * <p>
+     * This method splits this attributed string into multiple lines, each with a
+     * maximum width of the specified number of columns. The splitting is done based
+     * on the display width of characters, taking into account wide characters,
+     * zero-width characters, and hidden characters.
+     * </p>
+     *
+     * @param columns the maximum width of each line in columns
+     * @param includeNewlines whether to include newline characters in the resulting lines
+     * @param delayLineWrap whether to delay line wrapping until the last possible moment
+     * @return a list of attributed strings, each representing a line
+     */
     public List<AttributedString> columnSplitLength(int columns, boolean includeNewlines, boolean delayLineWrap) {
         List<AttributedString> strings = new ArrayList<>();
         int cur = 0;
@@ -425,6 +779,17 @@ public abstract class AttributedCharSequence implements CharSequence {
         return new String(buffer(), offset(), length());
     }
 
+    /**
+     * Converts this attributed character sequence to an AttributedString.
+     *
+     * <p>
+     * This method creates a new AttributedString that contains all the characters
+     * and styles from this attributed character sequence. This is useful for
+     * converting an AttributedCharSequence to an immutable AttributedString.
+     * </p>
+     *
+     * @return a new AttributedString containing all characters and styles from this sequence
+     */
     public AttributedString toAttributedString() {
         return substring(0, length());
     }

--- a/terminal/src/main/java/org/jline/utils/AttributedString.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -18,11 +18,35 @@ import java.util.regex.Pattern;
 import org.jline.terminal.Terminal;
 
 /**
- * Attributed string.
- * Instances of this class are immutables.
- * Substrings are created without any memory copy.
+ * An immutable character sequence with ANSI style attributes.
  *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * <p>
+ * The AttributedString class represents a character sequence where each character
+ * has associated style attributes (colors, bold, underline, etc.). It extends
+ * AttributedCharSequence and provides an immutable implementation, making it safe
+ * to use in concurrent contexts.
+ * </p>
+ *
+ * <p>
+ * Key features of this class include:
+ * </p>
+ * <ul>
+ *   <li>Immutability - Once created, instances cannot be modified</li>
+ *   <li>Memory efficiency - Substrings are created without any memory copy</li>
+ *   <li>Rich styling - Support for foreground/background colors and text attributes</li>
+ *   <li>Concatenation - Multiple AttributedStrings can be joined together</li>
+ *   <li>Pattern matching - Regular expressions can be applied to find and extract parts</li>
+ * </ul>
+ *
+ * <p>
+ * This class is commonly used for displaying styled text in terminal applications,
+ * such as prompts, menus, and highlighted output. For building AttributedStrings
+ * dynamically, use {@link AttributedStringBuilder}.
+ * </p>
+ *
+ * @see AttributedCharSequence
+ * @see AttributedStringBuilder
+ * @see AttributedStyle
  */
 public class AttributedString extends AttributedCharSequence {
 
@@ -30,21 +54,84 @@ public class AttributedString extends AttributedCharSequence {
     final long[] style;
     final int start;
     final int end;
+    /**
+     * An empty AttributedString with no characters.
+     */
     public static final AttributedString EMPTY = new AttributedString("");
+
+    /**
+     * An AttributedString containing only a newline character.
+     */
     public static final AttributedString NEWLINE = new AttributedString("\n");
 
+    /**
+     * Creates a new AttributedString from the specified character sequence.
+     *
+     * <p>
+     * This constructor creates a new AttributedString containing the characters
+     * from the specified character sequence with default style (no attributes).
+     * </p>
+     *
+     * @param str the character sequence to copy
+     */
     public AttributedString(CharSequence str) {
         this(str, 0, str.length(), null);
     }
 
+    /**
+     * Creates a new AttributedString from a subsequence of the specified character sequence.
+     *
+     * <p>
+     * This constructor creates a new AttributedString containing the characters
+     * from the specified range of the character sequence with default style (no attributes).
+     * </p>
+     *
+     * @param str the character sequence to copy
+     * @param start the index of the first character to copy (inclusive)
+     * @param end the index after the last character to copy (exclusive)
+     * @throws InvalidParameterException if end is less than start
+     */
     public AttributedString(CharSequence str, int start, int end) {
         this(str, start, end, null);
     }
 
+    /**
+     * Creates a new AttributedString from the specified character sequence with the specified style.
+     *
+     * <p>
+     * This constructor creates a new AttributedString containing the characters
+     * from the specified character sequence with the specified style applied to all characters.
+     * </p>
+     *
+     * @param str the character sequence to copy
+     * @param s the style to apply to all characters, or null for default style
+     */
     public AttributedString(CharSequence str, AttributedStyle s) {
         this(str, 0, str.length(), s);
     }
 
+    /**
+     * Creates a new AttributedString from a subsequence of the specified character sequence
+     * with the specified style.
+     *
+     * <p>
+     * This constructor creates a new AttributedString containing the characters
+     * from the specified range of the character sequence with the specified style
+     * applied to all characters.
+     * </p>
+     *
+     * <p>
+     * If the character sequence is an AttributedString or AttributedStringBuilder,
+     * this constructor preserves the existing style information and applies the
+     * specified style on top of it (if not null).
+     * </p>
+     *
+     * @param str the character sequence to copy
+     * @param start the index of the first character to copy (inclusive)
+     * @param end the index after the last character to copy (exclusive)
+     * @param s the style to apply to all characters, or null to preserve existing styles
+     * @throws InvalidParameterException if end is less than start
+     */
     public AttributedString(CharSequence str, int start, int end, AttributedStyle s) {
         if (end < start) {
             throw new InvalidParameterException();
@@ -89,6 +176,19 @@ public class AttributedString extends AttributedCharSequence {
         }
     }
 
+    /**
+     * Creates a new AttributedString with the specified buffer, style, and range.
+     *
+     * <p>
+     * This constructor is package-private and used internally for creating
+     * AttributedString instances without copying the buffer and style arrays.
+     * </p>
+     *
+     * @param buffer the character buffer
+     * @param style the style buffer
+     * @param start the start index in the buffers
+     * @param end the end index in the buffers
+     */
     AttributedString(char[] buffer, long[] style, int start, int end) {
         this.buffer = buffer;
         this.style = style;
@@ -96,18 +196,71 @@ public class AttributedString extends AttributedCharSequence {
         this.end = end;
     }
 
+    /**
+     * Creates an AttributedString from an ANSI-encoded string.
+     *
+     * <p>
+     * This method parses the ANSI escape sequences in the input string and
+     * creates an AttributedString with the corresponding styles. This is useful
+     * for converting ANSI-colored output from external commands into styled
+     * text that can be displayed in the terminal.
+     * </p>
+     *
+     * @param ansi the ANSI-encoded string to parse
+     * @return an AttributedString with styles based on the ANSI escape sequences
+     * @see #fromAnsi(String, Terminal)
+     */
     public static AttributedString fromAnsi(String ansi) {
         return fromAnsi(ansi, 0);
     }
 
+    /**
+     * Creates an AttributedString from an ANSI-encoded string with a specified tab size.
+     *
+     * <p>
+     * This method parses the ANSI escape sequences in the input string and
+     * creates an AttributedString with the corresponding styles. It also handles
+     * tab characters according to the specified tab size.
+     * </p>
+     *
+     * @param ansi the ANSI-encoded string to parse
+     * @param tabs the tab size in columns
+     * @return an AttributedString with styles based on the ANSI escape sequences
+     */
     public static AttributedString fromAnsi(String ansi, int tabs) {
         return fromAnsi(ansi, Arrays.asList(tabs));
     }
 
+    /**
+     * Creates an AttributedString from an ANSI-encoded string with custom tab stops.
+     *
+     * <p>
+     * This method parses the ANSI escape sequences in the input string and
+     * creates an AttributedString with the corresponding styles. It also handles
+     * tab characters according to the specified tab stops.
+     * </p>
+     *
+     * @param ansi the ANSI-encoded string to parse
+     * @param tabs the list of tab stop positions, or null for default tab stops
+     * @return an AttributedString with styles based on the ANSI escape sequences
+     */
     public static AttributedString fromAnsi(String ansi, List<Integer> tabs) {
         return fromAnsi(ansi, tabs, null, null);
     }
 
+    /**
+     * Creates an AttributedString from an ANSI-encoded string, using terminal capabilities.
+     *
+     * <p>
+     * This method parses the ANSI escape sequences in the input string and
+     * creates an AttributedString with the corresponding styles. It uses the
+     * specified terminal's capabilities to handle alternate character sets.
+     * </p>
+     *
+     * @param ansi the ANSI-encoded string to parse
+     * @param terminal the terminal to use for capabilities, or null
+     * @return an AttributedString with styles based on the ANSI escape sequences
+     */
     public static AttributedString fromAnsi(String ansi, Terminal terminal) {
         String alternateIn, alternateOut;
         if (!DISABLE_ALTERNATE_CHARSET) {
@@ -120,6 +273,23 @@ public class AttributedString extends AttributedCharSequence {
         return fromAnsi(ansi, Arrays.asList(0), alternateIn, alternateOut);
     }
 
+    /**
+     * Creates an AttributedString from an ANSI-encoded string with custom tab stops
+     * and alternate character set sequences.
+     *
+     * <p>
+     * This method parses the ANSI escape sequences in the input string and
+     * creates an AttributedString with the corresponding styles. It also handles
+     * tab characters according to the specified tab stops and alternate character
+     * set sequences.
+     * </p>
+     *
+     * @param ansi the ANSI-encoded string to parse
+     * @param tabs the list of tab stop positions, or null for default tab stops
+     * @param altIn the sequence to enable the alternate character set, or null
+     * @param altOut the sequence to disable the alternate character set, or null
+     * @return an AttributedString with styles based on the ANSI escape sequences
+     */
     public static AttributedString fromAnsi(String ansi, List<Integer> tabs, String altIn, String altOut) {
         if (ansi == null) {
             return null;
@@ -131,6 +301,18 @@ public class AttributedString extends AttributedCharSequence {
                 .toAttributedString();
     }
 
+    /**
+     * Strips ANSI escape sequences from a string.
+     *
+     * <p>
+     * This method removes all ANSI escape sequences from the input string,
+     * returning a plain text string with no styling information. This is useful
+     * for extracting the text content from ANSI-colored output.
+     * </p>
+     *
+     * @param ansi the ANSI-encoded string to strip
+     * @return a plain text string with ANSI escape sequences removed, or null if the input is null
+     */
     public static String stripAnsi(String ansi) {
         if (ansi == null) {
             return null;
@@ -138,36 +320,125 @@ public class AttributedString extends AttributedCharSequence {
         return new AttributedStringBuilder(ansi.length()).ansiAppend(ansi).toString();
     }
 
+    /**
+     * Returns the character buffer for this attributed string.
+     *
+     * <p>
+     * This method is used internally by the AttributedCharSequence implementation
+     * to access the underlying character buffer.
+     * </p>
+     *
+     * @return the character buffer
+     */
     @Override
     protected char[] buffer() {
         return buffer;
     }
 
+    /**
+     * Returns the offset in the buffer where this attributed string starts.
+     *
+     * <p>
+     * This method is used internally by the AttributedCharSequence implementation
+     * to determine the starting position in the buffer.
+     * </p>
+     *
+     * @return the offset in the buffer
+     */
     @Override
     protected int offset() {
         return start;
     }
 
+    /**
+     * Returns the length of this attributed string.
+     *
+     * <p>
+     * This method returns the number of characters in this attributed string.
+     * </p>
+     *
+     * @return the number of characters in this attributed string
+     */
     @Override
     public int length() {
         return end - start;
     }
 
+    /**
+     * Returns the style at the specified index in this attributed string.
+     *
+     * <p>
+     * This method returns the AttributedStyle object associated with the
+     * character at the specified index in this attributed string.
+     * </p>
+     *
+     * @param index the index of the character whose style to return
+     * @return the style at the specified index
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     @Override
     public AttributedStyle styleAt(int index) {
         return new AttributedStyle(style[start + index], style[start + index]);
     }
 
+    /**
+     * Returns the style code at the specified index in this attributed string.
+     *
+     * <p>
+     * This method returns the raw style code (as a long value) associated with the
+     * character at the specified index in this attributed string.
+     * </p>
+     *
+     * @param index the index of the character whose style code to return
+     * @return the style code at the specified index
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     @Override
     long styleCodeAt(int index) {
         return style[start + index];
     }
 
+    /**
+     * Returns a new AttributedString that is a subsequence of this attributed string.
+     *
+     * <p>
+     * This method returns a new AttributedString that contains the characters and
+     * styles from this attributed string starting at the specified start index
+     * (inclusive) and ending at the specified end index (exclusive).
+     * </p>
+     *
+     * <p>
+     * The subsequence preserves the style information from the original string.
+     * </p>
+     *
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the specified subsequence with its attributes
+     * @throws IndexOutOfBoundsException if start or end are negative,
+     *         if end is greater than length(), or if start is greater than end
+     */
     @Override
     public AttributedString subSequence(int start, int end) {
         return new AttributedString(this, start, end);
     }
 
+    /**
+     * Returns a new AttributedString with the specified style applied to all matches of the pattern.
+     *
+     * <p>
+     * This method finds all matches of the specified regular expression pattern in this
+     * attributed string and applies the specified style to the matching regions. It returns
+     * a new AttributedString with the modified styles.
+     * </p>
+     *
+     * <p>
+     * If no matches are found, this method returns the original attributed string.
+     * </p>
+     *
+     * @param pattern the regular expression pattern to match
+     * @param style the style to apply to matching regions
+     * @return a new AttributedString with the specified style applied to matching regions
+     */
     public AttributedString styleMatches(Pattern pattern, AttributedStyle style) {
         Matcher matcher = pattern.matcher(this);
         boolean result = matcher.find();
@@ -184,6 +455,17 @@ public class AttributedString extends AttributedCharSequence {
         return this;
     }
 
+    /**
+     * Compares this AttributedString with another object for equality.
+     *
+     * <p>
+     * Two AttributedString objects are considered equal if they have the same
+     * length, the same characters, and the same styles at each position.
+     * </p>
+     *
+     * @param o the object to compare with
+     * @return {@code true} if the objects are equal, {@code false} otherwise
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -194,6 +476,21 @@ public class AttributedString extends AttributedCharSequence {
                 && arrEq(style, that.style, start, that.start, end - start);
     }
 
+    /**
+     * Compares two character arrays for equality within a specified range.
+     *
+     * <p>
+     * This private helper method compares two character arrays starting at the
+     * specified offsets for the specified length.
+     * </p>
+     *
+     * @param a1 the first array
+     * @param a2 the second array
+     * @param s1 the starting offset in the first array
+     * @param s2 the starting offset in the second array
+     * @param l the length to compare
+     * @return {@code true} if the arrays are equal in the specified range, {@code false} otherwise
+     */
     private boolean arrEq(char[] a1, char[] a2, int s1, int s2, int l) {
         for (int i = 0; i < l; i++) {
             if (a1[s1 + i] != a2[s2 + i]) {
@@ -203,6 +500,21 @@ public class AttributedString extends AttributedCharSequence {
         return true;
     }
 
+    /**
+     * Compares two long arrays for equality within a specified range.
+     *
+     * <p>
+     * This private helper method compares two long arrays starting at the
+     * specified offsets for the specified length.
+     * </p>
+     *
+     * @param a1 the first array
+     * @param a2 the second array
+     * @param s1 the starting offset in the first array
+     * @param s2 the starting offset in the second array
+     * @param l the length to compare
+     * @return {@code true} if the arrays are equal in the specified range, {@code false} otherwise
+     */
     private boolean arrEq(long[] a1, long[] a2, int s1, int s2, int l) {
         for (int i = 0; i < l; i++) {
             if (a1[s1 + i] != a2[s2 + i]) {
@@ -212,6 +524,16 @@ public class AttributedString extends AttributedCharSequence {
         return true;
     }
 
+    /**
+     * Returns a hash code for this AttributedString.
+     *
+     * <p>
+     * The hash code is computed based on the characters, styles, and range
+     * of this attributed string.
+     * </p>
+     *
+     * @return a hash code value for this object
+     */
     @Override
     public int hashCode() {
         int result = Arrays.hashCode(buffer);
@@ -221,12 +543,44 @@ public class AttributedString extends AttributedCharSequence {
         return result;
     }
 
+    /**
+     * Joins multiple AttributedString objects with a delimiter.
+     *
+     * <p>
+     * This method concatenates the specified AttributedString elements, inserting
+     * the specified delimiter between each element. The resulting AttributedString
+     * preserves the styles of all elements and the delimiter.
+     * </p>
+     *
+     * @param delimiter the delimiter to insert between elements
+     * @param elements the elements to join
+     * @return a new AttributedString containing the joined elements
+     * @throws NullPointerException if delimiter or elements is null
+     */
     public static AttributedString join(AttributedString delimiter, AttributedString... elements) {
         Objects.requireNonNull(delimiter);
         Objects.requireNonNull(elements);
         return join(delimiter, Arrays.asList(elements));
     }
 
+    /**
+     * Joins an Iterable of AttributedString objects with a delimiter.
+     *
+     * <p>
+     * This method concatenates the AttributedString elements in the specified Iterable,
+     * inserting the specified delimiter between each element. The resulting AttributedString
+     * preserves the styles of all elements and the delimiter.
+     * </p>
+     *
+     * <p>
+     * If the delimiter is null, the elements are concatenated without any separator.
+     * </p>
+     *
+     * @param delimiter the delimiter to insert between elements, or null for no delimiter
+     * @param elements the elements to join
+     * @return a new AttributedString containing the joined elements
+     * @throws NullPointerException if elements is null
+     */
     public static AttributedString join(AttributedString delimiter, Iterable<AttributedString> elements) {
         Objects.requireNonNull(elements);
         AttributedStringBuilder sb = new AttributedStringBuilder();

--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -17,9 +17,39 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Attributed string builder
+ * A mutable builder for creating styled text strings with ANSI attributes.
  *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * <p>
+ * The AttributedStringBuilder class provides a mutable implementation of AttributedCharSequence
+ * for constructing styled text strings. It allows for dynamic building of attributed strings
+ * by appending characters, strings, or other attributed strings with various styles.
+ * </p>
+ *
+ * <p>
+ * This class is similar to StringBuilder but with added support for ANSI style attributes.
+ * It provides methods for appending text with different styles, manipulating the content,
+ * and converting the result to an immutable AttributedString when building is complete.
+ * </p>
+ *
+ * <p>
+ * Key features include:
+ * </p>
+ * <ul>
+ *   <li>Append operations with different styles</li>
+ *   <li>Tab expansion with configurable tab stops</li>
+ *   <li>Style manipulation (foreground/background colors, bold, underline, etc.)</li>
+ *   <li>Regular expression based styling</li>
+ *   <li>Alternative character set support</li>
+ * </ul>
+ *
+ * <p>
+ * This class is commonly used for building complex styled output for terminal applications,
+ * such as syntax highlighting, interactive prompts, and formatted displays.
+ * </p>
+ *
+ * @see AttributedCharSequence
+ * @see AttributedString
+ * @see AttributedStyle
  */
 public class AttributedStringBuilder extends AttributedCharSequence implements Appendable {
 
@@ -33,6 +63,18 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
     private int lastLineLength = 0;
     private AttributedStyle current = AttributedStyle.DEFAULT;
 
+    /**
+     * Creates an AttributedString by appending multiple character sequences.
+     *
+     * <p>
+     * This static utility method creates a new AttributedString by appending
+     * all the specified character sequences. It is a convenient way to concatenate
+     * multiple strings or AttributedStrings into a single AttributedString.
+     * </p>
+     *
+     * @param strings the character sequences to append
+     * @return a new AttributedString containing all the appended sequences
+     */
     public static AttributedString append(CharSequence... strings) {
         AttributedStringBuilder sb = new AttributedStringBuilder();
         for (CharSequence s : strings) {
@@ -41,52 +83,165 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return sb.toAttributedString();
     }
 
+    /**
+     * Creates a new AttributedStringBuilder with the default initial capacity.
+     *
+     * <p>
+     * This constructor creates a new AttributedStringBuilder with an initial
+     * capacity of 64 characters. The builder will automatically grow as needed
+     * when more characters are appended.
+     * </p>
+     */
     public AttributedStringBuilder() {
         this(64);
     }
 
+    /**
+     * Creates a new AttributedStringBuilder with the specified initial capacity.
+     *
+     * <p>
+     * This constructor creates a new AttributedStringBuilder with the specified
+     * initial capacity. The builder will automatically grow as needed when more
+     * characters are appended.
+     * </p>
+     *
+     * @param capacity the initial capacity of the builder
+     */
     public AttributedStringBuilder(int capacity) {
         buffer = new char[capacity];
         style = new long[capacity];
         length = 0;
     }
 
+    /**
+     * Returns the length of this attributed string builder.
+     *
+     * <p>
+     * This method returns the number of characters in this attributed string builder.
+     * </p>
+     *
+     * @return the number of characters in this attributed string builder
+     */
     @Override
     public int length() {
         return length;
     }
 
+    /**
+     * Returns the character at the specified index in this attributed string builder.
+     *
+     * <p>
+     * This method returns the character at the specified index in this
+     * attributed string builder.
+     * </p>
+     *
+     * @param index the index of the character to return
+     * @return the character at the specified index
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     @Override
     public char charAt(int index) {
         return buffer[index];
     }
 
+    /**
+     * Returns the style at the specified index in this attributed string builder.
+     *
+     * <p>
+     * This method returns the AttributedStyle object associated with the
+     * character at the specified index in this attributed string builder.
+     * </p>
+     *
+     * @param index the index of the character whose style to return
+     * @return the style at the specified index
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     @Override
     public AttributedStyle styleAt(int index) {
         return new AttributedStyle(style[index], style[index]);
     }
 
+    /**
+     * Returns the style code at the specified index in this attributed string builder.
+     *
+     * <p>
+     * This method returns the raw style code (as a long value) associated with the
+     * character at the specified index in this attributed string builder.
+     * </p>
+     *
+     * @param index the index of the character whose style code to return
+     * @return the style code at the specified index
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
     @Override
     long styleCodeAt(int index) {
         return style[index];
     }
 
+    /**
+     * Returns the character buffer for this attributed string builder.
+     *
+     * <p>
+     * This method is used internally by the AttributedCharSequence implementation
+     * to access the underlying character buffer.
+     * </p>
+     *
+     * @return the character buffer
+     */
     @Override
     protected char[] buffer() {
         return buffer;
     }
 
+    /**
+     * Returns the offset in the buffer where this attributed string builder starts.
+     *
+     * <p>
+     * This method is used internally by the AttributedCharSequence implementation
+     * to determine the starting position in the buffer. For AttributedStringBuilder,
+     * this is always 0 since the builder uses the entire buffer.
+     * </p>
+     *
+     * @return the offset in the buffer (always 0 for AttributedStringBuilder)
+     */
     @Override
     protected int offset() {
         return 0;
     }
 
+    /**
+     * Returns a new AttributedString that is a subsequence of this attributed string builder.
+     *
+     * <p>
+     * This method returns a new AttributedString that contains the characters and
+     * styles from this attributed string builder starting at the specified start index
+     * (inclusive) and ending at the specified end index (exclusive).
+     * </p>
+     *
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the specified subsequence with its attributes
+     * @throws IndexOutOfBoundsException if start or end are negative,
+     *         if end is greater than length(), or if start is greater than end
+     */
     @Override
     public AttributedString subSequence(int start, int end) {
         return new AttributedString(
                 Arrays.copyOfRange(buffer, start, end), Arrays.copyOfRange(style, start, end), 0, end - start);
     }
 
+    /**
+     * Appends the specified character sequence to this builder.
+     *
+     * <p>
+     * This method appends the specified character sequence to this builder,
+     * applying the current style to all characters. If the character sequence
+     * is null, the string "null" is appended, as required by the Appendable interface.
+     * </p>
+     *
+     * @param csq the character sequence to append, or null
+     * @return this builder
+     */
     @Override
     public AttributedStringBuilder append(CharSequence csq) {
         if (csq == null) {
@@ -95,6 +250,22 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return append(new AttributedString(csq, current));
     }
 
+    /**
+     * Appends a subsequence of the specified character sequence to this builder.
+     *
+     * <p>
+     * This method appends a subsequence of the specified character sequence to this builder,
+     * applying the current style to all characters. If the character sequence
+     * is null, the string "null" is appended, as required by the Appendable interface.
+     * </p>
+     *
+     * @param csq the character sequence to append, or null
+     * @param start the index of the first character to append
+     * @param end the index after the last character to append
+     * @return this builder
+     * @throws IndexOutOfBoundsException if start or end are negative, or if
+     *         end is greater than csq.length(), or if start is greater than end
+     */
     @Override
     public AttributedStringBuilder append(CharSequence csq, int start, int end) {
         if (csq == null) {
@@ -103,11 +274,34 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return append(csq.subSequence(start, end));
     }
 
+    /**
+     * Appends the specified character to this builder.
+     *
+     * <p>
+     * This method appends the specified character to this builder,
+     * applying the current style to the character.
+     * </p>
+     *
+     * @param c the character to append
+     * @return this builder
+     */
     @Override
     public AttributedStringBuilder append(char c) {
         return append(Character.toString(c));
     }
 
+    /**
+     * Appends the specified character to this builder multiple times.
+     *
+     * <p>
+     * This method appends the specified character to this builder the specified
+     * number of times, applying the current style to all characters.
+     * </p>
+     *
+     * @param c the character to append
+     * @param repeat the number of times to append the character
+     * @return this builder
+     */
     public AttributedStringBuilder append(char c, int repeat) {
         AttributedString s = new AttributedString(Character.toString(c), current);
         while (repeat-- > 0) {
@@ -116,28 +310,117 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return this;
     }
 
+    /**
+     * Appends the specified character sequence to this builder with the specified style.
+     *
+     * <p>
+     * This method appends the specified character sequence to this builder,
+     * applying the specified style to all characters. This allows appending text
+     * with a style different from the current style without changing the current style.
+     * </p>
+     *
+     * @param csq the character sequence to append
+     * @param style the style to apply to the appended characters
+     * @return this builder
+     */
     public AttributedStringBuilder append(CharSequence csq, AttributedStyle style) {
         return append(new AttributedString(csq, style));
     }
 
+    /**
+     * Sets the current style for this builder.
+     *
+     * <p>
+     * This method sets the current style for this builder, which will be applied
+     * to all characters appended after this call (until the style is changed again).
+     * </p>
+     *
+     * @param style the new current style
+     * @return this builder
+     */
     public AttributedStringBuilder style(AttributedStyle style) {
         current = style;
         return this;
     }
 
+    /**
+     * Updates the current style for this builder using a function.
+     *
+     * <p>
+     * This method updates the current style for this builder by applying the
+     * specified function to the current style. This allows for fluent style
+     * modifications without creating intermediate style objects.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * builder.style(s -> s.bold().foreground(AttributedStyle.RED));
+     * </pre>
+     *
+     * @param style the function to apply to the current style
+     * @return this builder
+     */
     public AttributedStringBuilder style(Function<AttributedStyle, AttributedStyle> style) {
         current = style.apply(current);
         return this;
     }
 
+    /**
+     * Appends the specified character sequence with a temporarily modified style.
+     *
+     * <p>
+     * This method temporarily modifies the current style using the specified function,
+     * appends the specified character sequence with that style, and then restores
+     * the original style. This allows for appending styled text without permanently
+     * changing the current style.
+     * </p>
+     *
+     * @param style the function to apply to the current style
+     * @param cs the character sequence to append
+     * @return this builder
+     */
     public AttributedStringBuilder styled(Function<AttributedStyle, AttributedStyle> style, CharSequence cs) {
         return styled(style, sb -> sb.append(cs));
     }
 
+    /**
+     * Appends the specified character sequence with the specified style.
+     *
+     * <p>
+     * This method temporarily sets the current style to the specified style,
+     * appends the specified character sequence with that style, and then restores
+     * the original style. This allows for appending styled text without permanently
+     * changing the current style.
+     * </p>
+     *
+     * @param style the style to use
+     * @param cs the character sequence to append
+     * @return this builder
+     */
     public AttributedStringBuilder styled(AttributedStyle style, CharSequence cs) {
         return styled(s -> style, sb -> sb.append(cs));
     }
 
+    /**
+     * Performs operations with a temporarily modified style.
+     *
+     * <p>
+     * This method temporarily modifies the current style using the specified function,
+     * performs the operations specified by the consumer with that style, and then
+     * restores the original style. This allows for performing complex styling
+     * operations without permanently changing the current style.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * builder.styled(s -> s.bold().foreground(AttributedStyle.RED),
+     *               sb -> sb.append("Error: ").append(errorMessage));
+     * </pre>
+     *
+     * @param style the function to apply to the current style
+     * @param consumer the consumer that performs operations on this builder
+     * @return this builder
+     */
     public AttributedStringBuilder styled(
             Function<AttributedStyle, AttributedStyle> style, Consumer<AttributedStringBuilder> consumer) {
         AttributedStyle prev = current;
@@ -147,22 +430,93 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return this;
     }
 
+    /**
+     * Returns the current style for this builder.
+     *
+     * <p>
+     * This method returns the current style for this builder, which is applied
+     * to all characters appended after the style was set (until the style is changed).
+     * </p>
+     *
+     * @return the current style
+     */
     public AttributedStyle style() {
         return current;
     }
 
+    /**
+     * Appends the specified AttributedString to this builder.
+     *
+     * <p>
+     * This method appends the specified AttributedString to this builder,
+     * preserving its character attributes. The current style is applied to
+     * any attributes that are not explicitly set in the AttributedString.
+     * </p>
+     *
+     * @param str the AttributedString to append
+     * @return this builder
+     */
     public AttributedStringBuilder append(AttributedString str) {
         return append((AttributedCharSequence) str, 0, str.length());
     }
 
+    /**
+     * Appends a subsequence of the specified AttributedString to this builder.
+     *
+     * <p>
+     * This method appends a subsequence of the specified AttributedString to this builder,
+     * preserving its character attributes. The current style is applied to
+     * any attributes that are not explicitly set in the AttributedString.
+     * </p>
+     *
+     * @param str the AttributedString to append
+     * @param start the index of the first character to append
+     * @param end the index after the last character to append
+     * @return this builder
+     * @throws IndexOutOfBoundsException if start or end are negative, or if
+     *         end is greater than str.length(), or if start is greater than end
+     */
     public AttributedStringBuilder append(AttributedString str, int start, int end) {
         return append((AttributedCharSequence) str, start, end);
     }
 
+    /**
+     * Appends the specified AttributedCharSequence to this builder.
+     *
+     * <p>
+     * This method appends the specified AttributedCharSequence to this builder,
+     * preserving its character attributes. The current style is applied to
+     * any attributes that are not explicitly set in the AttributedCharSequence.
+     * </p>
+     *
+     * @param str the AttributedCharSequence to append
+     * @return this builder
+     */
     public AttributedStringBuilder append(AttributedCharSequence str) {
         return append(str, 0, str.length());
     }
 
+    /**
+     * Appends a subsequence of the specified AttributedCharSequence to this builder.
+     *
+     * <p>
+     * This method appends a subsequence of the specified AttributedCharSequence to this builder,
+     * preserving its character attributes. The current style is applied to
+     * any attributes that are not explicitly set in the AttributedCharSequence.
+     * </p>
+     *
+     * <p>
+     * If the sequence contains tab characters and tab stops are defined, the tabs
+     * will be expanded according to the current tab stop settings.
+     * </p>
+     *
+     * @param str the AttributedCharSequence to append
+     * @param start the index of the first character to append
+     * @param end the index after the last character to append
+     * @return this builder
+     * @throws IndexOutOfBoundsException if start or end are negative, or if
+     *         end is greater than str.length(), or if start is greater than end
+     */
     public AttributedStringBuilder append(AttributedCharSequence str, int start, int end) {
         ensureCapacity(length + end - start);
         for (int i = start; i < end; i++) {
@@ -196,10 +550,45 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         }
     }
 
+    /**
+     * Appends the specified ANSI-encoded string to this builder.
+     *
+     * <p>
+     * This method parses the ANSI escape sequences in the input string and
+     * appends the text with the corresponding styles to this builder.
+     * This is useful for converting ANSI-colored output from external commands
+     * into styled text.
+     * </p>
+     *
+     * <p>
+     * This method is equivalent to {@link #ansiAppend(String)} but returns void.
+     * </p>
+     *
+     * @param ansi the ANSI-encoded string to parse and append
+     * @see #ansiAppend(String)
+     */
     public void appendAnsi(String ansi) {
         ansiAppend(ansi);
     }
 
+    /**
+     * Appends the specified ANSI-encoded string to this builder.
+     *
+     * <p>
+     * This method parses the ANSI escape sequences in the input string and
+     * appends the text with the corresponding styles to this builder.
+     * This is useful for converting ANSI-colored output from external commands
+     * into styled text.
+     * </p>
+     *
+     * <p>
+     * The method recognizes standard ANSI SGR (Select Graphic Rendition) sequences
+     * for text attributes (bold, underline, etc.) and colors (foreground and background).
+     * </p>
+     *
+     * @param ansi the ANSI-encoded string to parse and append
+     * @return this builder
+     */
     public AttributedStringBuilder ansiAppend(String ansi) {
         int ansiStart = 0;
         int ansiState = 0;
@@ -442,6 +831,24 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         lastLineLength += nb;
     }
 
+    /**
+     * Sets the length of this attributed string builder.
+     *
+     * <p>
+     * This method sets the length of this attributed string builder. If the
+     * specified length is less than the current length, the builder is truncated;
+     * if it is greater than the current length, the builder is extended with
+     * undefined characters and styles.
+     * </p>
+     *
+     * <p>
+     * Note that extending the builder with this method may result in undefined
+     * behavior if the extended region is accessed without first setting its
+     * characters and styles.
+     * </p>
+     *
+     * @param l the new length
+     */
     public void setLength(int l) {
         length = l;
     }
@@ -461,6 +868,20 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return tabs(Arrays.asList(tabsize));
     }
 
+    /**
+     * Sets the tab stops for this attributed string builder.
+     *
+     * <p>
+     * This method sets the tab stops for this attributed string builder,
+     * which are used for tab expansion when appending tab characters.
+     * Tab stops cannot be changed after text has been added to prevent
+     * inconsistent indentation.
+     * </p>
+     *
+     * @param tabs the list of tab stop positions
+     * @return this attributed string builder
+     * @throws IllegalStateException if text has already been appended
+     */
     public AttributedStringBuilder tabs(List<Integer> tabs) {
         if (length > 0) {
             throw new IllegalStateException("Cannot change tab size after appending text");
@@ -469,6 +890,21 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return this;
     }
 
+    /**
+     * Sets the alternate character set sequences for this builder.
+     *
+     * <p>
+     * This method sets the alternate character set sequences for this builder,
+     * which are used for handling special characters like box drawing characters.
+     * The alternate character set cannot be changed after text has been added
+     * to prevent inconsistent character rendering.
+     * </p>
+     *
+     * @param altIn the sequence to enable the alternate character set, or null to disable
+     * @param altOut the sequence to disable the alternate character set, or null to disable
+     * @return this builder
+     * @throws IllegalStateException if text has already been appended
+     */
     public AttributedStringBuilder altCharset(String altIn, String altOut) {
         if (length > 0) {
             throw new IllegalStateException("Cannot change alternative charset after appending text");
@@ -478,6 +914,25 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return this;
     }
 
+    /**
+     * Applies the specified style to all matches of the pattern in this builder.
+     *
+     * <p>
+     * This method finds all matches of the specified regular expression pattern in this
+     * builder and applies the specified style to the matching regions. The style is
+     * applied to all characters in each match.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * builder.append("Error: File not found")
+     *        .styleMatches(Pattern.compile("Error:"), AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
+     * </pre>
+     *
+     * @param pattern the regular expression pattern to match
+     * @param s the style to apply to matching regions
+     * @return this builder
+     */
     public AttributedStringBuilder styleMatches(Pattern pattern, AttributedStyle s) {
         Matcher matcher = pattern.matcher(this);
         while (matcher.find()) {
@@ -488,6 +943,30 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return this;
     }
 
+    /**
+     * Applies different styles to different capture groups in pattern matches.
+     *
+     * <p>
+     * This method finds all matches of the specified regular expression pattern in this
+     * builder and applies different styles to different capture groups in each match.
+     * The first style in the list is applied to the first capture group, the second style
+     * to the second capture group, and so on.
+     * </p>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * builder.append("Error: File not found")
+     *        .styleMatches(Pattern.compile("(Error): (File not found)"),
+     *                     Arrays.asList(
+     *                         AttributedStyle.DEFAULT.foreground(AttributedStyle.RED),
+     *                         AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW)));
+     * </pre>
+     *
+     * @param pattern the regular expression pattern to match
+     * @param styles the list of styles to apply to capture groups
+     * @return this builder
+     * @throws IndexOutOfBoundsException if the pattern has fewer capture groups than styles
+     */
     public AttributedStringBuilder styleMatches(Pattern pattern, List<AttributedStyle> styles) {
         Matcher matcher = pattern.matcher(this);
         while (matcher.find()) {

--- a/terminal/src/main/java/org/jline/utils/AttributedStyle.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -9,9 +9,48 @@
 package org.jline.utils;
 
 /**
- * Text styling.
+ * Text styling for terminal output with support for colors, fonts, and other attributes.
  *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * <p>
+ * The AttributedStyle class represents the styling attributes that can be applied to
+ * text in a terminal. It supports various text attributes such as bold, italic, underline,
+ * as well as foreground and background colors. The class uses a bit-packed long value to
+ * efficiently store multiple attributes.
+ * </p>
+ *
+ * <p>
+ * This class provides a fluent API for building styles by chaining method calls. Styles
+ * are immutable, so each method returns a new instance with the requested modifications.
+ * </p>
+ *
+ * <p>
+ * Color support includes:
+ * </p>
+ * <ul>
+ *   <li>8 standard ANSI colors (black, red, green, yellow, blue, magenta, cyan, white)</li>
+ *   <li>8 bright variants of the standard colors</li>
+ *   <li>256-color indexed mode</li>
+ *   <li>24-bit true color (RGB) mode</li>
+ * </ul>
+ *
+ * <p>
+ * Text attributes include bold, faint, italic, underline, blink, inverse, conceal, and crossed-out.
+ * </p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * // Create a style with red foreground, bold, and underline
+ * AttributedStyle style = AttributedStyle.DEFAULT
+ *     .foreground(AttributedStyle.RED)
+ *     .bold()
+ *     .underline();
+ *
+ * // Create a string with this style
+ * AttributedString str = new AttributedString("Error message", style);
+ * </pre>
+ *
+ * @see AttributedString
+ * @see AttributedStringBuilder
  */
 public class AttributedStyle {
 
@@ -49,25 +88,87 @@ public class AttributedStyle {
     static final long FG_COLOR = 0xFFFFFFL << FG_COLOR_EXP;
     static final long BG_COLOR = 0xFFFFFFL << BG_COLOR_EXP;
 
+    /**
+     * Default style with no attributes or colors set.
+     */
     public static final AttributedStyle DEFAULT = new AttributedStyle();
+
+    /**
+     * Style with bold attribute enabled.
+     */
     public static final AttributedStyle BOLD = DEFAULT.bold();
+
+    /**
+     * Style with bold attribute explicitly disabled.
+     */
     public static final AttributedStyle BOLD_OFF = DEFAULT.boldOff();
+
+    /**
+     * Style with inverse (reverse video) attribute enabled.
+     */
     public static final AttributedStyle INVERSE = DEFAULT.inverse();
+
+    /**
+     * Style with inverse (reverse video) attribute explicitly disabled.
+     */
     public static final AttributedStyle INVERSE_OFF = DEFAULT.inverseOff();
+
+    /**
+     * Style with hidden attribute enabled.
+     */
     public static final AttributedStyle HIDDEN = DEFAULT.hidden();
+
+    /**
+     * Style with hidden attribute explicitly disabled.
+     */
     public static final AttributedStyle HIDDEN_OFF = DEFAULT.hiddenOff();
 
     final long style;
     final long mask;
 
+    /**
+     * Creates a new AttributedStyle with no attributes or colors set.
+     *
+     * <p>
+     * This constructor creates a default style with no attributes or colors set.
+     * It is equivalent to {@link #DEFAULT}.
+     * </p>
+     */
     public AttributedStyle() {
         this(0, 0);
     }
 
+    /**
+     * Creates a new AttributedStyle by copying another style.
+     *
+     * <p>
+     * This constructor creates a new style with the same attributes and colors
+     * as the specified style.
+     * </p>
+     *
+     * @param s the style to copy
+     */
     public AttributedStyle(AttributedStyle s) {
         this(s.style, s.mask);
     }
 
+    /**
+     * Creates a new AttributedStyle with the specified style and mask values.
+     *
+     * <p>
+     * This constructor creates a new style with the specified style and mask values.
+     * The style value contains the actual attributes and colors, while the mask value
+     * indicates which attributes and colors are explicitly set (as opposed to being
+     * inherited or default).
+     * </p>
+     *
+     * <p>
+     * This constructor is primarily for internal use and advanced scenarios.
+     * </p>
+     *
+     * @param style the style value containing attributes and colors
+     * @param mask the mask value indicating which attributes and colors are set
+     */
     public AttributedStyle(long style, long mask) {
         this.style = style;
         this.mask = mask & MASK
@@ -75,151 +176,669 @@ public class AttributedStyle {
                 | ((style & F_BACKGROUND) != 0 ? BG_COLOR : 0);
     }
 
+    /**
+     * Returns a new style with the bold attribute enabled.
+     *
+     * <p>
+     * This method returns a new style with the bold attribute enabled.
+     * The bold attribute typically makes text appear with a heavier or thicker font.
+     * </p>
+     *
+     * @return a new style with the bold attribute enabled
+     * @see #boldOff()
+     * @see #boldDefault()
+     */
     public AttributedStyle bold() {
         return new AttributedStyle(style | F_BOLD, mask | F_BOLD);
     }
 
+    /**
+     * Returns a new style with the bold attribute explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the bold attribute explicitly disabled.
+     * This is different from {@link #boldDefault()}, which removes any explicit
+     * setting for the bold attribute.
+     * </p>
+     *
+     * @return a new style with the bold attribute explicitly disabled
+     * @see #bold()
+     * @see #boldDefault()
+     */
     public AttributedStyle boldOff() {
         return new AttributedStyle(style & ~F_BOLD, mask | F_BOLD);
     }
 
+    /**
+     * Returns a new style with the bold attribute set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the bold attribute.
+     * When this style is applied, the bold attribute will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the bold attribute set to its default state
+     * @see #bold()
+     * @see #boldOff()
+     */
     public AttributedStyle boldDefault() {
         return new AttributedStyle(style & ~F_BOLD, mask & ~F_BOLD);
     }
 
+    /**
+     * Returns a new style with the faint attribute enabled.
+     *
+     * <p>
+     * This method returns a new style with the faint attribute enabled.
+     * The faint attribute typically makes text appear with a lighter or thinner font,
+     * or with reduced intensity.
+     * </p>
+     *
+     * @return a new style with the faint attribute enabled
+     * @see #faintOff()
+     * @see #faintDefault()
+     */
     public AttributedStyle faint() {
         return new AttributedStyle(style | F_FAINT, mask | F_FAINT);
     }
 
+    /**
+     * Returns a new style with the faint attribute explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the faint attribute explicitly disabled.
+     * This is different from {@link #faintDefault()}, which removes any explicit
+     * setting for the faint attribute.
+     * </p>
+     *
+     * @return a new style with the faint attribute explicitly disabled
+     * @see #faint()
+     * @see #faintDefault()
+     */
     public AttributedStyle faintOff() {
         return new AttributedStyle(style & ~F_FAINT, mask | F_FAINT);
     }
 
+    /**
+     * Returns a new style with the faint attribute set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the faint attribute.
+     * When this style is applied, the faint attribute will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the faint attribute set to its default state
+     * @see #faint()
+     * @see #faintOff()
+     */
     public AttributedStyle faintDefault() {
         return new AttributedStyle(style & ~F_FAINT, mask & ~F_FAINT);
     }
 
+    /**
+     * Returns a new style with the italic attribute enabled.
+     *
+     * <p>
+     * This method returns a new style with the italic attribute enabled.
+     * The italic attribute typically makes text appear slanted or cursive.
+     * </p>
+     *
+     * @return a new style with the italic attribute enabled
+     * @see #italicOff()
+     * @see #italicDefault()
+     */
     public AttributedStyle italic() {
         return new AttributedStyle(style | F_ITALIC, mask | F_ITALIC);
     }
 
+    /**
+     * Returns a new style with the italic attribute explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the italic attribute explicitly disabled.
+     * This is different from {@link #italicDefault()}, which removes any explicit
+     * setting for the italic attribute.
+     * </p>
+     *
+     * @return a new style with the italic attribute explicitly disabled
+     * @see #italic()
+     * @see #italicDefault()
+     */
     public AttributedStyle italicOff() {
         return new AttributedStyle(style & ~F_ITALIC, mask | F_ITALIC);
     }
 
+    /**
+     * Returns a new style with the italic attribute set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the italic attribute.
+     * When this style is applied, the italic attribute will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the italic attribute set to its default state
+     * @see #italic()
+     * @see #italicOff()
+     */
     public AttributedStyle italicDefault() {
         return new AttributedStyle(style & ~F_ITALIC, mask & ~F_ITALIC);
     }
 
+    /**
+     * Returns a new style with the underline attribute enabled.
+     *
+     * <p>
+     * This method returns a new style with the underline attribute enabled.
+     * The underline attribute typically draws a line under the text.
+     * </p>
+     *
+     * @return a new style with the underline attribute enabled
+     * @see #underlineOff()
+     * @see #underlineDefault()
+     */
     public AttributedStyle underline() {
         return new AttributedStyle(style | F_UNDERLINE, mask | F_UNDERLINE);
     }
 
+    /**
+     * Returns a new style with the underline attribute explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the underline attribute explicitly disabled.
+     * This is different from {@link #underlineDefault()}, which removes any explicit
+     * setting for the underline attribute.
+     * </p>
+     *
+     * @return a new style with the underline attribute explicitly disabled
+     * @see #underline()
+     * @see #underlineDefault()
+     */
     public AttributedStyle underlineOff() {
         return new AttributedStyle(style & ~F_UNDERLINE, mask | F_UNDERLINE);
     }
 
+    /**
+     * Returns a new style with the underline attribute set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the underline attribute.
+     * When this style is applied, the underline attribute will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the underline attribute set to its default state
+     * @see #underline()
+     * @see #underlineOff()
+     */
     public AttributedStyle underlineDefault() {
         return new AttributedStyle(style & ~F_UNDERLINE, mask & ~F_UNDERLINE);
     }
 
+    /**
+     * Returns a new style with the blink attribute enabled.
+     *
+     * <p>
+     * This method returns a new style with the blink attribute enabled.
+     * The blink attribute typically makes text flash on and off, though
+     * support varies across terminals.
+     * </p>
+     *
+     * @return a new style with the blink attribute enabled
+     * @see #blinkOff()
+     * @see #blinkDefault()
+     */
     public AttributedStyle blink() {
         return new AttributedStyle(style | F_BLINK, mask | F_BLINK);
     }
 
+    /**
+     * Returns a new style with the blink attribute explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the blink attribute explicitly disabled.
+     * This is different from {@link #blinkDefault()}, which removes any explicit
+     * setting for the blink attribute.
+     * </p>
+     *
+     * @return a new style with the blink attribute explicitly disabled
+     * @see #blink()
+     * @see #blinkDefault()
+     */
     public AttributedStyle blinkOff() {
         return new AttributedStyle(style & ~F_BLINK, mask | F_BLINK);
     }
 
+    /**
+     * Returns a new style with the blink attribute set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the blink attribute.
+     * When this style is applied, the blink attribute will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the blink attribute set to its default state
+     * @see #blink()
+     * @see #blinkOff()
+     */
     public AttributedStyle blinkDefault() {
         return new AttributedStyle(style & ~F_BLINK, mask & ~F_BLINK);
     }
 
+    /**
+     * Returns a new style with the inverse attribute enabled.
+     *
+     * <p>
+     * This method returns a new style with the inverse attribute enabled.
+     * The inverse attribute (also known as reverse video) typically swaps
+     * the foreground and background colors of the text.
+     * </p>
+     *
+     * @return a new style with the inverse attribute enabled
+     * @see #inverseOff()
+     * @see #inverseDefault()
+     * @see #inverseNeg()
+     */
     public AttributedStyle inverse() {
         return new AttributedStyle(style | F_INVERSE, mask | F_INVERSE);
     }
 
+    /**
+     * Returns a new style with the inverse attribute toggled.
+     *
+     * <p>
+     * This method returns a new style with the inverse attribute toggled from its
+     * current state. If the inverse attribute is currently enabled, it will be disabled,
+     * and if it is currently disabled, it will be enabled.
+     * </p>
+     *
+     * @return a new style with the inverse attribute toggled
+     * @see #inverse()
+     * @see #inverseOff()
+     * @see #inverseDefault()
+     */
     public AttributedStyle inverseNeg() {
         long s = (style & F_INVERSE) != 0 ? style & ~F_INVERSE : style | F_INVERSE;
         return new AttributedStyle(s, mask | F_INVERSE);
     }
 
+    /**
+     * Returns a new style with the inverse attribute explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the inverse attribute explicitly disabled.
+     * This is different from {@link #inverseDefault()}, which removes any explicit
+     * setting for the inverse attribute.
+     * </p>
+     *
+     * @return a new style with the inverse attribute explicitly disabled
+     * @see #inverse()
+     * @see #inverseDefault()
+     * @see #inverseNeg()
+     */
     public AttributedStyle inverseOff() {
         return new AttributedStyle(style & ~F_INVERSE, mask | F_INVERSE);
     }
 
+    /**
+     * Returns a new style with the inverse attribute set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the inverse attribute.
+     * When this style is applied, the inverse attribute will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the inverse attribute set to its default state
+     * @see #inverse()
+     * @see #inverseOff()
+     * @see #inverseNeg()
+     */
     public AttributedStyle inverseDefault() {
         return new AttributedStyle(style & ~F_INVERSE, mask & ~F_INVERSE);
     }
 
+    /**
+     * Returns a new style with the conceal attribute enabled.
+     *
+     * <p>
+     * This method returns a new style with the conceal attribute enabled.
+     * The conceal attribute typically hides text from display, though
+     * support varies across terminals.
+     * </p>
+     *
+     * @return a new style with the conceal attribute enabled
+     * @see #concealOff()
+     * @see #concealDefault()
+     */
     public AttributedStyle conceal() {
         return new AttributedStyle(style | F_CONCEAL, mask | F_CONCEAL);
     }
 
+    /**
+     * Returns a new style with the conceal attribute explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the conceal attribute explicitly disabled.
+     * This is different from {@link #concealDefault()}, which removes any explicit
+     * setting for the conceal attribute.
+     * </p>
+     *
+     * @return a new style with the conceal attribute explicitly disabled
+     * @see #conceal()
+     * @see #concealDefault()
+     */
     public AttributedStyle concealOff() {
         return new AttributedStyle(style & ~F_CONCEAL, mask | F_CONCEAL);
     }
 
+    /**
+     * Returns a new style with the conceal attribute set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the conceal attribute.
+     * When this style is applied, the conceal attribute will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the conceal attribute set to its default state
+     * @see #conceal()
+     * @see #concealOff()
+     */
     public AttributedStyle concealDefault() {
         return new AttributedStyle(style & ~F_CONCEAL, mask & ~F_CONCEAL);
     }
 
+    /**
+     * Returns a new style with the crossed-out attribute enabled.
+     *
+     * <p>
+     * This method returns a new style with the crossed-out attribute enabled.
+     * The crossed-out attribute typically draws a line through the text,
+     * though support varies across terminals.
+     * </p>
+     *
+     * @return a new style with the crossed-out attribute enabled
+     * @see #crossedOutOff()
+     * @see #crossedOutDefault()
+     */
     public AttributedStyle crossedOut() {
         return new AttributedStyle(style | F_CROSSED_OUT, mask | F_CROSSED_OUT);
     }
 
+    /**
+     * Returns a new style with the crossed-out attribute explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the crossed-out attribute explicitly disabled.
+     * This is different from {@link #crossedOutDefault()}, which removes any explicit
+     * setting for the crossed-out attribute.
+     * </p>
+     *
+     * @return a new style with the crossed-out attribute explicitly disabled
+     * @see #crossedOut()
+     * @see #crossedOutDefault()
+     */
     public AttributedStyle crossedOutOff() {
         return new AttributedStyle(style & ~F_CROSSED_OUT, mask | F_CROSSED_OUT);
     }
 
+    /**
+     * Returns a new style with the crossed-out attribute set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the crossed-out attribute.
+     * When this style is applied, the crossed-out attribute will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the crossed-out attribute set to its default state
+     * @see #crossedOut()
+     * @see #crossedOutOff()
+     */
     public AttributedStyle crossedOutDefault() {
         return new AttributedStyle(style & ~F_CROSSED_OUT, mask & ~F_CROSSED_OUT);
     }
 
+    /**
+     * Returns a new style with the specified foreground color.
+     *
+     * <p>
+     * This method returns a new style with the specified foreground color.
+     * The color is specified as an index into the terminal's color palette.
+     * Standard ANSI colors are defined as constants in this class (BLACK, RED, etc.).
+     * </p>
+     *
+     * <p>
+     * For 256-color support, use values from 0 to 255. For standard ANSI colors,
+     * use values from 0 to 7, or add BRIGHT (8) for bright variants.
+     * </p>
+     *
+     * @param color the foreground color index
+     * @return a new style with the specified foreground color
+     * @see #foregroundOff()
+     * @see #foregroundDefault()
+     * @see #foreground(int, int, int)
+     * @see #foregroundRgb(int)
+     */
     public AttributedStyle foreground(int color) {
         return new AttributedStyle(
                 style & ~FG_COLOR | F_FOREGROUND_IND | (((long) color << FG_COLOR_EXP) & FG_COLOR),
                 mask | F_FOREGROUND_IND);
     }
 
+    /**
+     * Returns a new style with the specified RGB foreground color.
+     *
+     * <p>
+     * This method returns a new style with the specified RGB foreground color.
+     * The color is specified as separate red, green, and blue components,
+     * each with a value from 0 to 255.
+     * </p>
+     *
+     * <p>
+     * Note that true color support (24-bit RGB) may not be available in all terminals.
+     * In terminals without true color support, the color will be approximated using
+     * the closest available color in the terminal's palette.
+     * </p>
+     *
+     * @param r the red component (0-255)
+     * @param g the green component (0-255)
+     * @param b the blue component (0-255)
+     * @return a new style with the specified RGB foreground color
+     * @see #foregroundRgb(int)
+     * @see #foregroundOff()
+     * @see #foregroundDefault()
+     */
     public AttributedStyle foreground(int r, int g, int b) {
         return foregroundRgb(r << 16 | g << 8 | b);
     }
 
+    /**
+     * Returns a new style with the specified RGB foreground color.
+     *
+     * <p>
+     * This method returns a new style with the specified RGB foreground color.
+     * The color is specified as a single integer in the format 0xRRGGBB,
+     * where RR, GG, and BB are the red, green, and blue components in hexadecimal.
+     * </p>
+     *
+     * <p>
+     * Note that true color support (24-bit RGB) may not be available in all terminals.
+     * In terminals without true color support, the color will be approximated using
+     * the closest available color in the terminal's palette.
+     * </p>
+     *
+     * @param color the RGB color value (0xRRGGBB)
+     * @return a new style with the specified RGB foreground color
+     * @see #foreground(int, int, int)
+     * @see #foregroundOff()
+     * @see #foregroundDefault()
+     */
     public AttributedStyle foregroundRgb(int color) {
         return new AttributedStyle(
                 style & ~FG_COLOR | F_FOREGROUND_RGB | ((((long) color & 0xFFFFFF) << FG_COLOR_EXP) & FG_COLOR),
                 mask | F_FOREGROUND_RGB);
     }
 
+    /**
+     * Returns a new style with the foreground color explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the foreground color explicitly disabled.
+     * This is different from {@link #foregroundDefault()}, which removes any explicit
+     * setting for the foreground color.
+     * </p>
+     *
+     * <p>
+     * When a style with the foreground color disabled is applied, the text will
+     * typically be displayed using the terminal's default foreground color.
+     * </p>
+     *
+     * @return a new style with the foreground color explicitly disabled
+     * @see #foreground(int)
+     * @see #foregroundDefault()
+     */
     public AttributedStyle foregroundOff() {
         return new AttributedStyle(style & ~FG_COLOR & ~F_FOREGROUND, mask | F_FOREGROUND);
     }
 
+    /**
+     * Returns a new style with the foreground color set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the foreground color.
+     * When this style is applied, the foreground color will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the foreground color set to its default state
+     * @see #foreground(int)
+     * @see #foregroundOff()
+     */
     public AttributedStyle foregroundDefault() {
         return new AttributedStyle(style & ~FG_COLOR & ~F_FOREGROUND, mask & ~(F_FOREGROUND | FG_COLOR));
     }
 
+    /**
+     * Returns a new style with the specified background color.
+     *
+     * <p>
+     * This method returns a new style with the specified background color.
+     * The color is specified as an index into the terminal's color palette.
+     * Standard ANSI colors are defined as constants in this class (BLACK, RED, etc.).
+     * </p>
+     *
+     * <p>
+     * For 256-color support, use values from 0 to 255. For standard ANSI colors,
+     * use values from 0 to 7, or add BRIGHT (8) for bright variants.
+     * </p>
+     *
+     * @param color the background color index
+     * @return a new style with the specified background color
+     * @see #backgroundOff()
+     * @see #backgroundDefault()
+     * @see #background(int, int, int)
+     * @see #backgroundRgb(int)
+     */
     public AttributedStyle background(int color) {
         return new AttributedStyle(
                 style & ~BG_COLOR | F_BACKGROUND_IND | (((long) color << BG_COLOR_EXP) & BG_COLOR),
                 mask | F_BACKGROUND_IND);
     }
 
+    /**
+     * Returns a new style with the specified RGB background color.
+     *
+     * <p>
+     * This method returns a new style with the specified RGB background color.
+     * The color is specified as separate red, green, and blue components,
+     * each with a value from 0 to 255.
+     * </p>
+     *
+     * <p>
+     * Note that true color support (24-bit RGB) may not be available in all terminals.
+     * In terminals without true color support, the color will be approximated using
+     * the closest available color in the terminal's palette.
+     * </p>
+     *
+     * @param r the red component (0-255)
+     * @param g the green component (0-255)
+     * @param b the blue component (0-255)
+     * @return a new style with the specified RGB background color
+     * @see #backgroundRgb(int)
+     * @see #backgroundOff()
+     * @see #backgroundDefault()
+     */
     public AttributedStyle background(int r, int g, int b) {
         return backgroundRgb(r << 16 | g << 8 | b);
     }
 
+    /**
+     * Returns a new style with the specified RGB background color.
+     *
+     * <p>
+     * This method returns a new style with the specified RGB background color.
+     * The color is specified as a single integer in the format 0xRRGGBB,
+     * where RR, GG, and BB are the red, green, and blue components in hexadecimal.
+     * </p>
+     *
+     * <p>
+     * Note that true color support (24-bit RGB) may not be available in all terminals.
+     * In terminals without true color support, the color will be approximated using
+     * the closest available color in the terminal's palette.
+     * </p>
+     *
+     * @param color the RGB color value (0xRRGGBB)
+     * @return a new style with the specified RGB background color
+     * @see #background(int, int, int)
+     * @see #backgroundOff()
+     * @see #backgroundDefault()
+     */
     public AttributedStyle backgroundRgb(int color) {
         return new AttributedStyle(
                 style & ~BG_COLOR | F_BACKGROUND_RGB | ((((long) color & 0xFFFFFF) << BG_COLOR_EXP) & BG_COLOR),
                 mask | F_BACKGROUND_RGB);
     }
 
+    /**
+     * Returns a new style with the background color explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the background color explicitly disabled.
+     * This is different from {@link #backgroundDefault()}, which removes any explicit
+     * setting for the background color.
+     * </p>
+     *
+     * <p>
+     * When a style with the background color disabled is applied, the text will
+     * typically be displayed using the terminal's default background color.
+     * </p>
+     *
+     * @return a new style with the background color explicitly disabled
+     * @see #background(int)
+     * @see #backgroundDefault()
+     */
     public AttributedStyle backgroundOff() {
         return new AttributedStyle(style & ~BG_COLOR & ~F_BACKGROUND, mask | F_BACKGROUND);
     }
 
+    /**
+     * Returns a new style with the background color set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the background color.
+     * When this style is applied, the background color will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the background color set to its default state
+     * @see #background(int)
+     * @see #backgroundOff()
+     */
     public AttributedStyle backgroundDefault() {
         return new AttributedStyle(style & ~BG_COLOR & ~F_BACKGROUND, mask & ~(F_BACKGROUND | BG_COLOR));
     }
@@ -235,22 +854,83 @@ public class AttributedStyle {
         return new AttributedStyle(style | F_HIDDEN, mask | F_HIDDEN);
     }
 
+    /**
+     * Returns a new style with the hidden attribute explicitly disabled.
+     *
+     * <p>
+     * This method returns a new style with the hidden attribute explicitly disabled.
+     * This is different from {@link #hiddenDefault()}, which removes any explicit
+     * setting for the hidden attribute.
+     * </p>
+     *
+     * @return a new style with the hidden attribute explicitly disabled
+     * @see #hidden()
+     * @see #hiddenDefault()
+     */
     public AttributedStyle hiddenOff() {
         return new AttributedStyle(style & ~F_HIDDEN, mask | F_HIDDEN);
     }
 
+    /**
+     * Returns a new style with the hidden attribute set to its default state.
+     *
+     * <p>
+     * This method returns a new style with no explicit setting for the hidden attribute.
+     * When this style is applied, the hidden attribute will be inherited from the
+     * parent style or use the terminal's default.
+     * </p>
+     *
+     * @return a new style with the hidden attribute set to its default state
+     * @see #hidden()
+     * @see #hiddenOff()
+     */
     public AttributedStyle hiddenDefault() {
         return new AttributedStyle(style & ~F_HIDDEN, mask & ~F_HIDDEN);
     }
 
+    /**
+     * Returns the raw style value of this style.
+     *
+     * <p>
+     * This method returns the raw style value, which contains all the attributes
+     * and colors encoded as bit flags in a long value. This is primarily for
+     * internal use and advanced scenarios.
+     * </p>
+     *
+     * @return the raw style value
+     * @see #getMask()
+     */
     public long getStyle() {
         return style;
     }
 
+    /**
+     * Returns the raw mask value of this style.
+     *
+     * <p>
+     * This method returns the raw mask value, which indicates which attributes
+     * and colors are explicitly set (as opposed to being inherited or default).
+     * This is primarily for internal use and advanced scenarios.
+     * </p>
+     *
+     * @return the raw mask value
+     * @see #getStyle()
+     */
     public long getMask() {
         return mask;
     }
 
+    /**
+     * Compares this AttributedStyle with another object for equality.
+     *
+     * <p>
+     * Two AttributedStyle objects are considered equal if they have the same
+     * style and mask values.
+     * </p>
+     *
+     * @param o the object to compare with
+     * @return {@code true} if the objects are equal, {@code false} otherwise
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -260,11 +940,37 @@ public class AttributedStyle {
         return mask == that.mask;
     }
 
+    /**
+     * Returns a hash code for this AttributedStyle.
+     *
+     * <p>
+     * The hash code is computed based on the style and mask values.
+     * </p>
+     *
+     * @return a hash code value for this object
+     */
     @Override
     public int hashCode() {
         return 31 * Long.hashCode(style) + Long.hashCode(mask);
     }
 
+    /**
+     * Returns an ANSI escape sequence string that represents this style.
+     *
+     * <p>
+     * This method generates an ANSI escape sequence string that, when printed to
+     * a terminal, would apply this style. This is useful for debugging or for
+     * generating ANSI-colored output for terminals that support it.
+     * </p>
+     *
+     * <p>
+     * The method works by creating a temporary AttributedStringBuilder, applying
+     * this style to a space character, and then extracting the ANSI escape sequences
+     * from the resulting string.
+     * </p>
+     *
+     * @return an ANSI escape sequence string representing this style
+     */
     public String toAnsi() {
         AttributedStringBuilder sb = new AttributedStringBuilder();
         sb.styled(this, " ");
@@ -272,6 +978,17 @@ public class AttributedStyle {
         return s.length() > 1 ? s.substring(2, s.indexOf('m')) : s;
     }
 
+    /**
+     * Returns a string representation of this AttributedStyle.
+     *
+     * <p>
+     * This method returns a string representation of this AttributedStyle,
+     * including the style value, mask value, and ANSI escape sequence.
+     * This is primarily useful for debugging.
+     * </p>
+     *
+     * @return a string representation of this AttributedStyle
+     */
     @Override
     public String toString() {
         return "AttributedStyle{" + "style=" + style + ", mask=" + mask + ", ansi=" + toAnsi() + '}';

--- a/terminal/src/main/java/org/jline/utils/ClosedException.java
+++ b/terminal/src/main/java/org/jline/utils/ClosedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -10,6 +10,22 @@ package org.jline.utils;
 
 import java.io.IOException;
 
+/**
+ * Exception thrown when attempting to use a closed resource.
+ *
+ * <p>
+ * The ClosedException is thrown when an operation is attempted on a resource
+ * (such as a terminal, reader, or writer) that has been closed. This exception
+ * extends IOException and provides the same constructors for different ways of
+ * specifying the error message and cause.
+ * </p>
+ *
+ * <p>
+ * This exception is typically thrown by JLine components when methods are called
+ * after the component has been closed, such as attempting to read from a closed
+ * terminal or write to a closed output stream.
+ * </p>
+ */
 public class ClosedException extends IOException {
 
     private static final long serialVersionUID = 3085420657077696L;

--- a/terminal/src/main/java/org/jline/utils/ColorPalette.java
+++ b/terminal/src/main/java/org/jline/utils/ColorPalette.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -17,7 +17,35 @@ import java.util.List;
 import org.jline.terminal.Terminal;
 
 /**
- * Color palette
+ * Color palette for terminal color management and conversion.
+ *
+ * <p>
+ * The ColorPalette class provides functionality for managing terminal colors,
+ * including color conversion between different formats (RGB, ANSI, indexed),
+ * color distance calculation, and color remapping. It helps bridge the gap
+ * between the different color capabilities of various terminals.
+ * </p>
+ *
+ * <p>
+ * This class supports various terminal color modes:
+ * </p>
+ * <ul>
+ *   <li>8-color mode (standard ANSI colors)</li>
+ *   <li>16-color mode (standard ANSI colors + bright variants)</li>
+ *   <li>256-color mode (indexed colors)</li>
+ *   <li>24-bit true color mode (RGB colors)</li>
+ * </ul>
+ *
+ * <p>
+ * The palette can be used to convert between these color modes, find the closest
+ * matching color in a more limited palette, and even modify the terminal's color
+ * palette on supported terminals.
+ * </p>
+ *
+ * <p>
+ * This class is used internally by JLine components to handle color output across
+ * different terminal types with varying color support capabilities.
+ * </p>
  */
 public class ColorPalette {
 

--- a/terminal/src/main/java/org/jline/utils/Colors.java
+++ b/terminal/src/main/java/org/jline/utils/Colors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -19,6 +19,31 @@ import java.util.stream.Stream;
 
 import static org.jline.terminal.TerminalBuilder.PROP_COLOR_DISTANCE;
 
+/**
+ * Utility class for color-related operations and definitions.
+ *
+ * <p>
+ * The Colors class provides utility methods and constants for working with colors
+ * in terminal applications. It includes color palettes, color name mappings, and
+ * methods for color parsing and conversion.
+ * </p>
+ *
+ * <p>
+ * This class defines standard color palettes for different terminal color modes:
+ * </p>
+ * <ul>
+ *   <li>8 standard ANSI colors</li>
+ *   <li>256-color indexed palette</li>
+ *   <li>Named color mappings (e.g., "red", "blue", "navy")</li>
+ * </ul>
+ *
+ * <p>
+ * It also provides methods for parsing color specifications in various formats,
+ * such as RGB hex codes, CSS-style color names, and indexed color references.
+ * These utilities help with consistent color handling across different terminal
+ * types and color capabilities.
+ * </p>
+ */
 public class Colors {
 
     // @spotless:off

--- a/terminal/src/main/java/org/jline/utils/Curses.java
+++ b/terminal/src/main/java/org/jline/utils/Curses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -15,9 +15,36 @@ import java.io.StringWriter;
 import java.util.ArrayDeque;
 
 /**
- * Curses helper methods.
+ * Utility class for terminal cursor and screen manipulation using ANSI escape sequences.
  *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * <p>
+ * The Curses class provides methods for manipulating the terminal display using
+ * ANSI escape sequences and terminal capabilities. It includes functionality for
+ * cursor movement, screen clearing, text attributes, and other terminal operations.
+ * </p>
+ *
+ * <p>
+ * This class is named after the curses library commonly used in Unix-like systems
+ * for terminal control, though it provides a simplified subset of functionality.
+ * It handles the complexities of formatting and interpreting terminal capability
+ * strings, allowing for portable terminal manipulation across different terminal types.
+ * </p>
+ *
+ * <p>
+ * Key features include:
+ * </p>
+ * <ul>
+ *   <li>Cursor positioning and movement</li>
+ *   <li>Screen and line clearing</li>
+ *   <li>Text attribute control (bold, underline, etc.)</li>
+ *   <li>Color manipulation</li>
+ *   <li>Terminal capability string parsing and execution</li>
+ * </ul>
+ *
+ * <p>
+ * This class is used internally by JLine components to perform terminal operations
+ * in a consistent way across different terminal types and platforms.
+ * </p>
  */
 public final class Curses {
 

--- a/terminal/src/main/java/org/jline/utils/DiffHelper.java
+++ b/terminal/src/main/java/org/jline/utils/DiffHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -12,9 +12,34 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Class containing the diff method.
- * This diff is ANSI aware and will correctly handle text attributes
- * so that any text in a Diff object is a valid ansi string.
+ * Utility class for computing differences between strings with ANSI attribute awareness.
+ *
+ * <p>
+ * The DiffHelper class provides methods for computing the differences between two strings
+ * while being aware of ANSI escape sequences and text attributes. This allows for proper
+ * diffing of styled text without breaking the ANSI escape sequences.
+ * </p>
+ *
+ * <p>
+ * Unlike standard diff algorithms, this implementation ensures that any text in a Diff
+ * object is a valid ANSI string with properly balanced escape sequences. This is particularly
+ * important when diffing AttributedStrings or other text with embedded styling information.
+ * </p>
+ *
+ * <p>
+ * The diff algorithm identifies three types of operations:
+ * </p>
+ * <ul>
+ *   <li>DELETE - Text that exists in the first string but not in the second</li>
+ *   <li>INSERT - Text that exists in the second string but not in the first</li>
+ *   <li>EQUAL - Text that is common to both strings</li>
+ * </ul>
+ *
+ * <p>
+ * This class is particularly useful for implementing features like change highlighting
+ * in terminal applications, where differences between versions of text need to be
+ * displayed with proper styling.
+ * </p>
  */
 public class DiffHelper {
 

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -19,9 +19,38 @@ import org.jline.terminal.Terminal;
 import org.jline.utils.InfoCmp.Capability;
 
 /**
- * Handle display and visual cursor.
+ * Manages terminal display and efficient screen updates with cursor positioning.
  *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * <p>
+ * The Display class provides functionality for managing the display of content on
+ * the terminal screen. It handles the complexities of cursor positioning, line wrapping,
+ * and efficient screen updates to minimize the amount of data sent to the terminal.
+ * </p>
+ *
+ * <p>
+ * This class supports two main modes of operation:
+ * </p>
+ * <ul>
+ *   <li><b>Full-screen mode</b> - Takes over the entire terminal screen</li>
+ *   <li><b>Partial-screen mode</b> - Updates only a portion of the screen, preserving content above</li>
+ * </ul>
+ *
+ * <p>
+ * Key features include:
+ * </p>
+ * <ul>
+ *   <li>Efficient screen updates using cursor positioning</li>
+ *   <li>Support for multi-line content with proper wrapping</li>
+ *   <li>Handling of ANSI-styled text (colors, attributes)</li>
+ *   <li>Size-aware rendering that adapts to terminal dimensions</li>
+ *   <li>Cursor positioning relative to the display area</li>
+ * </ul>
+ *
+ * <p>
+ * This class is used by various JLine components, such as LineReader, to provide
+ * efficient terminal display management for features like command-line editing,
+ * completion menus, and status messages.
+ * </p>
  */
 public class Display {
 

--- a/terminal/src/main/java/org/jline/utils/ExecHelper.java
+++ b/terminal/src/main/java/org/jline/utils/ExecHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -18,7 +18,30 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Helper methods for running unix commands.
+ * Utility class for executing external commands and capturing their output.
+ *
+ * <p>
+ * The ExecHelper class provides methods for executing external commands (primarily
+ * on Unix-like systems) and capturing their output. It handles the complexities of
+ * process creation, input/output redirection, and process termination.
+ * </p>
+ *
+ * <p>
+ * This class is used by various JLine components that need to interact with the
+ * underlying operating system, such as terminal detection, capability querying,
+ * and terminal size determination. It provides a simplified interface for executing
+ * commands and capturing their output as strings.
+ * </p>
+ *
+ * <p>
+ * The methods in this class handle common error conditions, such as interrupted
+ * execution and I/O errors, and provide appropriate logging for debugging purposes.
+ * </p>
+ *
+ * <p>
+ * Note that while this class is primarily designed for Unix-like systems, some
+ * functionality may work on other platforms depending on the available commands.
+ * </p>
  */
 public final class ExecHelper {
 

--- a/terminal/src/main/java/org/jline/utils/FastBufferedOutputStream.java
+++ b/terminal/src/main/java/org/jline/utils/FastBufferedOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) 2009-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -13,7 +13,34 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * A simple buffering output stream with no synchronization.
+ * A simple, non-synchronized buffered output stream for improved performance.
+ *
+ * <p>
+ * The FastBufferedOutputStream class provides a buffered output stream implementation
+ * that improves performance by reducing the number of calls to the underlying output
+ * stream. Unlike the standard BufferedOutputStream, this implementation does not
+ * include synchronization, making it faster but not thread-safe.
+ * </p>
+ *
+ * <p>
+ * This class is particularly useful in single-threaded contexts where the overhead
+ * of synchronization is unnecessary. It uses a fixed-size buffer (8192 bytes) to
+ * collect written data before flushing it to the underlying output stream.
+ * </p>
+ *
+ * <p>
+ * Key features include:
+ * </p>
+ * <ul>
+ *   <li>No synchronization overhead for improved performance</li>
+ *   <li>Fixed-size buffer to reduce system calls</li>
+ *   <li>Compatible with the standard OutputStream API</li>
+ * </ul>
+ *
+ * <p>
+ * Note that this class is not thread-safe and should not be used in multi-threaded
+ * contexts without external synchronization.
+ * </p>
  */
 public class FastBufferedOutputStream extends FilterOutputStream {
 

--- a/terminal/src/main/java/org/jline/utils/InfoCmp.java
+++ b/terminal/src/main/java/org/jline/utils/InfoCmp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2019, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -20,9 +20,41 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * Infocmp helper methods.
+ * Utility class for terminal capability handling and terminfo database access.
  *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * <p>
+ * The InfoCmp class provides utilities for working with terminal capabilities and
+ * accessing the terminfo database. It includes functionality for parsing terminfo
+ * entries, accessing capability values, and formatting capability strings with
+ * parameters.
+ * </p>
+ *
+ * <p>
+ * Terminal capabilities are properties that describe what a terminal can do, such as
+ * moving the cursor, changing colors, or clearing the screen. These capabilities are
+ * typically stored in a terminfo database and are accessed by terminal type (e.g.,
+ * "xterm", "vt100").
+ * </p>
+ *
+ * <p>
+ * This class defines three types of capabilities:
+ * </p>
+ * <ul>
+ *   <li><b>Boolean capabilities</b> - Indicate whether a terminal supports a feature</li>
+ *   <li><b>Numeric capabilities</b> - Provide numeric values for terminal properties</li>
+ *   <li><b>String capabilities</b> - Define escape sequences for terminal operations</li>
+ * </ul>
+ *
+ * <p>
+ * The class is named after the "infocmp" utility found in Unix-like systems, which
+ * is used to compare or print terminfo descriptions. It provides similar functionality
+ * for accessing and comparing terminal capabilities in Java.
+ * </p>
+ *
+ * <p>
+ * This class is used extensively throughout JLine to determine terminal capabilities
+ * and generate appropriate escape sequences for terminal operations.
+ * </p>
  */
 public final class InfoCmp {
 

--- a/terminal/src/main/java/org/jline/utils/InputStreamReader.java
+++ b/terminal/src/main/java/org/jline/utils/InputStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -22,20 +22,47 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.charset.MalformedInputException;
 import java.nio.charset.UnmappableCharacterException;
 
-/*
- * NOTE for JLine: the default InputStreamReader that comes from the JRE
- * usually read more bytes than needed from the input stream, which
- * is not usable in a character per character model used in the terminal.
- * We thus use the harmony code which only reads the minimal number of bytes.
- */
-
 /**
- * A class for turning a byte stream into a character stream. Data read from the
+ * A specialized InputStreamReader that reads the minimal number of bytes needed.
+ *
+ * <p>
+ * This class is a custom implementation of InputStreamReader that reads only the
+ * minimal number of bytes needed from the input stream to decode characters. Unlike
+ * the standard JRE InputStreamReader, which often reads more bytes than necessary,
+ * this implementation is optimized for character-by-character reading, which is
+ * essential for terminal input handling.
+ * </p>
+ *
+ * <p>
+ * The standard InputStreamReader's behavior of reading ahead is problematic for
+ * terminal applications because:
+ * </p>
+ * <ul>
+ *   <li>It can consume bytes that belong to the next user input</li>
+ *   <li>It makes it difficult to implement non-blocking character reading</li>
+ *   <li>It interferes with the character-by-character model used in terminals</li>
+ * </ul>
+ *
+ * <p>
+ * This implementation is based on the Apache Harmony code and has been adapted for
+ * JLine's needs. It provides the same functionality as the standard InputStreamReader
+ * but with more precise control over how many bytes are read from the underlying
+ * input stream.
+ * </p>
+ *
+ * <p>
+ * This class turns a byte stream into a character stream. Data read from the
  * source input stream is converted into characters by either a default or a
  * provided character converter. The default encoding is taken from the
- * "file.encoding" system property. {@code InputStreamReader} contains a buffer
- * of bytes read from the source stream and converts these into characters as
- * needed. The buffer size is 8K.
+ * "file.encoding" system property. It contains a buffer of bytes read from
+ * the source stream and converts these into characters as needed. The buffer
+ * size is 8K.
+ * </p>
+ *
+ * <p>
+ * This class is used internally by JLine components that need to read characters
+ * from input streams, such as terminal input handling and non-blocking readers.
+ * </p>
  *
  * @see OutputStreamWriter
  */

--- a/terminal/src/main/java/org/jline/utils/Levenshtein.java
+++ b/terminal/src/main/java/org/jline/utils/Levenshtein.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -12,9 +12,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
+ * Utility class for computing string similarity using the Damerau-Levenshtein algorithm.
+ *
+ * <p>
  * The Damerau-Levenshtein Algorithm is an extension to the Levenshtein
  * Algorithm which solves the edit distance problem between a source string and
  * a target string with the following operations:
+ * </p>
  *
  * <ul>
  * <li>Character Insertion</li>
@@ -23,25 +27,33 @@ import java.util.Map;
  * <li>Adjacent Character Swap</li>
  * </ul>
  *
+ * <p>
  * Note that the adjacent character swap operation is an edit that may be
  * applied when two adjacent characters in the source string match two adjacent
  * characters in the target string, but in reverse order, rather than a general
  * allowance for adjacent character swaps.
- * <p>
+ * </p>
  *
+ * <p>
  * This implementation allows the client to specify the costs of the various
  * edit operations with the restriction that the cost of two swap operations
  * must not be less than the cost of a delete operation followed by an insert
  * operation. This restriction is required to preclude two swaps involving the
  * same character being required for optimality which, in turn, enables a fast
  * dynamic programming solution.
- * <p>
+ * </p>
  *
+ * <p>
  * The running time of the Damerau-Levenshtein algorithm is O(n*m) where n is
  * the length of the source string and m is the length of the target string.
  * This implementation consumes O(n*m) space.
+ * </p>
  *
- * @author Kevin L. Stern
+ * <p>
+ * This class is used in JLine for features like command completion and suggestion,
+ * where string similarity is used to find potential matches or corrections for
+ * user input.
+ * </p>
  */
 public class Levenshtein {
 

--- a/terminal/src/main/java/org/jline/utils/Log.java
+++ b/terminal/src/main/java/org/jline/utils/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -16,10 +16,49 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 /**
- * Internal logger.
+ * Internal logging utility for JLine components.
  *
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * <p>
+ * The Log class provides a simple logging facility for JLine components, using
+ * Java's standard logging API (java.util.logging) under the hood. It offers
+ * methods for logging at various levels (trace, debug, info, warn, error) and
+ * supports both direct message logging and lazy evaluation through suppliers.
+ * </p>
+ *
+ * <p>
+ * This class uses a single logger named "org.jline" for all JLine components.
+ * The actual log level can be configured through the standard Java logging
+ * configuration mechanisms, such as logging.properties files or programmatic
+ * configuration of the java.util.logging framework.
+ * </p>
+ *
+ * <p>
+ * Key features include:
+ * </p>
+ * <ul>
+ *   <li>Simple static methods for different log levels</li>
+ *   <li>Support for multiple message objects that are concatenated</li>
+ *   <li>Lazy evaluation of log messages using Supplier interfaces</li>
+ *   <li>Automatic exception handling with stack trace logging</li>
+ *   <li>Performance optimization to avoid string concatenation when logging is disabled</li>
+ * </ul>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * // Simple logging
+ * Log.debug("Processing command: ", command);
+ *
+ * // Logging with lazy evaluation
+ * Log.trace(() -> "Expensive computation result: " + computeResult());
+ *
+ * // Logging exceptions
+ * try {
+ *     // Some operation
+ * } catch (Exception e) {
+ *     Log.error("Failed to process: ", e);
+ * }
+ * </pre>
+ *
  * @since 2.0
  */
 public final class Log {

--- a/terminal/src/main/java/org/jline/utils/NonBlocking.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlocking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -18,6 +18,32 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
 
+/**
+ * Factory class for creating non-blocking I/O components.
+ *
+ * <p>
+ * The NonBlocking class provides factory methods for creating various non-blocking
+ * input/output components used in JLine. These components allow for non-blocking
+ * reading operations, which are essential for interactive terminal applications
+ * that need to perform other tasks while waiting for user input.
+ * </p>
+ *
+ * <p>
+ * This class offers methods to create:
+ * </p>
+ * <ul>
+ *   <li>Non-blocking readers from various sources (streams, readers)</li>
+ *   <li>Non-blocking input streams</li>
+ *   <li>Pump readers and streams for buffered non-blocking I/O</li>
+ *   <li>Character encoding/decoding utilities for non-blocking I/O</li>
+ * </ul>
+ *
+ * <p>
+ * The non-blocking components created by this factory are used throughout JLine
+ * to implement features like input handling with timeouts, background processing
+ * while waiting for input, and efficient terminal I/O.
+ * </p>
+ */
 public class NonBlocking {
 
     public static NonBlockingPumpReader nonBlockingPumpReader() {

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -12,7 +12,34 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Non blocking input stream
+ * An input stream that supports non-blocking read operations with timeouts.
+ *
+ * <p>
+ * The NonBlockingInputStream class extends InputStream to provide non-blocking read
+ * operations. Unlike standard input streams, which block indefinitely until data is
+ * available or the end of the stream is reached, non-blocking input streams can be
+ * configured to return immediately or after a specified timeout if no data is available.
+ * </p>
+ *
+ * <p>
+ * This class defines two special return values:
+ * </p>
+ * <ul>
+ *   <li>{@link #EOF} (-1) - Indicates that the end of the stream has been reached</li>
+ *   <li>{@link #READ_EXPIRED} (-2) - Indicates that the read operation timed out</li>
+ * </ul>
+ *
+ * <p>
+ * This abstract class provides the framework for non-blocking input operations, with
+ * concrete implementations handling the details of how the non-blocking behavior is
+ * achieved (e.g., through NIO, separate threads, or native methods).
+ * </p>
+ *
+ * <p>
+ * Non-blocking input streams are particularly useful for terminal applications that
+ * need to perform other tasks while waiting for user input, or that need to implement
+ * features like input timeouts or polling.
+ * </p>
  */
 public abstract class NonBlockingInputStream extends InputStream {
 

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReader.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -12,16 +12,61 @@ import java.io.IOException;
 import java.io.Reader;
 
 /**
- * Non blocking reader
+ * A reader that provides non-blocking read operations.
+ *
+ * <p>
+ * The NonBlockingReader class extends the standard Reader class to provide
+ * non-blocking read operations. Unlike standard readers, which block until
+ * data is available or the end of the stream is reached, non-blocking readers
+ * can be configured to return immediately or after a specified timeout if no
+ * data is available.
+ * </p>
+ *
+ * <p>
+ * This class is particularly useful for terminal applications that need to
+ * perform other tasks while waiting for user input, or that need to implement
+ * features like input timeouts or polling.
+ * </p>
+ *
+ * <p>
+ * The class defines two special return values:
+ * </p>
+ * <ul>
+ *   <li>{@link #EOF} (-1) - Indicates that the end of the stream has been reached</li>
+ *   <li>{@link #READ_EXPIRED} (-2) - Indicates that the read operation timed out</li>
+ * </ul>
+ *
+ * <p>
+ * Implementations of this class typically use a separate thread to handle
+ * blocking I/O operations, allowing the main thread to continue execution.
+ * The {@link #shutdown()} method can be used to terminate this background
+ * thread when it is no longer needed.
+ * </p>
  */
 public abstract class NonBlockingReader extends Reader {
     public static final int EOF = -1;
     public static final int READ_EXPIRED = -2;
 
     /**
-     * Shuts down the thread that is handling blocking I/O. Note that if the
-     * thread is currently blocked waiting for I/O it will not actually
-     * shut down until the I/O is received.
+     * Shuts down the thread that is handling blocking I/O.
+     *
+     * <p>
+     * This method terminates the background thread that is used to handle
+     * blocking I/O operations. This allows the application to clean up resources
+     * and prevent thread leaks when the reader is no longer needed.
+     * </p>
+     *
+     * <p>
+     * Note that if the thread is currently blocked waiting for I/O, it will not
+     * actually shut down until the I/O is received or the thread is interrupted.
+     * In some implementations, this method may interrupt the thread to force it
+     * to shut down immediately.
+     * </p>
+     *
+     * <p>
+     * After calling this method, the reader should not be used anymore, as
+     * subsequent read operations may fail or block indefinitely.
+     * </p>
      */
     public void shutdown() {}
 

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -26,7 +26,6 @@ import java.io.Reader;
  *          the thread that handles blocking I/O.
  * </ul>
  * @since 2.7
- * @author Scott C. Gray &lt;scottgray1@gmail.com&gt;
  */
 public class NonBlockingReaderImpl extends NonBlockingReader {
     public static final int READ_EXPIRED = -2;

--- a/terminal/src/main/java/org/jline/utils/OSUtils.java
+++ b/terminal/src/main/java/org/jline/utils/OSUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -10,6 +10,39 @@ package org.jline.utils;
 
 import java.io.File;
 
+/**
+ * Utility class for operating system detection and OS-specific operations.
+ *
+ * <p>
+ * The OSUtils class provides constants and methods for detecting the current operating
+ * system and performing OS-specific operations. It helps JLine components adapt their
+ * behavior based on the platform they're running on, which is particularly important
+ * for terminal handling where different operating systems have different terminal
+ * implementations and capabilities.
+ * </p>
+ *
+ * <p>
+ * This class includes constants for detecting common operating systems:
+ * </p>
+ * <ul>
+ *   <li>Windows - Including detection of Cygwin and MSYS environments</li>
+ *   <li>Linux</li>
+ *   <li>macOS (OSX)</li>
+ *   <li>AIX</li>
+ *   <li>Other Unix-like systems</li>
+ * </ul>
+ *
+ * <p>
+ * It also provides utility methods for working with file paths, environment variables,
+ * and other OS-specific features that affect terminal behavior.
+ * </p>
+ *
+ * <p>
+ * This class is used throughout JLine to ensure correct behavior across different
+ * platforms, particularly for terminal detection, path handling, and native library
+ * loading.
+ * </p>
+ */
 public class OSUtils {
 
     public static final boolean IS_LINUX =

--- a/terminal/src/main/java/org/jline/utils/PumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/PumpReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -18,6 +18,37 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 
+/**
+ * A reader implementation with an associated writer for buffered character transfer.
+ *
+ * <p>
+ * The PumpReader class provides a Reader implementation with an associated Writer
+ * that allows characters to be written to the writer and then read from the reader.
+ * This creates a character pipe or pump that can be used to transfer character data
+ * between different components.
+ * </p>
+ *
+ * <p>
+ * This class is particularly useful for:
+ * </p>
+ * <ul>
+ *   <li>Creating character streams for testing without actual I/O</li>
+ *   <li>Buffering characters between producer and consumer threads</li>
+ *   <li>Implementing character-based pipes with flow control</li>
+ *   <li>Simulating input for terminal emulation</li>
+ * </ul>
+ *
+ * <p>
+ * The PumpReader maintains internal buffers for reading and writing, with both buffers
+ * backed by the same array. It provides methods for reading characters with optional
+ * timeouts and for checking the availability of characters without blocking.
+ * </p>
+ *
+ * <p>
+ * This class is used in JLine for various purposes, including implementing non-blocking
+ * readers and for testing terminal input handling without actual terminal devices.
+ * </p>
+ */
 public class PumpReader extends Reader {
 
     private static final int EOF = -1;

--- a/terminal/src/main/java/org/jline/utils/ShutdownHooks.java
+++ b/terminal/src/main/java/org/jline/utils/ShutdownHooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -15,7 +15,37 @@ import java.util.Objects;
 /**
  * Manages the JLine shutdown-hook thread and tasks to execute on shutdown.
  *
- * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
+ * <p>
+ * The ShutdownHooks class provides a centralized mechanism for registering tasks
+ * that should be executed when the JVM shuts down. It manages a single shutdown
+ * hook thread that executes all registered tasks in the reverse order of their
+ * registration.
+ * </p>
+ *
+ * <p>
+ * This class is particularly useful for terminal applications that need to perform
+ * cleanup operations when the application is terminated, such as restoring the
+ * terminal to its original state, closing open files, or releasing other resources.
+ * </p>
+ *
+ * <p>
+ * Tasks are registered using the {@link #add(Task)} method and can be removed using
+ * the {@link #remove(Task)} method. All tasks must implement the {@link Task} interface,
+ * which defines a single {@link Task#run()} method that is called when the JVM shuts down.
+ * </p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * // Create a task to restore the terminal on shutdown
+ * ShutdownHooks.Task task = ShutdownHooks.add(() -> {
+ *     terminal.setAttributes(originalAttributes);
+ *     terminal.close();
+ * });
+ *
+ * // Later, if the task is no longer needed
+ * ShutdownHooks.remove(task);
+ * </pre>
+ *
  * @since 2.7
  */
 public final class ShutdownHooks {
@@ -23,6 +53,26 @@ public final class ShutdownHooks {
 
     private static Thread hook;
 
+    /**
+     * Adds a task to be executed when the JVM shuts down.
+     *
+     * <p>
+     * This method registers a task to be executed when the JVM shuts down. Tasks are
+     * executed in the reverse order of their registration, so the most recently added
+     * task will be executed first.
+     * </p>
+     *
+     * <p>
+     * If this is the first task to be added, a shutdown hook thread will be created
+     * and registered with the JVM. This thread will execute all registered tasks when
+     * the JVM shuts down.
+     * </p>
+     *
+     * @param <T> the type of the task
+     * @param task the task to be executed on shutdown
+     * @return the task that was added (for method chaining)
+     * @throws NullPointerException if the task is null
+     */
     public static synchronized <T extends Task> T add(final T task) {
         Objects.requireNonNull(task);
 

--- a/terminal/src/main/java/org/jline/utils/Signals.java
+++ b/terminal/src/main/java/org/jline/utils/Signals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -14,9 +14,27 @@ import java.lang.reflect.Proxy;
 import java.util.Objects;
 
 /**
- * Signals helpers.
+ * Signal handling utilities for terminal applications.
  *
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * <p>
+ * The Signals class provides utilities for registering and handling system signals
+ * in a platform-independent way. It allows terminal applications to respond to
+ * signals such as SIGINT (Ctrl+C), SIGTSTP (Ctrl+Z), and others, without having
+ * to use platform-specific code.
+ * </p>
+ *
+ * <p>
+ * This class uses reflection to access the underlying signal handling mechanisms
+ * of the JVM, which may vary depending on the platform and JVM implementation.
+ * It provides a consistent API for signal handling across different environments.
+ * </p>
+ *
+ * <p>
+ * Signal handling is particularly important for terminal applications that need
+ * to respond to user interrupts or that need to perform cleanup operations when
+ * the application is terminated.
+ * </p>
+ *
  * @since 3.0
  */
 public final class Signals {
@@ -24,11 +42,41 @@ public final class Signals {
     private Signals() {}
 
     /**
+     * Registers a handler for the specified signal.
      *
-     * @param name the signal, CONT, STOP, etc...
-     * @param handler the callback to run
+     * <p>
+     * This method registers a handler for the specified signal. The handler will be
+     * called when the signal is received. The method returns an object that can be
+     * used to unregister the handler later.
+     * </p>
      *
-     * @return an object that needs to be passed to the {@link #unregister(String, Object)}
+     * <p>
+     * Signal names are platform-dependent, but common signals include:
+     * </p>
+     * <ul>
+     *   <li>INT - Interrupt signal (typically Ctrl+C)</li>
+     *   <li>TERM - Termination signal</li>
+     *   <li>HUP - Hangup signal</li>
+     *   <li>CONT - Continue signal</li>
+     *   <li>STOP - Stop signal (typically Ctrl+Z)</li>
+     *   <li>WINCH - Window change signal</li>
+     * </ul>
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * Object handle = Signals.register("INT", () -> {
+     *     System.out.println("Caught SIGINT");
+     *     // Perform cleanup
+     * });
+     *
+     * // Later, when no longer needed
+     * Signals.unregister("INT", handle);
+     * </pre>
+     *
+     * @param name the signal name (e.g., "INT", "TERM", "HUP")
+     * @param handler the callback to run when the signal is received
+     * @return an object that can be used to unregister the handler
+     * @see #unregister(String, Object)
      *         method to unregister the handler
      */
     public static Object register(String name, Runnable handler) {

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2019, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -19,6 +19,42 @@ import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.AbstractTerminal;
 import org.jline.utils.InfoCmp.Capability;
 
+/**
+ * Manages a status bar at the bottom of the terminal.
+ *
+ * <p>
+ * The Status class provides functionality for displaying and managing a status bar
+ * at the bottom of the terminal. It allows applications to show persistent status
+ * information to the user while still using the rest of the terminal for normal
+ * input and output.
+ * </p>
+ *
+ * <p>
+ * Key features include:
+ * </p>
+ * <ul>
+ *   <li>Support for multiple status lines</li>
+ *   <li>Styled text with ANSI colors and attributes</li>
+ *   <li>Automatic resizing based on terminal dimensions</li>
+ *   <li>Optional border between main display and status area</li>
+ *   <li>Ability to temporarily suspend the status display</li>
+ * </ul>
+ *
+ * <p>
+ * The status bar is particularly useful for displaying persistent information such as:
+ * </p>
+ * <ul>
+ *   <li>Application mode or state</li>
+ *   <li>Current file or context</li>
+ *   <li>Key bindings or available commands</li>
+ *   <li>Error messages or notifications</li>
+ * </ul>
+ *
+ * <p>
+ * This class is used by various JLine components to provide status information
+ * to the user without disrupting the main terminal interaction.
+ * </p>
+ */
 public class Status {
 
     protected final Terminal terminal;

--- a/terminal/src/main/java/org/jline/utils/StyleResolver.java
+++ b/terminal/src/main/java/org/jline/utils/StyleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -19,7 +19,35 @@ import static org.jline.utils.AttributedStyle.*;
 // TODO: document style specification
 
 /**
- * Resolves named (or source-referenced) {@link AttributedStyle}.
+ * Resolves named styles and style expressions into AttributedStyle objects.
+ *
+ * <p>
+ * The StyleResolver class provides functionality for resolving style specifications
+ * into AttributedStyle objects. It supports a rich expression language for defining
+ * styles, including named colors, RGB values, and various text attributes.
+ * </p>
+ *
+ * <p>
+ * Style specifications can include:
+ * </p>
+ * <ul>
+ *   <li>Named colors (e.g., "red", "blue", "bright-green")</li>
+ *   <li>RGB color values (e.g., "#ff0000", "rgb:ff/00/00")</li>
+ *   <li>Text attributes (e.g., "bold", "underline", "italic")</li>
+ *   <li>Compound styles with foreground and background (e.g., "red,bold,bg:blue")</li>
+ *   <li>References to styles defined elsewhere (e.g., "${named.style}")</li>
+ * </ul>
+ *
+ * <p>
+ * This class is used throughout JLine for resolving style specifications in configuration
+ * files, command-line options, and programmatic style definitions. It provides a consistent
+ * way to define and apply styles across different components.
+ * </p>
+ *
+ * <p>
+ * The resolver can be configured with a source function that looks up named styles,
+ * allowing for hierarchical style definitions and style inheritance.
+ * </p>
  *
  * @since 3.6
  */

--- a/terminal/src/main/java/org/jline/utils/Timeout.java
+++ b/terminal/src/main/java/org/jline/utils/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -9,7 +9,42 @@
 package org.jline.utils;
 
 /**
- * Helper class ti use during I/O operations with an eventual timeout.
+ * Helper class for managing timeouts during I/O operations.
+ *
+ * <p>
+ * The Timeout class provides a simple mechanism for tracking timeouts during I/O
+ * operations. It helps with implementing operations that should complete within
+ * a specified time limit, such as non-blocking reads with timeouts.
+ * </p>
+ *
+ * <p>
+ * This class supports both finite timeouts (specified in milliseconds) and infinite
+ * timeouts (indicated by zero or negative timeout values). It provides methods for
+ * starting the timeout countdown, checking if the timeout has expired, and calculating
+ * the remaining time.
+ * </p>
+ *
+ * <p>
+ * The class is designed to be used in scenarios where multiple I/O operations need
+ * to share a single timeout, ensuring that the total time for all operations does
+ * not exceed the specified limit.
+ * </p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * // Create a timeout of 5 seconds
+ * Timeout timeout = new Timeout(5000);
+ *
+ * // Start the timeout countdown
+ * timeout.start();
+ *
+ * // Perform I/O operations, checking for timeout
+ * while (!timeout.isExpired() &amp;&amp; !operationComplete()) {
+ *     // Perform a partial operation with the remaining time
+ *     long remaining = timeout.remaining();
+ *     performPartialOperation(remaining);
+ * }
+ * </pre>
  */
 public class Timeout {
 

--- a/terminal/src/main/java/org/jline/utils/WCWidth.java
+++ b/terminal/src/main/java/org/jline/utils/WCWidth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -8,6 +8,33 @@
  */
 package org.jline.utils;
 
+/**
+ * Utility class for determining the display width of Unicode characters.
+ *
+ * <p>
+ * The WCWidth class provides methods for calculating the display width of Unicode
+ * characters in terminal environments. This is important for proper text alignment
+ * and cursor positioning, especially when dealing with wide characters (such as
+ * East Asian characters) and zero-width characters (such as combining marks).
+ * </p>
+ *
+ * <p>
+ * This implementation is based on Markus Kuhn's wcwidth implementation, which follows
+ * the Unicode Standard guidelines for character width. It categorizes characters as:
+ * </p>
+ * <ul>
+ *   <li>Zero width (0) - Control characters, combining marks, format characters</li>
+ *   <li>Single width (1) - Most Latin, Greek, Cyrillic, and other scripts</li>
+ *   <li>Double width (2) - East Asian scripts (Chinese, Japanese, Korean)</li>
+ *   <li>Ambiguous width (-1) - Characters with context-dependent width</li>
+ * </ul>
+ *
+ * <p>
+ * This class is used throughout JLine for calculating string display widths,
+ * which is essential for proper terminal display formatting, cursor positioning,
+ * and text alignment.
+ * </p>
+ */
 public final class WCWidth {
 
     private WCWidth() {}

--- a/terminal/src/main/java/org/jline/utils/WriterOutputStream.java
+++ b/terminal/src/main/java/org/jline/utils/WriterOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -19,8 +19,29 @@ import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 
 /**
- * Redirects an {@link OutputStream} to a {@link Writer} by decoding the data
- * using the specified {@link Charset}.
+ * An OutputStream implementation that writes to a Writer, bridging byte and character streams.
+ *
+ * <p>
+ * The WriterOutputStream class provides an OutputStream implementation that redirects
+ * its output to a Writer by decoding the bytes using a specified character encoding.
+ * This allows code that expects to write to an OutputStream to work with a Writer
+ * destination instead.
+ * </p>
+ *
+ * <p>
+ * This class handles the complexities of character encoding conversion, including:
+ * </p>
+ * <ul>
+ *   <li>Proper handling of multi-byte character encodings</li>
+ *   <li>Buffering of partial character sequences</li>
+ *   <li>Configurable behavior for malformed input and unmappable characters</li>
+ * </ul>
+ *
+ * <p>
+ * This class is particularly useful in JLine for bridging between byte-oriented
+ * and character-oriented I/O in terminal handling, especially when dealing with
+ * legacy APIs that expect byte streams.
+ * </p>
  *
  * <p><b>Note:</b> This class should only be used if it is necessary to
  * redirect an {@link OutputStream} to a {@link Writer} for compatibility

--- a/terminal/src/main/java/org/jline/utils/package-info.java
+++ b/terminal/src/main/java/org/jline/utils/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author or authors.
+ * Copyright (c) 2002-2025, the original author or authors.
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -7,7 +7,10 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 /**
- * JLine 3.
+ * JLine utility classes.
+ *
+ * This package contains utility classes for terminal operations, including text styling,
+ * cursor manipulation, ANSI escape sequence handling, and other terminal-related functionality.
  *
  * @since 3.0
  */

--- a/terminal/src/test/java/org/jline/terminal/impl/AbstractPtyTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/AbstractPtyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) 2023-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/exec/ExecPtyTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/exec/ExecPtyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/AttributedStringBuilderTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) 2023-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/ColorPaletteTest.java
+++ b/terminal/src/test/java/org/jline/utils/ColorPaletteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2024, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/ColorsTest.java
+++ b/terminal/src/test/java/org/jline/utils/ColorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/CursesTest.java
+++ b/terminal/src/test/java/org/jline/utils/CursesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * Tests for the Curses utility class.
  */
 public class CursesTest {
 

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the original author(s).
+ * Copyright (c) 2021-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
+++ b/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
+ * Tests for the InfoCmp class.
  */
 public class InfoCmpTest {
 

--- a/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) 2023-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/PumpReaderTest.java
+++ b/terminal/src/test/java/org/jline/utils/PumpReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/ScreenTerminal.java
+++ b/terminal/src/test/java/org/jline/utils/ScreenTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/WriterOutputStreamTest.java
+++ b/terminal/src/test/java/org/jline/utils/WriterOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.


### PR DESCRIPTION
This PR adds comprehensive Javadoc to the JLine Terminal and Reader modules, improving the API documentation for developers. It includes detailed documentation for all public classes and methods, with clear explanations, parameter descriptions, and cross-references between related methods.