### PR TITLE
docs: improve Javadoc in console module

### DIFF
--- a/console/src/main/java/org/jline/console/ArgDesc.java
+++ b/console/src/main/java/org/jline/console/ArgDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -13,14 +13,34 @@ import java.util.List;
 
 import org.jline.utils.AttributedString;
 
+/**
+ * Represents a command argument description used for generating command help and documentation.
+ * This class stores the name of an argument and its description as a list of attributed strings,
+ * which can include formatting and styling.
+ */
 public class ArgDesc {
+    /** The name of the argument */
     private final String name;
+    /** The description of the argument as a list of attributed strings */
     private final List<AttributedString> description;
 
+    /**
+     * Creates a new argument description with the specified name and an empty description.
+     *
+     * @param name the name of the argument
+     * @throws IllegalArgumentException if the name contains spaces or tabs
+     */
     public ArgDesc(String name) {
         this(name, new ArrayList<>());
     }
 
+    /**
+     * Creates a new argument description with the specified name and description.
+     *
+     * @param name the name of the argument
+     * @param description the description of the argument as a list of attributed strings
+     * @throws IllegalArgumentException if the name contains spaces or tabs
+     */
     public ArgDesc(String name, List<AttributedString> description) {
         if (name.contains("\t") || name.contains(" ")) {
             throw new IllegalArgumentException("Bad argument name: " + name);
@@ -29,14 +49,31 @@ public class ArgDesc {
         this.description = new ArrayList<>(description);
     }
 
+    /**
+     * Returns the name of the argument.
+     *
+     * @return the argument name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the description of the argument as a list of attributed strings.
+     *
+     * @return the argument description
+     */
     public List<AttributedString> getDescription() {
         return description;
     }
 
+    /**
+     * Creates a list of argument descriptions from a list of argument names.
+     * Each argument description will have an empty description.
+     *
+     * @param names the list of argument names
+     * @return a list of argument descriptions
+     */
     public static List<ArgDesc> doArgNames(List<String> names) {
         List<ArgDesc> out = new ArrayList<>();
         for (String n : names) {

--- a/console/src/main/java/org/jline/console/CmdDesc.java
+++ b/console/src/main/java/org/jline/console/CmdDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -13,33 +13,75 @@ import java.util.regex.Pattern;
 
 import org.jline.utils.AttributedString;
 
+/**
+ * Represents a command description used for generating command help and documentation.
+ * This class stores information about a command, including its main description,
+ * argument descriptions, and option descriptions. It is used by the JLine Widgets
+ * framework to display command help in the terminal.
+ */
 public class CmdDesc {
+    /** The main description of the command */
     private List<AttributedString> mainDesc;
+    /** The descriptions of the command's arguments */
     private List<ArgDesc> argsDesc;
+    /** The descriptions of the command's options */
     private TreeMap<String, List<AttributedString>> optsDesc;
+    /** Pattern used to identify errors in the command */
     private Pattern errorPattern;
+    /** Index of the error in the command, or -1 if no error */
     private int errorIndex = -1;
+    /** Whether the command is valid */
     private boolean valid = true;
+    /** Whether this is a command (as opposed to a method or syntax) */
     private boolean command = false;
+    /** Whether this is a subcommand */
     private boolean subcommand = false;
+    /** Whether the command should be highlighted */
     private boolean highlighted = true;
 
+    /**
+     * Creates a new command description that is not a command.
+     */
     public CmdDesc() {
         command = false;
     }
 
+    /**
+     * Creates a new command description with the specified validity.
+     *
+     * @param valid whether the command is valid
+     */
     public CmdDesc(boolean valid) {
         this.valid = valid;
     }
 
+    /**
+     * Creates a new command description with the specified argument descriptions.
+     *
+     * @param argsDesc the descriptions of the command's arguments
+     */
     public CmdDesc(List<ArgDesc> argsDesc) {
         this(new ArrayList<>(), argsDesc, new HashMap<>());
     }
 
+    /**
+     * Creates a new command description with the specified argument and option descriptions.
+     *
+     * @param argsDesc the descriptions of the command's arguments
+     * @param optsDesc the descriptions of the command's options
+     */
     public CmdDesc(List<ArgDesc> argsDesc, Map<String, List<AttributedString>> optsDesc) {
         this(new ArrayList<>(), argsDesc, optsDesc);
     }
 
+    /**
+     * Creates a new command description with the specified main description, argument descriptions,
+     * and option descriptions.
+     *
+     * @param mainDesc the main description of the command
+     * @param argsDesc the descriptions of the command's arguments
+     * @param optsDesc the descriptions of the command's options
+     */
     public CmdDesc(
             List<AttributedString> mainDesc, List<ArgDesc> argsDesc, Map<String, List<AttributedString>> optsDesc) {
         this.argsDesc = new ArrayList<>(argsDesc);
@@ -53,67 +95,149 @@ public class CmdDesc {
         this.command = true;
     }
 
+    /**
+     * Returns whether the command is valid.
+     *
+     * @return true if the command is valid, false otherwise
+     */
     public boolean isValid() {
         return valid;
     }
 
+    /**
+     * Returns whether this is a command (as opposed to a method or syntax).
+     *
+     * @return true if this is a command, false otherwise
+     */
     public boolean isCommand() {
         return command;
     }
 
+    /**
+     * Sets whether this is a subcommand.
+     *
+     * @param subcommand true if this is a subcommand, false otherwise
+     */
     public void setSubcommand(boolean subcommand) {
         this.subcommand = subcommand;
     }
 
+    /**
+     * Returns whether this is a subcommand.
+     *
+     * @return true if this is a subcommand, false otherwise
+     */
     public boolean isSubcommand() {
         return subcommand;
     }
 
+    /**
+     * Sets whether the command should be highlighted.
+     *
+     * @param highlighted true if the command should be highlighted, false otherwise
+     */
     public void setHighlighted(boolean highlighted) {
         this.highlighted = highlighted;
     }
 
+    /**
+     * Returns whether the command should be highlighted.
+     *
+     * @return true if the command should be highlighted, false otherwise
+     */
     public boolean isHighlighted() {
         return highlighted;
     }
 
+    /**
+     * Sets the main description of the command and returns this command description.
+     *
+     * @param mainDesc the main description of the command
+     * @return this command description
+     */
     public CmdDesc mainDesc(List<AttributedString> mainDesc) {
         this.mainDesc = new ArrayList<>(mainDesc);
         return this;
     }
 
+    /**
+     * Sets the main description of the command.
+     *
+     * @param mainDesc the main description of the command
+     */
     public void setMainDesc(List<AttributedString> mainDesc) {
         this.mainDesc = new ArrayList<>(mainDesc);
     }
 
+    /**
+     * Returns the main description of the command.
+     *
+     * @return the main description of the command
+     */
     public List<AttributedString> getMainDesc() {
         return mainDesc;
     }
 
+    /**
+     * Returns the descriptions of the command's options.
+     *
+     * @return the descriptions of the command's options
+     */
     public TreeMap<String, List<AttributedString>> getOptsDesc() {
         return optsDesc;
     }
 
+    /**
+     * Sets the pattern used to identify errors in the command.
+     *
+     * @param errorPattern the pattern used to identify errors
+     */
     public void setErrorPattern(Pattern errorPattern) {
         this.errorPattern = errorPattern;
     }
 
+    /**
+     * Returns the pattern used to identify errors in the command.
+     *
+     * @return the pattern used to identify errors
+     */
     public Pattern getErrorPattern() {
         return errorPattern;
     }
 
+    /**
+     * Sets the index of the error in the command.
+     *
+     * @param errorIndex the index of the error, or -1 if no error
+     */
     public void setErrorIndex(int errorIndex) {
         this.errorIndex = errorIndex;
     }
 
+    /**
+     * Returns the index of the error in the command.
+     *
+     * @return the index of the error, or -1 if no error
+     */
     public int getErrorIndex() {
         return errorIndex;
     }
 
+    /**
+     * Returns the descriptions of the command's arguments.
+     *
+     * @return the descriptions of the command's arguments
+     */
     public List<ArgDesc> getArgsDesc() {
         return argsDesc;
     }
 
+    /**
+     * Returns whether the specified option takes a value.
+     *
+     * @param option the option to check
+     * @return true if the option takes a value, false otherwise
+     */
     public boolean optionWithValue(String option) {
         for (String key : optsDesc.keySet()) {
             if (key.matches("(^|.*\\s)" + option + "($|=.*|\\s.*)")) {
@@ -123,6 +247,12 @@ public class CmdDesc {
         return false;
     }
 
+    /**
+     * Returns the description of the specified option.
+     *
+     * @param key the option key
+     * @return the description of the option, or an empty string if the option has no description
+     */
     public AttributedString optionDescription(String key) {
         return !optsDesc.get(key).isEmpty() ? optsDesc.get(key).get(0) : new AttributedString("");
     }

--- a/console/src/main/java/org/jline/console/CmdLine.java
+++ b/console/src/main/java/org/jline/console/CmdLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -11,7 +11,16 @@ package org.jline.console;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Represents a command line with its parsed components.
+ * This class stores information about a command line, including the original line,
+ * the part before and after the cursor, the parsed arguments, and the type of
+ * description that should be displayed for the command.
+ */
 public class CmdLine {
+    /**
+     * Enumeration specifying the type of description that should be displayed for the command.
+     */
     public enum DescriptionType {
         /**
          * Cursor is at the end of line. The args[0] is completed, the line does not have unclosed opening parenthesis
@@ -28,19 +37,25 @@ public class CmdLine {
         SYNTAX
     }
 
+    /** The original command line */
     private final String line;
+    /** The part of the command line before the cursor, with method parameters and opening parenthesis removed */
     private final String head;
+    /** The part of the command line after the cursor, with method parameters and closing parenthesis removed */
     private final String tail;
+    /** The parsed command line arguments */
     private final List<String> args;
+    /** The type of description that should be displayed for the command */
     private final DescriptionType descType;
 
     /**
-     * CmdLine class constructor.
-     * @param line     Command line
-     * @param head     Command line till cursor, method parameters and opening parenthesis before the cursor are removed.
-     * @param tail     Command line after cursor, method parameters and closing parenthesis after the cursor are removed.
-     * @param args     Parsed command line arguments.
-     * @param descType Request COMMAND, METHOD or SYNTAX description
+     * Creates a new command line with the specified components.
+     *
+     * @param line     The original command line
+     * @param head     The part of the command line before the cursor, with method parameters and opening parenthesis removed
+     * @param tail     The part of the command line after the cursor, with method parameters and closing parenthesis removed
+     * @param args     The parsed command line arguments
+     * @param descType The type of description that should be displayed for the command
      */
     public CmdLine(String line, String head, String tail, List<String> args, DescriptionType descType) {
         this.line = line;
@@ -50,22 +65,47 @@ public class CmdLine {
         this.descType = descType;
     }
 
+    /**
+     * Returns the original command line.
+     *
+     * @return the original command line
+     */
     public String getLine() {
         return line;
     }
 
+    /**
+     * Returns the part of the command line before the cursor, with method parameters and opening parenthesis removed.
+     *
+     * @return the part of the command line before the cursor
+     */
     public String getHead() {
         return head;
     }
 
+    /**
+     * Returns the part of the command line after the cursor, with method parameters and closing parenthesis removed.
+     *
+     * @return the part of the command line after the cursor
+     */
     public String getTail() {
         return tail;
     }
 
+    /**
+     * Returns the parsed command line arguments.
+     *
+     * @return the parsed command line arguments
+     */
     public List<String> getArgs() {
         return args;
     }
 
+    /**
+     * Returns the type of description that should be displayed for the command.
+     *
+     * @return the type of description
+     */
     public DescriptionType getDescriptionType() {
         return descType;
     }

--- a/console/src/main/java/org/jline/console/CommandInput.java
+++ b/console/src/main/java/org/jline/console/CommandInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -13,15 +13,34 @@ import java.io.PrintStream;
 
 import org.jline.terminal.Terminal;
 
+/**
+ * Encapsulates the input and output streams for a command execution.
+ * This class provides access to the command name, arguments, terminal, and I/O streams
+ * needed for command execution in the console environment.
+ */
 public class CommandInput {
+    /** The command name */
     String command;
+    /** String representation of command arguments */
     String[] args;
+    /** Original object arguments */
     Object[] xargs;
+    /** Terminal instance for the command */
     Terminal terminal;
+    /** Input stream for the command */
     InputStream in;
+    /** Output stream for the command */
     PrintStream out;
+    /** Error stream for the command */
     PrintStream err;
 
+    /**
+     * Creates a new CommandInput with the specified command, arguments, and session.
+     *
+     * @param command the command name
+     * @param xargs the command arguments as objects
+     * @param session the command session containing terminal and I/O streams
+     */
     public CommandInput(String command, Object[] xargs, CommandRegistry.CommandSession session) {
         if (xargs != null) {
             this.xargs = xargs;
@@ -37,39 +56,89 @@ public class CommandInput {
         this.err = session.err();
     }
 
+    /**
+     * Creates a new CommandInput with the specified command, arguments, terminal, and I/O streams.
+     *
+     * @param command the command name
+     * @param args the command arguments as objects
+     * @param terminal the terminal instance
+     * @param in the input stream
+     * @param out the output stream
+     * @param err the error stream
+     */
     public CommandInput(
             String command, Object[] args, Terminal terminal, InputStream in, PrintStream out, PrintStream err) {
         this(command, args, new CommandRegistry.CommandSession(terminal, in, out, err));
     }
 
+    /**
+     * Returns the command name.
+     *
+     * @return the command name
+     */
     public String command() {
         return command;
     }
 
+    /**
+     * Returns the command arguments as strings.
+     *
+     * @return the command arguments as strings
+     */
     public String[] args() {
         return args;
     }
 
+    /**
+     * Returns the original command arguments as objects.
+     *
+     * @return the command arguments as objects
+     */
     public Object[] xargs() {
         return xargs;
     }
 
+    /**
+     * Returns the terminal instance for this command.
+     *
+     * @return the terminal instance
+     */
     public Terminal terminal() {
         return terminal;
     }
 
+    /**
+     * Returns the input stream for this command.
+     *
+     * @return the input stream
+     */
     public InputStream in() {
         return in;
     }
 
+    /**
+     * Returns the output stream for this command.
+     *
+     * @return the output stream
+     */
     public PrintStream out() {
         return out;
     }
 
+    /**
+     * Returns the error stream for this command.
+     *
+     * @return the error stream
+     */
     public PrintStream err() {
         return err;
     }
 
+    /**
+     * Creates and returns a new CommandSession using this command's terminal and I/O streams.
+     *
+     * @return a new command session
+     */
     public CommandRegistry.CommandSession session() {
         return new CommandRegistry.CommandSession(terminal, in, out, err);
     }

--- a/console/src/main/java/org/jline/console/CommandMethods.java
+++ b/console/src/main/java/org/jline/console/CommandMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -14,15 +14,41 @@ import java.util.function.Function;
 
 import org.jline.reader.Completer;
 
+/**
+ * Class that encapsulates the execution and completion methods for a command.
+ * <p>
+ * CommandMethods provides a way to associate a command execution function with
+ * a completer compilation function. This allows commands to be registered with
+ * both their execution logic and their completion logic in a single object.
+ */
 public class CommandMethods {
+    /** The function that executes the command */
     Function<CommandInput, ?> execute;
+    /** The function that compiles completers for the command */
     Function<String, List<Completer>> compileCompleter;
 
+    /**
+     * Creates a new CommandMethods with the specified execution and completer compilation functions.
+     * <p>
+     * This constructor takes a function that returns a result when executing the command.
+     *
+     * @param execute the function that executes the command and returns a result
+     * @param compileCompleter the function that compiles completers for the command
+     */
     public CommandMethods(Function<CommandInput, ?> execute, Function<String, List<Completer>> compileCompleter) {
         this.execute = execute;
         this.compileCompleter = compileCompleter;
     }
 
+    /**
+     * Creates a new CommandMethods with the specified execution and completer compilation functions.
+     * <p>
+     * This constructor takes a consumer that doesn't return a result when executing the command.
+     * The execution function is wrapped to return null after executing the consumer.
+     *
+     * @param execute the consumer that executes the command without returning a result
+     * @param compileCompleter the function that compiles completers for the command
+     */
     public CommandMethods(Consumer<CommandInput> execute, Function<String, List<Completer>> compileCompleter) {
         this.execute = (CommandInput i) -> {
             execute.accept(i);
@@ -31,10 +57,20 @@ public class CommandMethods {
         this.compileCompleter = compileCompleter;
     }
 
+    /**
+     * Returns the function that executes the command.
+     *
+     * @return the function that executes the command
+     */
     public Function<CommandInput, ?> execute() {
         return execute;
     }
 
+    /**
+     * Returns the function that compiles completers for the command.
+     *
+     * @return the function that compiles completers for the command
+     */
     public Function<String, List<Completer>> compileCompleter() {
         return compileCompleter;
     }

--- a/console/src/main/java/org/jline/console/CommandRegistry.java
+++ b/console/src/main/java/org/jline/console/CommandRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -17,16 +17,30 @@ import org.jline.reader.impl.completer.SystemCompleter;
 import org.jline.terminal.Terminal;
 
 /**
- * Store command information, compile tab completers and execute registered commands.
+ * Interface for registering, describing, and executing commands in a console application.
+ * <p>
+ * The CommandRegistry provides methods for managing a set of commands, including:
+ * <ul>
+ *   <li>Registering commands and their aliases</li>
+ *   <li>Providing command descriptions and usage information</li>
+ *   <li>Executing commands with arguments</li>
+ *   <li>Creating command completers for tab completion</li>
+ * </ul>
+ * <p>
+ * Implementations of this interface can be used to create custom command registries
+ * for specific domains or applications.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public interface CommandRegistry {
 
     /**
-     * Aggregate SystemCompleters of commandRegisteries
-     * @param commandRegistries command registeries which completers is to be aggregated
-     * @return uncompiled SystemCompleter
+     * Aggregates SystemCompleters from multiple command registries into a single completer.
+     * <p>
+     * This method combines the completers from all provided command registries without compiling them.
+     * The resulting completer can be used for tab completion across all commands from the provided registries.
+     *
+     * @param commandRegistries the command registries whose completers are to be aggregated
+     * @return an uncompiled SystemCompleter containing all completers from the provided registries
      */
     static SystemCompleter aggregateCompleters(CommandRegistry... commandRegistries) {
         SystemCompleter out = new SystemCompleter();
@@ -37,9 +51,14 @@ public interface CommandRegistry {
     }
 
     /**
-     * Aggregate and compile SystemCompleters of commandRegisteries
-     * @param commandRegistries command registeries which completers is to be aggregated and compile
-     * @return compiled SystemCompleter
+     * Aggregates and compiles SystemCompleters from multiple command registries into a single completer.
+     * <p>
+     * This method combines the completers from all provided command registries and compiles them into
+     * a single completer. The resulting completer can be used for tab completion across all commands
+     * from the provided registries.
+     *
+     * @param commandRegistries the command registries whose completers are to be aggregated and compiled
+     * @return a compiled SystemCompleter containing all completers from the provided registries
      */
     static SystemCompleter compileCompleters(CommandRegistry... commandRegistries) {
         SystemCompleter out = aggregateCompleters(commandRegistries);
@@ -47,6 +66,16 @@ public interface CommandRegistry {
         return out;
     }
 
+    /**
+     * Creates a completion candidate for the specified command.
+     * <p>
+     * This method searches for the command in the provided registries and creates a completion
+     * candidate with the command's name, group, and description.
+     *
+     * @param commandRegistries the command registries to search for the command
+     * @param command the command name
+     * @return a completion candidate for the command
+     */
     static Candidate createCandidate(CommandRegistry[] commandRegistries, String command) {
         String group = null, desc = null;
         for (CommandRegistry registry : commandRegistries) {
@@ -121,12 +150,27 @@ public interface CommandRegistry {
                 "CommandRegistry method invoke(session, command, ... args) is not implemented!");
     }
 
+    /**
+     * Class representing a command execution session.
+     * <p>
+     * A CommandSession encapsulates the terminal and I/O streams used for command execution.
+     * It provides access to the terminal, input stream, output stream, and error stream
+     * for the command being executed.
+     */
     class CommandSession {
+        /** The terminal for the command session */
         private final Terminal terminal;
+        /** The input stream for the command session */
         private final InputStream in;
+        /** The output stream for the command session */
         private final PrintStream out;
+        /** The error stream for the command session */
         private final PrintStream err;
 
+        /**
+         * Creates a new command session with the system's standard I/O streams.
+         * The terminal will be null in this case.
+         */
         public CommandSession() {
             this.in = System.in;
             this.out = System.out;
@@ -134,10 +178,24 @@ public interface CommandRegistry {
             this.terminal = null;
         }
 
+        /**
+         * Creates a new command session with the specified terminal.
+         * The I/O streams will be derived from the terminal.
+         *
+         * @param terminal the terminal for the command session
+         */
         public CommandSession(Terminal terminal) {
             this(terminal, terminal.input(), new PrintStream(terminal.output()), new PrintStream(terminal.output()));
         }
 
+        /**
+         * Creates a new command session with the specified terminal and I/O streams.
+         *
+         * @param terminal the terminal for the command session
+         * @param in the input stream for the command session
+         * @param out the output stream for the command session
+         * @param err the error stream for the command session
+         */
         public CommandSession(Terminal terminal, InputStream in, PrintStream out, PrintStream err) {
             this.terminal = terminal;
             this.in = in;
@@ -145,18 +203,38 @@ public interface CommandRegistry {
             this.err = err;
         }
 
+        /**
+         * Returns the terminal for the command session.
+         *
+         * @return the terminal, or null if no terminal is associated with this session
+         */
         public Terminal terminal() {
             return terminal;
         }
 
+        /**
+         * Returns the input stream for the command session.
+         *
+         * @return the input stream
+         */
         public InputStream in() {
             return in;
         }
 
+        /**
+         * Returns the output stream for the command session.
+         *
+         * @return the output stream
+         */
         public PrintStream out() {
             return out;
         }
 
+        /**
+         * Returns the error stream for the command session.
+         *
+         * @return the error stream
+         */
         public PrintStream err() {
             return err;
         }

--- a/console/src/main/java/org/jline/console/ConsoleEngine.java
+++ b/console/src/main/java/org/jline/console/ConsoleEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -19,281 +19,471 @@ import org.jline.reader.LineReader;
 import org.jline.reader.Widget;
 
 /**
- * Manage console variables, commands and script executions.
+ * Interface for managing console variables, commands, and script execution in a console application.
+ * <p>
+ * The ConsoleEngine extends CommandRegistry to provide additional functionality for:
+ * <ul>
+ *   <li>Managing console variables and their values</li>
+ *   <li>Executing scripts and commands</li>
+ *   <li>Handling command line expansion and parameter substitution</li>
+ *   <li>Managing aliases and pipes</li>
+ *   <li>Post-processing command execution results</li>
+ * </ul>
+ * <p>
+ * Implementations of this interface can be used to create custom console engines
+ * for specific scripting languages or execution environments.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public interface ConsoleEngine extends CommandRegistry {
 
     /**
-     * Console string variable of nanorc file full path
+     * Console string variable containing the full path to the nanorc configuration file.
+     * This variable can be used to customize the nano editor's behavior when used within the console.
      */
     String VAR_NANORC = "NANORC";
 
     /**
-     * Removes the command name first character if it is colon
-     * @param command the name of the command to complete
-     * @return command name without starting colon
+     * Removes the first character of the command name if it is a colon.
+     * <p>
+     * This method is used to normalize command names that may be prefixed with a colon,
+     * which is a common convention in some command-line interfaces.
+     *
+     * @param command the name of the command to normalize
+     * @return the command name without the starting colon, or the original command name if it doesn't start with a colon
      */
     static String plainCommand(String command) {
         return command.startsWith(":") ? command.substring(1) : command;
     }
 
     /**
-     * Sets lineReader
-     * @param reader LineReader
+     * Sets the LineReader instance to be used by this console engine.
+     * <p>
+     * The LineReader is used for reading input from the user and providing features
+     * like command history, tab completion, and line editing.
+     *
+     * @param reader the LineReader instance to use
      */
     void setLineReader(LineReader reader);
 
     /**
-     * Sets systemRegistry
-     * @param systemRegistry SystemRegistry
+     * Sets the SystemRegistry instance to be used by this console engine.
+     * <p>
+     * The SystemRegistry is used for executing commands and managing the console environment.
+     * It provides access to registered commands and handles command execution.
+     *
+     * @param systemRegistry the SystemRegistry instance to use
      */
     void setSystemRegistry(SystemRegistry systemRegistry);
 
     /**
-     * Substituting args references with their values.
+     * Substitutes argument references with their values.
+     * <p>
+     * This method expands arguments that reference variables or other values,
+     * replacing them with their actual values. For example, a reference like "$VAR"
+     * might be replaced with the value of the variable "VAR".
+     *
      * @param args the arguments to be expanded
-     * @return expanded arguments
-     * @throws Exception in case of error
+     * @return the expanded arguments with references replaced by their values
+     * @throws Exception if an error occurs during expansion
      */
     Object[] expandParameters(String[] args) throws Exception;
 
     /**
-     * Substitutes command line with system registry invoke method call.
-     * @param line command line to be expanded
-     * @return expanded command line
+     * Substitutes a command line with a system registry invoke method call.
+     * <p>
+     * This method expands a command line by replacing it with a call to the system registry's
+     * invoke method. This is used to handle command execution through the system registry.
+     *
+     * @param line the command line to be expanded
+     * @return the expanded command line with the system registry invoke method call
      */
     String expandCommandLine(String line);
 
     /**
-     * Expands parameter list to string
-     * @param params list of script parameters
-     * @return expanded parameters list
+     * Expands a list of script parameters to a string representation.
+     * <p>
+     * This method converts a list of script parameters into a string that can be used
+     * in script execution. The parameters may be expanded or formatted according to
+     * the console engine's rules.
+     *
+     * @param params the list of script parameters to expand
+     * @return a string representation of the expanded parameters list
      */
     String expandToList(List<String> params);
 
     /**
-     * Returns all scripts found from PATH
-     * @return map keys have script file names and value is true if it is console script
+     * Returns all scripts found in the PATH environment variable.
+     * <p>
+     * This method searches for scripts in the directories specified by the PATH environment
+     * variable and returns a map of script names to a boolean indicating whether each script
+     * is a console script.
+     *
+     * @return a map where keys are script file names and values are true if the script is a console script
      */
     Map<String, Boolean> scripts();
 
     /**
-     * Sets file name extension used by console scripts
-     * @param extension console script file extension
+     * Sets the file name extension used by console scripts.
+     * <p>
+     * This method configures the file extension that the console engine will recognize
+     * as indicating a console script. Files with this extension will be treated as
+     * console scripts when executing scripts.
+     *
+     * @param extension the file extension to use for console scripts (e.g., ".jsh")
      */
     void setScriptExtension(String extension);
 
     /**
-     * Returns true if alias 'name' exists
-     * @param name alias name
-     * @return true if alias exists
+     * Checks if an alias with the specified name exists.
+     * <p>
+     * This method determines whether an alias has been defined for the specified name.
+     * Aliases can be used to create shortcuts for commands or command sequences.
+     *
+     * @param name the alias name to check
+     * @return true if an alias with the specified name exists, false otherwise
      */
     boolean hasAlias(String name);
 
     /**
-     * Returns alias 'name' value
-     * @param name alias name
-     * @return value of alias
+     * Returns the value of the alias with the specified name.
+     * <p>
+     * This method retrieves the command or command sequence that the specified alias
+     * is defined to represent. Aliases can be used to create shortcuts for commands
+     * or command sequences.
+     *
+     * @param name the alias name
+     * @return the value of the alias, or null if no alias with the specified name exists
      */
     String getAlias(String name);
 
     /**
-     * Returns defined pipes
-     * @return map of defined pipes
+     * Returns all defined pipes.
+     * <p>
+     * This method retrieves a map of all pipes defined in the console engine.
+     * Pipes are used to connect the output of one command to the input of another.
+     *
+     * @return a map of defined pipes, where keys are pipe names and values are pipe definitions
      */
     Map<String, List<String>> getPipes();
 
     /**
-     * Returns named pipe names
-     * @return list of named pipe names
+     * Returns the names of all named pipes.
+     * <p>
+     * This method retrieves a list of all named pipes defined in the console engine.
+     * Named pipes are pipes that have been given a specific name for easier reference.
+     *
+     * @return a list of named pipe names
      */
     List<String> getNamedPipes();
 
     /**
-     * Returns script and variable completers
-     * @return script and variable completers
+     * Returns completers for scripts and variables.
+     * <p>
+     * This method retrieves a list of completers that can be used for tab completion
+     * of script names and variable names in the console.
+     *
+     * @return a list of completers for scripts and variables
      */
     List<Completer> scriptCompleters();
 
     /**
-     * Persist object to file
-     * @param file file where object should be written
-     * @param object object to persist
+     * Persists an object to a file.
+     * <p>
+     * This method serializes the specified object and writes it to the specified file.
+     * The object can later be read back using the {@link #slurp(Path)} method.
+     *
+     * @param file the file to write the object to
+     * @param object the object to persist
      */
     void persist(Path file, Object object);
 
     /**
-     * Read object from file
-     * @param file file from where object should be read
-     * @return object
-     * @throws IOException in case of error
+     * Reads an object from a file.
+     * <p>
+     * This method reads and deserializes an object from the specified file.
+     * The object should have been written using the {@link #persist(Path, Object)} method.
+     *
+     * @param file the file to read the object from
+     * @return the deserialized object
+     * @throws IOException if an I/O error occurs while reading the file
      */
     Object slurp(Path file) throws IOException;
 
     /**
-     * Read console option value
-     * @param <T> option type
-     * @param option option name
-     * @param defval default value
-     * @return option value
+     * Reads a console option value with a default value if the option doesn't exist.
+     * <p>
+     * This method retrieves the value of a console option, returning a default value
+     * if the option doesn't exist. Console options are used to configure the behavior
+     * of the console engine and its components.
+     *
+     * @param <T> the type of the option value
+     * @param option the name of the option to read
+     * @param defval the default value to return if the option doesn't exist
+     * @return the value of the option, or the default value if the option doesn't exist
      */
     <T> T consoleOption(String option, T defval);
 
     /**
-     * Set console option value
-     * @param name the option name
-     * @param value value to assign console option
+     * Sets a console option value.
+     * <p>
+     * This method sets the value of a console option. Console options are used to
+     * configure the behavior of the console engine and its components.
+     *
+     * @param name the name of the option to set
+     * @param value the value to assign to the option
      */
     void setConsoleOption(String name, Object value);
 
     /**
-     * Executes command line that does not contain known command by the system registry.
-     * If the line is neither JLine or ScriptEngine script it will be evaluated
-     * as ScriptEngine statement.
-     * @param name parsed command/script name
-     * @param rawLine raw command line
-     * @param args parsed arguments of the command
-     * @return command line execution result
-     * @throws Exception in case of error
+     * Executes a command line that does not contain a command known by the system registry.
+     * <p>
+     * This method handles the execution of command lines that are not recognized as commands
+     * by the system registry. If the line is neither a JLine script nor a ScriptEngine script,
+     * it will be evaluated as a ScriptEngine statement.
+     *
+     * @param name the parsed command or script name
+     * @param rawLine the raw command line as entered by the user
+     * @param args the parsed arguments of the command
+     * @return the result of executing the command line
+     * @throws Exception if an error occurs during execution
      */
     Object execute(String name, String rawLine, String[] args) throws Exception;
 
     /**
-     * Executes either JLine or ScriptEngine script.
-     * @param script script file
-     * @return script execution result
-     * @throws Exception in case of error
+     * Executes either a JLine script or a ScriptEngine script.
+     * <p>
+     * This method executes the specified script file, determining whether it is a JLine script
+     * or a ScriptEngine script based on its extension or content. This is a convenience method
+     * that calls {@link #execute(Path, String, String[])} with an empty raw line and no arguments.
+     *
+     * @param script the script file to execute
+     * @return the result of executing the script
+     * @throws Exception if an error occurs during execution
      */
     default Object execute(File script) throws Exception {
         return execute(script, "", new String[0]);
     }
 
     /**
-     * Executes either JLine or ScriptEngine script.
-     * @param script script file
-     * @param rawLine raw command line
-     * @param args script arguments
-     * @return script execution result
-     * @throws Exception in case of error
+     * Executes either a JLine script or a ScriptEngine script with the specified arguments.
+     * <p>
+     * This method executes the specified script file with the specified arguments, determining
+     * whether it is a JLine script or a ScriptEngine script based on its extension or content.
+     * This is a convenience method that calls {@link #execute(Path, String, String[])} with the
+     * script file converted to a Path.
+     *
+     * @param script the script file to execute
+     * @param rawLine the raw command line as entered by the user
+     * @param args the arguments to pass to the script
+     * @return the result of executing the script
+     * @throws Exception if an error occurs during execution
      */
     default Object execute(File script, String rawLine, String[] args) throws Exception {
         return execute(script != null ? script.toPath() : null, rawLine, args);
     }
 
     /**
-     * Executes either JLine or ScriptEngine script.
-     * @param script script file
-     * @param rawLine raw command line
-     * @param args script arguments
-     * @return script execution result
-     * @throws Exception in case of error
+     * Executes either a JLine script or a ScriptEngine script with the specified arguments.
+     * <p>
+     * This method executes the specified script file with the specified arguments, determining
+     * whether it is a JLine script or a ScriptEngine script based on its extension or content.
+     *
+     * @param script the script file to execute
+     * @param rawLine the raw command line as entered by the user
+     * @param args the arguments to pass to the script
+     * @return the result of executing the script
+     * @throws Exception if an error occurs during execution
      */
     Object execute(Path script, String rawLine, String[] args) throws Exception;
 
     /**
-     * Post processes execution result. If result is to be assigned to the console variable
-     * then method will return null.
-     * @param line command line
-     * @param result command result to process
-     * @param output command redirected output
-     * @return processed result
+     * Post-processes the result of executing a command.
+     * <p>
+     * This method processes the result of executing a command, handling any special cases
+     * such as assigning the result to a console variable. If the result is to be assigned
+     * to a console variable, this method will return null.
+     *
+     * @param line the command line that was executed
+     * @param result the result of executing the command
+     * @param output the redirected output of the command, if any
+     * @return the processed result, or null if the result was assigned to a console variable
      */
     ExecutionResult postProcess(String line, Object result, String output);
 
     /**
-     * Post processes execution result.
-     * @param result command result to process
-     * @return processed result
+     * Post-processes the result of executing a command.
+     * <p>
+     * This method processes the result of executing a command, handling any special cases.
+     * This is a convenience method that calls {@link #postProcess(String, Object, String)}
+     * with a null command line and output.
+     *
+     * @param result the result of executing the command
+     * @return the processed result
      */
     ExecutionResult postProcess(Object result);
 
     /**
-     * Print object if trace is enabled
-     * @param object object to print
+     * Prints an object if tracing is enabled.
+     * <p>
+     * This method prints the specified object to the console if tracing is enabled.
+     * Tracing can be used for debugging or logging purposes.
+     *
+     * @param object the object to print
      */
     void trace(Object object);
 
     /**
-     * Print object.
-     * @param object object to print
+     * Prints an object to the console.
+     * <p>
+     * This method prints the specified object to the console, regardless of whether
+     * tracing is enabled.
+     *
+     * @param object the object to print
      */
     void println(Object object);
 
     /**
-     * Create console variable
-     * @param name name of the variable
-     * @param value value of the variable
+     * Creates or updates a console variable.
+     * <p>
+     * This method creates a new console variable with the specified name and value,
+     * or updates an existing variable if one with the specified name already exists.
+     *
+     * @param name the name of the variable to create or update
+     * @param value the value to assign to the variable
      */
     void putVariable(String name, Object value);
 
     /**
-     * Get variable value
-     * @param name name of the variable
-     * @return variable value
+     * Gets the value of a console variable.
+     * <p>
+     * This method retrieves the value of the console variable with the specified name.
+     *
+     * @param name the name of the variable to get
+     * @return the value of the variable, or null if no variable with the specified name exists
      */
     Object getVariable(String name);
 
     /**
-     * Test if variable with name exists
-     * @param name name of the variable
-     * @return true if variable with name exists
+     * Tests if a variable with the specified name exists.
+     * <p>
+     * This method determines whether a console variable with the specified name exists.
+     *
+     * @param name the name of the variable to check
+     * @return true if a variable with the specified name exists, false otherwise
      */
     boolean hasVariable(String name);
 
     /**
-     * Delete temporary console variables
+     * Deletes temporary console variables.
+     * <p>
+     * This method removes all temporary console variables, which are typically
+     * created during command execution and are not meant to persist between commands.
      */
     void purge();
 
     /**
-     * Execute widget function
-     * @param function to execute
-     * @return true on success
+     * Executes a widget function.
+     * <p>
+     * This method executes the specified widget function, which can be used to
+     * perform custom actions in the console.
+     *
+     * @param function the widget function to execute
+     * @return true if the function was executed successfully, false otherwise
      */
     boolean executeWidget(Object function);
 
     /**
-     * Checks if consoleEngine is executing script
-     * @return true when executing script
+     * Checks if the console engine is currently executing a script.
+     * <p>
+     * This method determines whether the console engine is in the process of
+     * executing a script, as opposed to processing interactive commands.
+     *
+     * @return true if the console engine is executing a script, false otherwise
      */
     boolean isExecuting();
 
+    /**
+     * Class representing the result of executing a command.
+     * <p>
+     * An ExecutionResult encapsulates the status code and result value of a command execution.
+     */
     class ExecutionResult {
+        /** The status code of the command execution */
         final int status;
+        /** The result value of the command execution */
         final Object result;
 
+        /**
+         * Creates a new execution result with the specified status code and result value.
+         *
+         * @param status the status code of the command execution
+         * @param result the result value of the command execution
+         */
         public ExecutionResult(int status, Object result) {
             this.status = status;
             this.result = result;
         }
 
+        /**
+         * Returns the status code of the command execution.
+         *
+         * @return the status code
+         */
         public int status() {
             return status;
         }
 
+        /**
+         * Returns the result value of the command execution.
+         *
+         * @return the result value
+         */
         public Object result() {
             return result;
         }
     }
 
+    /**
+     * Class for creating widgets from console functions.
+     * <p>
+     * A WidgetCreator creates a widget that executes a function defined in the console.
+     * This allows console functions to be bound to key sequences and used as widgets.
+     */
     class WidgetCreator implements Widget {
+        /** The console engine that will execute the function */
         private final ConsoleEngine consoleEngine;
+        /** The function to execute */
         private final Object function;
+        /** The name of the function */
         private final String name;
 
+        /**
+         * Creates a new widget creator for the specified function.
+         *
+         * @param consoleEngine the console engine that will execute the function
+         * @param function the name of the function to execute
+         */
         public WidgetCreator(ConsoleEngine consoleEngine, String function) {
             this.consoleEngine = consoleEngine;
             this.name = function;
             this.function = consoleEngine.getVariable(function);
         }
 
+        /**
+         * Executes the function when the widget is applied.
+         *
+         * @return true if the function was executed successfully, false otherwise
+         */
         @Override
         public boolean apply() {
             return consoleEngine.executeWidget(function);
         }
 
+        /**
+         * Returns the name of the function.
+         *
+         * @return the name of the function
+         */
         @Override
         public String toString() {
             return name;

--- a/console/src/main/java/org/jline/console/Printer.java
+++ b/console/src/main/java/org/jline/console/Printer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -14,14 +14,31 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Print object to the console.
+ * Interface for printing objects to the console with various formatting options.
+ * The Printer interface provides methods for displaying objects in different formats,
+ * such as tables or structured output, with customizable styling and formatting options.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
+ * Implementations of this interface handle the conversion of various object types to
+ * formatted text output, with support for syntax highlighting and structured display.
  */
 public interface Printer {
+    /**
+     * Enumeration specifying which rows in a table should be highlighted.
+     */
     enum TableRows {
+        /**
+         * Highlight only even-numbered rows in the table.
+         */
         EVEN,
+
+        /**
+         * Highlight only odd-numbered rows in the table.
+         */
         ODD,
+
+        /**
+         * Highlight all rows in the table.
+         */
         ALL
     }
     //
@@ -212,18 +229,43 @@ public interface Printer {
             VALUE_STYLE_ALL,
             MULTI_COLUMNS);
 
+    /**
+     * Prints an object to the console using default formatting options.
+     * This is a convenience method that calls {@link #println(Map, Object)} with an empty options map.
+     *
+     * @param object the object to print
+     */
     default void println(Object object) {
         println(new HashMap<>(), object);
     }
 
+    /**
+     * Prints an object to the console with the specified formatting options.
+     * The method handles different object types and formats them according to the provided options.
+     *
+     * @param options a map of formatting options that control how the object is displayed
+     * @param object the object to print
+     */
     void println(Map<String, Object> options, Object object);
 
+    /**
+     * Executes a print command with the given input.
+     * This method can be implemented by printer implementations to handle specific print commands.
+     * The default implementation returns null, indicating no error occurred.
+     *
+     * @param input the command input containing the command and its arguments
+     * @return an Exception if an error occurred during command execution, or null if successful
+     */
     default Exception prntCommand(CommandInput input) {
         return null;
     }
 
     /**
-     * Clear printer syntax highlighter cache
+     * Clears the printer's syntax highlighter cache and refreshes internal state.
+     * This method should be called when the highlighting rules or styles have changed
+     * and need to be reapplied.
+     *
+     * @return true if the refresh operation was successful, false otherwise
      */
     boolean refresh();
 }

--- a/console/src/main/java/org/jline/console/ScriptEngine.java
+++ b/console/src/main/java/org/jline/console/ScriptEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -15,190 +15,307 @@ import java.util.*;
 import org.jline.reader.Completer;
 
 /**
- * Manage scriptEngine variables, statements and script execution.
- *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
+ * Interface for managing script engine variables, statements, and script execution.
+ * <p>
+ * The ScriptEngine interface provides methods for interacting with a script engine,
+ * such as executing scripts and statements, managing variables, and serializing/deserializing
+ * objects. It serves as a bridge between JLine and various scripting languages like
+ * JavaScript, Groovy, etc.
+ * <p>
+ * The ScriptEngine is responsible for:
+ * <ul>
+ *   <li>Executing scripts and statements in the underlying script engine</li>
+ *   <li>Managing variables in the script engine's context</li>
+ *   <li>Converting objects between Java and the script engine's native format</li>
+ *   <li>Serializing and deserializing objects to/from various formats</li>
+ *   <li>Providing completers for script-specific syntax</li>
+ * </ul>
  */
 public interface ScriptEngine {
 
     /**
+     * Returns the name of the underlying script engine.
+     * <p>
+     * This method retrieves the name of the script engine implementation being used,
+     * such as "JavaScript", "Groovy", etc.
      *
-     * @return scriptEngine name
+     * @return the name of the script engine
      */
     String getEngineName();
 
     /**
+     * Returns the file name extensions associated with this script engine.
+     * <p>
+     * This method retrieves the file extensions that are recognized by this script engine,
+     * such as ".js" for JavaScript, ".groovy" for Groovy, etc.
      *
-     * @return script file name extensions
+     * @return a collection of file name extensions associated with this script engine
      */
     Collection<String> getExtensions();
 
     /**
+     * Returns a completer for script-specific syntax.
+     * <p>
+     * This method retrieves a completer that can provide completion for script-specific
+     * syntax, such as keywords, built-in functions, etc. The completer can be used for
+     * tab completion in the console.
      *
-     * @return script tab completer
+     * @return a completer for script-specific syntax
      */
     Completer getScriptCompleter();
 
     /**
-     * Tests if console variable exists
-     * @param name variable name
-     * @return true if variable exists
+     * Tests if a variable exists in the script engine's context.
+     * <p>
+     * This method determines whether a variable with the specified name exists
+     * in the script engine's context.
+     *
+     * @param name the name of the variable to check
+     * @return true if a variable with the specified name exists, false otherwise
      */
     boolean hasVariable(String name);
 
     /**
-     * Creates variable
-     * @param name variable name
-     * @param value value
+     * Creates or updates a variable in the script engine's context.
+     * <p>
+     * This method creates a new variable with the specified name and value in the
+     * script engine's context, or updates an existing variable if one with the
+     * specified name already exists.
+     *
+     * @param name the name of the variable to create or update
+     * @param value the value to assign to the variable
      */
     void put(String name, Object value);
 
     /**
-     * Gets variable value
-     * @param name variable name
-     * @return value of the variable
+     * Gets the value of a variable from the script engine's context.
+     * <p>
+     * This method retrieves the value of the variable with the specified name
+     * from the script engine's context.
+     *
+     * @param name the name of the variable to get
+     * @return the value of the variable, or null if no variable with the specified name exists
      */
     Object get(String name);
 
     /**
-     * Gets all variables with values
-     * @return map of the variables
+     * Gets all variables with their values from the script engine's context.
+     * <p>
+     * This method retrieves all variables and their values from the script engine's context.
+     * This is a convenience method that calls {@link #find(String)} with a null pattern.
+     *
+     * @return a map of variable names to their values
      */
     default Map<String, Object> find() {
         return find(null);
     }
 
     /**
-     * Gets all the variables that match the name. Name can contain * wild cards.
-     * @param name variable name
-     * @return map the variables
+     * Gets all variables that match the specified pattern.
+     * <p>
+     * This method retrieves all variables whose names match the specified pattern
+     * from the script engine's context. The pattern can contain wildcard characters (*)
+     * to match multiple variable names.
+     *
+     * @param name the pattern to match variable names against, or null to match all variables
+     * @return a map of matching variable names to their values
      */
     Map<String, Object> find(String name);
 
     /**
-     * Deletes variables. Variable name can contain * wild cards.
-     * @param vars variables to be deleted
+     * Deletes variables from the script engine's context.
+     * <p>
+     * This method removes variables from the script engine's context. The variable names
+     * can contain wildcard characters (*) to match multiple variables.
+     *
+     * @param vars the names of the variables to delete, which can contain wildcard characters
      */
     void del(String... vars);
 
     /**
-     * Serialize object to JSON string.
-     * @param object object to serialize to JSON
-     * @return formatted JSON string
+     * Serializes an object to a JSON string.
+     * <p>
+     * This method converts the specified object to a formatted JSON string representation.
+     * The exact format of the JSON string depends on the script engine implementation.
+     *
+     * @param object the object to serialize to JSON
+     * @return a formatted JSON string representation of the object
      */
     String toJson(Object object);
 
     /**
-     * Converts object to string.
-     * @param object the object
-     * @return object string value
+     * Converts an object to its string representation.
+     * <p>
+     * This method converts the specified object to a string representation.
+     * The exact format of the string depends on the script engine implementation.
+     *
+     * @param object the object to convert to a string
+     * @return a string representation of the object
      */
     String toString(Object object);
 
     /**
-     * Converts object fields to map.
-     * @param object the object
-     * @return object fields map
+     * Converts an object's fields to a map.
+     * <p>
+     * This method extracts the fields of the specified object and returns them as a map
+     * of field names to field values. The exact set of fields included in the map depends
+     * on the script engine implementation.
+     *
+     * @param object the object whose fields to extract
+     * @return a map of field names to field values
      */
     Map<String, Object> toMap(Object object);
 
     /**
-     * Deserialize value
-     * @param value the value
-     * @return deserialized value
+     * Deserializes a value from its string representation.
+     * <p>
+     * This method converts the specified string representation back to an object.
+     * This is a convenience method that calls {@link #deserialize(String, String)}
+     * with a null format.
+     *
+     * @param value the string representation to deserialize
+     * @return the deserialized object
      */
     default Object deserialize(String value) {
         return deserialize(value, null);
     }
 
     /**
-     * Deserialize value
-     * @param value the value
-     * @param format serialization format
-     * @return deserialized value
+     * Deserializes a value from its string representation using the specified format.
+     * <p>
+     * This method converts the specified string representation back to an object
+     * using the specified serialization format.
+     *
+     * @param value the string representation to deserialize
+     * @param format the serialization format to use, or null to use the default format
+     * @return the deserialized object
      */
     Object deserialize(String value, String format);
 
     /**
+     * Returns the serialization formats supported by this script engine.
+     * <p>
+     * This method retrieves the names of the serialization formats that can be used
+     * with the {@link #persist(Path, Object, String)} method.
      *
-     * @return Supported serialization formats
+     * @return a list of supported serialization format names
      */
     List<String> getSerializationFormats();
 
     /**
+     * Returns the deserialization formats supported by this script engine.
+     * <p>
+     * This method retrieves the names of the deserialization formats that can be used
+     * with the {@link #deserialize(String, String)} method.
      *
-     * @return Supported deserialization formats
+     * @return a list of supported deserialization format names
      */
     List<String> getDeserializationFormats();
 
     /**
-     * Persists object value to file.
-     * @param file file
-     * @param object object
+     * Persists an object to a file.
+     * <p>
+     * This method serializes the specified object and writes it to the specified file.
+     * This is a convenience method that calls {@link #persist(Path, Object, String)}
+     * with a null format.
+     *
+     * @param file the file to write the serialized object to
+     * @param object the object to serialize and persist
      */
     void persist(Path file, Object object);
 
     /**
-     * Persists object value to file.
-     * @param file the file
-     * @param object the object
-     * @param format serialization format
+     * Persists an object to a file using the specified serialization format.
+     * <p>
+     * This method serializes the specified object using the specified format
+     * and writes it to the specified file.
+     *
+     * @param file the file to write the serialized object to
+     * @param object the object to serialize and persist
+     * @param format the serialization format to use, or null to use the default format
      */
     void persist(Path file, Object object, String format);
 
     /**
-     * Executes scriptEngine statement
-     * @param statement the statement
-     * @return result
-     * @throws Exception in case of error
+     * Executes a script engine statement.
+     * <p>
+     * This method evaluates the specified statement in the script engine and returns
+     * the result of the evaluation.
+     *
+     * @param statement the statement to execute
+     * @return the result of executing the statement
+     * @throws Exception if an error occurs during execution
      */
     Object execute(String statement) throws Exception;
 
     /**
-     * Executes scriptEngine script
-     * @param script the script
-     * @return result
-     * @throws Exception in case of error
+     * Executes a script from a file.
+     * <p>
+     * This method executes the script contained in the specified file and returns
+     * the result of the execution. This is a convenience method that calls
+     * {@link #execute(File, Object[])} with null arguments.
+     *
+     * @param script the file containing the script to execute
+     * @return the result of executing the script
+     * @throws Exception if an error occurs during execution
      */
     default Object execute(Path script) throws Exception {
         return execute(script.toFile(), null);
     }
 
     /**
-     * Executes scriptEngine script
-     * @param script the script
-     * @return result
-     * @throws Exception in case of error
+     * Executes a script from a file.
+     * <p>
+     * This method executes the script contained in the specified file and returns
+     * the result of the execution. This is a convenience method that calls
+     * {@link #execute(File, Object[])} with null arguments.
+     *
+     * @param script the file containing the script to execute
+     * @return the result of executing the script
+     * @throws Exception if an error occurs during execution
      */
     default Object execute(File script) throws Exception {
         return execute(script, null);
     }
 
     /**
-     * Executes scriptEngine script
-     * @param script the script
-     * @param args arguments
-     * @return result
-     * @throws Exception in case of error
+     * Executes a script from a file with the specified arguments.
+     * <p>
+     * This method executes the script contained in the specified file with the specified
+     * arguments and returns the result of the execution. This is a convenience method
+     * that calls {@link #execute(File, Object[])} with the file converted to a File object.
+     *
+     * @param script the file containing the script to execute
+     * @param args the arguments to pass to the script, or null if no arguments
+     * @return the result of executing the script
+     * @throws Exception if an error occurs during execution
      */
     default Object execute(Path script, Object[] args) throws Exception {
         return execute(script.toFile(), args);
     }
 
     /**
-     * Executes scriptEngine script
-     * @param script the script
-     * @param args arguments
-     * @return result
-     * @throws Exception in case of error
+     * Executes a script from a file with the specified arguments.
+     * <p>
+     * This method executes the script contained in the specified file with the specified
+     * arguments and returns the result of the execution.
+     *
+     * @param script the file containing the script to execute
+     * @param args the arguments to pass to the script, or null if no arguments
+     * @return the result of executing the script
+     * @throws Exception if an error occurs during execution
      */
     Object execute(File script, Object[] args) throws Exception;
 
     /**
-     * Executes scriptEngine closure
-     * @param closure closure
-     * @param args arguments
-     * @return result
+     * Executes a script engine closure with the specified arguments.
+     * <p>
+     * This method executes the specified closure (a callable object) with the specified
+     * arguments and returns the result of the execution.
+     *
+     * @param closure the closure to execute
+     * @param args the arguments to pass to the closure
+     * @return the result of executing the closure
      */
     Object execute(Object closure, Object... args);
 }

--- a/console/src/main/java/org/jline/console/SystemRegistry.java
+++ b/console/src/main/java/org/jline/console/SystemRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -19,162 +19,281 @@ import org.jline.reader.ParsedLine;
 import org.jline.terminal.Terminal;
 
 /**
- * Aggregate command registries and dispatch command executions.
- *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
+ * Interface for aggregating command registries and dispatching command executions in a console application.
+ * <p>
+ * The SystemRegistry serves as the central registry for commands in a console application.
+ * It aggregates multiple command registries, handles command execution, and provides
+ * facilities for command completion, description, and error handling.
+ * <p>
+ * The SystemRegistry is responsible for:
+ * <ul>
+ *   <li>Aggregating multiple command registries</li>
+ *   <li>Dispatching command executions to the appropriate registry</li>
+ *   <li>Providing command completion and description</li>
+ *   <li>Handling command execution errors</li>
+ *   <li>Managing console options and variables</li>
+ * </ul>
  */
 public interface SystemRegistry extends CommandRegistry, ConsoleOptionGetter {
 
     /**
-     * Set command registries
-     * @param commandRegistries command registries used by the application
+     * Sets the command registries to be used by this system registry.
+     * <p>
+     * This method configures the command registries that will be aggregated by this
+     * system registry. Commands from all of these registries will be available for
+     * execution through this system registry.
+     *
+     * @param commandRegistries the command registries to be used by the application
      */
     void setCommandRegistries(CommandRegistry... commandRegistries);
 
     /**
-     * Register subcommand registry
-     * @param command main command
-     * @param subcommandRegistry subcommand registry
+     * Registers a subcommand registry for a main command.
+     * <p>
+     * This method associates a subcommand registry with a main command, allowing
+     * the system registry to delegate subcommand execution to the appropriate registry.
+     * This is useful for implementing command hierarchies.
+     *
+     * @param command the main command name
+     * @param subcommandRegistry the registry containing the subcommands for the main command
      */
     void register(String command, CommandRegistry subcommandRegistry);
 
     /**
-     * Initialize consoleEngine environment by executing console script
-     * @param script initialization script
+     * Initializes the console engine environment by executing a console script.
+     * <p>
+     * This method executes the specified script to initialize the console engine
+     * environment. The script can set up variables, aliases, and other configuration
+     * needed for the console application.
+     *
+     * @param script the initialization script to execute
      */
     void initialize(File script);
 
     /**
+     * Returns the names of all pipes defined in this system registry.
+     * <p>
+     * This method retrieves the names of all pipes that have been defined in this
+     * system registry. Pipes are used to connect the output of one command to the
+     * input of another.
      *
-     * @return pipe names defined in systemRegistry
+     * @return a collection of pipe names defined in this system registry
      */
     Collection<String> getPipeNames();
 
     /**
-     * Returns command completer that includes also console variable and script completion.
-     * @return command completer
+     * Returns a command completer that includes console variable and script completion.
+     * <p>
+     * This method creates a completer that can provide completion for commands,
+     * console variables, and scripts. The completer can be used for tab completion
+     * in the console.
+     *
+     * @return a completer for commands, console variables, and scripts
      */
     Completer completer();
 
     /**
-     * Returns a command, method or syntax description for use in the JLine Widgets framework.
-     * @param line command line whose description to return
-     * @return command description for JLine TailTipWidgets to be displayed
-     *         in the terminal status bar.
+     * Returns a description for a command, method, or syntax for use in the JLine Widgets framework.
+     * <p>
+     * This method generates a description for the specified command line, which can be
+     * displayed in the terminal status bar by JLine TailTipWidgets. The description
+     * includes information about the command's arguments, options, and usage.
+     *
+     * @param line the command line whose description to return
+     * @return a command description for JLine TailTipWidgets to be displayed in the terminal status bar
      */
     CmdDesc commandDescription(CmdLine line);
 
     /**
-     * Execute a command, script or evaluate scriptEngine statement
-     * @param line command line to be executed
-     * @return execution result
-     * @throws Exception in case of error
+     * Executes a command, script, or evaluates a script engine statement.
+     * <p>
+     * This method parses and executes the specified command line. If the line contains
+     * a known command, it will be executed. If it contains a script name, the script
+     * will be executed. Otherwise, the line will be evaluated as a script engine statement.
+     *
+     * @param line the command line to be executed
+     * @return the result of executing the command line
+     * @throws Exception if an error occurs during execution
      */
     Object execute(String line) throws Exception;
 
     /**
-     * Delete temporary console variables and reset output streams
+     * Deletes temporary console variables and resets output streams.
+     * <p>
+     * This method cleans up temporary console variables and resets output streams
+     * to their default state. It should be called after command execution to ensure
+     * that temporary variables and redirected output streams don't affect subsequent
+     * commands.
      */
     void cleanUp();
 
     /**
-     * Print exception on terminal
-     * @param exception exception to print on terminal
+     * Prints an exception on the terminal.
+     * <p>
+     * This method prints the specified exception on the terminal, including its
+     * message and stack trace. This is a convenience method that calls
+     * {@link #trace(boolean, Throwable)} with stack=true.
+     *
+     * @param exception the exception to print on the terminal
      */
     void trace(Throwable exception);
 
     /**
-     * Print exception on terminal
-     * @param stack print stack trace if stack true otherwise message
-     * @param exception exception to be printed
+     * Prints an exception on the terminal with control over stack trace display.
+     * <p>
+     * This method prints the specified exception on the terminal. If stack is true,
+     * the full stack trace will be printed. Otherwise, only the exception message
+     * will be printed.
+     *
+     * @param stack whether to print the full stack trace (true) or just the message (false)
+     * @param exception the exception to be printed
      */
     void trace(boolean stack, Throwable exception);
 
     /**
-     * Return console option value
-     * @param name the option name
-     * @return option value
+     * Returns the value of a console option.
+     * <p>
+     * This method retrieves the value of the console option with the specified name.
+     * Console options are used to configure the behavior of the console and its components.
+     *
+     * @param name the name of the option to retrieve
+     * @return the value of the option, or null if the option doesn't exist
      */
     Object consoleOption(String name);
 
     /**
-     * Return console option value
-     * @param name the option name
-     * @param defVal value to return if console option does not exists
-     * @return option value
+     * Returns the value of a console option with a default value if the option doesn't exist.
+     * <p>
+     * This method retrieves the value of the console option with the specified name,
+     * returning a default value if the option doesn't exist. Console options are used
+     * to configure the behavior of the console and its components.
+     *
+     * @param <T> the type of the option value
+     * @param name the name of the option to retrieve
+     * @param defVal the default value to return if the option doesn't exist
+     * @return the value of the option, or the default value if the option doesn't exist
      */
     <T> T consoleOption(String name, T defVal);
 
     /**
-     * Set console option value
-     * @param name the option name
-     * @param value value to assign console option
+     * Sets the value of a console option.
+     * <p>
+     * This method sets the value of the console option with the specified name.
+     * Console options are used to configure the behavior of the console and its components.
+     *
+     * @param name the name of the option to set
+     * @param value the value to assign to the option
      */
     void setConsoleOption(String name, Object value);
 
     /**
-     * @return terminal
+     * Returns the terminal associated with this system registry.
+     * <p>
+     * This method retrieves the terminal that is used by this system registry for
+     * input and output operations.
+     *
+     * @return the terminal associated with this system registry
      */
     Terminal terminal();
 
     /**
-     * Execute command with arguments
-     * @param command command to be executed
-     * @param args arguments of the command
-     * @return command execution result
-     * @throws Exception in case of error
+     * Executes a command with the specified arguments.
+     * <p>
+     * This method executes the specified command with the specified arguments.
+     * The command is looked up in the command registries associated with this system registry.
+     *
+     * @param command the command to be executed
+     * @param args the arguments to pass to the command
+     * @return the result of executing the command
+     * @throws Exception if an error occurs during execution
      */
     Object invoke(String command, Object... args) throws Exception;
 
     /**
-     * Returns whether a line contains command/script that is known to this registry.
+     * Checks if a parsed line contains a command or script that is known to this registry.
+     * <p>
+     * This method determines whether the specified parsed command line contains a command
+     * or script that is known to this registry. This can be used to determine whether
+     * the line can be executed by this registry.
+     *
      * @param line the parsed command line to test
-     * @return true if the specified line has a command registered
+     * @return true if the specified line contains a command or script that is known to this registry, false otherwise
      */
     boolean isCommandOrScript(ParsedLine line);
 
     /**
-     * Returns whether command is known to this registry.
-     * @param command the command to test
-     * @return true if the specified command is known
+     * Checks if a command or script is known to this registry.
+     * <p>
+     * This method determines whether the specified command or script is known to this registry.
+     * This can be used to determine whether the command or script can be executed by this registry.
+     *
+     * @param command the command or script name to test
+     * @return true if the specified command or script is known to this registry, false otherwise
      */
     boolean isCommandOrScript(String command);
 
     /**
-     * Returns whether alias is known command alias.
+     * Checks if an alias is a known command alias.
+     * <p>
+     * This method determines whether the specified alias is a known command alias.
+     * Command aliases are alternative names for commands that can be used to invoke them.
+     *
      * @param alias the alias to test
-     * @return true if the alias is known command alias
+     * @return true if the specified alias is a known command alias, false otherwise
      */
     boolean isCommandAlias(String alias);
 
     /**
-     * Orderly close SystemRegistry.
+     * Orderly closes this system registry.
+     * <p>
+     * This method performs an orderly shutdown of this system registry, releasing
+     * any resources it holds and performing any necessary cleanup operations.
+     * It should be called when the system registry is no longer needed.
      */
     void close();
     /**
-     * @return systemRegistry of the current thread
+     * Returns the system registry associated with the current thread.
+     * <p>
+     * This method retrieves the system registry that has been associated with the
+     * current thread using the {@link #add(SystemRegistry)} method. This can be used
+     * to access the system registry from code that doesn't have a direct reference to it.
+     *
+     * @return the system registry associated with the current thread, or null if none is associated
      */
     static SystemRegistry get() {
         return Registeries.getInstance().getSystemRegistry();
     }
 
     /**
-     * Add systemRegistry to the thread map
-     * @param systemRegistry the systemRegistry
+     * Associates a system registry with the current thread.
+     * <p>
+     * This method associates the specified system registry with the current thread,
+     * making it accessible via the {@link #get()} method. This can be used to make
+     * the system registry available to code that doesn't have a direct reference to it.
+     *
+     * @param systemRegistry the system registry to associate with the current thread
      */
     static void add(SystemRegistry systemRegistry) {
         Registeries.getInstance().addRegistry(systemRegistry);
     }
 
     /**
-     * Remove systemRegistry of the current thread from the thread map
+     * Removes the system registry association from the current thread.
+     * <p>
+     * This method removes the association between the current thread and its system registry,
+     * making the system registry no longer accessible via the {@link #get()} method.
+     * This should be called when the thread is done using the system registry.
      */
     static void remove() {
         Registeries.getInstance().removeRegistry();
     }
 
     /**
-     * Manage systemRegistry store
+     * Class for managing the system registry store.
+     * <p>
+     * This class provides a thread-local store for system registries, allowing each thread
+     * to have its own associated system registry. It is used internally by the
+     * {@link #get()}, {@link #add(SystemRegistry)}, and {@link #remove()} methods.
      */
     class Registeries {
         private static final Registeries instance = new Registeries();

--- a/console/src/main/java/org/jline/console/impl/AbstractCommandRegistry.java
+++ b/console/src/main/java/org/jline/console/impl/AbstractCommandRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -20,16 +20,37 @@ import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
 
 /**
- * CommandRegistry common methods.
+ * Abstract base class implementing common methods for command registries.
+ * <p>
+ * AbstractCommandRegistry provides a base implementation of the CommandRegistry interface,
+ * with common methods for registering commands, generating command descriptions,
+ * and handling command execution. Concrete implementations can extend this class
+ * to create specific command registry types.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public abstract class AbstractCommandRegistry implements CommandRegistry {
+    /** The internal registry of commands */
     private CmdRegistry cmdRegistry;
+    /** The last exception that occurred during command execution */
     private Exception exception;
 
+    /**
+     * Creates a new AbstractCommandRegistry.
+     * The command registry is initialized lazily when commands are registered.
+     */
     public AbstractCommandRegistry() {}
 
+    /**
+     * Creates a command description for a help command.
+     * <p>
+     * This method combines the command information with the command description
+     * to create a comprehensive help description for the command.
+     *
+     * @param command the command name
+     * @param info the command information as a list of strings
+     * @param cmdDesc the command description
+     * @return a command description for the help command
+     */
     public CmdDesc doHelpDesc(String command, List<String> info, CmdDesc cmdDesc) {
         List<AttributedString> mainDesc = new ArrayList<>();
         AttributedStringBuilder asb = new AttributedStringBuilder();

--- a/console/src/main/java/org/jline/console/impl/Builtins.java
+++ b/console/src/main/java/org/jline/console/impl/Builtins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -37,11 +37,26 @@ import static org.jline.builtins.SyntaxHighlighter.DEFAULT_NANORC_FILE;
 import static org.jline.builtins.SyntaxHighlighter.TYPE_NANORCTHEME;
 
 /**
- * Builtins: create tab completers, execute and create descriptions for builtins commands.
+ * Implementation of CommandRegistry that provides built-in commands for JLine.
+ * <p>
+ * The Builtins class provides a set of common commands that are useful in any
+ * JLine-based console application, such as:
+ * <ul>
+ *   <li>File editing (nano)</li>
+ *   <li>File viewing (less)</li>
+ *   <li>Command history management</li>
+ *   <li>Widget and keymap configuration</li>
+ *   <li>Terminal and system information display</li>
+ * </ul>
+ * <p>
+ * This class creates tab completers, executes commands, and provides descriptions
+ * for these built-in commands.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public class Builtins extends JlineCommandRegistry implements CommandRegistry {
+    /**
+     * Enumeration of built-in commands provided by this class.
+     */
     public enum Command {
         NANO,
         LESS,

--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -49,7 +49,6 @@ import org.jline.utils.OSUtils;
 /**
  * Manage console variables, commands and script execution.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEngine {
     public enum Command {

--- a/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
+++ b/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2024, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -36,9 +36,21 @@ import static org.jline.builtins.SyntaxHighlighter.DEFAULT_NANORC_FILE;
 import static org.jline.console.ConsoleEngine.VAR_NANORC;
 
 /**
- * Print highlighted objects to console.
+ * Default implementation of the Printer interface that provides syntax highlighting and formatting.
+ * <p>
+ * DefaultPrinter provides functionality for printing various types of objects to the console
+ * with syntax highlighting and formatting. It supports printing:
+ * <ul>
+ *   <li>Simple objects (strings, numbers, etc.)</li>
+ *   <li>Collections and maps</li>
+ *   <li>Tables with row highlighting</li>
+ *   <li>JSON and other structured data</li>
+ *   <li>Source code with syntax highlighting</li>
+ * </ul>
+ * <p>
+ * The printer can be configured with various options to control the formatting and highlighting
+ * of the output, such as maximum number of rows, indentation, and highlighting styles.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public class DefaultPrinter extends JlineCommandRegistry implements Printer {
     protected static final String VAR_PRNT_OPTIONS = "PRNT_OPTIONS";

--- a/console/src/main/java/org/jline/console/impl/JlineCommandRegistry.java
+++ b/console/src/main/java/org/jline/console/impl/JlineCommandRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -28,7 +28,6 @@ import org.jline.utils.Log;
 /**
  * CommandRegistry common methods for JLine commands that are using HelpException.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public abstract class JlineCommandRegistry extends AbstractCommandRegistry {
 

--- a/console/src/main/java/org/jline/console/impl/SystemHighlighter.java
+++ b/console/src/main/java/org/jline/console/impl/SystemHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -30,9 +30,19 @@ import static org.jline.builtins.Styles.NANORC_THEME;
 import static org.jline.builtins.SyntaxHighlighter.REGEX_TOKEN_NAME;
 
 /**
- * Highlight command and language syntax using nanorc highlighter.
+ * Highlighter implementation that provides syntax highlighting for commands and languages.
+ * <p>
+ * SystemHighlighter extends DefaultHighlighter to provide syntax highlighting for:
+ * <ul>
+ *   <li>Command syntax (command names, options, arguments)</li>
+ *   <li>Programming language syntax (for various languages)</li>
+ *   <li>File content based on file extensions</li>
+ * </ul>
+ * <p>
+ * The highlighter uses nanorc syntax definitions for highlighting, making it compatible
+ * with existing nanorc configuration files. It can be customized with different styles
+ * and supports dynamic refreshing of highlighting rules.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public class SystemHighlighter extends DefaultHighlighter {
     private StyleResolver resolver = Styles.lsStyle();

--- a/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
+++ b/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -51,7 +51,6 @@ import static org.jline.keymap.KeyMap.ctrl;
 /**
  * Aggregate command registries.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
  */
 public class SystemRegistryImpl implements SystemRegistry {
 
@@ -1017,7 +1016,7 @@ public class SystemRegistryImpl implements SystemRegistry {
          *            A string optionally containing standard java escape sequences.
          * @return The translated string.
          *
-         * @author Udo Klimaschewski, https://gist.github.com/uklimaschewski/6741769
+         * Based on code by Udo Klimaschewski, https://gist.github.com/uklimaschewski/6741769
          */
         private String unescape(String arg) {
             if (arg == null || !parser.isEscapeChar('\\')) {

--- a/console/src/main/java/org/jline/console/package-info.java
+++ b/console/src/main/java/org/jline/console/package-info.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * JLine Console package provides a framework for building interactive command-line applications.
+ * <p>
+ * This package contains classes and interfaces for:
+ * <ul>
+ *   <li>Command registration and execution</li>
+ *   <li>Command argument parsing and description</li>
+ *   <li>Command output formatting and printing</li>
+ *   <li>Script execution and variable management</li>
+ *   <li>System registry for command execution</li>
+ * </ul>
+ * <p>
+ * Key components include:
+ * <ul>
+ *   <li>{@link org.jline.console.CommandRegistry} - Interface for registering and executing commands</li>
+ *   <li>{@link org.jline.console.ConsoleEngine} - Interface for managing console variables, commands, and script execution</li>
+ *   <li>{@link org.jline.console.SystemRegistry} - Interface for executing commands and managing the console environment</li>
+ *   <li>{@link org.jline.console.Printer} - Interface for printing objects to the console with various formatting options</li>
+ *   <li>{@link org.jline.console.CmdDesc} - Class for describing commands and their arguments</li>
+ *   <li>{@link org.jline.console.ArgDesc} - Class for describing command arguments</li>
+ *   <li>{@link org.jline.console.CmdLine} - Class for representing a parsed command line</li>
+ *   <li>{@link org.jline.console.CommandInput} - Class for encapsulating command input and output streams</li>
+ * </ul>
+ * <p>
+ * The console package is designed to be used with the JLine reader package to create
+ * interactive command-line applications with features like command completion,
+ * command history, and command help.
+ */
+package org.jline.console;

--- a/console/src/main/java/org/jline/widget/AutopairWidgets.java
+++ b/console/src/main/java/org/jline/widget/AutopairWidgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -20,15 +20,22 @@ import org.jline.reader.LineReader;
 import org.jline.reader.Reference;
 
 /**
- * Creates and manages widgets that auto-closes, deletes and skips over matching delimiters intelligently.
- *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
+ * Creates and manages widgets that intelligently handle matching delimiters in the console.
+ * <p>
+ * AutopairWidgets provides functionality for automatically:
+ * <ul>
+ *   <li>Closing matching delimiters (brackets, quotes, etc.) when the opening delimiter is typed</li>
+ *   <li>Deleting matching delimiter pairs when backspace is pressed</li>
+ *   <li>Skipping over closing delimiters when they are typed and already present</li>
+ * </ul>
+ * <p>
+ * This behavior is similar to what many modern code editors provide, making it easier
+ * to work with paired delimiters in the console.
+ * <p>
+ * Inspired by zsh-autopair: https://github.com/hlissner/zsh-autopair
  */
 public class AutopairWidgets extends Widgets {
-    /*
-     *  Inspired by zsh-autopair
-     *  https://github.com/hlissner/zsh-autopair
-     */
+    // Configuration for delimiter pairs and boundary characters
     private static final Map<String, String> LBOUNDS;
     private static final Map<String, String> RBOUNDS;
     private final Map<String, String> pairs;

--- a/console/src/main/java/org/jline/widget/AutosuggestionWidgets.java
+++ b/console/src/main/java/org/jline/widget/AutosuggestionWidgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -14,10 +14,19 @@ import org.jline.reader.LineReader.SuggestionType;
 import org.jline.reader.impl.BufferImpl;
 
 /**
- * Creates and manages widgets for as you type command line suggestions.
- * Suggestions are created using a using command history.
- *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
+ * Creates and manages widgets for as-you-type command line suggestions based on command history.
+ * <p>
+ * AutosuggestionWidgets provides functionality for displaying and accepting suggestions
+ * as the user types in the console. These suggestions are derived from the command history,
+ * making it easier to repeat or modify previously entered commands.
+ * <p>
+ * The widgets support:
+ * <ul>
+ *   <li>Displaying suggestions as you type</li>
+ *   <li>Accepting the entire suggestion</li>
+ *   <li>Accepting part of a suggestion (word by word)</li>
+ *   <li>Toggling suggestion functionality on and off</li>
+ * </ul>
  */
 public class AutosuggestionWidgets extends Widgets {
     private boolean enabled = false;

--- a/console/src/main/java/org/jline/widget/TailTipWidgets.java
+++ b/console/src/main/java/org/jline/widget/TailTipWidgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -30,24 +30,37 @@ import org.jline.utils.*;
 import static org.jline.keymap.KeyMap.key;
 
 /**
- * Creates and manages widgets for as you type command line suggestions.
- * Suggestions are created using a command completer data and/or positional argument descriptions.
- *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
+ * Creates and manages widgets for as-you-type command line suggestions.
+ * <p>
+ * TailTipWidgets provides real-time command line suggestions as the user types,
+ * based on command completer data and/or positional argument descriptions. These
+ * suggestions are displayed in the terminal's status bar, helping users understand
+ * the available options and arguments for commands.
+ * <p>
+ * The widgets can be configured to use different suggestion types and display styles,
+ * and can be bound to key sequences for manual invocation.
  */
 public class TailTipWidgets extends Widgets {
+    /**
+     * Enumeration specifying the type of suggestions to display.
+     */
     public enum TipType {
         /**
-         * Prepare command line suggestions using a command positional argument descriptions.
+         * Prepare command line suggestions using a command's positional argument descriptions.
+         * This type focuses on showing information about the expected arguments at the current position.
          */
         TAIL_TIP,
+
         /**
-         * Prepare command line suggestions using a command completer data.
+         * Prepare command line suggestions using a command's completer data.
+         * This type focuses on showing possible completions based on the current input.
          */
         COMPLETER,
+
         /**
-         * Prepare command line suggestions using either a command positional argument descriptions if exists
-         * or command completers data.
+         * Prepare command line suggestions using either a command's positional argument descriptions if they exist,
+         * or command completer data if no argument descriptions are available.
+         * This type provides the most comprehensive suggestions by combining both approaches.
          */
         COMBINED
     }
@@ -61,52 +74,63 @@ public class TailTipWidgets extends Widgets {
     private Object readerErrors;
 
     /**
-     * Creates tailtip widgets used in command line suggestions. Suggestions are created using a command
-     * positional argument names. If argument descriptions do not exists command completer data will be used.
-     * Status bar for argument descriptions will not be created.
+     * Creates tailtip widgets used in command line suggestions.
+     * <p>
+     * This constructor creates widgets that use both positional argument descriptions and completer data
+     * for suggestions (TipType.COMBINED). If argument descriptions don't exist, command completer data
+     * will be used. No status bar for argument descriptions will be created (descriptionSize = 0).
      *
-     * @param reader      LineReader.
-     * @param tailTips    Commands options and positional argument descriptions.
-     * @throws IllegalStateException     If widgets are already created.
+     * @param reader    the LineReader instance to associate with these widgets
+     * @param tailTips  a map of command names to their descriptions, containing options and positional argument information
+     * @throws IllegalStateException if widgets are already created for the LineReader
      */
     public TailTipWidgets(LineReader reader, Map<String, CmdDesc> tailTips) {
         this(reader, tailTips, 0, TipType.COMBINED);
     }
 
     /**
-     * Creates tailtip widgets used in command line suggestions.
-     * Status bar for argument descriptions will not be created.
+     * Creates tailtip widgets used in command line suggestions with a specific tip type.
+     * <p>
+     * This constructor allows specifying which data source to use for suggestions (positional argument
+     * descriptions, completer data, or both). No status bar for argument descriptions will be created
+     * (descriptionSize = 0).
      *
-     * @param reader      LineReader.
-     * @param tailTips    Commands options and positional argument descriptions.
-     * @param tipType     Defines which data will be used for suggestions.
-     * @throws IllegalStateException     If widgets are already created.
+     * @param reader    the LineReader instance to associate with these widgets
+     * @param tailTips  a map of command names to their descriptions, containing options and positional argument information
+     * @param tipType   defines which data will be used for suggestions (TAIL_TIP, COMPLETER, or COMBINED)
+     * @throws IllegalStateException if widgets are already created for the LineReader
      */
     public TailTipWidgets(LineReader reader, Map<String, CmdDesc> tailTips, TipType tipType) {
         this(reader, tailTips, 0, tipType);
     }
 
     /**
-     * Creates tailtip widgets used in command line suggestions. Suggestions are created using a command
-     * positional argument names. If argument descriptions do not exists command completer data will be used.
+     * Creates tailtip widgets used in command line suggestions with a status bar.
+     * <p>
+     * This constructor creates widgets that use both positional argument descriptions and completer data
+     * for suggestions (TipType.COMBINED). If argument descriptions don't exist, command completer data
+     * will be used. A status bar for argument descriptions will be created with the specified size.
      *
-     * @param reader           LineReader.
-     * @param tailTips         Commands options and positional argument descriptions.
-     * @param descriptionSize  Size of the status bar.
-     * @throws IllegalStateException     If widgets are already created.
+     * @param reader           the LineReader instance to associate with these widgets
+     * @param tailTips         a map of command names to their descriptions, containing options and positional argument information
+     * @param descriptionSize  the size of the status bar for displaying argument descriptions (0 for no status bar)
+     * @throws IllegalStateException if widgets are already created for the LineReader
      */
     public TailTipWidgets(LineReader reader, Map<String, CmdDesc> tailTips, int descriptionSize) {
         this(reader, tailTips, descriptionSize, TipType.COMBINED);
     }
 
     /**
-     * Creates tailtip widgets used in command line suggestions.
+     * Creates tailtip widgets used in command line suggestions with a status bar and specific tip type.
+     * <p>
+     * This constructor allows full customization of the widgets, specifying both the status bar size
+     * and which data source to use for suggestions (positional argument descriptions, completer data, or both).
      *
-     * @param reader           LineReader.
-     * @param tailTips         Commands options and  positional argument descriptions.
-     * @param descriptionSize  Size of the status bar.
-     * @param tipType          Defines which data will be used for suggestions.
-     * @throws IllegalStateException     If widgets are already created.
+     * @param reader           the LineReader instance to associate with these widgets
+     * @param tailTips         a map of command names to their descriptions, containing options and positional argument information
+     * @param descriptionSize  the size of the status bar for displaying argument descriptions (0 for no status bar)
+     * @param tipType          defines which data will be used for suggestions (TAIL_TIP, COMPLETER, or COMBINED)
+     * @throws IllegalStateException if widgets are already created for the LineReader
      */
     public TailTipWidgets(LineReader reader, Map<String, CmdDesc> tailTips, int descriptionSize, TipType tipType) {
         this(reader, tailTips, descriptionSize, tipType, null);

--- a/console/src/main/java/org/jline/widget/Widgets.java
+++ b/console/src/main/java/org/jline/widget/Widgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -29,9 +29,12 @@ import static org.jline.keymap.KeyMap.alt;
 import static org.jline.keymap.KeyMap.ctrl;
 
 /**
- * Create custom widgets by extending Widgets class
+ * Base class for creating custom widgets for JLine's LineReader.
  *
- * @author <a href="mailto:matti.rintanikkola@gmail.com">Matti Rinta-Nikkola</a>
+ * This abstract class provides methods for creating, managing, and interacting with
+ * widgets in JLine. Widgets are reusable components that can be bound to key sequences
+ * and provide specific functionality when invoked. Custom widget implementations should
+ * extend this class to leverage its utility methods for widget management.
  */
 public abstract class Widgets {
     public static final String TAILTIP_TOGGLE = "tailtip-toggle";
@@ -42,8 +45,14 @@ public abstract class Widgets {
     protected static final String AP_BACKWARD_DELETE_CHAR = "_autopair-backward-delete-char";
     protected static final String TT_ACCEPT_LINE = "_tailtip-accept-line";
 
+    /** The LineReader instance associated with these widgets */
     protected final LineReader reader;
 
+    /**
+     * Creates a new Widgets instance for the specified LineReader.
+     *
+     * @param reader the LineReader to associate with these widgets
+     */
     public Widgets(LineReader reader) {
         this.reader = reader;
     }
@@ -57,6 +66,14 @@ public abstract class Widgets {
         reader.getWidgets().put(name, namedWidget(name, widget));
     }
 
+    /**
+     * Creates a named widget that delegates to the specified widget.
+     * This is used internally to create widgets with specific names.
+     *
+     * @param name the name of the widget
+     * @param widget the widget to delegate to
+     * @return a new widget that delegates to the specified widget and has the specified name
+     */
     private Widget namedWidget(final String name, final Widget widget) {
         return new Widget() {
             @Override
@@ -130,6 +147,14 @@ public abstract class Widgets {
         return false;
     }
 
+    /**
+     * Resolves a widget name to the corresponding widget.
+     * If the name starts with a dot, it is treated as a builtin widget name.
+     *
+     * @param name the name of the widget to resolve
+     * @return the resolved widget
+     * @throws InvalidParameterException if no widget with the specified name exists
+     */
     private Widget widget(String name) {
         Widget out;
         if (name.startsWith(".")) {

--- a/console/src/main/java/org/jline/widget/package-info.java
+++ b/console/src/main/java/org/jline/widget/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * JLine Widget package provides a framework for creating and managing widgets for JLine's LineReader.
+ * <p>
+ * This package contains classes for:
+ * <ul>
+ *   <li>Creating custom widgets that can be bound to key sequences</li>
+ *   <li>Managing widget state and behavior</li>
+ *   <li>Interacting with the LineReader's buffer and terminal</li>
+ *   <li>Implementing specialized widgets for auto-completion, auto-suggestion, and more</li>
+ * </ul>
+ * <p>
+ * Key components include:
+ * <ul>
+ *   <li>{@link org.jline.widget.Widgets} - Base class for creating custom widgets</li>
+ *   <li>{@link org.jline.widget.AutopairWidgets} - Widgets for auto-pairing brackets and quotes</li>
+ *   <li>{@link org.jline.widget.AutosuggestionWidgets} - Widgets for auto-suggestion functionality</li>
+ *   <li>{@link org.jline.widget.TailTipWidgets} - Widgets for displaying command hints in the terminal</li>
+ * </ul>
+ * <p>
+ * Widgets are reusable components that can be bound to key sequences and provide specific
+ * functionality when invoked. They can be used to enhance the functionality of the LineReader
+ * with features like auto-completion, auto-suggestion, and command hints.
+ */
+package org.jline.widget;


### PR DESCRIPTION
This PR improves the Javadoc documentation in the console module:

- Add comprehensive class and method documentation
- Add package-level documentation for org.jline.console and org.jline.widget packages
- Remove @author tags
- Update copyright years to 2025
- Add cross-references between related methods using @link tags
- Improve formatting with HTML tags like `<p>`, `<ul>`, and `<li>`
- Add detailed documentation for inner classes and enums

These improvements make the JLine console package more accessible to developers, making it easier to understand and use the various components of the package.