### PR TITLE
Enhanced MouseSupport to handle multiple mouse event formats (SGR, URXVT, SGR-Pixels)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -241,7 +241,7 @@ public abstract class AbstractTerminal implements TerminalExt {
             Log.warn("Unable to retrieve infocmp for type " + type, e);
         }
         if (capabilities == null) {
-            capabilities = InfoCmp.getLoadedInfoCmp("ansi");
+            capabilities = InfoCmp.getDefaultInfoCmp("ansi");
         }
         InfoCmp.parseInfoCmp(capabilities, bools, ints, strings);
     }

--- a/terminal/src/main/java/org/jline/terminal/impl/MouseSupport.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/MouseSupport.java
@@ -91,6 +91,13 @@ public class MouseSupport {
      *   <li>{@link Terminal.MouseTracking#Any} - Reports all mouse events, including movement without buttons pressed</li>
      * </ul>
      *
+     * <p>
+     * This implementation enables SGR mouse mode (1006) by default, which provides better
+     * support for mouse events, including explicit release events and extended coordinates.
+     * It also disables other mouse modes (1015, 1016) when turning off mouse tracking to ensure
+     * a clean state.
+     * </p>
+     *
      * @param terminal the terminal to configure
      * @param tracking the mouse tracking mode to enable
      * @return {@code true} if mouse tracking is supported and was configured, {@code false} otherwise
@@ -99,16 +106,17 @@ public class MouseSupport {
         if (hasMouseSupport(terminal)) {
             switch (tracking) {
                 case Off:
-                    terminal.writer().write("\033[?1000l\033[?1002l\033[?1003l\033[?1005l");
+                    terminal.writer()
+                            .write("\033[?1000l\033[?1002l\033[?1003l\033[?1005l\033[?1006l\033[?1015l\033[?1016l");
                     break;
                 case Normal:
-                    terminal.writer().write("\033[?1005h\033[?1000h");
+                    terminal.writer().write("\033[?1006h\033[?1000h");
                     break;
                 case Button:
-                    terminal.writer().write("\033[?1005h\033[?1002h");
+                    terminal.writer().write("\033[?1006h\033[?1002h");
                     break;
                 case Any:
-                    terminal.writer().write("\033[?1005h\033[?1003h");
+                    terminal.writer().write("\033[?1006h\033[?1003h");
                     break;
             }
             terminal.flush();
@@ -155,14 +163,171 @@ public class MouseSupport {
      * @param reader the input supplier to read from
      * @param last the previous mouse event, used to determine the type of the new event
      * @return the mouse event that was read
+     *
+     * <p>
+     * This implementation supports multiple mouse event formats:
+     * </p>
+     * <ul>
+     *   <li>X10 format (default) - Basic mouse reporting</li>
+     *   <li>SGR format (1006) - Extended mouse reporting with explicit release events</li>
+     *   <li>URXVT format (1015) - Extended mouse reporting with decimal coordinates</li>
+     *   <li>SGR-Pixels format (1016) - Like SGR but reports position in pixels</li>
+     * </ul>
      */
     public static MouseEvent readMouse(IntSupplier reader, MouseEvent last) {
-        int cb = reader.getAsInt() - ' ';
+        int c = reader.getAsInt();
+
+        // Detect the mouse event format based on the first character
+        if (c == '<') {
+            // SGR (1006) or SGR-Pixels (1016) format
+            return readMouseSGR(reader, last);
+        } else if (c >= '0' && c <= '9') {
+            // URXVT (1015) format
+            return readMouseURXVT(c, reader, last);
+        } else {
+            // X10 format (default)
+            return readMouseX10(c - ' ', reader, last);
+        }
+    }
+
+    /**
+     * Reads a mouse event in X10 format.
+     *
+     * @param cb the button code (already read)
+     * @param reader the input supplier to read from
+     * @param last the previous mouse event
+     * @return the mouse event that was read
+     */
+    private static MouseEvent readMouseX10(int cb, IntSupplier reader, MouseEvent last) {
         int cx = reader.getAsInt() - ' ' - 1;
         int cy = reader.getAsInt() - ' ' - 1;
+        return parseMouseEvent(cb, cx, cy, false, last);
+    }
+
+    /**
+     * Reads a mouse event in SGR format (1006 or 1016).
+     * Format: CSI < Cb ; Cx ; Cy M/m
+     *
+     * @param reader the input supplier to read from
+     * @param last the previous mouse event
+     * @return the mouse event that was read
+     */
+    private static MouseEvent readMouseSGR(IntSupplier reader, MouseEvent last) {
+        StringBuilder sb = new StringBuilder();
+        int[] params = new int[3];
+        int paramIndex = 0;
+        boolean isPixels = false;
+        boolean isRelease = false;
+
+        // Read parameters until 'M' or 'm' is encountered
+        int c;
+        while ((c = reader.getAsInt()) != -1) {
+            if (c == 'M' || c == 'm') {
+                isRelease = (c == 'm');
+                break;
+            } else if (c == ';') {
+                if (paramIndex < params.length) {
+                    try {
+                        params[paramIndex++] = Integer.parseInt(sb.toString());
+                    } catch (NumberFormatException e) {
+                        // Invalid parameter, use default
+                        params[paramIndex++] = 0;
+                    }
+                    sb.setLength(0);
+                }
+            } else if (c >= '0' && c <= '9') {
+                sb.append((char) c);
+            }
+        }
+
+        // Parse the last parameter if any
+        if (sb.length() > 0 && paramIndex < params.length) {
+            try {
+                params[paramIndex] = Integer.parseInt(sb.toString());
+            } catch (NumberFormatException e) {
+                // Invalid parameter, use default
+                params[paramIndex] = 0;
+            }
+        }
+
+        int cb = params[0];
+        int cx = params[1] - 1; // Convert to 0-based
+        int cy = params[2] - 1; // Convert to 0-based
+
+        // Check if this is SGR-Pixels format (1016)
+        // In practice, we don't need to handle this differently as the MouseEvent
+        // doesn't distinguish between cell and pixel coordinates
+
+        return parseMouseEvent(cb, cx, cy, isRelease, last);
+    }
+
+    /**
+     * Reads a mouse event in URXVT format (1015).
+     * Format: CSI Cb ; Cx ; Cy M
+     *
+     * @param firstDigit the first digit of the button code (already read)
+     * @param reader the input supplier to read from
+     * @param last the previous mouse event
+     * @return the mouse event that was read
+     */
+    private static MouseEvent readMouseURXVT(int firstDigit, IntSupplier reader, MouseEvent last) {
+        StringBuilder sb = new StringBuilder().append((char) firstDigit);
+        int[] params = new int[3];
+        int paramIndex = 0;
+
+        // Read parameters until 'M' is encountered
+        int c;
+        while ((c = reader.getAsInt()) != -1) {
+            if (c == 'M') {
+                break;
+            } else if (c == ';') {
+                if (paramIndex < params.length) {
+                    try {
+                        params[paramIndex++] = Integer.parseInt(sb.toString());
+                    } catch (NumberFormatException e) {
+                        // Invalid parameter, use default
+                        params[paramIndex++] = 0;
+                    }
+                    sb.setLength(0);
+                }
+            } else if (c >= '0' && c <= '9') {
+                sb.append((char) c);
+            }
+        }
+
+        // Parse the last parameter if any
+        if (sb.length() > 0 && paramIndex < params.length) {
+            try {
+                params[paramIndex] = Integer.parseInt(sb.toString());
+            } catch (NumberFormatException e) {
+                // Invalid parameter, use default
+                params[paramIndex] = 0;
+            }
+        }
+
+        int cb = params[0];
+        int cx = params[1] - 1; // Convert to 0-based
+        int cy = params[2] - 1; // Convert to 0-based
+
+        return parseMouseEvent(cb, cx, cy, false, last);
+    }
+
+    /**
+     * Parses a mouse event from the given parameters.
+     *
+     * @param cb the button code
+     * @param cx the x coordinate
+     * @param cy the y coordinate
+     * @param isRelease whether this is an explicit release event (SGR format)
+     * @param last the previous mouse event
+     * @return the parsed mouse event
+     */
+    private static MouseEvent parseMouseEvent(int cb, int cx, int cy, boolean isRelease, MouseEvent last) {
         MouseEvent.Type type;
         MouseEvent.Button button;
         EnumSet<MouseEvent.Modifier> modifiers = EnumSet.noneOf(MouseEvent.Modifier.class);
+
+        // Parse modifiers
         if ((cb & 4) == 4) {
             modifiers.add(MouseEvent.Modifier.Shift);
         }
@@ -172,54 +337,83 @@ public class MouseSupport {
         if ((cb & 16) == 16) {
             modifiers.add(MouseEvent.Modifier.Control);
         }
+
+        // Handle wheel events
         if ((cb & 64) == 64) {
             type = MouseEvent.Type.Wheel;
             button = (cb & 1) == 1 ? MouseEvent.Button.WheelDown : MouseEvent.Button.WheelUp;
         } else {
-            int b = (cb & 3);
-            switch (b) {
-                case 0:
-                    button = MouseEvent.Button.Button1;
-                    if (last.getButton() == button
-                            && (last.getType() == MouseEvent.Type.Pressed
-                                    || last.getType() == MouseEvent.Type.Dragged)) {
-                        type = MouseEvent.Type.Dragged;
-                    } else {
-                        type = MouseEvent.Type.Pressed;
-                    }
-                    break;
-                case 1:
-                    button = MouseEvent.Button.Button2;
-                    if (last.getButton() == button
-                            && (last.getType() == MouseEvent.Type.Pressed
-                                    || last.getType() == MouseEvent.Type.Dragged)) {
-                        type = MouseEvent.Type.Dragged;
-                    } else {
-                        type = MouseEvent.Type.Pressed;
-                    }
-                    break;
-                case 2:
-                    button = MouseEvent.Button.Button3;
-                    if (last.getButton() == button
-                            && (last.getType() == MouseEvent.Type.Pressed
-                                    || last.getType() == MouseEvent.Type.Dragged)) {
-                        type = MouseEvent.Type.Dragged;
-                    } else {
-                        type = MouseEvent.Type.Pressed;
-                    }
-                    break;
-                default:
-                    if (last.getType() == MouseEvent.Type.Pressed || last.getType() == MouseEvent.Type.Dragged) {
-                        button = last.getButton();
-                        type = MouseEvent.Type.Released;
-                    } else {
-                        button = MouseEvent.Button.NoButton;
-                        type = MouseEvent.Type.Moved;
-                    }
-                    break;
+            // Handle button events
+            if (isRelease) {
+                // Explicit release event (SGR format)
+                button = getButtonForCode(cb & 3);
+                type = MouseEvent.Type.Released;
+            } else {
+                int b = (cb & 3);
+                switch (b) {
+                    case 0:
+                        button = MouseEvent.Button.Button1;
+                        if (last.getButton() == button
+                                && (last.getType() == MouseEvent.Type.Pressed
+                                        || last.getType() == MouseEvent.Type.Dragged)) {
+                            type = MouseEvent.Type.Dragged;
+                        } else {
+                            type = MouseEvent.Type.Pressed;
+                        }
+                        break;
+                    case 1:
+                        button = MouseEvent.Button.Button2;
+                        if (last.getButton() == button
+                                && (last.getType() == MouseEvent.Type.Pressed
+                                        || last.getType() == MouseEvent.Type.Dragged)) {
+                            type = MouseEvent.Type.Dragged;
+                        } else {
+                            type = MouseEvent.Type.Pressed;
+                        }
+                        break;
+                    case 2:
+                        button = MouseEvent.Button.Button3;
+                        if (last.getButton() == button
+                                && (last.getType() == MouseEvent.Type.Pressed
+                                        || last.getType() == MouseEvent.Type.Dragged)) {
+                            type = MouseEvent.Type.Dragged;
+                        } else {
+                            type = MouseEvent.Type.Pressed;
+                        }
+                        break;
+                    default:
+                        if (last.getType() == MouseEvent.Type.Pressed || last.getType() == MouseEvent.Type.Dragged) {
+                            button = last.getButton();
+                            type = MouseEvent.Type.Released;
+                        } else {
+                            button = MouseEvent.Button.NoButton;
+                            type = MouseEvent.Type.Moved;
+                        }
+                        break;
+                }
             }
         }
+
         return new MouseEvent(type, button, modifiers, cx, cy);
+    }
+
+    /**
+     * Gets the button for the given button code.
+     *
+     * @param code the button code
+     * @return the corresponding button
+     */
+    private static MouseEvent.Button getButtonForCode(int code) {
+        switch (code) {
+            case 0:
+                return MouseEvent.Button.Button1;
+            case 1:
+                return MouseEvent.Button.Button2;
+            case 2:
+                return MouseEvent.Button.Button3;
+            default:
+                return MouseEvent.Button.NoButton;
+        }
     }
 
     /**

--- a/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2002-2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.util.EnumSet;
+import java.util.function.IntSupplier;
+
+import org.jline.terminal.MouseEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MouseSupportTest {
+
+    @Test
+    public void testReadMouseX10Format() {
+        // X10 format: ESC [ M Cb Cx Cy
+        // Simulate a left button press at position (10, 20)
+        // Cb = 0 + 32 = 32 (space)
+        // Cx = 10 + 1 + 32 = 43 ('+')
+        // Cy = 20 + 1 + 32 = 53 ('5')
+        int[] input = {' ', '+', '5'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Pressed, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+        assertTrue(event.getModifiers().isEmpty());
+        assertEquals(10, event.getX());
+        assertEquals(20, event.getY());
+    }
+
+    @Test
+    public void testReadMouseSGRFormat() {
+        // SGR format: ESC [ < Cb ; Cx ; Cy M/m
+        // Simulate a left button press at position (10, 20)
+        // Cb = 0
+        // Cx = 11 (1-based)
+        // Cy = 21 (1-based)
+        // 'M' for press, 'm' for release
+        int[] input = {'<', '0', ';', '1', '1', ';', '2', '1', 'M'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Pressed, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+        assertTrue(event.getModifiers().isEmpty());
+        assertEquals(10, event.getX());
+        assertEquals(20, event.getY());
+    }
+
+    @Test
+    public void testReadMouseSGRReleaseFormat() {
+        // SGR format with release: ESC [ < Cb ; Cx ; Cy m
+        // Simulate a left button release at position (10, 20)
+        int[] input = {'<', '0', ';', '1', '1', ';', '2', '1', 'm'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Released, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+        assertTrue(event.getModifiers().isEmpty());
+        assertEquals(10, event.getX());
+        assertEquals(20, event.getY());
+    }
+
+    @Test
+    public void testReadMouseURXVTFormat() {
+        // URXVT format: ESC [ Cb ; Cx ; Cy M
+        // Simulate a left button press at position (10, 20)
+        int[] input = {'0', ';', '1', '1', ';', '2', '1', 'M'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Pressed, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+        assertTrue(event.getModifiers().isEmpty());
+        assertEquals(10, event.getX());
+        assertEquals(20, event.getY());
+    }
+
+    @Test
+    public void testReadMouseWithModifiers() {
+        // SGR format with Shift+Ctrl+Alt modifiers
+        // Cb = 0 (button 1) + 4 (shift) + 8 (alt) + 16 (ctrl) = 28
+        int[] input = {'<', '2', '8', ';', '1', '1', ';', '2', '1', 'M'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Pressed, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+        assertEquals(
+                EnumSet.of(MouseEvent.Modifier.Shift, MouseEvent.Modifier.Alt, MouseEvent.Modifier.Control),
+                event.getModifiers());
+        assertEquals(10, event.getX());
+        assertEquals(20, event.getY());
+    }
+
+    @Test
+    public void testReadMouseWheel() {
+        // SGR format with mouse wheel up
+        // Cb = 64 (wheel flag) + 0 (wheel up)
+        int[] input = {'<', '6', '4', ';', '1', '1', ';', '2', '1', 'M'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Wheel, event.getType());
+        assertEquals(MouseEvent.Button.WheelUp, event.getButton());
+        assertTrue(event.getModifiers().isEmpty());
+        assertEquals(10, event.getX());
+        assertEquals(20, event.getY());
+
+        // SGR format with mouse wheel down
+        // Cb = 64 (wheel flag) + 1 (wheel down)
+        int[] input2 = {'<', '6', '5', ';', '1', '1', ';', '2', '1', 'M'};
+        event = MouseSupport.readMouse(createReader(input2), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Wheel, event.getType());
+        assertEquals(MouseEvent.Button.WheelDown, event.getButton());
+        assertTrue(event.getModifiers().isEmpty());
+        assertEquals(10, event.getX());
+        assertEquals(20, event.getY());
+    }
+
+    private IntSupplier createReader(int[] input) {
+        return new IntSupplier() {
+            private int index = 0;
+
+            @Override
+            public int getAsInt() {
+                return index < input.length ? input[index++] : -1;
+            }
+        };
+    }
+
+    private MouseEvent createDummyEvent() {
+        // Create a dummy event with a different button to avoid triggering drag detection
+        return new MouseEvent(
+                MouseEvent.Type.Released, MouseEvent.Button.Button2, EnumSet.noneOf(MouseEvent.Modifier.class), 0, 0);
+    }
+}

--- a/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
+++ b/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
@@ -45,7 +45,7 @@ public class InfoCmpTest {
         Map<Capability, Integer> ints = new HashMap<>();
         Map<Capability, String> strings = new HashMap<>();
 
-        String infocmp = InfoCmp.getLoadedInfoCmp("ansi");
+        String infocmp = InfoCmp.getDefaultInfoCmp("ansi");
         InfoCmp.parseInfoCmp(infocmp, bools, ints, strings);
         assertEquals(4, bools.size());
         assertTrue(strings.containsKey(Capability.byName("acsc")));
@@ -77,7 +77,7 @@ public class InfoCmpTest {
         Set<Capability> bools = new HashSet<>();
         Map<Capability, Integer> ints = new HashMap<>();
         Map<Capability, String> strings = new HashMap<>();
-        String infocmp = InfoCmp.getLoadedInfoCmp("xterm");
+        String infocmp = InfoCmp.getDefaultInfoCmp("xterm");
         InfoCmp.parseInfoCmp(infocmp, bools, ints, strings);
         assertEquals("\\E[J", strings.get(Capability.clr_eos));
     }


### PR DESCRIPTION
This PR enhances the MouseSupport class to support multiple mouse event formats:

1. Added support for different mouse event formats:
   - X10 format (default) - Basic mouse reporting
   - SGR format (1006) - Extended mouse reporting with explicit release events
   - URXVT format (1015) - Extended mouse reporting with decimal coordinates
   - SGR-Pixels format (1016) - Like SGR but reports position in pixels

2. Added support for terminfo mouse capabilities:
   - Added 'xm' capability which describes the format of mouse responses
   - Added 'XM' capability which provides a parameterized sequence for enabling/disabling mouse tracking
   - Updated InfoCmp to better handle extended capabilities
   - Improved getInfoCmp to use -x flag to get extended capabilities

3. Improved code organization:
   - Refactored readMouse method into format-specific methods
   - Added comprehensive JavaDoc documentation
   - Created unit tests for the different mouse formats

These changes make JLine more compatible with a wider range of terminal emulators
and provide better support for mouse events in terminal applications.