### PR TITLE
docs: add syntax highlighting example classes for documentation

### DIFF
--- a/demo/src/main/java/org/jline/demo/examples/BasicHighlighterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/BasicHighlighterExample.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+
+import org.jline.reader.Highlighter;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating a basic highlighter that colors all text blue.
+ */
+public class BasicHighlighterExample {
+
+    // SNIPPET_START: BasicHighlighterExample
+    public static void main(String[] args) throws IOException {
+        // Create a simple highlighter that colors all text blue
+        Highlighter blueHighlighter = new Highlighter() {
+            @Override
+            public AttributedString highlight(LineReader reader, String buffer) {
+                // Apply blue color to the entire buffer
+                return new AttributedString(buffer, AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE));
+            }
+        };
+
+        // Create a terminal and reader with our highlighter
+        Terminal terminal = TerminalBuilder.builder().build();
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .highlighter(blueHighlighter)
+                .build();
+
+        // Read input with blue highlighting
+        String line = reader.readLine("prompt> ");
+        terminal.writer().println("You entered: " + line);
+
+        terminal.close();
+    }
+    // SNIPPET_END: BasicHighlighterExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/ErrorHighlightingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ErrorHighlightingExample.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+import java.util.Stack;
+
+import org.jline.reader.Highlighter;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating a highlighter that checks for balanced parentheses.
+ */
+public class ErrorHighlightingExample {
+
+    // SNIPPET_START: ErrorHighlightingExample
+    public static void main(String[] args) throws IOException {
+        // Create a highlighter that checks for balanced parentheses
+        Highlighter parenthesesHighlighter = new Highlighter() {
+            @Override
+            public AttributedString highlight(LineReader reader, String buffer) {
+                AttributedStringBuilder builder = new AttributedStringBuilder();
+
+                // Check for balanced parentheses
+                Stack<Integer> stack = new Stack<>();
+                boolean hasError = false;
+
+                for (int i = 0; i < buffer.length(); i++) {
+                    char c = buffer.charAt(i);
+
+                    if (c == '(') {
+                        // Push the position of the opening parenthesis
+                        stack.push(i);
+                    } else if (c == ')') {
+                        if (stack.isEmpty()) {
+                            // Unmatched closing parenthesis - highlight it as an error
+                            hasError = true;
+
+                            // Add text before the error
+                            if (i > 0) {
+                                builder.append(buffer.substring(0, i));
+                            }
+
+                            // Add the error character with red background
+                            builder.styled(
+                                    AttributedStyle.DEFAULT
+                                            .foreground(AttributedStyle.WHITE)
+                                            .background(AttributedStyle.RED),
+                                    String.valueOf(c));
+
+                            // Add text after the error
+                            if (i < buffer.length() - 1) {
+                                builder.append(buffer.substring(i + 1));
+                            }
+
+                            break;
+                        }
+
+                        // Matched parenthesis - pop from stack
+                        stack.pop();
+                    }
+                }
+
+                // If we have unmatched opening parentheses, highlight the first one
+                if (!hasError && !stack.isEmpty()) {
+                    int errorPos = stack.firstElement();
+
+                    // Add text before the error
+                    if (errorPos > 0) {
+                        builder.append(buffer.substring(0, errorPos));
+                    }
+
+                    // Add the error character with red background
+                    builder.styled(
+                            AttributedStyle.DEFAULT
+                                    .foreground(AttributedStyle.WHITE)
+                                    .background(AttributedStyle.RED),
+                            String.valueOf(buffer.charAt(errorPos)));
+
+                    // Add text after the error
+                    if (errorPos < buffer.length() - 1) {
+                        builder.append(buffer.substring(errorPos + 1));
+                    }
+                } else if (!hasError) {
+                    // No errors - return the buffer as is
+                    builder.append(buffer);
+                }
+
+                return builder.toAttributedString();
+            }
+        };
+
+        // Create a terminal and reader with our parentheses highlighter
+        Terminal terminal = TerminalBuilder.builder().build();
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .highlighter(parenthesesHighlighter)
+                .build();
+
+        // Display instructions
+        terminal.writer().println("Parentheses Error Highlighting Example");
+        terminal.writer().println("Try typing expressions with parentheses like: (1 + 2) * (3 - 4))");
+        terminal.writer().println("Unbalanced parentheses will be highlighted in red");
+        terminal.writer().println();
+
+        // Read input with parentheses error highlighting
+        String line = reader.readLine("expr> ");
+        terminal.writer().println("You entered: " + line);
+
+        terminal.close();
+    }
+    // SNIPPET_END: ErrorHighlightingExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/KeywordHighlighterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/KeywordHighlighterExample.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jline.reader.Highlighter;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating a highlighter that highlights SQL keywords.
+ */
+public class KeywordHighlighterExample {
+
+    // SNIPPET_START: KeywordHighlighterExample
+    public static void main(String[] args) throws IOException {
+        // Create a highlighter for SQL keywords
+        Highlighter sqlHighlighter = new Highlighter() {
+            // Pattern to match SQL keywords (case insensitive)
+            private final Pattern SQL_KEYWORDS = Pattern.compile(
+                    "\\b(SELECT|FROM|WHERE|JOIN|ON|GROUP BY|ORDER BY|HAVING|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)\\b",
+                    Pattern.CASE_INSENSITIVE);
+
+            @Override
+            public AttributedString highlight(LineReader reader, String buffer) {
+                AttributedStringBuilder builder = new AttributedStringBuilder();
+
+                // Find all SQL keywords in the buffer
+                Matcher matcher = SQL_KEYWORDS.matcher(buffer);
+                int lastEnd = 0;
+
+                while (matcher.find()) {
+                    // Add text before the keyword with default style
+                    builder.append(buffer.substring(lastEnd, matcher.start()));
+
+                    // Add the keyword with bold blue style
+                    builder.styled(
+                            AttributedStyle.BOLD.foreground(AttributedStyle.BLUE),
+                            buffer.substring(matcher.start(), matcher.end()));
+
+                    lastEnd = matcher.end();
+                }
+
+                // Add any remaining text
+                if (lastEnd < buffer.length()) {
+                    builder.append(buffer.substring(lastEnd));
+                }
+
+                return builder.toAttributedString();
+            }
+        };
+
+        // Create a terminal and reader with our SQL highlighter
+        Terminal terminal = TerminalBuilder.builder().build();
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .highlighter(sqlHighlighter)
+                .build();
+
+        // Display instructions
+        terminal.writer().println("SQL Keyword Highlighter Example");
+        terminal.writer().println("Try typing SQL queries like: SELECT * FROM users WHERE id = 1");
+        terminal.writer().println();
+
+        // Read input with SQL keyword highlighting
+        String line = reader.readLine("sql> ");
+        terminal.writer().println("You entered: " + line);
+
+        terminal.close();
+    }
+    // SNIPPET_END: KeywordHighlighterExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/SyntaxHighlighterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SyntaxHighlighterExample.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jline.reader.Highlighter;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating a more complex syntax highlighter for a simple programming language.
+ */
+public class SyntaxHighlighterExample {
+
+    // SNIPPET_START: SyntaxHighlighterExample
+    public static void main(String[] args) throws IOException {
+        // Create a syntax highlighter for a simple programming language
+        Highlighter syntaxHighlighter = new Highlighter() {
+            // Patterns for different syntax elements
+            private final Pattern KEYWORDS = Pattern.compile("\\b(if|else|while|for|return|function|var|let|const)\\b");
+
+            private final Pattern STRINGS =
+                    Pattern.compile("\"[^\"\\\\]*(\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(\\\\.[^'\\\\]*)*'");
+
+            private final Pattern NUMBERS = Pattern.compile("\\b\\d+(\\.\\d+)?\\b");
+
+            private final Pattern COMMENTS = Pattern.compile("//.*$|/\\*[\\s\\S]*?\\*/", Pattern.MULTILINE);
+
+            @Override
+            public AttributedString highlight(LineReader reader, String buffer) {
+                // First, create a copy of the buffer that we can modify
+                // as we process each syntax element
+                String workingBuffer = buffer;
+
+                // Create a builder for our highlighted string
+                AttributedStringBuilder builder = new AttributedStringBuilder();
+
+                // Process each type of syntax element in a specific order
+
+                // 1. First highlight comments (green)
+                workingBuffer = highlightPattern(
+                        builder, workingBuffer, COMMENTS, AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN));
+
+                // 2. Then highlight strings (yellow)
+                workingBuffer = highlightPattern(
+                        builder, workingBuffer, STRINGS, AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW));
+
+                // 3. Then highlight numbers (cyan)
+                workingBuffer = highlightPattern(
+                        builder, workingBuffer, NUMBERS, AttributedStyle.DEFAULT.foreground(AttributedStyle.CYAN));
+
+                // 4. Finally highlight keywords (bold magenta)
+                workingBuffer = highlightPattern(
+                        builder, workingBuffer, KEYWORDS, AttributedStyle.BOLD.foreground(AttributedStyle.MAGENTA));
+
+                // Add any remaining text with default style
+                if (!workingBuffer.isEmpty()) {
+                    builder.append(workingBuffer);
+                }
+
+                return builder.toAttributedString();
+            }
+
+            // Helper method to highlight a specific pattern
+            private String highlightPattern(
+                    AttributedStringBuilder builder, String buffer, Pattern pattern, AttributedStyle style) {
+
+                StringBuilder result = new StringBuilder();
+                Matcher matcher = pattern.matcher(buffer);
+                int lastEnd = 0;
+
+                // Find all matches of the pattern
+                while (matcher.find()) {
+                    // Add the text before this match to the result
+                    result.append(buffer, lastEnd, matcher.start());
+
+                    // Add the matched text with the specified style to the builder
+                    builder.styled(style, buffer.substring(matcher.start(), matcher.end()));
+
+                    lastEnd = matcher.end();
+                }
+
+                // Add any remaining text to the result
+                if (lastEnd < buffer.length()) {
+                    result.append(buffer.substring(lastEnd));
+                }
+
+                return result.toString();
+            }
+        };
+
+        // Create a terminal and reader with our syntax highlighter
+        Terminal terminal = TerminalBuilder.builder().build();
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .highlighter(syntaxHighlighter)
+                .build();
+
+        // Display instructions
+        terminal.writer().println("Syntax Highlighter Example");
+        terminal.writer().println("Try typing code like: function add(a, b) { return a + b; // Add numbers }");
+        terminal.writer().println();
+
+        // Read input with syntax highlighting
+        String line = reader.readLine("code> ");
+        terminal.writer().println("You entered: " + line);
+
+        terminal.close();
+    }
+    // SNIPPET_END: SyntaxHighlighterExample
+}


### PR DESCRIPTION
This PR adds four example classes demonstrating different syntax highlighting techniques:

- **BasicHighlighterExample**: Simple highlighter that colors all text blue
- **KeywordHighlighterExample**: Highlights SQL keywords in bold blue
- **SyntaxHighlighterExample**: Complex highlighter for a programming language with different colors for syntax elements
- **ErrorHighlightingExample**: Checks for balanced parentheses and highlights errors

These examples support the syntax-highlighting.md documentation page and provide users with clear, working examples of how to implement different types of syntax highlighting in JLine.

The examples are properly formatted with SNIPPET_START and SNIPPET_END markers, include necessary imports, implement the Highlighter interface, and are runnable as standalone examples.

I've verified that all examples compile successfully and that the snippets are properly extracted using the website's snippet extraction script.