### PR TITLE
Add getCurrentMouseTracking to Terminal interface

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1067,7 +1067,16 @@ public interface Terminal extends Closeable, Flushable {
     boolean trackMouse(MouseTracking tracking);
 
     /**
-     * Reads and decodes a mouse event from the terminal input stream.
+     * Returns the current mouse tracking mode.
+     *
+     * @see #trackMouse(MouseTracking)
+     */
+    MouseTracking getCurrentMouseTracking();
+
+    /**
+     * Read a MouseEvent from the terminal input stream.
+     * Such an event must have been detected by scanning the terminal's {@link Capability#key_mouse}
+     * in the stream immediately before reading the event.
      *
      * <p>
      * This method should be called after detecting the terminal's {@link Capability#key_mouse}

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -79,6 +79,7 @@ public abstract class AbstractTerminal implements TerminalExt {
     protected final ColorPalette palette;
     protected Status status;
     protected Runnable onClose;
+    protected MouseTracking currentMouseTracking = MouseTracking.Off;
 
     public AbstractTerminal(String name, String type) throws IOException {
         this(name, type, null, SignalHandler.SIG_DFL);
@@ -260,8 +261,18 @@ public abstract class AbstractTerminal implements TerminalExt {
     }
 
     @Override
+    public MouseTracking getCurrentMouseTracking() {
+        return currentMouseTracking;
+    }
+
+    @Override
     public boolean trackMouse(MouseTracking tracking) {
-        return MouseSupport.trackMouse(this, tracking);
+        if (MouseSupport.trackMouse(this, tracking)) {
+            currentMouseTracking = tracking;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR adds a new method to the Terminal interface to retrieve the current mouse tracking mode.

## Changes
- Added getCurrentMouseTracking() method to Terminal interface
- Added currentMouseTracking field to AbstractTerminal to track the state
- Updated trackMouse() implementation to maintain the current state
- Improved JavaDoc for mouse-related methods

This change allows clients to query the current mouse tracking mode, which is useful for toggling mouse tracking or restoring the previous state.