### PR TITLE
Fix: Properly fill screen lines with spaces when width is increased in ScreenTerminal

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -1634,10 +1634,20 @@ public class ScreenTerminal {
         // Set width
         for (int i = 0; i < height; i++) {
             if (screen[i].length < w) {
+                int oldLength = screen[i].length;
                 screen[i] = Arrays.copyOf(screen[i], w);
+                // Fill the rest with spaces
+                for (int j = oldLength; j < w; j++) {
+                    screen[i][j] = attr | 0x00000020;
+                }
             }
             if (screen2[i].length < w) {
+                int oldLength = screen2[i].length;
                 screen2[i] = Arrays.copyOf(screen2[i], w);
+                // Fill the rest with spaces
+                for (int j = oldLength; j < w; j++) {
+                    screen2[i][j] = attr | 0x00000020;
+                }
             }
         }
         if (cx >= w) {

--- a/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2024, the original author(s).
+ * Copyright (c) 2002-2025, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -54,5 +54,45 @@ public class ScreenTerminalTest {
         // We can verify this by dumping the terminal content
         String dump = terminal.dump(0, true);
         assertNotNull(dump);
+    }
+
+    /**
+     * Test for issue #1231: Missing space-filling in ScreenTerminal
+     * This test verifies that when the terminal width is increased, screen lines are properly
+     * filled with spaces rather than null characters.
+     */
+    @Test
+    public void testScreenLinesSpaceFillingOnWidthIncrease() throws InterruptedException {
+        // Create a terminal with initial size
+        int initialWidth = 80;
+        int initialHeight = 24;
+        ScreenTerminal terminal = new ScreenTerminal(initialWidth, initialHeight);
+
+        // Fill the terminal with some content
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < initialWidth; i++) {
+            sb.append('X');
+        }
+        String line = sb.toString();
+
+        // Write content to fill the screen
+        for (int i = 0; i < initialHeight; i++) {
+            terminal.write(line + "\n");
+        }
+
+        // Increase the width
+        int newWidth = 100;
+        terminal.setSize(newWidth, initialHeight);
+
+        // Dump the terminal content
+        String dump = terminal.dump(0, true);
+        assertNotNull(dump);
+
+        // Verify the content doesn't contain null characters
+        // The dump method converts the screen to HTML, so we'll use toString() instead
+        String content = terminal.toString();
+        for (int i = 0; i < content.length(); i++) {
+            assertNotEquals('\0', content.charAt(i), "Found null character at position " + i);
+        }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes issue #1231 where screen lines were not properly filled with spaces when the terminal width was increased in `ScreenTerminal.setSize()`.

### Problem

When increasing the width of the terminal in `ScreenTerminal.setSize()`, screen lines were extended using `Arrays.copyOf()` without filling the new space with spaces. This caused rendering issues as the new elements were initialized with null characters (0's), which have no width.

In contrast, history lines were properly handled by filling the extended space with spaces (attr | 0x00000020).

### Solution

This fix ensures that when the terminal width is increased, all screen lines are properly filled with spaces (attr | 0x00000020), similar to how history lines are handled.

The changes include:
1. Modifying the `setSize` method to fill the extended screen lines with spaces
2. Adding a new test method `testScreenLinesSpaceFillingOnWidthIncrease()` to verify the fix works correctly
3. Updating the copyright year in the test file to 2025

### Testing

Added a specific test that verifies no null characters are present in the terminal content after increasing the width. All tests pass successfully.

Fixes #1231
