### PR TITLE
Add comprehensive Javadoc to org.jline.style package

### DIFF
--- a/style/src/main/java/org/jline/style/MemoryStyleSource.java
+++ b/style/src/main/java/org/jline/style/MemoryStyleSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -18,9 +18,30 @@ import javax.annotation.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
- * In-memory {@link StyleSource}.
+ * In-memory implementation of {@link StyleSource}.
+ * <p>
+ * This class provides a thread-safe implementation of StyleSource that stores
+ * style definitions in memory using concurrent hash maps. It is suitable for
+ * use in applications that need to dynamically define and modify styles at runtime.
+ * </p>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ * MemoryStyleSource source = new MemoryStyleSource();
+ * source.set("messages", "error", "bold,fg:red");
+ * source.set("messages", "warning", "bold,fg:yellow");
+ * source.set("links", "url", "fg:blue,underline");
+ *
+ * // Use the source with a StyleResolver
+ * StyleResolver resolver = new StyleResolver(source, "messages");
+ * AttributedStyle errorStyle = resolver.resolve(".error");
+ * </pre>
  *
  * @since 3.4
+ * @see StyleSource
+ * @see StyleResolver
+ * @see Styler
  */
 public class MemoryStyleSource implements StyleSource {
     private static final Logger log = Logger.getLogger(MemoryStyleSource.class.getName());

--- a/style/src/main/java/org/jline/style/NopStyleSource.java
+++ b/style/src/main/java/org/jline/style/NopStyleSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -15,15 +15,47 @@ import javax.annotation.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
- * {@link StyleSource} which always returns {@code null}.
+ * A no-operation implementation of {@link StyleSource} that always returns {@code null}.
+ * <p>
+ * This class provides an implementation of StyleSource that does not store or
+ * retrieve any styles. All methods that modify styles are no-ops, and all methods
+ * that retrieve styles return empty results.
+ * </p>
+ * <p>
+ * This class is useful as a default or fallback StyleSource when no styles are
+ * needed or available. It is used by default in {@link Styler} until a different
+ * StyleSource is set.
+ * </p>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ * // Create a StyleResolver with a NopStyleSource
+ * StyleResolver resolver = new StyleResolver(new NopStyleSource(), "group");
+ *
+ * // Named style references will always resolve to null
+ * AttributedStyle style = resolver.resolve(".error"); // Uses default style if provided
+ * </pre>
  *
  * @since 3.4
+ * @see StyleSource
+ * @see MemoryStyleSource
+ * @see Styler#getSource()
  */
 public class NopStyleSource implements StyleSource {
     // NOTE: preconditions here to help validate usage when this impl is used
 
     /**
-     * Always returns {@code null}.
+     * Always returns {@code null} for any style lookup.
+     * <p>
+     * This implementation validates that the parameters are not null but
+     * otherwise always returns null, indicating that no style is defined.
+     * </p>
+     *
+     * @param group the style group name (must not be null)
+     * @param name the style name within the group (must not be null)
+     * @return always {@code null}
+     * @throws NullPointerException if group or name is null
      */
     @Nullable
     @Override
@@ -34,7 +66,16 @@ public class NopStyleSource implements StyleSource {
     }
 
     /**
-     * Non-operation.
+     * No-operation implementation of set that does nothing.
+     * <p>
+     * This implementation validates that the parameters are not null but
+     * otherwise does nothing. The style is not stored anywhere.
+     * </p>
+     *
+     * @param group the style group name (must not be null)
+     * @param name the style name within the group (must not be null)
+     * @param style the style definition string (must not be null)
+     * @throws NullPointerException if any parameter is null
      */
     @Override
     public void set(final String group, final String name, final String style) {
@@ -44,7 +85,14 @@ public class NopStyleSource implements StyleSource {
     }
 
     /**
-     * Non-operation.
+     * No-operation implementation of remove that does nothing.
+     * <p>
+     * This implementation validates that the parameter is not null but
+     * otherwise does nothing.
+     * </p>
+     *
+     * @param group the style group name to remove (must not be null)
+     * @throws NullPointerException if group is null
      */
     @Override
     public void remove(final String group) {
@@ -52,7 +100,15 @@ public class NopStyleSource implements StyleSource {
     }
 
     /**
-     * Non-operation.
+     * No-operation implementation of remove that does nothing.
+     * <p>
+     * This implementation validates that the parameters are not null but
+     * otherwise does nothing.
+     * </p>
+     *
+     * @param group the style group name (must not be null)
+     * @param name the style name to remove (must not be null)
+     * @throws NullPointerException if group or name is null
      */
     @Override
     public void remove(final String group, final String name) {
@@ -61,7 +117,10 @@ public class NopStyleSource implements StyleSource {
     }
 
     /**
-     * Non-operation.
+     * No-operation implementation of clear that does nothing.
+     * <p>
+     * Since this implementation doesn't store any styles, this method has no effect.
+     * </p>
      */
     @Override
     public void clear() {
@@ -69,7 +128,13 @@ public class NopStyleSource implements StyleSource {
     }
 
     /**
-     * Always returns empty list.
+     * Always returns an empty list of style groups.
+     * <p>
+     * Since this implementation doesn't store any styles, this method always
+     * returns an empty, immutable list.
+     * </p>
+     *
+     * @return an empty, immutable iterable
      */
     @Override
     public Iterable<String> groups() {
@@ -77,7 +142,14 @@ public class NopStyleSource implements StyleSource {
     }
 
     /**
-     * Always returns empty map.
+     * Always returns an empty map of styles.
+     * <p>
+     * Since this implementation doesn't store any styles, this method always
+     * returns an empty, immutable map regardless of the group specified.
+     * </p>
+     *
+     * @param group the style group name (not used in this implementation)
+     * @return an empty, immutable map
      */
     @Override
     public Map<String, String> styles(final String group) {

--- a/style/src/main/java/org/jline/style/StyleBundle.java
+++ b/style/src/main/java/org/jline/style/StyleBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -15,13 +15,56 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marker for proxy-based style bundles.
+ * Marker interface for proxy-based style bundles.
+ * <p>
+ * A StyleBundle is an interface that defines methods for creating styled text.
+ * Each method in the interface should return an {@link org.jline.utils.AttributedString}
+ * and take a single parameter that will be styled according to the method's
+ * {@link DefaultStyle} annotation or a style definition from a {@link StyleSource}.
+ * </p>
+ * <p>
+ * StyleBundle interfaces are not implemented directly. Instead, they are used with
+ * the {@link Styler#bundle(Class)} or {@link Styler#bundle(String, Class)} methods
+ * to create dynamic proxies that implement the interface.
+ * </p>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#64;StyleBundle.StyleGroup("mygroup")
+ * interface MyStyles extends StyleBundle {
+ *     &#64;StyleBundle.DefaultStyle("bold,fg:red")
+ *     AttributedString error(String message);
+ *
+ *     &#64;StyleBundle.DefaultStyle("bold,fg:yellow")
+ *     AttributedString warning(String message);
+ * }
+ *
+ * MyStyles styles = Styler.bundle(MyStyles.class);
+ * AttributedString errorText = styles.error("Error message");
+ * </pre>
  *
  * @since 3.4
+ * @see Styler#bundle(Class)
+ * @see Styler#bundle(String, Class)
  */
 public interface StyleBundle {
     /**
-     * Provides the style group-name.
+     * Annotation that specifies the style group name for a StyleBundle interface.
+     * <p>
+     * This annotation is required on StyleBundle interfaces used with
+     * {@link Styler#bundle(Class)}. It specifies the style group to use when
+     * looking up named styles in a {@link StyleSource}.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * &#64;StyleBundle.StyleGroup("mygroup")
+     * interface MyStyles extends StyleBundle {
+     *     // methods...
+     * }
+     * </pre>
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
@@ -31,9 +74,27 @@ public interface StyleBundle {
     }
 
     /**
-     * Allows overriding the style-name.
+     * Annotation that allows overriding the style name for a method in a StyleBundle interface.
      * <p>
-     * Default style-name is determined from method-name.
+     * By default, the style name used for a method is the method name itself.
+     * This annotation allows specifying a different name to use when looking up
+     * styles in a {@link StyleSource}.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * &#64;StyleBundle.StyleGroup("mygroup")
+     * interface MyStyles extends StyleBundle {
+     *     &#64;StyleBundle.StyleName("error-style")
+     *     &#64;StyleBundle.DefaultStyle("bold,fg:red")
+     *     AttributedString error(String message);
+     * }
+     * </pre>
+     * <p>
+     * In this example, the style name "error-style" will be used instead of "error"
+     * when looking up the style in the style source.
+     * </p>
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
@@ -43,7 +104,30 @@ public interface StyleBundle {
     }
 
     /**
-     * Provide default style-specification.
+     * Annotation that provides a default style specification for a method in a StyleBundle interface.
+     * <p>
+     * This annotation specifies the style to use if no style is found in the
+     * {@link StyleSource} for the method. The value should be a valid style
+     * specification string as understood by {@link org.jline.utils.StyleResolver}.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * &#64;StyleBundle.StyleGroup("mygroup")
+     * interface MyStyles extends StyleBundle {
+     *     &#64;StyleBundle.DefaultStyle("bold,fg:red")
+     *     AttributedString error(String message);
+     *
+     *     &#64;StyleBundle.DefaultStyle("fg:blue,underline")
+     *     AttributedString link(String url);
+     * }
+     * </pre>
+     * <p>
+     * If this annotation is not present and no style is found in the style source,
+     * a {@link StyleBundleInvocationHandler.StyleBundleMethodMissingDefaultStyleException}
+     * will be thrown when the method is called.
+     * </p>
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)

--- a/style/src/main/java/org/jline/style/StyleColor.java
+++ b/style/src/main/java/org/jline/style/StyleColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -9,10 +9,26 @@
 package org.jline.style;
 
 /**
- * Style colors.
+ * Enumeration of named colors for use in styles.
+ * <p>
+ * This enum provides a comprehensive list of named colors that can be used in style
+ * specifications. Each color has an associated ANSI color code and an RGB hex value
+ * (shown in comments).
+ * </p>
+ * <p>
+ * This class is deprecated in favor of {@link org.jline.utils.Colors#rgbColor(String)},
+ * which provides a more flexible way to specify colors using RGB values or X11 color names.
+ * </p>
+ * <p>
+ * Example usage (not recommended due to deprecation):
+ * </p>
+ * <pre>
+ * // Get the ANSI color code for a named color
+ * int code = StyleColor.red.code;  // 9
+ * </pre>
  *
  * @since 3.4
- * @deprecated use {@link org.jline.utils.Colors#rgbColor(String)}
+ * @deprecated use {@link org.jline.utils.Colors#rgbColor(String)} instead
  */
 @Deprecated
 public enum StyleColor {
@@ -273,8 +289,20 @@ public enum StyleColor {
     grey89(254), // #e4e4e4
     grey93(255); // #eeeeee
 
+    /**
+     * The ANSI color code for this color.
+     * <p>
+     * This code can be used in ANSI escape sequences to set the foreground or
+     * background color in a terminal.
+     * </p>
+     */
     public final int code;
 
+    /**
+     * Constructs a StyleColor with the specified ANSI color code.
+     *
+     * @param code the ANSI color code
+     */
     StyleColor(final int code) {
         this.code = code;
     }

--- a/style/src/main/java/org/jline/style/StyleExpression.java
+++ b/style/src/main/java/org/jline/style/StyleExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -15,27 +15,80 @@ import org.jline.utils.AttributedStyle;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Provides {@code @{style value}} expression evaluation.
+ * Provides evaluation of style expressions in the format {@code @{style value}}.
+ * <p>
+ * This class allows embedding styled text within regular strings using a special
+ * syntax. Style expressions are enclosed in {@code @{...}} delimiters, where the
+ * first part specifies the style and the rest is the text to be styled.
+ * </p>
+ * <p>
+ * Style expressions can be nested and combined with regular text. The style
+ * specification can be a direct style specification or a reference to a named
+ * style in a {@link StyleSource}.
+ * </p>
+ * <p>
+ * Examples of style expressions:
+ * </p>
+ * <pre>
+ * "Normal text with @{bold,fg:red important} parts"
+ * "@{bold Header}: @{fg:blue Value}"
+ * "@{.error Error message}" (references a named style "error")
+ * </pre>
  *
  * @since 3.4
+ * @see StyleResolver
+ * @see InterpolationHelper
  */
 public class StyleExpression {
 
     private final StyleResolver resolver;
 
+    /**
+     * Constructs a new StyleExpression with a default StyleResolver.
+     * <p>
+     * This constructor creates a StyleExpression with a StyleResolver that
+     * uses a {@link NopStyleSource} and an empty group name. This means that
+     * only direct style specifications will work; named style references will
+     * always resolve to null.
+     * </p>
+     */
     public StyleExpression() {
         this(new StyleResolver(new NopStyleSource(), ""));
     }
 
+    /**
+     * Constructs a new StyleExpression with the specified StyleResolver.
+     * <p>
+     * This constructor creates a StyleExpression that will use the specified
+     * StyleResolver to resolve style specifications within expressions.
+     * </p>
+     *
+     * @param resolver the style resolver to use (must not be null)
+     * @throws NullPointerException if resolver is null
+     */
     public StyleExpression(final StyleResolver resolver) {
         this.resolver = requireNonNull(resolver);
     }
 
     /**
-     * Evaluate expression and append to buffer.
+     * Evaluates a style expression and appends the result to the specified buffer.
+     * <p>
+     * This method processes the given expression, resolving any style expressions
+     * in the format {@code @{style value}}, and appends the resulting styled text
+     * to the provided buffer.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * AttributedStringBuilder buffer = new AttributedStringBuilder();
+     * StyleExpression expr = new StyleExpression(resolver);
+     * expr.evaluate(buffer, "Normal text with @{bold,fg:red important} parts");
+     * </pre>
      *
-     * @param buff the buffer to append to
-     * @param expression the expression to evaluate
+     * @param buff the buffer to append the evaluated expression to (must not be null)
+     * @param expression the expression to evaluate (must not be null)
+     * @throws NullPointerException if buff or expression is null
      */
     public void evaluate(final AttributedStringBuilder buff, final String expression) {
         requireNonNull(buff);
@@ -57,10 +110,23 @@ public class StyleExpression {
     }
 
     /**
-     * Evaluate expression.
+     * Evaluates a style expression and returns the result as an AttributedString.
+     * <p>
+     * This method processes the given expression, resolving any style expressions
+     * in the format {@code @{style value}}, and returns the resulting styled text
+     * as an AttributedString.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * StyleExpression expr = new StyleExpression(resolver);
+     * AttributedString result = expr.evaluate("Normal text with @{bold,fg:red important} parts");
+     * </pre>
      *
-     * @param expression the expression to evaluate
-     * @return the result string
+     * @param expression the expression to evaluate (must not be null)
+     * @return the resulting AttributedString
+     * @throws NullPointerException if expression is null
      */
     public AttributedString evaluate(final String expression) {
         AttributedStringBuilder buff = new AttributedStringBuilder();

--- a/style/src/main/java/org/jline/style/StyleFactory.java
+++ b/style/src/main/java/org/jline/style/StyleFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -14,23 +14,88 @@ import org.jline.utils.AttributedStyle;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Factory to create styled strings.
+ * Factory for creating styled strings using a specific style group.
+ * <p>
+ * This class provides methods for creating {@link AttributedString}s with styles
+ * applied to them. It uses a {@link StyleResolver} to resolve style specifications
+ * into {@link AttributedStyle} objects.
+ * </p>
+ * <p>
+ * The factory supports two main ways of creating styled strings:
+ * </p>
+ * <ul>
+ *   <li>Direct styling with the {@link #style(String, String)} methods</li>
+ *   <li>Style expression evaluation with the {@link #evaluate(String)} methods</li>
+ * </ul>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ * StyleFactory factory = Styler.factory("mygroup");
+ *
+ * // Direct styling
+ * AttributedString text1 = factory.style("bold,fg:red", "Important message");
+ * AttributedString text2 = factory.style(".error", "Error message"); // Named style
+ *
+ * // Style expression evaluation
+ * AttributedString text3 = factory.evaluate("Normal text with @{bold,fg:red important} parts");
+ * </pre>
  *
  * @since 3.4
+ * @see StyleResolver
+ * @see StyleExpression
+ * @see Styler#factory(String)
  */
 public class StyleFactory {
     private final StyleResolver resolver;
 
+    /**
+     * Constructs a new StyleFactory with the specified StyleResolver.
+     * <p>
+     * This constructor creates a StyleFactory that will use the specified
+     * StyleResolver to resolve style specifications when creating styled strings.
+     * </p>
+     * <p>
+     * Typically, you would use {@link Styler#factory(String)} to create a
+     * StyleFactory rather than constructing one directly.
+     * </p>
+     *
+     * @param resolver the style resolver to use (must not be null)
+     * @throws NullPointerException if resolver is null
+     * @see Styler#factory(String)
+     */
     public StyleFactory(final StyleResolver resolver) {
         this.resolver = requireNonNull(resolver);
     }
 
     /**
-     * Encode string with style applying value.
+     * Creates a styled string by applying the specified style to the given value.
+     * <p>
+     * This method resolves the style specification using the factory's StyleResolver
+     * and applies the resulting AttributedStyle to the value.
+     * </p>
+     * <p>
+     * The style specification can be in any format supported by {@link StyleResolver},
+     * including direct style specifications and named style references.
+     * </p>
+     * <p>
+     * Examples:
+     * </p>
+     * <pre>
+     * // Direct style specification
+     * AttributedString text1 = factory.style("bold,fg:red", "Important message");
      *
-     * @param style the style
-     * @param value the value
-     * @return the result string
+     * // Named style reference
+     * AttributedString text2 = factory.style(".error", "Error message");
+     *
+     * // Named style reference with default
+     * AttributedString text3 = factory.style(".missing:-bold,fg:blue", "Fallback message");
+     * </pre>
+     *
+     * @param style the style specification to apply (must not be null)
+     * @param value the text value to style (must not be null)
+     * @return the resulting AttributedString
+     * @throws NullPointerException if value is null
      */
     public AttributedString style(final String style, final String value) {
         requireNonNull(value);
@@ -39,13 +104,26 @@ public class StyleFactory {
     }
 
     /**
-     * Encode string with style formatted value.
+     * Creates a styled string by applying the specified style to a formatted value.
+     * <p>
+     * This method is similar to {@link #style(String, String)}, but it allows
+     * formatting the value using {@link String#format(String, Object...)} before
+     * applying the style.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * AttributedString text = factory.style("bold,fg:red", "Error: %s", "File not found");
+     * </pre>
      *
-     * @param style the style
-     * @param format the format
-     * @param params the parameters
-     * @return the result string
+     * @param style the style specification to apply (must not be null)
+     * @param format the format string (must not be null)
+     * @param params the parameters to use for formatting (must not be null, but may be empty)
+     * @return the resulting AttributedString
+     * @throws NullPointerException if format or params is null
      * @see #style(String, String)
+     * @see String#format(String, Object...)
      */
     public AttributedString style(final String style, final String format, final Object... params) {
         requireNonNull(format);
@@ -55,10 +133,24 @@ public class StyleFactory {
     }
 
     /**
-     * Evaluate a style expression.
+     * Evaluates a style expression and returns the result as an AttributedString.
+     * <p>
+     * This method processes the given expression, resolving any style expressions
+     * in the format {@code @{style value}}, and returns the resulting styled text
+     * as an AttributedString. It uses a {@link StyleExpression} with the factory's
+     * StyleResolver to evaluate the expression.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * AttributedString text = factory.evaluate("Normal text with @{bold,fg:red important} parts");
+     * </pre>
      *
-     * @param expression the expression to evaluate
-     * @return the result string
+     * @param expression the expression to evaluate (must not be null)
+     * @return the resulting AttributedString
+     * @throws NullPointerException if expression is null
+     * @see StyleExpression#evaluate(String)
      */
     public AttributedString evaluate(final String expression) {
         requireNonNull(expression);
@@ -66,12 +158,25 @@ public class StyleFactory {
     }
 
     /**
-     * Evaluate a style expression with format.
+     * Evaluates a style expression with formatting and returns the result as an AttributedString.
+     * <p>
+     * This method is similar to {@link #evaluate(String)}, but it allows
+     * formatting the expression using {@link String#format(String, Object...)}
+     * before evaluating it.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * AttributedString text = factory.evaluate("File: @{bold,fg:blue %s}", "example.txt");
+     * </pre>
      *
-     * @param format the format
-     * @param params the parameters
-     * @return the result string
+     * @param format the format string (must not be null)
+     * @param params the parameters to use for formatting (must not be null, but may be empty)
+     * @return the resulting AttributedString
+     * @throws NullPointerException if format or params is null
      * @see #evaluate(String)
+     * @see String#format(String, Object...)
      */
     public AttributedString evaluate(final String format, final Object... params) {
         requireNonNull(format);

--- a/style/src/main/java/org/jline/style/StyleResolver.java
+++ b/style/src/main/java/org/jline/style/StyleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -12,12 +12,38 @@ import org.jline.utils.AttributedStyle;
 
 import static java.util.Objects.requireNonNull;
 
-// TODO: document style specification
-
 /**
- * Resolves named (or source-referenced) {@link AttributedStyle}.
+ * Resolves named (or source-referenced) {@link AttributedStyle} for a specific style group.
+ * <p>
+ * This class extends {@link org.jline.utils.StyleResolver} to add support for style groups
+ * and style sources. It allows resolving style specifications into {@link AttributedStyle}
+ * objects, with the ability to look up named styles from a {@link StyleSource}.
+ * </p>
+ * <p>
+ * Style specifications can be in the following formats:
+ * </p>
+ * <ul>
+ *   <li>Direct style specifications: "bold,fg:red,bg:blue,underline"</li>
+ *   <li>Named style references: ".error" (looks up "error" in the current style group)</li>
+ *   <li>Named style references with defaults: ".error:-bold,fg:red" (uses default if named style is not found)</li>
+ * </ul>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ * StyleSource source = new MemoryStyleSource();
+ * source.set("mygroup", "error", "bold,fg:red");
+ *
+ * StyleResolver resolver = new StyleResolver(source, "mygroup");
+ * AttributedStyle style1 = resolver.resolve("bold,fg:blue");       // Direct style
+ * AttributedStyle style2 = resolver.resolve(".error");              // Named style
+ * AttributedStyle style3 = resolver.resolve(".missing:-underline"); // Default style
+ * </pre>
  *
  * @since 3.4
+ * @see org.jline.utils.StyleResolver
+ * @see StyleSource
+ * @see org.jline.utils.AttributedStyle
  */
 public class StyleResolver extends org.jline.utils.StyleResolver {
 
@@ -25,18 +51,46 @@ public class StyleResolver extends org.jline.utils.StyleResolver {
 
     private final String group;
 
+    /**
+     * Constructs a new StyleResolver for the specified source and group.
+     * <p>
+     * This constructor creates a StyleResolver that will look up named styles
+     * in the specified source and group. The resolver will use the source to
+     * resolve style names when a style specification starts with a dot (e.g., ".error").
+     * </p>
+     *
+     * @param source the style source to use for named style lookups (must not be null)
+     * @param group the style group to use for named style lookups (must not be null)
+     * @throws NullPointerException if source or group is null
+     */
     public StyleResolver(final StyleSource source, final String group) {
         super(s -> source.get(group, s));
         this.source = requireNonNull(source);
         this.group = requireNonNull(group);
     }
 
+    /**
+     * Returns the style source used by this resolver.
+     * <p>
+     * The style source is used to look up named styles when resolving
+     * style specifications that start with a dot (e.g., ".error").
+     * </p>
+     *
+     * @return the style source (never null)
+     */
     public StyleSource getSource() {
         return source;
     }
 
-    // TODO: could consider a small cache to reduce style calculations?
-
+    /**
+     * Returns the style group used by this resolver.
+     * <p>
+     * The style group is used to look up named styles in the style source
+     * when resolving style specifications that start with a dot (e.g., ".error").
+     * </p>
+     *
+     * @return the style group name (never null)
+     */
     public String getGroup() {
         return group;
     }

--- a/style/src/main/java/org/jline/style/StyleSource.java
+++ b/style/src/main/java/org/jline/style/StyleSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -12,62 +12,142 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * Provides the source of style configuration.
+ * Interface for sources of style configuration.
+ * <p>
+ * A StyleSource provides access to style definitions organized by groups and names.
+ * It allows retrieving, setting, and removing style definitions, as well as listing
+ * available style groups and styles.
+ * </p>
+ * <p>
+ * Style definitions are stored as strings in the format understood by
+ * {@link org.jline.utils.StyleResolver}, such as "bold,fg:red" or "underline,fg:blue".
+ * </p>
+ * <p>
+ * Implementations of this interface include:
+ * </p>
+ * <ul>
+ *   <li>{@link MemoryStyleSource} - Stores styles in memory</li>
+ *   <li>{@link NopStyleSource} - Always returns null (no styles)</li>
+ * </ul>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ * StyleSource source = new MemoryStyleSource();
+ * source.set("mygroup", "error", "bold,fg:red");
+ * source.set("mygroup", "warning", "bold,fg:yellow");
+ *
+ * String errorStyle = source.get("mygroup", "error"); // Returns "bold,fg:red"
+ * </pre>
  *
  * @since 3.4
+ * @see Styler
+ * @see StyleResolver
  */
 public interface StyleSource {
     /**
-     * Returns the appropriate style for the given style-group and style-name, or {@code null} if missing.
+     * Returns the style definition for the given style group and name, or {@code null} if not found.
+     * <p>
+     * This method retrieves a style definition from the source. Style definitions are
+     * strings in the format understood by {@link org.jline.utils.StyleResolver},
+     * such as "bold,fg:red" or "underline,fg:blue".
+     * </p>
+     * <p>
+     * Style groups are used to organize styles by category or purpose, such as
+     * "error", "warning", or "info" styles within a "messages" group.
+     * </p>
      *
-     * @param group the group
-     * @param name the style name
-     * @return the style
+     * @param group the style group name (must not be null)
+     * @param name the style name within the group (must not be null)
+     * @return the style definition string, or {@code null} if no style is defined for the given group and name
+     * @throws NullPointerException if group or name is null
      */
     @Nullable
     String get(String group, String name);
 
     /**
-     * Set a specific style in a style-group.
+     * Sets a style definition for the given style group and name.
+     * <p>
+     * This method stores a style definition in the source. Style definitions are
+     * strings in the format understood by {@link org.jline.utils.StyleResolver},
+     * such as "bold,fg:red" or "underline,fg:blue".
+     * </p>
+     * <p>
+     * If a style with the same group and name already exists, it will be replaced.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * source.set("messages", "error", "bold,fg:red");
+     * source.set("messages", "warning", "bold,fg:yellow");
+     * source.set("links", "url", "fg:blue,underline");
+     * </pre>
      *
-     * @param group the group
-     * @param name the style name
-     * @param style the style to set
+     * @param group the style group name (must not be null)
+     * @param name the style name within the group (must not be null)
+     * @param style the style definition string (must not be null)
+     * @throws NullPointerException if any parameter is null
      */
     void set(String group, String name, String style);
 
     /**
-     * Remove all styles for given style-group.
+     * Removes all styles for the given style group.
+     * <p>
+     * This method removes all style definitions associated with the specified group.
+     * If the group does not exist or has no styles, this method has no effect.
+     * </p>
      *
-     * @param group the group
+     * @param group the style group name to remove (must not be null)
+     * @throws NullPointerException if group is null
      */
     void remove(String group);
 
     /**
-     * Remove a specific style from style-group.
+     * Removes a specific style from a style group.
+     * <p>
+     * This method removes the style definition for the specified group and name.
+     * If the style does not exist, this method has no effect.
+     * </p>
      *
-     * @param group the group
-     * @param name the style name to remove
+     * @param group the style group name (must not be null)
+     * @param name the style name to remove (must not be null)
+     * @throws NullPointerException if group or name is null
      */
     void remove(String group, String name);
 
     /**
-     * Clear all styles.
+     * Clears all style definitions from this source.
+     * <p>
+     * This method removes all style groups and their associated styles from the source.
+     * After calling this method, the source will be empty.
+     * </p>
      */
     void clear();
 
     /**
-     * Returns configured style-group names.
+     * Returns the names of all configured style groups.
+     * <p>
+     * This method returns an iterable of all style group names that have been
+     * configured in this source. If no groups have been configured, an empty
+     * iterable is returned.
+     * </p>
      *
-     * @return Immutable collection.
+     * @return an immutable iterable of style group names (never null)
      */
     Iterable<String> groups();
 
     /**
-     * Returns configured styles for given style-group.
+     * Returns all configured styles for the given style group.
+     * <p>
+     * This method returns a map of style names to style definitions for the
+     * specified group. If the group does not exist or has no styles, an empty
+     * map is returned.
+     * </p>
      *
-     * @param group  the style group
-     * @return Immutable map.
+     * @param group the style group name (must not be null)
+     * @return an immutable map of style names to style definitions (never null)
+     * @throws NullPointerException if group is null
      */
     Map<String, String> styles(String group);
 }

--- a/style/src/main/java/org/jline/style/StyledWriter.java
+++ b/style/src/main/java/org/jline/style/StyledWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -20,15 +20,52 @@ import org.jline.utils.AttributedString;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Styled {@link PrintWriter} which is aware of {@link StyleExpression} syntax.
+ * A {@link PrintWriter} extension that understands and evaluates {@link StyleExpression} syntax.
+ * <p>
+ * This class extends PrintWriter to provide automatic evaluation of style expressions
+ * in the format {@code @{style value}} when writing strings. It uses a {@link StyleExpression}
+ * to evaluate the expressions and a {@link Terminal} to convert the resulting
+ * {@link AttributedString}s to ANSI escape sequences appropriate for the terminal.
+ * </p>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ * Terminal terminal = ...; // Get a Terminal instance
+ * StyleResolver resolver = Styler.resolver("mygroup");
+ *
+ * // Create a StyledWriter that writes to System.out
+ * StyledWriter writer = new StyledWriter(System.out, terminal, resolver, true);
+ *
+ * // Write styled text
+ * writer.println("Normal text with @{bold,fg:red important} parts");
+ * writer.printf("@{bold %s}: @{fg:blue %s}", "Name", "John Doe");
+ * </pre>
  *
  * @since 3.4
+ * @see StyleExpression
+ * @see PrintWriter
+ * @see Terminal
  */
 public class StyledWriter extends PrintWriter {
     private final Terminal terminal;
 
     private final StyleExpression expression;
 
+    /**
+     * Constructs a new StyledWriter that writes to a Writer.
+     * <p>
+     * This constructor creates a StyledWriter that will write to the specified Writer,
+     * using the specified Terminal to convert AttributedStrings to ANSI escape sequences
+     * and the specified StyleResolver to resolve style specifications.
+     * </p>
+     *
+     * @param out the Writer to write to
+     * @param terminal the Terminal to use for ANSI conversion (must not be null)
+     * @param resolver the StyleResolver to use for style resolution (must not be null)
+     * @param autoFlush whether to automatically flush the output after each print operation
+     * @throws NullPointerException if terminal is null
+     */
     public StyledWriter(
             final Writer out, final Terminal terminal, final StyleResolver resolver, final boolean autoFlush) {
         super(out, autoFlush);
@@ -36,6 +73,20 @@ public class StyledWriter extends PrintWriter {
         this.expression = new StyleExpression(resolver);
     }
 
+    /**
+     * Constructs a new StyledWriter that writes to an OutputStream.
+     * <p>
+     * This constructor creates a StyledWriter that will write to the specified OutputStream,
+     * using the specified Terminal to convert AttributedStrings to ANSI escape sequences
+     * and the specified StyleResolver to resolve style specifications.
+     * </p>
+     *
+     * @param out the OutputStream to write to
+     * @param terminal the Terminal to use for ANSI conversion (must not be null)
+     * @param resolver the StyleResolver to use for style resolution (must not be null)
+     * @param autoFlush whether to automatically flush the output after each print operation
+     * @throws NullPointerException if terminal is null
+     */
     public StyledWriter(
             final OutputStream out, final Terminal terminal, final StyleResolver resolver, final boolean autoFlush) {
         super(out, autoFlush);
@@ -43,6 +94,18 @@ public class StyledWriter extends PrintWriter {
         this.expression = new StyleExpression(resolver);
     }
 
+    /**
+     * Writes a string after evaluating any style expressions it contains.
+     * <p>
+     * This method overrides the standard write method to evaluate any style expressions
+     * in the format {@code @{style value}} in the input string before writing it.
+     * The resulting AttributedString is converted to ANSI escape sequences appropriate
+     * for the terminal.
+     * </p>
+     *
+     * @param value the string to write (must not be null)
+     * @throws NullPointerException if value is null
+     */
     @Override
     public void write(@Nonnull final String value) {
         AttributedString result = expression.evaluate(value);
@@ -51,12 +114,43 @@ public class StyledWriter extends PrintWriter {
 
     // Prevent partial output from being written while formatting or we will get rendering exceptions
 
+    /**
+     * Formats a string and writes it after evaluating any style expressions it contains.
+     * <p>
+     * This method overrides the standard format method to ensure that the entire
+     * formatted string is evaluated for style expressions before any output is written.
+     * This prevents partial output from being written, which could lead to rendering
+     * exceptions with ANSI escape sequences.
+     * </p>
+     *
+     * @param format the format string (must not be null)
+     * @param args the arguments referenced by the format specifiers in the format string
+     * @return this StyledWriter
+     * @throws NullPointerException if format is null
+     * @see String#format(String, Object...)
+     */
     @Override
     public PrintWriter format(@Nonnull final String format, final Object... args) {
         print(String.format(format, args));
         return this;
     }
 
+    /**
+     * Formats a string using the specified locale and writes it after evaluating any style expressions it contains.
+     * <p>
+     * This method overrides the standard format method to ensure that the entire
+     * formatted string is evaluated for style expressions before any output is written.
+     * This prevents partial output from being written, which could lead to rendering
+     * exceptions with ANSI escape sequences.
+     * </p>
+     *
+     * @param locale the locale to use for formatting
+     * @param format the format string (must not be null)
+     * @param args the arguments referenced by the format specifiers in the format string
+     * @return this StyledWriter
+     * @throws NullPointerException if format is null
+     * @see String#format(Locale, String, Object...)
+     */
     @Override
     public PrintWriter format(final Locale locale, @Nonnull final String format, final Object... args) {
         print(String.format(locale, format, args));

--- a/style/src/main/java/org/jline/style/Styler.java
+++ b/style/src/main/java/org/jline/style/Styler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -16,11 +16,33 @@ import org.jline.style.StyleBundle.StyleGroup;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Style facade.
+ * Style facade that provides static utility methods for working with styles.
+ * <p>
+ * The Styler class is the main entry point for the JLine style system. It provides
+ * access to the global {@link StyleSource} and factory methods for creating
+ * {@link StyleResolver}s, {@link StyleFactory}s, and {@link StyleBundle} proxies.
+ * </p>
+ * <p>
+ * Typical usage patterns include:
+ * </p>
+ * <pre>
+ * // Configure a global style source
+ * Styler.setSource(new MemoryStyleSource());
+ *
+ * // Create a style resolver for a specific group
+ * StyleResolver resolver = Styler.resolver("mygroup");
+ *
+ * // Create a style factory for a specific group
+ * StyleFactory factory = Styler.factory("mygroup");
+ *
+ * // Create a style bundle proxy
+ * MyStyles styles = Styler.bundle(MyStyles.class);
+ * </pre>
  *
  * @see StyleBundle
  * @see StyleFactory
  * @see StyleSource
+ * @see StyleResolver
  * @since 3.4
  */
 public class Styler {
@@ -33,18 +55,43 @@ public class Styler {
     }
 
     /**
-     * Returns global {@link StyleSource}.
+     * Returns the global {@link StyleSource} used by the Styler.
+     * <p>
+     * The global style source is used by all style operations that don't explicitly
+     * specify a different source. By default, a {@link NopStyleSource} is used,
+     * which doesn't provide any styles.
+     * </p>
      *
      * @return the global style source
+     * @see #setSource(StyleSource)
      */
     public static StyleSource getSource() {
         return source;
     }
 
     /**
-     * Install global {@link StyleSource}.
+     * Installs a new global {@link StyleSource}.
+     * <p>
+     * This method sets the global style source used by all style operations
+     * that don't explicitly specify a different source. A common implementation
+     * to use is {@link MemoryStyleSource}.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * // Create and configure a style source
+     * MemoryStyleSource source = new MemoryStyleSource();
+     * source.set("mygroup", "error", "bold,fg:red");
+     * source.set("mygroup", "warning", "bold,fg:yellow");
      *
-     * @param source the new global style source
+     * // Set it as the global source
+     * Styler.setSource(source);
+     * </pre>
+     *
+     * @param source the new global style source (must not be null)
+     * @throws NullPointerException if source is null
+     * @see #getSource()
      */
     public static void setSource(final StyleSource source) {
         Styler.source = requireNonNull(source);
@@ -55,45 +102,119 @@ public class Styler {
     }
 
     /**
-     * Create a resolver for the given style-group.
+     * Creates a {@link StyleResolver} for the given style group.
+     * <p>
+     * The style resolver is used to resolve style specifications into
+     * {@link org.jline.utils.AttributedStyle} objects. It uses the global
+     * style source to look up named styles within the specified group.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * StyleResolver resolver = Styler.resolver("mygroup");
+     * AttributedStyle style = resolver.resolve("bold,fg:red");
+     * AttributedStyle namedStyle = resolver.resolve(".error"); // Looks up "error" in "mygroup"
+     * </pre>
      *
-     * @param group the group
-     * @return the resolver
+     * @param group the style group name (must not be null)
+     * @return a new style resolver for the specified group
+     * @throws NullPointerException if group is null
      */
     public static StyleResolver resolver(final String group) {
         return new StyleResolver(source, group);
     }
 
     /**
-     * Create a factory for the given style-group.
+     * Creates a {@link StyleFactory} for the given style group.
+     * <p>
+     * The style factory provides methods for creating styled strings using
+     * style specifications or expressions. It uses a {@link StyleResolver}
+     * for the specified group to resolve styles.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * StyleFactory factory = Styler.factory("mygroup");
+     * AttributedString text = factory.style("bold,fg:red", "Important message");
+     * AttributedString namedText = factory.style(".error", "Error message");
+     * AttributedString expr = factory.evaluate("Normal text with @{bold,fg:red important} parts");
+     * </pre>
      *
-     * @param group the group
-     * @return the factory
+     * @param group the style group name (must not be null)
+     * @return a new style factory for the specified group
+     * @throws NullPointerException if group is null
      */
     public static StyleFactory factory(final String group) {
         return new StyleFactory(resolver(group));
     }
 
     /**
-     * Create a {@link StyleBundle} proxy.
+     * Creates a {@link StyleBundle} proxy for the specified interface.
      * <p>
-     * Target class must be annotated with {@link StyleGroup}.
+     * This method creates a dynamic proxy that implements the specified interface.
+     * Each method in the interface is expected to return an {@link org.jline.utils.AttributedString}
+     * and take a single parameter that will be styled according to the method's
+     * {@link StyleBundle.DefaultStyle} annotation or a style definition from the
+     * global style source.
+     * </p>
+     * <p>
+     * The target interface must be annotated with {@link StyleGroup} to specify
+     * the style group to use for style lookups.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * &#64;StyleBundle.StyleGroup("mygroup")
+     * interface MyStyles extends StyleBundle {
+     *     &#64;StyleBundle.DefaultStyle("bold,fg:red")
+     *     AttributedString error(String message);
      *
-     * @param <T> the interface to proxy
-     * @param type the interface to proxy
-     * @return the proxy
+     *     &#64;StyleBundle.DefaultStyle("bold,fg:yellow")
+     *     AttributedString warning(String message);
+     * }
+     *
+     * MyStyles styles = Styler.bundle(MyStyles.class);
+     * AttributedString errorText = styles.error("Error message");
+     * </pre>
+     *
+     * @param <T> the interface type to proxy
+     * @param type the interface class to proxy (must not be null and must be annotated with {@link StyleGroup})
+     * @return a proxy implementing the specified interface
+     * @throws NullPointerException if type is null
+     * @throws StyleBundleInvocationHandler.InvalidStyleGroupException if the interface is not annotated with {@link StyleGroup}
      */
     public static <T extends StyleBundle> T bundle(final Class<T> type) {
         return StyleBundleInvocationHandler.create(source, type);
     }
 
     /**
-     * Create a {@link StyleBundle} proxy with explicit style-group.
+     * Creates a {@link StyleBundle} proxy for the specified interface with an explicit style group.
+     * <p>
+     * This method is similar to {@link #bundle(Class)}, but it allows specifying the
+     * style group explicitly instead of requiring the interface to be annotated with
+     * {@link StyleGroup}.
+     * </p>
+     * <p>
+     * Example:
+     * </p>
+     * <pre>
+     * interface MyStyles extends StyleBundle {
+     *     &#64;StyleBundle.DefaultStyle("bold,fg:red")
+     *     AttributedString error(String message);
+     * }
      *
-     * @param <T> the interface to proxy
-     * @param group the group
-     * @param type the interface to proxy
-     * @return the proxy
+     * MyStyles styles = Styler.bundle("mygroup", MyStyles.class);
+     * AttributedString errorText = styles.error("Error message");
+     * </pre>
+     *
+     * @param <T> the interface type to proxy
+     * @param group the style group name to use (must not be null)
+     * @param type the interface class to proxy (must not be null)
+     * @return a proxy implementing the specified interface
+     * @throws NullPointerException if group or type is null
      */
     public static <T extends StyleBundle> T bundle(final String group, final Class<T> type) {
         return StyleBundleInvocationHandler.create(resolver(group), type);

--- a/style/src/main/java/org/jline/style/package-info.java
+++ b/style/src/main/java/org/jline/style/package-info.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * JLine Style package provides a comprehensive styling system for terminal output.
+ *
+ * <p>
+ * This package contains classes and interfaces for defining, managing, and applying
+ * styles to text displayed in the terminal. It supports:
+ * </p>
+ *
+ * <ul>
+ *   <li>Style specifications using a simple syntax (e.g., "bold,fg:red")</li>
+ *   <li>Named styles that can be referenced and reused</li>
+ *   <li>Style expressions with the format {@code @{style text}}</li>
+ *   <li>Style bundles using Java interfaces and proxies</li>
+ *   <li>Style sources for storing and retrieving style definitions</li>
+ * </ul>
+ *
+ * <p>
+ * The styling system integrates with JLine's {@link org.jline.utils.AttributedString} and
+ * {@link org.jline.utils.AttributedStyle} classes to provide rich text formatting capabilities.
+ * </p>
+ *
+ * <p>
+ * Key components of this package include:
+ * </p>
+ *
+ * <ul>
+ *   <li>{@link org.jline.style.StyleBundle} - Interface for proxy-based style bundles</li>
+ *   <li>{@link org.jline.style.StyleExpression} - Evaluates style expressions</li>
+ *   <li>{@link org.jline.style.StyleFactory} - Creates styled strings</li>
+ *   <li>{@link org.jline.style.StyleResolver} - Resolves named styles</li>
+ *   <li>{@link org.jline.style.StyleSource} - Interface for style storage</li>
+ *   <li>{@link org.jline.style.Styler} - Facade for style operations</li>
+ * </ul>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>
+ * // Using StyleFactory
+ * StyleFactory factory = Styler.factory("mygroup");
+ * AttributedString text = factory.style("bold,fg:red", "Important message");
+ *
+ * // Using StyleExpression
+ * StyleExpression expr = new StyleExpression(Styler.resolver("mygroup"));
+ * AttributedString text = expr.evaluate("Normal text with @{bold,fg:red important} parts");
+ *
+ * // Using StyleBundle
+ * &#64;StyleBundle.StyleGroup("mygroup")
+ * interface MyStyles extends StyleBundle {
+ *     &#64;DefaultStyle("bold,fg:red")
+ *     AttributedString important(String text);
+ * }
+ * MyStyles styles = Styler.bundle(MyStyles.class);
+ * AttributedString text = styles.important("Important message");
+ * </pre>
+ *
+ * @since 3.4
+ */
+package org.jline.style;


### PR DESCRIPTION
This PR adds comprehensive Javadoc documentation to all public classes and methods in the org.jline.style package. It includes:

- New package-info.java with package-level documentation
- Detailed class-level Javadoc for all public classes
- Comprehensive method-level Javadoc with parameters, return values, and exceptions
- Cross-references to related classes
- Example code snippets
- Updated copyright years to 2025

These improvements make the JLine style package more accessible to new users and provide better reference documentation for existing users.