### PR TITLE
docs: integrate GitHub wiki content into website documentation

### DIFF
--- a/demo/src/main/java/org/jline/demo/examples/AutoIndentationExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AutoIndentationExample.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.reader.impl.DefaultParser.Bracket;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+/**
+ * Example demonstrating auto indentation in JLine.
+ */
+public class AutoIndentationExample {
+
+    // SNIPPET_START: AutoIndentationExample
+    public static void main(String[] args) throws IOException {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a parser with EOF on unclosed brackets
+        DefaultParser parser = new DefaultParser();
+        parser.setEofOnUnclosedBracket(Bracket.CURLY, Bracket.ROUND, Bracket.SQUARE);
+
+        // Create a line reader with auto indentation
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .parser(parser)
+                .variable(LineReader.SECONDARY_PROMPT_PATTERN, "%M%P > ") // Secondary prompt
+                .variable(LineReader.INDENTATION, 2) // Indentation size
+                .option(LineReader.Option.INSERT_BRACKET, true) // Insert closing bracket automatically
+                .build();
+
+        // Display instructions
+        terminal.writer().println("Auto Indentation Example");
+        terminal.writer().println("------------------------");
+        terminal.writer().println("Try typing multi-line code with brackets:");
+        terminal.writer().println("Example: if (true) {");
+        terminal.writer().println("Note: You need to manually close the last bracket");
+        terminal.writer().println("Type 'exit' to quit");
+        terminal.writer().println();
+
+        // Read input with auto indentation
+        String line;
+        while (true) {
+            try {
+                line = reader.readLine("indent> ");
+
+                if (line.equalsIgnoreCase("exit")) {
+                    break;
+                }
+
+                terminal.writer().println("You entered: " + line);
+                terminal.writer().flush();
+            } catch (Exception e) {
+                terminal.writer().println("Error: " + e.getMessage());
+                terminal.writer().flush();
+            }
+        }
+
+        terminal.close();
+    }
+    // SNIPPET_END: AutoIndentationExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/AutopairWidgetsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AutopairWidgetsExample.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.widget.AutopairWidgets;
+
+/**
+ * Example demonstrating autopair widgets in JLine.
+ */
+public class AutopairWidgetsExample {
+
+    // SNIPPET_START: AutopairWidgetsExample
+    public static void main(String[] args) throws IOException {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a line reader
+        LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+
+        // Create autopair widgets
+        // The second parameter (true) enables curly bracket pairing
+        AutopairWidgets autopairWidgets = new AutopairWidgets(reader, true);
+
+        // Enable autopair
+        autopairWidgets.enable();
+
+        // Display instructions
+        terminal.writer().println("Autopair Widgets Example");
+        terminal.writer().println("-----------------------");
+        terminal.writer().println("Autopair widgets will automatically:");
+        terminal.writer().println("1. Insert matching pairs (quotes, brackets)");
+        terminal.writer().println("2. Skip over matched pairs");
+        terminal.writer().println("3. Auto-delete pairs on backspace");
+        terminal.writer().println("4. Expand/contract spaces between brackets");
+        terminal.writer().println();
+        terminal.writer().println("Try typing quotes, brackets, etc.");
+        terminal.writer().println("Type 'exit' to quit");
+        terminal.writer().println();
+
+        // Read input with autopair
+        String line;
+        while (true) {
+            try {
+                line = reader.readLine("autopair> ");
+
+                if (line.equalsIgnoreCase("exit")) {
+                    break;
+                }
+
+                terminal.writer().println("You entered: " + line);
+                terminal.writer().flush();
+            } catch (Exception e) {
+                terminal.writer().println("Error: " + e.getMessage());
+                terminal.writer().flush();
+            }
+        }
+
+        terminal.close();
+    }
+    // SNIPPET_END: AutopairWidgetsExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/AutosuggestionWidgetsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AutosuggestionWidgetsExample.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.impl.completer.StringsCompleter;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.widget.AutosuggestionWidgets;
+
+/**
+ * Example demonstrating autosuggestion widgets in JLine.
+ */
+public class AutosuggestionWidgetsExample {
+
+    // SNIPPET_START: AutosuggestionWidgetsExample
+    public static void main(String[] args) throws IOException {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a line reader with some completions for demonstration
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .completer(new StringsCompleter("help", "hello", "history", "exit", "quit", "clear"))
+                .build();
+
+        // Create autosuggestion widgets
+        AutosuggestionWidgets autosuggestionWidgets = new AutosuggestionWidgets(reader);
+
+        // Enable autosuggestions
+        autosuggestionWidgets.enable();
+
+        // Display instructions
+        terminal.writer().println("Autosuggestion Widgets Example");
+        terminal.writer().println("-----------------------------");
+        terminal.writer().println("As you type, you'll see suggestions based on history.");
+        terminal.writer().println("- Press RIGHT ARROW or END to accept the full suggestion");
+        terminal.writer().println("- Press Ctrl+F to accept the next word of the suggestion");
+        terminal.writer().println("- Type 'exit' to quit");
+        terminal.writer().println();
+
+        // Add some history entries for suggestions
+        reader.getHistory().add("help show available commands");
+        reader.getHistory().add("hello world");
+        reader.getHistory().add("history show command history");
+        reader.getHistory().add("clear screen");
+
+        // Read input with autosuggestions
+        String line;
+        while (true) {
+            try {
+                line = reader.readLine("autosuggestion> ");
+
+                if (line.equalsIgnoreCase("exit") || line.equalsIgnoreCase("quit")) {
+                    break;
+                }
+
+                terminal.writer().println("You entered: " + line);
+                terminal.writer().flush();
+            } catch (Exception e) {
+                terminal.writer().println("Error: " + e.getMessage());
+                terminal.writer().flush();
+            }
+        }
+
+        terminal.close();
+    }
+    // SNIPPET_END: AutosuggestionWidgetsExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/BasicStylingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/BasicStylingExample.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating basic styling with JLine.
+ */
+public class BasicStylingExample {
+
+    // SNIPPET_START: BasicStylingExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create styled text with foreground colors
+        AttributedString redText =
+                new AttributedString("This is red text", AttributedStyle.BOLD.foreground(AttributedStyle.RED));
+
+        AttributedString greenText =
+                new AttributedString("This is green text", AttributedStyle.BOLD.foreground(AttributedStyle.GREEN));
+
+        AttributedString blueText =
+                new AttributedString("This is blue text", AttributedStyle.BOLD.foreground(AttributedStyle.BLUE));
+
+        // Create styled text with background colors
+        AttributedString yellowBg = new AttributedString(
+                "Text with yellow background", AttributedStyle.DEFAULT.background(AttributedStyle.YELLOW));
+
+        // Create styled text with both foreground and background
+        AttributedString fgBg = new AttributedString(
+                "White on black",
+                AttributedStyle.BOLD.foreground(AttributedStyle.WHITE).background(AttributedStyle.BLACK));
+
+        // Create styled text with other attributes
+        AttributedString underlined = new AttributedString("Underlined text", AttributedStyle.DEFAULT.underline());
+
+        AttributedString blink = new AttributedString("Blinking text", AttributedStyle.DEFAULT.blink());
+
+        AttributedString inverse = new AttributedString("Inverse text", AttributedStyle.DEFAULT.inverse());
+
+        // Print the styled text
+        terminal.writer().println(redText);
+        terminal.writer().println(greenText);
+        terminal.writer().println(blueText);
+        terminal.writer().println();
+        terminal.writer().println(yellowBg);
+        terminal.writer().println(fgBg);
+        terminal.writer().println();
+        terminal.writer().println(underlined);
+        terminal.writer().println(blink);
+        terminal.writer().println(inverse);
+
+        terminal.flush();
+        terminal.close();
+    }
+    // SNIPPET_END: BasicStylingExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/ConsoleScriptExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ConsoleScriptExample.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Example demonstrating a console script in JLine.
+ * This is not a runnable Java class but shows the structure of a console script.
+ */
+public class ConsoleScriptExample {
+
+    // SNIPPET_START: ConsoleScriptExample
+    /**
+     * Example of a JLine console script (hello.jline)
+     *
+     * Console scripts are executed by the REPL console and can contain
+     * any commands that you would type interactively.
+     *
+     * This is not actual Java code but a representation of what a console script looks like.
+     */
+    public static void consoleScriptExample() throws IOException {
+        // This is what a console script (hello.jline) might look like:
+        String consoleScript = "#!/usr/bin/env jline\n" + "\n"
+                + "# This is a simple JLine console script\n"
+                + "# It demonstrates how to use parameters and execute commands\n"
+                + "\n"
+                + "# Access script parameters using $1, $2, etc.\n"
+                + "name=$1\n"
+                + "if [ -z \"$name\" ]; then\n"
+                + "    name=\"World\"\n"
+                + "fi\n"
+                + "\n"
+                + "# Execute commands just like in interactive mode\n"
+                + ":echo \"Hello, $name!\"\n"
+                + "\n"
+                + "# You can use variables\n"
+                + "count=5\n"
+                + ":echo \"Counting to $count:\"\n"
+                + "\n"
+                + "# Loop example\n"
+                + "i=1\n"
+                + "while [ $i -le $count ]; do\n"
+                + "    :echo \"  $i\"\n"
+                + "    i=$((i+1))\n"
+                + "done\n"
+                + "\n"
+                + "# Return a value from the script\n"
+                + "exit \"Script completed successfully!\"\n";
+
+        // Write the example script to a file for demonstration purposes
+        Path scriptPath = Paths.get("hello.jline");
+        Files.write(scriptPath, consoleScript.getBytes());
+
+        System.out.println("Created example console script: " + scriptPath.toAbsolutePath());
+        System.out.println("You can run this script in a JLine REPL console with:");
+        System.out.println("  ./hello.jline YourName");
+    }
+    // SNIPPET_END: ConsoleScriptExample
+
+    public static void main(String[] args) throws IOException {
+        consoleScriptExample();
+    }
+}

--- a/demo/src/main/java/org/jline/demo/examples/CustomKeyBindingsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomKeyBindingsExample.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.keymap.BindingReader;
+import org.jline.keymap.KeyMap;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.Reference;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.InfoCmp.Capability;
+
+/**
+ * Example demonstrating custom key bindings.
+ */
+public class CustomKeyBindingsExample {
+
+    // SNIPPET_START: CustomKeyBindingsExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a line reader with custom key bindings
+        LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+
+        // Define custom key bindings
+
+        // 1. Bind Ctrl+T to transpose characters
+        reader.getKeyMaps().get(LineReader.MAIN).bind(new Reference("transpose-chars"), "\u0014"); // Ctrl+T
+
+        // 2. Bind Alt+U to uppercase word
+        reader.getKeyMaps().get(LineReader.MAIN).bind(new Reference("up-case-word"), "\u001b\u0075"); // Alt+U
+
+        // 3. Bind Alt+L to lowercase word
+        reader.getKeyMaps().get(LineReader.MAIN).bind(new Reference("down-case-word"), "\u001b\u006C"); // Alt+L
+
+        // 4. Bind Alt+C to capitalize word
+        reader.getKeyMaps().get(LineReader.MAIN).bind(new Reference("capitalize-word"), "\u001b\u0063"); // Alt+C
+
+        // 5. Bind F5 to clear screen
+        reader.getKeyMaps()
+                .get(LineReader.MAIN)
+                .bind(new Reference("clear-screen"), terminal.getStringCapability(Capability.key_f5));
+
+        // 6. Bind Ctrl+X Ctrl+E to edit-and-execute-command
+        reader.getKeyMaps()
+                .get(LineReader.MAIN)
+                .bind(new Reference("edit-and-execute-command"), "\u0018\u0005"); // Ctrl+X Ctrl+E
+
+        // Print instructions
+        terminal.writer().println("Custom Key Bindings Example");
+        terminal.writer().println("Try these key combinations:");
+        terminal.writer().println("  Ctrl+T  - Transpose characters");
+        terminal.writer().println("  Alt+U   - Uppercase word");
+        terminal.writer().println("  Alt+L   - Lowercase word");
+        terminal.writer().println("  Alt+C   - Capitalize word");
+        terminal.writer().println("  F5      - Clear screen");
+        terminal.writer().println("  Ctrl+X Ctrl+E - Edit command in external editor");
+        terminal.writer().println();
+
+        // Read input with custom key bindings
+        String line = reader.readLine("custom-keys> ");
+        terminal.writer().println("You entered: " + line);
+
+        // Demonstrate a custom key map with a binding reader
+        terminal.writer().println("\nCustom KeyMap Example:");
+        terminal.writer().println("Press 'q' to quit, 'h' for help, or 'a', 'b', 'c' for actions");
+
+        // Create a custom key map
+        KeyMap<String> keyMap = new KeyMap<>();
+        keyMap.bind("quit", "q");
+        keyMap.bind("help", "h");
+        keyMap.bind("action-a", "a");
+        keyMap.bind("action-b", "b");
+        keyMap.bind("action-c", "c");
+
+        // Create a binding reader
+        BindingReader bindingReader = new BindingReader(terminal.reader());
+
+        // Process key bindings
+        while (true) {
+            String operation = bindingReader.readBinding(keyMap);
+
+            if ("quit".equals(operation)) {
+                terminal.writer().println("Quitting...");
+                break;
+            } else if ("help".equals(operation)) {
+                terminal.writer().println("Help: Press a, b, c for actions, q to quit");
+            } else if ("action-a".equals(operation)) {
+                terminal.writer().println("Executing action A");
+            } else if ("action-b".equals(operation)) {
+                terminal.writer().println("Executing action B");
+            } else if ("action-c".equals(operation)) {
+                terminal.writer().println("Executing action C");
+            }
+
+            terminal.flush();
+        }
+
+        terminal.close();
+    }
+    // SNIPPET_END: CustomKeyBindingsExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/CustomPromptExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomPromptExample.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.UserInterruptException;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating custom prompts in JLine.
+ */
+public class CustomPromptExample {
+
+    // SNIPPET_START: CustomPromptExample
+    public static void main(String[] args) {
+        try {
+            // Create a terminal
+            Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+            // Create a line reader
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+
+            // Set variables for prompt customization
+            reader.setVariable("prompt", "%N@%M:%w%n> ");
+            reader.setVariable("rprompt", "%T");
+            reader.setVariable(LineReader.SECONDARY_PROMPT_PATTERN, "%M> ");
+
+            // Custom prompt with colors
+            AttributedString prompt =
+                    new AttributedString("jline> ", AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN));
+
+            // Custom right prompt with colors
+            AttributedString rightPrompt =
+                    new AttributedString("[demo]", AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE));
+
+            // Read lines with different prompt styles
+            try {
+                // Using pattern-based prompt
+                String line1 = reader.readLine();
+                terminal.writer().println("You entered: " + line1);
+
+                // Using AttributedString prompt (convert to String)
+                String line2 = reader.readLine(prompt.toAnsi(), rightPrompt.toAnsi(), (Character) null, null);
+                terminal.writer().println("You entered: " + line2);
+
+                // Using a simple string prompt
+                String line3 = reader.readLine("simple> ");
+                terminal.writer().println("You entered: " + line3);
+
+                // Using a masked prompt for passwords
+                String password = reader.readLine("Password: ", '*');
+                terminal.writer().println("Password length: " + password.length());
+
+            } catch (UserInterruptException e) {
+                // Ctrl+C
+                terminal.writer().println("Interrupted");
+            } catch (EndOfFileException e) {
+                // Ctrl+D
+                terminal.writer().println("EOF");
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    // SNIPPET_END: CustomPromptExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/CustomWidgetsClassExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomWidgetsClassExample.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.Reference;
+import org.jline.reader.UserInterruptException;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.widget.Widgets;
+
+import static org.jline.keymap.KeyMap.alt;
+import static org.jline.keymap.KeyMap.ctrl;
+
+/**
+ * Example demonstrating how to create a custom widgets class in JLine.
+ */
+public class CustomWidgetsClassExample {
+
+    // SNIPPET_START: CustomWidgetsClassExample
+    /**
+     * Custom widgets class that extends the base Widgets class.
+     */
+    public static class MyWidgets extends Widgets {
+
+        /**
+         * Factory method to create and set up a MyWidgets instance.
+         *
+         * @param reader The LineReader to associate with these widgets
+         * @return The configured MyWidgets instance
+         */
+        public static MyWidgets create(LineReader reader) {
+            MyWidgets widgets = new MyWidgets(reader);
+
+            // Add a widget that executes the first word as a command
+            widgets.addWidget("execute-command", widgets::executeCommand);
+
+            // Add a widget that clears the line
+            widgets.addWidget("clear-line", widgets::clearLine);
+
+            // Bind keys to the widgets
+            // Ctrl+Alt+X for execute-command
+            widgets.getKeyMap().bind(new Reference("execute-command"), alt(ctrl('X')));
+
+            // Ctrl+Alt+C for clear-line
+            widgets.getKeyMap().bind(new Reference("clear-line"), alt(ctrl('C')));
+
+            return widgets;
+        }
+
+        /**
+         * Private constructor to force use of factory method.
+         */
+        private MyWidgets(LineReader reader) {
+            super(reader);
+        }
+
+        /**
+         * Widget that takes the first word of the buffer and executes it as a command.
+         * In this example, it just calls the corresponding widget if it exists.
+         */
+        public boolean executeCommand() {
+            try {
+                // Get the first word from the buffer
+                String buffer = buffer().toString();
+                String[] words = buffer.split("\\s+");
+
+                if (words.length > 0 && !words[0].isEmpty()) {
+                    String command = words[0];
+                    System.out.println("\nExecuting command: " + command);
+
+                    // Try to call a widget with this name
+                    try {
+                        reader.callWidget(command);
+                        return true;
+                    } catch (Exception e) {
+                        System.out.println("No widget named: " + command);
+                        return false;
+                    }
+                }
+            } catch (Exception e) {
+                return false;
+            }
+            return true;
+        }
+
+        /**
+         * Widget that clears the current line.
+         */
+        public boolean clearLine() {
+            buffer().clear();
+            return true;
+        }
+    }
+
+    public static void main(String[] args) {
+        try {
+            // Create a terminal
+            Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+            // Create a line reader
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+
+            // Create and register our custom widgets
+            MyWidgets widgets = MyWidgets.create(reader);
+
+            // Display instructions
+            terminal.writer().println("Custom Widgets Class Example");
+            terminal.writer().println("  Ctrl+Alt+X: Execute the first word as a command");
+            terminal.writer().println("  Ctrl+Alt+C: Clear the line");
+            terminal.writer().println();
+            terminal.writer().println("Try typing 'clear-line' and then press Ctrl+Alt+X");
+            terminal.writer().flush();
+
+            // REPL loop
+            String prompt = "widgets> ";
+            while (true) {
+                try {
+                    String line = reader.readLine(prompt);
+
+                    if ("exit".equalsIgnoreCase(line)) {
+                        break;
+                    }
+
+                    terminal.writer().println("You entered: " + line);
+                    terminal.writer().flush();
+                } catch (UserInterruptException e) {
+                    // Ctrl+C pressed
+                    terminal.writer().println("KeyboardInterrupt (Ctrl+C)");
+                    terminal.writer().flush();
+                } catch (EndOfFileException e) {
+                    // Ctrl+D pressed
+                    terminal.writer().println("End of file (Ctrl+D)");
+                    terminal.writer().flush();
+                    break;
+                }
+            }
+
+            terminal.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    // SNIPPET_END: CustomWidgetsClassExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/FileNameCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/FileNameCompleterExample.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.builtins.Completers.FileNameCompleter;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+/**
+ * Example demonstrating the FileNameCompleter.
+ */
+public class FileNameCompleterExample {
+
+    // SNIPPET_START: FileNameCompleterExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a file name completer
+        FileNameCompleter completer = new FileNameCompleter();
+
+        // Create a line reader with the file name completer
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .completer(completer)
+                .build();
+
+        // Read input with file name completion
+        String line = reader.readLine("Enter a file path: ");
+        System.out.println("You entered: " + line);
+
+        terminal.close();
+    }
+    // SNIPPET_END: FileNameCompleterExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/FileOperationsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/FileOperationsExample.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+/**
+ * Example demonstrating file operations using JLine.
+ */
+public class FileOperationsExample {
+
+    // SNIPPET_START: FileOperationsExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a temporary directory for file operations
+        Path workDir = Files.createTempDirectory("jline-demo");
+        workDir.toFile().deleteOnExit();
+
+        // Create some sample files
+        Path file1 = workDir.resolve("sample1.txt");
+        Path file2 = workDir.resolve("sample2.txt");
+        Files.write(
+                file1,
+                "This is sample file 1\nWith multiple lines\nFor demonstration".getBytes(StandardCharsets.UTF_8));
+        Files.write(
+                file2,
+                "This is sample file 2\nWith different content\nFor comparison".getBytes(StandardCharsets.UTF_8));
+
+        // Create a line reader
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .parser(new DefaultParser())
+                .build();
+
+        // Print instructions
+        terminal.writer().println("File Operations Example");
+        terminal.writer().println("Working directory: " + workDir);
+        terminal.writer().println("Available commands: cat, ls, grep");
+        terminal.writer().println("Type 'exit' to quit");
+        terminal.writer().println();
+
+        // Main command loop
+        while (true) {
+            String line = reader.readLine("file-ops> ");
+
+            if (line.equals("exit") || line.equals("quit")) {
+                break;
+            }
+
+            try {
+                // Parse the command
+                String[] parts = line.split("\\s+");
+                String command = parts[0];
+
+                // Execute the command
+                if (command.equals("ls")) {
+                    // List files in the working directory
+                    File[] files = workDir.toFile().listFiles();
+                    if (files != null) {
+                        for (File file : files) {
+                            terminal.writer().println(file.getName() + "\t" + file.length() + " bytes");
+                        }
+                    }
+                } else if (command.equals("cat") && parts.length > 1) {
+                    // Display file content
+                    Path filePath = workDir.resolve(parts[1]);
+                    if (Files.exists(filePath)) {
+                        Files.lines(filePath).forEach(terminal.writer()::println);
+                    } else {
+                        terminal.writer().println("File not found: " + parts[1]);
+                    }
+                } else if (command.equals("grep") && parts.length > 2) {
+                    // Search for pattern in file
+                    String pattern = parts[1];
+                    Path filePath = workDir.resolve(parts[2]);
+                    if (Files.exists(filePath)) {
+                        Files.lines(filePath)
+                                .filter(line2 -> line2.contains(pattern))
+                                .forEach(terminal.writer()::println);
+                    } else {
+                        terminal.writer().println("File not found: " + parts[2]);
+                    }
+                } else {
+                    terminal.writer().println("Unknown command or invalid syntax: " + line);
+                    terminal.writer().println("Available commands: cat <file>, ls, grep <pattern> <file>");
+                }
+            } catch (Exception e) {
+                terminal.writer().println("Error: " + e.getMessage());
+            }
+
+            terminal.flush();
+        }
+
+        terminal.writer().println("Goodbye!");
+        terminal.close();
+    }
+    // SNIPPET_END: FileOperationsExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/GroovyScriptExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/GroovyScriptExample.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Example demonstrating a Groovy script in JLine.
+ * This is not a runnable Java class but shows the structure of a Groovy script.
+ */
+public class GroovyScriptExample {
+
+    // SNIPPET_START: GroovyScriptExample
+    /**
+     * Example of a JLine Groovy script (hello.groovy)
+     *
+     * Groovy scripts are executed by the REPL console and can contain
+     * Groovy code that interacts with the console.
+     *
+     * This is not actual Java code but a representation of what a Groovy script looks like.
+     */
+    public static void groovyScriptExample() throws IOException {
+        // This is what a Groovy script (hello.groovy) might look like:
+        String groovyScript = "#!/usr/bin/env groovy\n" + "\n"
+                + "// This is a simple JLine Groovy script\n"
+                + "// It demonstrates how to use parameters and execute commands\n"
+                + "\n"
+                + "// Access script parameters using the _args list\n"
+                + "def name = _args.size() > 0 ? _args[0] : \"World\"\n"
+                + "\n"
+                + "// Print directly using Groovy\n"
+                + "println \"Hello, ${name}!\"\n"
+                + "\n"
+                + "// Execute console commands using SystemRegistry\n"
+                + "import org.jline.console.SystemRegistry\n"
+                + "\n"
+                + "// Create a map to print\n"
+                + "def user = [name: name, greeting: \"Hello\", count: 5]\n"
+                + "\n"
+                + "// Print the map using the prnt command\n"
+                + "SystemRegistry.get().invoke(\"prnt\", \"-s\", \"JSON\", user)\n"
+                + "\n"
+                + "// Loop example\n"
+                + "println \"Counting to ${user.count}:\"\n"
+                + "for (i in 1..user.count) {\n"
+                + "    println \"  ${i}\"\n"
+                + "}\n"
+                + "\n"
+                + "// Return a value from the script\n"
+                + "return \"Script completed successfully!\"\n";
+
+        // Write the example script to a file for demonstration purposes
+        Path scriptPath = Paths.get("hello.groovy");
+        Files.write(scriptPath, groovyScript.getBytes());
+
+        System.out.println("Created example Groovy script: " + scriptPath.toAbsolutePath());
+        System.out.println("You can run this script in a JLine REPL console with:");
+        System.out.println("  ./hello.groovy YourName");
+    }
+    // SNIPPET_END: GroovyScriptExample
+
+    public static void main(String[] args) throws IOException {
+        groovyScriptExample();
+    }
+}

--- a/demo/src/main/java/org/jline/demo/examples/HighlighterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HighlighterExample.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.reader.Highlighter;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.impl.DefaultHighlighter;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating a custom highlighter.
+ */
+public class HighlighterExample {
+
+    // SNIPPET_START: HighlighterExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a custom highlighter
+        Highlighter highlighter = new DefaultHighlighter() {
+            @Override
+            public AttributedString highlight(LineReader reader, String buffer) {
+                // Create a builder for the highlighted text
+                AttributedStringBuilder builder = new AttributedStringBuilder();
+
+                // Apply different styles based on content
+                if (buffer.contains("error")) {
+                    // Highlight "error" in red
+                    int index = buffer.indexOf("error");
+                    builder.append(buffer.substring(0, index));
+                    builder.styled(
+                            AttributedStyle.BOLD.foreground(AttributedStyle.RED), buffer.substring(index, index + 5));
+                    builder.append(buffer.substring(index + 5));
+                } else if (buffer.contains("warning")) {
+                    // Highlight "warning" in yellow
+                    int index = buffer.indexOf("warning");
+                    builder.append(buffer.substring(0, index));
+                    builder.styled(
+                            AttributedStyle.BOLD.foreground(AttributedStyle.YELLOW),
+                            buffer.substring(index, index + 7));
+                    builder.append(buffer.substring(index + 7));
+                } else if (buffer.startsWith("command")) {
+                    // Highlight commands in blue
+                    builder.styled(AttributedStyle.BOLD.foreground(AttributedStyle.BLUE), buffer);
+                } else {
+                    // Default highlighting
+                    builder.append(buffer);
+                }
+
+                return builder.toAttributedString();
+            }
+        };
+
+        // Create a line reader with the custom highlighter
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .highlighter(highlighter)
+                .build();
+
+        // Read input with custom highlighting
+        // Try typing: "command", "error message", or "warning message"
+        String line = reader.readLine("Enter text (try 'error' or 'warning'): ");
+        System.out.println("You entered: " + line);
+
+        terminal.close();
+    }
+    // SNIPPET_END: HighlighterExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/KeyBindingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/KeyBindingExample.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.keymap.KeyMap;
+import org.jline.reader.Binding;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.Reference;
+import org.jline.reader.UserInterruptException;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+import static org.jline.keymap.KeyMap.alt;
+import static org.jline.keymap.KeyMap.ctrl;
+
+/**
+ * Example demonstrating key bindings in JLine.
+ */
+public class KeyBindingExample {
+
+    // SNIPPET_START: KeyBindingExample
+    public static void main(String[] args) {
+        try {
+            // Create a terminal
+            Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+            // Create a line reader
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+
+            // Get the main key map
+            KeyMap<Binding> keyMap = reader.getKeyMaps().get(LineReader.MAIN);
+
+            // Bind Ctrl+T to transpose characters (swap the character before and at the cursor)
+            keyMap.bind(new Reference(LineReader.TRANSPOSE_CHARS), ctrl('T'));
+
+            // Bind Alt+U to uppercase the current word
+            keyMap.bind(new Reference("upcase-word"), alt('U'));
+
+            // Bind Alt+L to lowercase the current word
+            keyMap.bind(new Reference("downcase-word"), alt('L'));
+
+            // Bind Alt+C to capitalize the current word
+            keyMap.bind(new Reference(LineReader.CAPITALIZE_WORD), alt('C'));
+
+            // Bind Ctrl+K to kill (cut) text from cursor to end of line
+            keyMap.bind(new Reference(LineReader.KILL_LINE), ctrl('K'));
+
+            // Bind Ctrl+Y to yank (paste) previously killed text
+            keyMap.bind(new Reference(LineReader.YANK), ctrl('Y'));
+
+            // Bind Ctrl+R to reverse search in history
+            keyMap.bind(new Reference(LineReader.HISTORY_INCREMENTAL_SEARCH_BACKWARD), ctrl('R'));
+
+            // Display instructions
+            terminal.writer().println("Key Binding Example");
+            terminal.writer().println("------------------");
+            terminal.writer().println("Try these key bindings:");
+            terminal.writer().println("  Ctrl+T: Transpose characters");
+            terminal.writer().println("  Alt+U: Uppercase word");
+            terminal.writer().println("  Alt+L: Lowercase word");
+            terminal.writer().println("  Alt+C: Capitalize word");
+            terminal.writer().println("  Ctrl+K: Kill line");
+            terminal.writer().println("  Ctrl+Y: Yank");
+            terminal.writer().println("  Ctrl+R: Search history");
+            terminal.writer().println();
+            terminal.writer().println("Type 'exit' to quit");
+            terminal.writer().println();
+
+            // Read lines with custom key bindings
+            while (true) {
+                try {
+                    String line = reader.readLine("keybinding> ");
+
+                    if ("exit".equalsIgnoreCase(line)) {
+                        break;
+                    }
+
+                    terminal.writer().println("You entered: " + line);
+                    terminal.writer().flush();
+                } catch (UserInterruptException e) {
+                    // Ctrl+C
+                    terminal.writer().println("Interrupted");
+                } catch (EndOfFileException e) {
+                    // Ctrl+D
+                    terminal.writer().println("EOF");
+                    break;
+                }
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    // SNIPPET_END: KeyBindingExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/NanoLessCustomizationExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/NanoLessCustomizationExample.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+/**
+ * Example demonstrating Nano and Less customization in JLine.
+ */
+public class NanoLessCustomizationExample {
+
+    // SNIPPET_START: NanoLessCustomizationExample
+    public static void main(String[] args) {
+        try {
+            // Create a terminal
+            Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+            // Create a line reader
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .parser(new DefaultParser())
+                    .build();
+
+            // Create configuration files
+            Path jnanorcPath = createJnanorcFile();
+            Path jlessrcPath = createJlessrcFile();
+
+            // Display information about the configuration
+            terminal.writer().println("Nano and Less Customization Example");
+            terminal.writer().println("----------------------------------");
+            terminal.writer().println("jnanorc file: " + jnanorcPath);
+            terminal.writer().println("jlessrc file: " + jlessrcPath);
+            terminal.writer().println();
+            terminal.writer().println("To use nano with this configuration:");
+            terminal.writer().println("  nano -rcfile " + jnanorcPath + " filename.txt");
+            terminal.writer().println();
+            terminal.writer().println("To use less with this configuration:");
+            terminal.writer().println("  less -f " + jlessrcPath + " filename.txt");
+            terminal.writer().println();
+
+            // Create a sample file to edit
+            Path sampleFile = createSampleFile();
+            terminal.writer().println("Sample file created: " + sampleFile);
+            terminal.writer().println();
+
+            // In a real application, you would use the Nano or Less commands here
+            // But for this example, we'll just show the configuration files
+
+            terminal.writer().println("Press Enter to exit...");
+            terminal.reader().read();
+
+            terminal.writer().println("Goodbye!");
+            terminal.writer().flush();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static Path createJnanorcFile() throws IOException {
+        String nanorcContent = "# JLine nano configuration file\n" + "set tabstospaces\n"
+                + "set autoindent\n"
+                + "set tempfile\n"
+                + "set historylog search.log\n"
+                + "\n"
+                + "# Include syntax highlighting files\n"
+                + "include /usr/share/nano/*.nanorc\n"
+                + "\n"
+                + "# Use theme system\n"
+                + "theme example-theme.nanorctheme\n";
+
+        Path nanorcFile = Paths.get("jnanorc");
+        Files.write(nanorcFile, nanorcContent.getBytes());
+        return nanorcFile;
+    }
+
+    private static Path createJlessrcFile() throws IOException {
+        String lessrcContent = "# JLine less configuration file\n" + "set casesearch\n"
+                + "set autoindent\n"
+                + "set historylog search.log\n"
+                + "\n"
+                + "# Include syntax highlighting files\n"
+                + "include /usr/share/nano/*.nanorc\n"
+                + "\n"
+                + "# Use theme system\n"
+                + "theme example-theme.nanorctheme\n";
+
+        Path lessrcFile = Paths.get("jlessrc");
+        Files.write(lessrcFile, lessrcContent.getBytes());
+        return lessrcFile;
+    }
+
+    private static Path createSampleFile() throws IOException {
+        String sampleContent = "// Sample Java file for nano and less customization\n" + "\n"
+                + "/**\n"
+                + " * This is a sample class to demonstrate syntax highlighting\n"
+                + " */\n"
+                + "public class SampleClass {\n"
+                + "    // Constants\n"
+                + "    private static final int MAX_COUNT = 100;\n"
+                + "    \n"
+                + "    // Instance variables\n"
+                + "    private String name;\n"
+                + "    private int count;\n"
+                + "    private boolean active;\n"
+                + "    \n"
+                + "    /**\n"
+                + "     * Constructor\n"
+                + "     */\n"
+                + "    public SampleClass(String name) {\n"
+                + "        this.name = name;\n"
+                + "        this.count = 0;\n"
+                + "        this.active = true;\n"
+                + "    }\n"
+                + "    \n"
+                + "    // TODO: Add more methods\n"
+                + "    \n"
+                + "    /**\n"
+                + "     * Main method\n"
+                + "     */\n"
+                + "    public static void main(String[] args) {\n"
+                + "        SampleClass sample = new SampleClass(\"Test\");\n"
+                + "        System.out.println(\"Created: \" + sample.name);\n"
+                + "        \n"
+                + "        // Loop example\n"
+                + "        for (int i = 0; i < 5; i++) {\n"
+                + "            System.out.println(\"Count: \" + i);\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+
+        Path sampleFile = Paths.get("SampleClass.java");
+        Files.write(sampleFile, sampleContent.getBytes());
+        return sampleFile;
+    }
+    // SNIPPET_END: NanoLessCustomizationExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/RegexCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/RegexCompleterExample.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.jline.builtins.Completers.FileNameCompleter;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.impl.completer.StringsCompleter;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+/**
+ * Example demonstrating the RegexCompleter.
+ */
+public class RegexCompleterExample {
+
+    // SNIPPET_START: RegexCompleterExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a pattern-based completer that simulates regex completion
+        // Format: command [--option] <file>
+        // Where command can be: cat, ls, or grep
+        Completer commandCompleter = new StringsCompleter("cat", "ls", "grep");
+        Completer optionCompleter = new StringsCompleter("--color", "--help", "--version");
+        Completer fileCompleter = new FileNameCompleter();
+
+        // Create a custom completer that uses patterns to determine completion
+        Completer patternCompleter = new Completer() {
+            private final Pattern commandPattern = Pattern.compile("^(cat|ls|grep)$");
+            private final Pattern optionPattern = Pattern.compile("^(cat|ls|grep)\\s+(--[a-z]+)$");
+            private final Pattern filePattern = Pattern.compile("^(cat|ls|grep)\\s+(--[a-z]+\\s+)?(.*)$");
+
+            @Override
+            public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+                String buffer = line.line();
+
+                if (buffer.trim().isEmpty() || commandPattern.matcher(buffer).matches()) {
+                    // Complete command
+                    commandCompleter.complete(reader, line, candidates);
+                } else if (optionPattern.matcher(buffer).matches()) {
+                    // Complete option
+                    optionCompleter.complete(reader, line, candidates);
+                } else if (filePattern.matcher(buffer).matches()) {
+                    // Complete file
+                    fileCompleter.complete(reader, line, candidates);
+                }
+            }
+        };
+
+        // Create a line reader with the pattern completer
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .completer(patternCompleter)
+                .build();
+
+        // Read input with pattern-based completion
+        String line = reader.readLine("Enter a command: ");
+        System.out.println("You entered: " + line);
+
+        terminal.close();
+    }
+    // SNIPPET_END: RegexCompleterExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/ReplConsoleExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ReplConsoleExample.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.UserInterruptException;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+/**
+ * Example demonstrating a simple REPL console with JLine.
+ */
+public class ReplConsoleExample {
+
+    // SNIPPET_START: ReplConsoleExample
+    public static void main(String[] args) {
+        try {
+            // Setup the terminal
+            Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+            // Create the line reader
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .parser(new DefaultParser())
+                    .build();
+
+            // Set the prompt
+            String prompt = "repl> ";
+
+            // REPL loop
+            while (true) {
+                try {
+                    // Read a line
+                    String line = reader.readLine(prompt);
+
+                    // Process the line (in this example, just echo it back)
+                    if (line.equalsIgnoreCase("exit")) {
+                        break;
+                    }
+
+                    // Display the result
+                    terminal.writer().println("You entered: " + line);
+                    terminal.writer().flush();
+
+                } catch (UserInterruptException e) {
+                    // Ignore Ctrl+C
+                } catch (EndOfFileException e) {
+                    // Exit on Ctrl+D
+                    return;
+                }
+            }
+
+            terminal.writer().println("Goodbye!");
+            terminal.writer().flush();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    // SNIPPET_END: ReplConsoleExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/SimpleLineReadingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SimpleLineReadingExample.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.UserInterruptException;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+/**
+ * Example showing a simple REPL (Read-Eval-Print Loop) using JLine.
+ */
+public class SimpleLineReadingExample {
+
+    // SNIPPET_START: SimpleLineReadingExample
+    public static void main(String[] args) {
+        try {
+            // Create a terminal
+            Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+            // Create a line reader
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+
+            // Set the prompt
+            String prompt = "jline> ";
+
+            // REPL loop
+            while (true) {
+                String line = null;
+                try {
+                    // Read a line
+                    line = reader.readLine(prompt);
+
+                    // Process the line (in this example, just echo it back)
+                    System.out.println("You entered: " + line);
+
+                    // Exit if the user types "exit"
+                    if ("exit".equalsIgnoreCase(line)) {
+                        break;
+                    }
+                } catch (UserInterruptException e) {
+                    // Ctrl+C pressed, ignore
+                    System.out.println("KeyboardInterrupt (Ctrl+C)");
+                } catch (EndOfFileException e) {
+                    // Ctrl+D pressed, exit
+                    System.out.println("End of file (Ctrl+D)");
+                    return;
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    // SNIPPET_END: SimpleLineReadingExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/StyleExpressionExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/StyleExpressionExample.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating style expressions in JLine.
+ */
+public class StyleExpressionExample {
+
+    // SNIPPET_START: StyleExpressionExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create styled text using AttributedStringBuilder
+        AttributedStringBuilder builder = new AttributedStringBuilder();
+
+        // Create bold red text
+        AttributedString text1 = builder.style(AttributedStyle.BOLD.foreground(AttributedStyle.RED))
+                .append("This is bold red text")
+                .style(AttributedStyle.DEFAULT)
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Create text with yellow foreground on blue background
+        AttributedString text2 = builder.style(
+                        AttributedStyle.BOLD.foreground(AttributedStyle.YELLOW).background(AttributedStyle.BLUE))
+                .append("Text with yellow foreground on blue background")
+                .style(AttributedStyle.DEFAULT)
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Create text with underlined italic section
+        AttributedString text3 = builder.append("Normal text with ")
+                .style(AttributedStyle.DEFAULT.underline().italic())
+                .append("underlined italic")
+                .style(AttributedStyle.DEFAULT)
+                .append(" section")
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Create mixed styled text
+        AttributedString text4 = builder.append("Mix of ")
+                .style(AttributedStyle.BOLD.foreground(AttributedStyle.RED))
+                .append("bold red")
+                .style(AttributedStyle.DEFAULT)
+                .append(" and ")
+                .style(AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.BLUE))
+                .append("italic blue")
+                .style(AttributedStyle.DEFAULT)
+                .append(" text")
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Create a complex example with different styles
+        AttributedString complex = builder.append("Status: ")
+                .style(AttributedStyle.BOLD.foreground(AttributedStyle.GREEN))
+                .append("SUCCESS")
+                .style(AttributedStyle.DEFAULT)
+                .append(" | Errors: ")
+                .style(AttributedStyle.BOLD.foreground(AttributedStyle.RED))
+                .append("0")
+                .style(AttributedStyle.DEFAULT)
+                .append(" | Warnings: ")
+                .style(AttributedStyle.BOLD.foreground(AttributedStyle.YELLOW))
+                .append("2")
+                .style(AttributedStyle.DEFAULT)
+                .toAttributedString();
+
+        // Print the styled text
+        terminal.writer().println(text1);
+        terminal.writer().println(text2);
+        terminal.writer().println(text3);
+        terminal.writer().println(text4);
+        terminal.writer().println();
+        terminal.writer().println(complex);
+
+        terminal.flush();
+        terminal.close();
+    }
+    // SNIPPET_END: StyleExpressionExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/StyleResolverExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/StyleResolverExample.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating the StyleResolver in JLine.
+ */
+public class StyleResolverExample {
+
+    // SNIPPET_START: StyleResolverExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create an AttributedStringBuilder for building styled strings
+        AttributedStringBuilder builder = new AttributedStringBuilder();
+
+        // Define some common styles
+        AttributedStyle errorStyle = AttributedStyle.BOLD.foreground(AttributedStyle.RED);
+        AttributedStyle warningStyle = AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW);
+        AttributedStyle infoStyle = AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE);
+        AttributedStyle successStyle = AttributedStyle.BOLD.foreground(AttributedStyle.GREEN);
+        AttributedStyle headerStyle = AttributedStyle.BOLD.foreground(AttributedStyle.CYAN);
+
+        // Create a default styled text
+        AttributedString defaultText = builder.style(AttributedStyle.BOLD.foreground(AttributedStyle.RED))
+                .append("Error: ")
+                .style(AttributedStyle.DEFAULT)
+                .append("File not found")
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Create styled text with error style
+        AttributedString errorText = builder.style(errorStyle)
+                .append("Error: ")
+                .style(AttributedStyle.DEFAULT)
+                .append("File not found")
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Create styled text with warning style
+        AttributedString warningText = builder.style(warningStyle)
+                .append("Warning: ")
+                .style(AttributedStyle.DEFAULT)
+                .append("Disk space low")
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Create styled text with info style
+        AttributedString infoText = builder.style(infoStyle)
+                .append("Info: ")
+                .style(AttributedStyle.DEFAULT)
+                .append("Operation in progress")
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Create styled text with success style
+        AttributedString successText = builder.style(successStyle)
+                .append("Success: ")
+                .style(AttributedStyle.DEFAULT)
+                .append("Operation completed")
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Create styled text with header style
+        AttributedString headerText = builder.style(headerStyle)
+                .append("System Status Report")
+                .style(AttributedStyle.DEFAULT)
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Print the styled text
+        terminal.writer().println("Default resolver:");
+        terminal.writer().println(defaultText);
+        terminal.writer().println();
+
+        terminal.writer().println("Custom resolver with named styles:");
+        terminal.writer().println(headerText);
+        terminal.writer().println(errorText);
+        terminal.writer().println(warningText);
+        terminal.writer().println(infoText);
+        terminal.writer().println(successText);
+
+        terminal.flush();
+        terminal.close();
+    }
+    // SNIPPET_END: StyleResolverExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/StylerExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/StylerExample.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating styling in JLine.
+ */
+public class StylerExample {
+
+    // SNIPPET_START: StylerExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a builder for styled text
+        AttributedStringBuilder builder = new AttributedStringBuilder();
+
+        // Create different styles for different types of content
+        AttributedStyle errorStyle = AttributedStyle.BOLD.foreground(AttributedStyle.RED);
+        AttributedStyle warningStyle = AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW);
+        AttributedStyle infoStyle = AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE);
+        AttributedStyle successStyle = AttributedStyle.BOLD.foreground(AttributedStyle.GREEN);
+
+        // Apply styles to strings
+        AttributedString errorText =
+                builder.style(errorStyle).append("ERROR: File not found").toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        AttributedString warningText =
+                builder.style(warningStyle).append("WARNING: Disk space low").toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        AttributedString infoText =
+                builder.style(infoStyle).append("INFO: Operation in progress").toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        AttributedString successText = builder.style(successStyle)
+                .append("SUCCESS: Operation completed")
+                .toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        AttributedString plainText = builder.append("This is plain text").toAttributedString();
+        builder = new AttributedStringBuilder();
+
+        // Print the styled text
+        terminal.writer().println(errorText);
+        terminal.writer().println(warningText);
+        terminal.writer().println(infoText);
+        terminal.writer().println(successText);
+        terminal.writer().println(plainText);
+
+        // Create a combined style
+        AttributedStyle combinedStyle =
+                AttributedStyle.BOLD.foreground(AttributedStyle.RED).underline();
+
+        // Apply combined style
+        AttributedString combinedText =
+                builder.style(combinedStyle).append("Bold, red, and underlined").toAttributedString();
+
+        terminal.writer().println();
+        terminal.writer().println(combinedText);
+
+        terminal.flush();
+        terminal.close();
+    }
+    // SNIPPET_END: StylerExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/SystemRegistryExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SystemRegistryExample.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+/**
+ * Example demonstrating a simple command registry.
+ */
+public class SystemRegistryExample {
+
+    // SNIPPET_START: SystemRegistryExample
+    public static void main(String[] args) throws Exception {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Set up working directory
+        Path workDir = Paths.get(System.getProperty("user.dir"));
+
+        // Create a line reader
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .parser(new DefaultParser())
+                .build();
+
+        // Create a simple command registry
+        Map<String, Function<String[], Integer>> commands = new HashMap<>();
+
+        // Add commands to the registry
+        commands.put("hello", cmdArgs -> {
+            terminal.writer().println("Hello, JLine!");
+            return 0;
+        });
+
+        commands.put("echo", cmdArgs -> {
+            if (cmdArgs.length > 1) {
+                for (int i = 1; i < cmdArgs.length; i++) {
+                    terminal.writer().print(cmdArgs[i]);
+                    if (i < cmdArgs.length - 1) {
+                        terminal.writer().print(" ");
+                    }
+                }
+                terminal.writer().println();
+            }
+            return 0;
+        });
+
+        commands.put("pwd", cmdArgs -> {
+            terminal.writer().println(workDir.toAbsolutePath());
+            return 0;
+        });
+
+        commands.put("help", cmdArgs -> {
+            terminal.writer().println("Available commands:");
+            for (String cmd : commands.keySet()) {
+                terminal.writer().println("  " + cmd);
+            }
+            return 0;
+        });
+
+        // Print instructions
+        terminal.writer().println("SystemRegistry Example");
+        terminal.writer().println("Available commands: hello, echo, pwd, help");
+        terminal.writer().println("Type 'exit' to quit");
+        terminal.writer().println();
+
+        // Main command loop
+        while (true) {
+            String line = reader.readLine("registry> ");
+
+            if (line.equals("exit") || line.equals("quit")) {
+                break;
+            }
+
+            try {
+                // Parse the line
+                ParsedLine pl = reader.getParser().parse(line, 0);
+                String[] cmdArgs = pl.words().toArray(new String[0]);
+
+                if (cmdArgs.length > 0) {
+                    String command = cmdArgs[0];
+
+                    // Execute the command if it exists
+                    if (commands.containsKey(command)) {
+                        commands.get(command).apply(cmdArgs);
+                    } else {
+                        terminal.writer().println("Unknown command: " + command);
+                        terminal.writer().println("Type 'help' for a list of commands");
+                    }
+                }
+            } catch (Exception e) {
+                terminal.writer().println("Error: " + e.getMessage());
+            }
+
+            terminal.flush();
+        }
+
+        terminal.writer().println("Goodbye!");
+        terminal.close();
+    }
+    // SNIPPET_END: SystemRegistryExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/TailTipWidgetsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TailTipWidgetsExample.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jline.console.CmdDesc;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.impl.completer.StringsCompleter;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.widget.TailTipWidgets;
+import org.jline.widget.TailTipWidgets.TipType;
+
+/**
+ * Example demonstrating TailTip widgets in JLine.
+ */
+public class TailTipWidgetsExample {
+
+    // SNIPPET_START: TailTipWidgetsExample
+    public static void main(String[] args) throws IOException {
+        // Create a terminal
+        Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+        // Create a line reader with some completions for demonstration
+        LineReader reader = LineReaderBuilder.builder()
+                .terminal(terminal)
+                .completer(new StringsCompleter("help", "widget", "exit", "clear"))
+                .build();
+
+        // Create command descriptions for TailTipWidgets
+        Map<String, CmdDesc> tailTips = new HashMap<>();
+
+        // Description for 'help' command
+        tailTips.put("help", new CmdDesc(Arrays.asList(new AttributedString("Display help information")), null, null));
+
+        // Description for 'widget' command with options
+        List<AttributedString> mainDesc = Arrays.asList(
+                new AttributedString("widget -N new-widget [function-name]"),
+                new AttributedString("widget -D widget ..."),
+                new AttributedString("widget -A old-widget new-widget"),
+                new AttributedString("widget -l [options]"));
+
+        Map<String, List<AttributedString>> widgetOpts = new HashMap<>();
+        widgetOpts.put("-N", Arrays.asList(new AttributedString("Create new widget")));
+        widgetOpts.put("-D", Arrays.asList(new AttributedString("Delete widgets")));
+        widgetOpts.put("-A", Arrays.asList(new AttributedString("Create alias to widget")));
+        widgetOpts.put("-l", Arrays.asList(new AttributedString("List user-defined widgets")));
+
+        tailTips.put("widget", new CmdDesc(mainDesc, null, widgetOpts));
+
+        // Create tailtip widgets that uses description window size 5
+        // and displays suggestions based on the completer
+        TailTipWidgets tailtipWidgets = new TailTipWidgets(reader, tailTips, 5, TipType.COMPLETER);
+
+        // Enable tailtip widgets
+        tailtipWidgets.enable();
+
+        // Display instructions
+        terminal.writer().println("TailTip Widgets Example");
+        terminal.writer().println("----------------------");
+        terminal.writer().println("As you type commands, you'll see suggestions and descriptions.");
+        terminal.writer().println("Try typing 'widget' to see command options and descriptions.");
+        terminal.writer().println("- Type 'exit' to quit");
+        terminal.writer().println();
+
+        // Read input with tailtip widgets
+        String line;
+        while (true) {
+            try {
+                line = reader.readLine("tailtip> ");
+
+                if (line.equalsIgnoreCase("exit")) {
+                    break;
+                } else if (line.equalsIgnoreCase("clear")) {
+                    terminal.writer().print("\033[H\033[2J");
+                    terminal.writer().flush();
+                } else {
+                    terminal.writer().println("You entered: " + line);
+                    terminal.writer().flush();
+                }
+            } catch (Exception e) {
+                terminal.writer().println("Error: " + e.getMessage());
+                terminal.writer().flush();
+            }
+        }
+
+        terminal.close();
+    }
+    // SNIPPET_END: TailTipWidgetsExample
+}

--- a/demo/src/main/java/org/jline/demo/examples/ThemeSystemExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ThemeSystemExample.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Example demonstrating the JLine theme system.
+ */
+public class ThemeSystemExample {
+
+    // SNIPPET_START: ThemeSystemExample
+    public static void main(String[] args) {
+        try {
+            // Create a terminal
+            Terminal terminal = TerminalBuilder.builder().system(true).build();
+
+            // Create a line reader
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+
+            // Create a theme system file
+            Path themeFile = createThemeFile();
+
+            // Create a syntax file that uses the theme
+            Path syntaxFile = createSyntaxFile();
+
+            // Create a map for theme styles
+            Map<String, AttributedStyle> themeMap = new HashMap<>();
+
+            // Add some example styles
+            themeMap.put("BOOLEAN", AttributedStyle.DEFAULT.foreground(AttributedStyle.WHITE));
+            themeMap.put("NUMBER", AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE));
+            themeMap.put("CONSTANT", AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW));
+            themeMap.put("COMMENT", AttributedStyle.DEFAULT.foreground(AttributedStyle.BRIGHT | AttributedStyle.BLACK));
+            themeMap.put("STRING", AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN));
+
+            // Display information about the theme system
+            terminal.writer().println("Theme System Example");
+            terminal.writer().println("-------------------");
+            terminal.writer().println("Theme file: " + themeFile);
+            terminal.writer().println("Syntax file: " + syntaxFile);
+            terminal.writer().println();
+
+            // Display the theme styles
+            terminal.writer().println("Theme Styles:");
+            for (Map.Entry<String, AttributedStyle> entry : themeMap.entrySet()) {
+                AttributedStringBuilder asb = new AttributedStringBuilder();
+                asb.append("  ");
+                asb.append(entry.getKey(), entry.getValue());
+                asb.append(": ");
+                asb.styled(entry.getValue(), "This is styled text");
+                terminal.writer().println(asb.toAttributedString());
+            }
+            terminal.writer().println();
+
+            // Display a sample of styled text
+            terminal.writer().println("Sample Styled Text:");
+            String sampleCode = "// This is a comment\n" + "public class Example {\n"
+                    + "    public static void main(String[] args) {\n"
+                    + "        boolean flag = true;\n"
+                    + "        int number = 42;\n"
+                    + "        System.out.println(\"Hello, World!\");\n"
+                    + "    }\n"
+                    + "}\n";
+
+            for (String line : sampleCode.split("\n")) {
+                AttributedStringBuilder asb = new AttributedStringBuilder();
+
+                // Apply simple styling based on content
+                if (line.trim().startsWith("//")) {
+                    asb.styled(themeMap.get("COMMENT"), line);
+                } else if (line.contains("true")) {
+                    String before = line.substring(0, line.indexOf("true"));
+                    String keyword = "true";
+                    String after = line.substring(line.indexOf("true") + 4);
+                    asb.append(before);
+                    asb.styled(themeMap.get("BOOLEAN"), keyword);
+                    asb.append(after);
+                } else if (line.contains("42")) {
+                    String before = line.substring(0, line.indexOf("42"));
+                    String number = "42";
+                    String after = line.substring(line.indexOf("42") + 2);
+                    asb.append(before);
+                    asb.styled(themeMap.get("NUMBER"), number);
+                    asb.append(after);
+                } else if (line.contains("\"Hello, World!\"")) {
+                    String before = line.substring(0, line.indexOf("\"Hello, World!\""));
+                    String string = "\"Hello, World!\"";
+                    String after = line.substring(line.indexOf("\"Hello, World!\"") + 15);
+                    asb.append(before);
+                    asb.styled(themeMap.get("STRING"), string);
+                    asb.append(after);
+                } else {
+                    asb.append(line);
+                }
+
+                terminal.writer().println(asb.toAttributedString());
+            }
+
+            terminal.writer().flush();
+            terminal.close();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static Path createThemeFile() throws IOException {
+        String themeContent = "# Theme system configuration file\n" + "BOOLEAN     brightwhite\n"
+                + "NUMBER      blue\n"
+                + "CONSTANT    yellow\n"
+                + "COMMENT     brightblack\n"
+                + "DOC_COMMENT white\n"
+                + "TODO        brightwhite,yellow\n"
+                + "WHITESPACE  ,green\n"
+                + "STRING      green\n"
+                + "KEYWORD     brightblue\n"
+                + "TYPE        cyan\n"
+                + "IDENTIFIER  white\n"
+                + "OPERATOR    red\n"
+                + "#\n"
+                + "# mixin\n"
+                + "#\n"
+                + "+LINT   WHITESPACE: \"[[:space:]]+$\" \\n WHITESPACE: \"\\t*\"\n"
+                + "#\n"
+                + "# parser\n"
+                + "#\n"
+                + "$LINE_COMMENT   COMMENT \\n TODO: \"(FIXME|TODO|XXX)\"\n"
+                + "$BLOCK_COMMENT  COMMENT \\n DOC_COMMENT: startWith=/** \\n TODO: \"(FIXME|TODO|XXX)\"\n";
+
+        Path themeFile = Paths.get("example-theme.nanorctheme");
+        Files.write(themeFile, themeContent.getBytes());
+        return themeFile;
+    }
+
+    private static Path createSyntaxFile() throws IOException {
+        String syntaxContent = "# Syntax file for Java\n" + "syntax \"java\" \"\\.java$\"\n"
+                + "\n"
+                + "# Keywords\n"
+                + "KEYWORD: \"\\b(abstract|assert|break|case|catch|class|const|continue|default|do|else|enum|extends|final|finally|for|goto|if|implements|import|instanceof|interface|native|new|package|private|protected|public|return|static|strictfp|super|switch|synchronized|this|throw|throws|transient|try|volatile|while)\\b\"\n"
+                + "\n"
+                + "# Types\n"
+                + "TYPE: \"\\b(boolean|byte|char|double|float|int|long|short|void)\\b\"\n"
+                + "\n"
+                + "# Boolean and null literals\n"
+                + "BOOLEAN: \"\\b(true|false|null)\\b\"\n"
+                + "\n"
+                + "# Numbers\n"
+                + "~NUMBER: \"\\b([0-9]+)\\b\" \"\\b0x[0-9a-fA-F]+\\b\"\n"
+                + "\n"
+                + "# String literals\n"
+                + "STRING: \"\\\".*?\\\"\" \"'.*?'\"\n"
+                + "\n"
+                + "# Constants\n"
+                + "CONSTANT: \"\\b[A-Z]+([_]{1}[A-Z]+){0,}\\b\"\n"
+                + "\n"
+                + "# Comments\n"
+                + "$LINE_COMMENT: \"//\"\n"
+                + "$BLOCK_COMMENT: \"/*, */\"\n"
+                + "\n"
+                + "# Include the LINT mixin\n"
+                + "+LINT\n";
+
+        Path syntaxFile = Paths.get("java.nanorc");
+        Files.write(syntaxFile, syntaxContent.getBytes());
+        return syntaxFile;
+    }
+    // SNIPPET_END: ThemeSystemExample
+}

--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -440,6 +440,7 @@ public interface LineReader {
         HISTORY_IGNORE_DUPS(true),
         HISTORY_REDUCE_BLANKS(true),
         HISTORY_BEEP(true),
+        /** automatically save history when the line reader reads a new line (enabled by default) */
         HISTORY_INCREMENTAL(true),
         HISTORY_TIMESTAMPED(true),
         /** when displaying candidates, group them by {@link Candidate#group()} */

--- a/website/docs/advanced/auto-indentation-pairing.md
+++ b/website/docs/advanced/auto-indentation-pairing.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 15
+---
+
+# Auto Indentation and Pairing
+
+import CodeSnippet from '@site/src/components/CodeSnippet';
+
+JLine provides features for auto-indentation and auto-pairing of brackets and quotes, which can enhance the user experience when writing multi-line commands or code snippets.
+
+## AutopairWidgets
+
+A simple plugin that auto-closes, deletes and skips over matching delimiters in JLine. `AutopairWidgets` has been ported to JLine/Java from [zsh-autopair](https://github.com/hlissner/zsh-autopair/).
+
+<CodeSnippet name="AutopairWidgetsExample" />
+
+### Functionality
+
+`AutopairWidgets` does 5 things for you:
+
+1. **It inserts matching pairs** (by default, that means brackets, quotes and spaces):
+   
+   e.g. `echo |` => " => `echo "|"`
+
+2. **It skips over matched pairs**:
+   
+   e.g. `cat ./*.{py,rb|}` => } => `cat ./*.{py,rb}|`
+
+3. **It auto-deletes pairs on backspace**:
+   
+   e.g. `git commit -m "|"` => backspace => `git commit -m |`
+
+4. **And does all of the above only when it makes sense to do so**. e.g. when the pair is balanced and when the cursor isn't next to a boundary character:
+   
+   e.g. `echo "|""` => backspace => `echo |""` (doesn't aggressively eat up too many quotes)
+
+5. **Spaces between brackets are expanded and contracted**:
+   
+   e.g. `echo [|]` => space => `echo [ | ]` => backspace => `echo [|]`
+
+**Note:** _In above examples cursor position is marked as |._
+
+### Configuration
+
+By default curly brackets `{}` are not paired by AutopairWidgets. Curly bracket pairing can be enabled by creating AutopairWidgets as:
+
+```java
+AutopairWidgets autopairWidgets = new AutopairWidgets(reader, true);
+```
+
+### Key Bindings
+
+This plugin provides `autopair-toggle` widget that toggles between enabled/disabled autopair.
+
+## Auto Indentation
+
+Command line auto indentation has been implemented in `DefaultParser` and `LineReaderImpl` classes.
+
+<CodeSnippet name="AutoIndentationExample" />
+
+### Functionality
+
+Widget `accept-line` calls `Parser`'s method `parser(...)` that in case of unclosed brackets will throw `EOFError` exception that is caught by `accept-line` widget. `EOFError` exception contains necessary information to add indentation and the next closing bracket to the buffer.
+
+Note that the last closing bracket must be entered manually even when option `INSERT_BRACKET` has been set to `true`.
+
+## Best Practices
+
+When using auto-indentation and pairing in JLine, consider these best practices:
+
+1. **Selective Enabling**: Enable these features only when they add value to the user experience, such as in REPL environments or code editors.
+
+2. **User Control**: Always provide a way for users to toggle these features on/off.
+
+3. **Consistent Indentation**: Use a consistent indentation size throughout your application.
+
+4. **Bracket Handling**: Consider whether you want to include curly brackets in auto-pairing based on your application's needs.
+
+5. **Documentation**: Document these features and their key bindings for your users.
+
+6. **Testing**: Test these features with various input patterns to ensure they behave as expected.
+
+7. **Combine with Syntax Highlighting**: These features work best when combined with syntax highlighting to provide visual feedback.
+
+8. **Language-Specific Configuration**: Consider customizing these features based on the programming language or command syntax your application supports.

--- a/website/docs/advanced/autosuggestions.md
+++ b/website/docs/advanced/autosuggestions.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 14
+---
+
+# Autosuggestions
+
+import CodeSnippet from '@site/src/components/CodeSnippet';
+
+JLine provides powerful autosuggestion capabilities that can enhance the user experience by suggesting commands as they type. This page explains how to use autosuggestions in your JLine applications.
+
+## AutosuggestionWidgets
+
+Fish-like autosuggestions for JLine. `AutosuggestionWidgets` suggests commands as you type based on command history.
+
+<CodeSnippet name="AutosuggestionWidgetsExample" />
+
+### Usage
+
+As you type commands, you will see a completion offered after the cursor in a muted gray color.
+
+If you press the → key (`forward-char` widget) or End (`end-of-line` widget) with the cursor at the end of the buffer, it will accept the suggestion, replacing the contents of the command line buffer with the suggestion.
+
+If you invoke the `forward-word` widget, it will partially accept the suggestion up to the point that the cursor moves to.
+
+### Key Bindings
+
+This plugin provides `autosuggest-toggle` widget that toggles between enabled/disabled suggestions.
+
+## TailTipWidgets
+
+`TailTipWidgets` suggests commands as you type based on command completer data and/or command arguments and options descriptions.
+
+<CodeSnippet name="TailTipWidgetsExample" />
+
+### Usage
+
+As you type commands, you will see a completion offered after the cursor in a muted gray color and argument/option description on status pane.
+
+Command line tab completion works as normal.
+
+### Configuration
+
+Description pane can be disabled by setting `descriptionSize = 0`. Suggestions type can be configured using constructor parameter `tipType`:
+
+1. `COMPLETER` - Tab completions are displayed below command line. No suggestions are displayed after cursor.
+2. `TAIL_TIP` - Argument suggestions are displayed after cursor. No tab completions are displayed.
+3. `COMBINED` - Argument suggestions are shown if available otherwise tab completions are displayed.
+
+The maximum number of completer suggestions displayed can be controlled by JLine variable `list-max`.
+
+For example, creating TailTipWidgets as:
+
+```java
+TailTipWidgets tailtipWidgets = new TailTipWidgets(reader, tailTips, 0, TipType.TAIL_TIP);
+```
+
+you will obtain Redis-like suggestions.
+
+### Key Bindings
+
+This plugin provides two widgets:
+
+1. `tailtip-toggle` - Toggles between enabled/disabled suggestions.
+2. `tailtip-window` - Toggles tailtip description pane.
+
+For example, this would bind alt + w to toggle tailtip description pane:
+
+```java
+reader.getKeyMaps().get(LineReader.MAIN).bind(new Reference("tailtip-window"), KeyMap.alt('w'));
+```
+
+## Best Practices
+
+When using autosuggestions in JLine, consider these best practices:
+
+1. **Selective Enabling**: Enable autosuggestions only when they add value to the user experience.
+
+2. **Performance**: Be mindful of performance, especially with large history files or complex completers.
+
+3. **Visual Distinction**: Ensure that suggestions are visually distinct from user input.
+
+4. **User Control**: Always provide a way for users to toggle autosuggestions on/off.
+
+5. **Combine with History**: Autosuggestions work best when combined with a well-maintained history.
+
+6. **Context Awareness**: Use TailTipWidgets for context-aware suggestions based on command syntax.
+
+7. **Documentation**: Document the autosuggestion features and key bindings for your users.
+
+8. **Testing**: Test autosuggestions with various input patterns to ensure they behave as expected.

--- a/website/docs/advanced/nano-less-customization.md
+++ b/website/docs/advanced/nano-less-customization.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 17
+---
+
+# Nano and Less Customization
+
+import CodeSnippet from '@site/src/components/CodeSnippet';
+
+JLine provides built-in support for customizing the behavior of the `nano` and `less` commands through configuration files. This page explains how to customize these commands to suit your needs.
+
+## Overview
+
+Both `nano` and `less` commands in JLine can be customized using configuration files similar to the standard [nanorc](https://www.nano-editor.org/dist/latest/nanorc.5.html) format. These configuration files are named `jnanorc` and `jlessrc` respectively.
+
+<CodeSnippet name="NanoLessCustomizationExample" />
+
+## Configuration Setup
+
+To set up the configuration for `nano` and `less` commands, you need to create a `ConfigurationPath` object that specifies where to look for configuration files:
+
+```java
+ConfigurationPath configPath = new ConfigurationPath(
+    Paths.get("/pub/myApp"),                           // application-wide settings
+    Paths.get(System.getProperty("user.home"), ".myApp") // user-specific settings
+);
+```
+
+Then, you can use this configuration path when creating the `Builtins` and `SystemRegistry` objects:
+
+```java
+Supplier<Path> workDir = () -> Paths.get("");
+Builtins builtins = new Builtins(workDir, configPath, null);
+SystemRegistry systemRegistry = new SystemRegistry(parser, terminal, workDir, configPath);
+systemRegistry.setCommandRegistries(builtins);
+```
+
+## Configuration Options
+
+The `jnanorc`/`jlessrc` file contains the default settings for `nano`/`less`. During startup, the command tries to read the user-specific settings first and then its application-wide settings. Application-wide settings are read only if user-specific settings do not exist.
+
+The configuration file accepts a series of **set** and **unset** commands, which can be used to configure `nano`/`less` on startup without using command-line options.
+
+In addition, the configuration file might have '**include** syntaxfile' commands to read self-contained color syntaxes from a syntax file. The syntax file parameter can have '\*' and '?' wildcards in its file name.
+
+If neither application-wide nor user-specific settings are found at command startup, then syntax files are searched from a standard installation location: `/usr/share/nano`.
+
+### Example Configuration
+
+Here's an example of a `jnanorc` configuration file:
+
+```
+include /usr/share/nano/*.nanorc
+set tabstospaces
+set autoindent
+set tempfile
+set historylog search.log
+```
+
+Note that the history log is saved in the user-specific directory, and the file can be shared between `nano` and `less` applications.
+
+## Theme System
+
+JLine version > 3.21.0 includes a [Theme System](theme-system.md) that allows highlight rules to be specified in terms of token type names, mixins, and parser configurations, instead of hard-coded colors in nanorc files.
+
+Optional theme system configuration is set by adding a '**theme** theme-system-file' command in `jnanorc`/`jlessrc` configuration files.
+
+## Syntax Highlighting
+
+JLine's nanorc [SyntaxHighlighter](syntax-highlighting.md) works with standard nanorc [syntax files](https://github.com/scopatz/nanorc).
+
+JLine supports the following nanorc keywords:
+- **syntax**: Defines a new syntax highlighting rule set
+- **color**: Defines a color for a specific pattern
+- **icolor**: Defines a case-insensitive color for a specific pattern
+
+Other nanorc keywords are quietly ignored.
+
+## Rebinding Keys
+
+Key rebinding is not currently supported in JLine's implementation of `nano` and `less`.
+
+## Best Practices
+
+When customizing `nano` and `less` in JLine, consider these best practices:
+
+1. **Configuration Organization**: Keep your configuration files organized and well-documented.
+
+2. **Syntax Highlighting**: Use syntax highlighting to improve readability of code and other structured text.
+
+3. **Theme System**: Use the theme system to maintain consistent highlighting across different file types.
+
+4. **User-Specific Settings**: Provide sensible defaults in application-wide settings, but allow users to override them with user-specific settings.
+
+5. **Documentation**: Document your customizations for other users.
+
+6. **Testing**: Test your customizations with different types of files to ensure they work as expected.
+
+7. **Performance**: Be mindful of performance, especially when defining complex syntax highlighting rules.
+
+8. **Compatibility**: Try to maintain compatibility with standard nanorc syntax where possible.

--- a/website/docs/advanced/theme-system.md
+++ b/website/docs/advanced/theme-system.md
@@ -1,0 +1,174 @@
+---
+sidebar_position: 16
+---
+
+# Theme System
+
+import CodeSnippet from '@site/src/components/CodeSnippet';
+
+JLine provides a flexible theme system that allows you to customize the appearance of your terminal applications. This page explains how to use and configure the theme system.
+
+## Overview
+
+In the JLine theme system, highlight styles are specified in nanorc theme configuration files using token type names, mixins, and parser configurations, instead of hard-coded styles. This approach provides a more flexible and maintainable way to define syntax highlighting and other visual elements.
+
+The theme system is particularly useful for:
+
+- Creating consistent syntax highlighting across different file types
+- Customizing the appearance of command-line interfaces
+- Supporting different color schemes for different environments
+
+## Functionality
+
+Theme system configuration is set by adding a `theme theme-system-file` command in the `jnanorc` configuration file. At startup, theme system token type name configurations are copied to the CLI console map variable `CONSOLE_OPTIONS[NANORC_THEME]`.
+
+All the REPL highlight styles are defined by either nano `syntaxHighlighter`s or console variables. Highlight styles in various configurations are specified using the theme system token type names.
+
+The console variable `CONSOLE_OPTIONS[NANORC_THEME]` is recreated when executing the built-in command: `highlighter --refresh` or `highlighter --switch=<new-theme>`. The `highlighter` command will refresh also `lineReader`'s `COMPLETION_STYLE`s and all `syntaxHighlighter`s used by the REPL demo.
+
+<CodeSnippet name="ThemeSystemExample" />
+
+## Theme System File Syntax
+
+### Token Type Name
+
+Token type name configuration:
+
+```
+TOKEN_TYPE_NAME <style>
+```
+
+Where:
+- `TOKEN_TYPE_NAME` is the name of the token type in camel case
+- `<style>` is its style (see [nanorc style definition syntax](https://jline.org/docs/advanced/syntax-highlighting))
+
+### Mixin
+
+Mixin configuration:
+
+```
++MIXIN_NAME TOKEN_TYPE_1 <regex> ... \n TOKEN_TYPE_2 <regex2> ... \n ...
+```
+
+Where:
+- `MIXIN_NAME` is the name in camel case
+- `TOKEN_TYPE_<n>` are the token type names
+
+Mixin configurations are relevant only in nanorc syntax highlighting.
+
+### Parser Configurations
+
+The theme system implements three parsing configurations for line comments, block comments, and literal strings:
+- `$LINE_COMMENT`
+- `$BLOCK_COMMENT`
+- `$BALANCED_DELIMITERS`
+
+The literal string and comment delimiters parsing configuration is placed in the nanorc syntax file, and syntax highlight rules are in the system theme file.
+
+nanorc syntax file:
+
+```
+$LINE_COMMENT        "<delimiter>"
+$BLOCK_COMMENT       "<start_delimiter>, <end_delimiter>"
+$BALANCED_DELIMITERS "<delimiter_1>, <delimiter_2>, ..."
+```
+
+nanorctheme file:
+
+```
+$PARSER TOKEN_TYPE \n TOKEN_TYPE_2: <condition> \n ...
+```
+
+Where:
+- `<condition> = <regex> ... | startWith=<value> | continueAs=<regex>`
+- `TOKEN_TYPE_<n>` are the token type names
+
+Parser configurations are relevant only in nanorc syntax highlighting.
+
+## Example
+
+Theme system configuration file:
+
+```
+BOOLEAN     brightwhite
+NUMBER      blue
+CONSTANT    yellow
+COMMENT     brightblack
+DOC_COMMENT white
+TODO        brightwhite,yellow
+WHITESPACE  ,green
+#
+# mixin
+#
++LINT   WHITESPACE: "[[:space:]]+$" \n WHITESPACE: "\t*"
+#
+# parser
+#
+$LINE_COMMENT   COMMENT \n TODO: "(FIXME|TODO|XXX)"
+$BLOCK_COMMENT  COMMENT \n DOC_COMMENT: startWith=/** \n TODO: "(FIXME|TODO|XXX)"
+```
+
+nanorc syntax file using the above system theme configurations:
+
+```
+BOOLEAN:  "\b(true|false)\b"
+CONSTANT: "\b[A-Z]+([_]{1}[A-Z]+){0,}\b"
+~NUMBER:  "\b(([1-9][0-9]+)|0+)\.[0-9]+\b" "\b[1-9][0-9]*\b" "\b0[0-7]*\b" "\b0x[1-9a-f][0-9a-f]*\b"
+$LINE_COMMENT:        "//"
+$BLOCK_COMMENT:       "/*, */"
++LINT
+```
+
+Equivalent self-contained nanorc syntax file that does not use the theme system:
+
+```
+color brightwhite "\b(true|false)\b"
+color yellow      "\b[A-Z]+([_]{1}[A-Z]+){0,}\b"
+icolor blue       "\b(([1-9][0-9]+)|0+)\.[0-9]+\b" "\b[1-9][0-9]*\b" "\b0[0-7]*\b" "\b0x[1-9a-f][0-9a-f]*\b"
+color brightblack "//.*"
+color brightblack start="^\s*/\*" end="\*/"
+color white       start="/\*\*" end="\*/"
+color brightwhite,yellow "(FIXME|TODO|XXX)"
+color ,green      "[[:space:]]+$"
+color ,green      "\t*"
+```
+
+**Note:** In the case of a self-contained nanorc syntax file, the highlighter uses only regexes for highlighting.
+
+## Creating Nanorc Themes
+
+You can define your nanorc theme using a 16-color palette and switch between different color themes by changing your terminal palette. Available themes and installation instructions can be found in projects like:
+- [Gogh](https://mayccoll.github.io/Gogh/)
+- [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes)
+- [microsoft/ColorTool](https://github.com/microsoft/terminal/tree/main/src/tools/ColorTool)
+
+If your terminal color palette is not easily replaceable (or a 16-color palette is not enough), you can use hard-coded color definitions in your nanorc theme file. A nanorc theme with hard-coded color definitions can be created using `nanorctheme.template`, `apply-colors.sh`, and [Gogh](https://gogh-co.github.io/Gogh/).
+
+On Linux:
+
+```bash
+cd git/jline3
+./build rebuild
+cd demo/target/nanorc
+bash -c "$(wget -qO- https://git.io/vQgMr)"
+```
+
+## Best Practices
+
+When using the JLine theme system, consider these best practices:
+
+1. **Consistent Naming**: Use consistent token type names across your theme files.
+
+2. **Reuse Mixins**: Create mixins for common patterns to avoid duplication.
+
+3. **Theme Organization**: Keep your theme files organized and well-documented.
+
+4. **Testing**: Test your themes in different terminal environments to ensure compatibility.
+
+5. **Color Accessibility**: Consider color blindness and other accessibility concerns when designing themes.
+
+6. **Documentation**: Document your themes and their intended use cases.
+
+7. **Version Control**: Keep your theme files under version control to track changes.
+
+8. **Sharing**: Share your themes with the community to benefit others.

--- a/website/docs/history.md
+++ b/website/docs/history.md
@@ -38,17 +38,83 @@ You can access the history programmatically:
 
 <CodeSnippet name="ProgrammaticHistoryAccessExample" />
 
+## On Startup
+
+The line reader will load history on the first use, but you can pre-load history if you like:
+
+```java
+History history = myLineReader.getHistory();
+// Make sure the instance has access to the reader's variable set,
+// and load history.
+history.attach(myLineReader);
+```
+
+## On Exit
+
+By default, JLine automatically saves history when the line reader reads a new line, thanks to the `HISTORY_INCREMENTAL` option which is enabled by default. However, if you've disabled this option or want to ensure history is saved at the end of your application, you should explicitly save the history:
+
+```java
+try {
+    myLineReader.getHistory().save();
+} catch (IOException e) {
+    // Handle exception
+}
+```
+
+This is particularly important if the reader loop exits with an exception. You might put your save call in a `finally` block, in a shutdown hook, or signal handler.
+
+To control automatic history saving, you can set the `HISTORY_INCREMENTAL` option:
+
+```java
+// Enable automatic history saving (this is the default)
+lineReader.setOption(LineReader.Option.HISTORY_INCREMENTAL, true);
+
+// Disable automatic history saving
+lineReader.setOption(LineReader.Option.HISTORY_INCREMENTAL, false);
+```
+
 ## History Expansion
 
 JLine supports history expansion similar to Bash:
 
 <CodeSnippet name="HistoryExpansionExample" />
 
+If you want to disable history expansion (commands like `!`, `!!`, `!n`, `!-n`, `!string`, and `^string1^string2`) and escape character interpretation, you can use the `DISABLE_EVENT_EXPANSION` option:
+
+```java
+// Disable history expansion and escape character interpretation
+lineReader.setOption(LineReader.Option.DISABLE_EVENT_EXPANSION, true);
+
+// Enable history expansion and escape character interpretation (this is the default)
+lineReader.setOption(LineReader.Option.DISABLE_EVENT_EXPANSION, false);
+```
+
+Disabling event expansion is useful in applications where:
+- The `!` character is commonly used for other purposes
+- You need to support Windows-style paths with backslashes (e.g., `C:\Users\name`) without having the backslashes interpreted as escape characters
+
 ## History Search
 
 You can search through history programmatically:
 
 <CodeSnippet name="HistorySearchExample" />
+
+## Race Conditions
+
+Beware that if a single user has multiple instances of your program running concurrently, saving history from one could clobber content from another.
+
+This is not usually a problem in practice since the default `History` implementation takes care to only append history entries from the current session:
+
+```java
+try (Writer writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8,
+        StandardOpenOption.WRITE, StandardOpenOption.APPEND, StandardOpenOption.CREATE)) {
+    for (Entry entry : items.subList(from, items.size())) {
+        if (isPersistable(entry)) {
+            writer.append(format(entry));
+        }
+    }
+}
+```
 
 ## Best Practices
 
@@ -73,3 +139,7 @@ When using history in JLine, consider these best practices:
 9. **Testing**: Test history functionality thoroughly, especially persistence and expansion.
 
 10. **Cleanup**: Provide a way for users to clear their history if needed.
+
+11. **Save on Exit**: Always save history when your application exits, preferably in a finally block or shutdown hook.
+
+12. **Race Conditions**: Be aware of potential race conditions when multiple instances of your application are running concurrently.

--- a/website/docs/line-reader.md
+++ b/website/docs/line-reader.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Line Reading
 
-The `LineReader` is one of JLine's core components, providing sophisticated line editing capabilities for your command-line applications.
+The `LineReader` is one of JLine's core components, providing sophisticated line editing capabilities for your command-line applications. It allows reading lines from a terminal, with full input/line editing.
 
 ## Creating a LineReader
 
@@ -12,7 +12,40 @@ Use the `LineReaderBuilder` to create a `LineReader` instance:
 
 import CodeSnippet from '@site/src/components/CodeSnippet';
 
+```java
+Terminal terminal = ...;
+LineReader lineReader = LineReaderBuilder.builder()
+                        .terminal(terminal)
+                        .build();
+```
+
 <CodeSnippet name="LineReaderCreationExample" />
+
+## LineReader Building Options
+
+The builder can be customized to create more suitable line readers:
+
+```java
+LineReader lineReader = LineReaderBuilder.builder()
+                        .terminal(terminal)
+                        .completer(new MyCompleter())
+                        .highlighter(new MyHighlighter())
+                        .parser(new MyParser())
+                        .build();
+```
+
+Here are the main options available:
+
+| Option | Description |
+|--------|-------------|
+| terminal | The `Terminal` to use |
+| appName | The application name |
+| variables | A `Map<String, Object>` containing variables |
+| completer | The `Completer` component to use |
+| history | The `History` component to use |
+| highlighter | The `Highlighter` component to use |
+| parser | The `Parser` component to use |
+| expander | The `Expander` component to use |
 
 ## Reading Input
 
@@ -71,6 +104,103 @@ JLine can highlight input as it's typed:
 
 <CodeSnippet name="HighlighterExample" />
 
+## Simple Line Reading
+
+For REPL style programs, you can use a simple loop:
+
+```java
+LineReader reader = LineReaderBuilder.builder().build();
+String prompt = ...;
+while (true) {
+    String line = null;
+    try {
+        line = reader.readLine(prompt);
+    } catch (UserInterruptException e) {
+        // Ignore
+    } catch (EndOfFileException e) {
+        return;
+    }
+    // Process the line
+    ...
+}
+```
+
+## Various ReadLine Methods
+
+There are a few overridden `readLine` methods that take various parameters, depending on the use cases. They all delegate to the most generic one which is:
+
+```java
+String readLine(String prompt, String rightPrompt, Character mask, String buffer) throws UserInterruptException, EndOfFileException;
+```
+
+- `prompt` is the unexpanded prompt pattern that will be displayed to the user on the left of the input line
+- `rightPrompt` is the unexpanded prompt pattern that will be displayed on the right of the first input line
+- `mask` is the character used to hide user input (when reading a password for example)
+- `buffer` is the initial content of the input line
+
+## Widgets and Key Mapping
+
+JLine has a couple of built-in widgets: `AutoPairWidgets`, `AutosuggestionWidgets` and `TailTipWidgets`.
+
+You can create custom widgets and bind them to keystrokes:
+
+```java
+import static org.jline.keymap.KeyMap.ctrl;
+import static org.jline.keymap.KeyMap.alt;
+import org.jline.reader.LineReader;
+import org.jline.reader.Reference;
+
+public static class MyWidgets extends org.jline.widget.Widgets {
+
+    public MyWidgets(LineReader reader) {
+        super(reader);
+        addWidget("test-widget", this::testWidget);
+        getKeyMap().bind(new Reference("test-widget"), alt(ctrl('X')));
+    }
+
+    public boolean testWidget() {
+        try {
+            String name = buffer().toString().split("\\s+")[0];
+            reader.callWidget(name);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+}
+```
+
+## Simple Line Reading
+
+For REPL style programs, you can use a simple loop:
+
+<CodeSnippet name="SimpleLineReadingExample" />
+
+## Various ReadLine Methods
+
+There are a few overridden `readLine` methods that take various parameters, depending on the use cases. They all delegate to the most generic one which is:
+
+```java
+String readLine(String prompt, String rightPrompt, Character mask, String buffer) throws UserInterruptException, EndOfFileException;
+```
+
+- `prompt` is the unexpanded prompt pattern that will be displayed to the user on the left of the input line
+- `rightPrompt` is the unexpanded prompt pattern that will be displayed on the right of the first input line
+- `mask` is the character used to hide user input (when reading a password for example)
+- `buffer` is the initial content of the input line
+
+## Widgets and Key Mapping
+
+JLine has a couple of built-in widgets: `AutoPairWidgets`, `AutosuggestionWidgets` and `TailTipWidgets`.
+
+You can create custom widgets and bind them to keystrokes:
+
+<CodeSnippet name="CustomWidgetExample" />
+
+You can also create a custom widgets class that extends the base `Widgets` class:
+
+<CodeSnippet name="CustomWidgetsClassExample" />
+
 ## Best Practices
 
 - Always close the terminal when your application exits
@@ -78,3 +208,6 @@ JLine can highlight input as it's typed:
 - Configure history appropriately for your application
 - Consider using a parser for complex command syntax
 - Provide helpful completion options for better user experience
+- Handle exceptions like `UserInterruptException` and `EndOfFileException` appropriately
+- Save history on application exit
+- Use widgets to extend functionality

--- a/website/docs/modules/repl-console.md
+++ b/website/docs/modules/repl-console.md
@@ -1,0 +1,209 @@
+---
+sidebar_position: 6
+---
+
+# REPL Console
+
+import CodeSnippet from '@site/src/components/CodeSnippet';
+
+JLine provides built-in support for creating REPL (Read-Eval-Print Loop) consoles with features like console variables, scripts, custom pipes, widgets, and object printing.
+
+## Overview
+
+The REPL console module provides a rich interactive environment for command-line applications, similar to shells like Bash or Zsh, but with integration for JVM scripting languages.
+
+<CodeSnippet name="ReplConsoleExample" />
+
+## Integration with JVM Scripting Languages
+
+JLine's REPL console can integrate with JVM scripting languages like Groovy, making it easy to create powerful interactive environments.
+
+### Key Interfaces
+
+1. **ScriptEngine** - Manages JVM scripting language variables and script execution.
+2. **ConsoleEngine** - Extends the CommandRegistry interface. Manages console variables, console script execution, and object printing. ConsoleEngineImpl implements console commands: `show`, `del`, `prnt`, `pipe`, `alias`, `unalias`, and `slurp`.
+3. **SystemRegistry** - Extends the CommandRegistry interface. Aggregates CommandRegistries, compiles command pipelines, and dispatches command executions to the command registries. SystemRegistryImpl implements commands: `help` and `exit`.
+
+## Variables
+
+JLine's REPL console provides a rich variable system for storing and manipulating data.
+
+### Reserved Variable Names
+
+- `PATH` - A list of directories from where scripts are searched
+- `NANORC` - Nanorc configuration file
+- `PRNT_OPTIONS` - `prnt` command default options
+- `CONSOLE_OPTIONS` - Console options
+- `_` - The last result of the command execution
+- `exception` - The last exception
+- `output` - Redirected print output if command also returns value
+- `_args` - Command parameter list for the groovy script (used inside a script)
+- `_buffer` - Closure that will call `lineReader.getBuffer()` (available for widget functions)
+- `_reader` - `lineReader` (available for widget functions)
+- `_widget` - Closure that will call `lineReader.callWidget()` (available for widget functions)
+- `_widgetFunction` - Function that will be launched when executing widget
+- `_pipe<N>` - Temporary variables used to execute command pipeline
+- `_executionResult` - Command execution result
+- `_return` - Used to return execution result from console script
+
+### Variable Name Conventions
+
+1. Variables whose name start with underscore character `_` are temporary variables that are deleted in the REPL loop.
+2. Variables whose name is in CAMEL_CASE format are not deleted when using wildcard in delete command like `del *`.
+
+### Variable Expansion
+
+Variable expansion substitutes variable references with their values:
+
+```
+groovy-repl> # create a map and print it
+groovy-repl> user=[name:'Pippo',age:10]
+groovy-repl> prnt $user
+name Pippo
+age  10
+groovy-repl> prnt ${user}.name
+Pippo
+```
+
+Command object parameters can also be written directly using either Groovy object notation or JSON:
+
+```
+groovy-repl> prnt -s JSON [user:'pippo',age:10]
+{
+    "user": "pippo",
+    "age": 10
+}
+groovy-repl> prnt -s JSON {user:pippo,age:10}
+{
+    "user": "pippo",
+    "age": 10
+}
+```
+
+## Scripts
+
+JLine's REPL console supports two types of scripts:
+
+### Console Scripts
+
+In console scripts, application commands are entered just like you do interactively. Script parameters are accessed inside a script using the variables `$1`, `$2`, `$3`, and so on.
+
+Note that inside a code block, command line must be either of the forms `:command arg1 arg2` or `var=:command arg1 arg2`. Use the `exit` command to exit and return a value from the script.
+
+Console scripts have two built-in options: `-?` for script help and `-v` for verbose execution. Console script output cannot be redirected.
+
+<CodeSnippet name="ConsoleScriptExample" />
+
+### Groovy Scripts
+
+A temporary list variable `_args` will be created to assign command parameters to the script. Application commands can be executed inside a script using statements like:
+
+```java
+SystemRegistry.get().invoke('prnt', '-s', 'JSON', map)
+```
+
+Groovy scripts have a built-in help option `-?`.
+
+<CodeSnippet name="GroovyScriptExample" />
+
+## Pipes and Output Redirection
+
+The main purpose of pipes is to make things more concise and create a more familiar REPL console for those who are used to working in bash/zsh.
+
+### Builtin Pipe Operators
+
+#### Output Redirection
+
+Command output/return value can be redirected to a variable:
+
+```
+groovy-repl> resp=widget -l
+groovy-repl> resp
+_tailtip-accept-line (_tailtip-accept-line)
+_tailtip-backward-delete-char (_tailtip-backward-delete-char)
+...
+```
+
+Note that no spaces are allowed between variable/command and equal sign.
+
+Command output can be redirected to a file using standard redirection operators `>` and `>>`.
+
+#### Logical Pipe Operators
+
+- The _and_ operator (`&&`) executes the second command only if the execution of the first command succeeds.
+- The _or_ operator (`||`) executes the second command only if the execution of the first command fails.
+
+Note that all pipe operators must be enclosed by space characters, and the command line cannot be enclosed by parentheses or quotes.
+
+#### Flip Pipe Operator
+
+The flip pipe operator `|;` flips around the command and argument:
+
+```
+groovy-repl> widget -l |; prnt -s JSON
+[
+    "_tailtip-accept-line (_tailtip-accept-line)",
+    "_tailtip-backward-delete-char (_tailtip-backward-delete-char)",
+    ...
+]
+```
+
+#### Named Pipe Operator
+
+The reserved pipe operator `|` is used by custom named pipes and pipeline aliases.
+
+### Custom Pipe Operators
+
+Pipe operator name convention: If a pipe operator name contains only alphanumeric characters, it is a named pipe operator and will be used with the operator `|`.
+
+```
+# Custom Groovy pipes
+pipe |.  '.collect{' '}'
+pipe |:  '.collectEntries{' '}'
+pipe |:: '.collectMany{' '}'
+pipe |?  '.findAll{' '}'
+pipe |?1 '.find{' '}'
+pipe |&  '.' ' '
+
+# Named pipe and two pipe line aliases
+pipe grep '.collect{it.toString()}.findAll{it=~/' '/}'
+alias null '|& identity{}' 
+alias xargs '|; %{0} %{1} %{2} %{3} %{4} %{5} %{6} %{7} %{8} %{9}'
+```
+
+Note that pipeline alias value starts with a known pipe operator.
+
+## Widgets
+
+In widget functions, you will have available temporary variables: `_reader` (`lineReader`), `_buffer` (closure that will call `lineReader.getBuffer()`), and `_widget` (closure that will call `lineReader.callWidget()`).
+
+```groovy
+# Create test-widget and bind it to ctrl-alt-x
+# It will read widget name from buffer and execute it
+def testWidget() {
+    def name = _buffer().toString().split('\\s+')[0]
+    _widget "$name"
+}
+widget -N test-widget testWidget 
+keymap '^[^x' test-widget
+```
+
+## Best Practices
+
+When using JLine's REPL console, consider these best practices:
+
+1. **Consistent Variable Naming**: Follow the variable naming conventions to make your scripts more maintainable.
+
+2. **Script Organization**: Keep scripts organized in a logical directory structure and set the PATH variable accordingly.
+
+3. **Error Handling**: Implement proper error handling in your scripts, especially when integrating with external systems.
+
+4. **Custom Pipes**: Create custom pipes for common operations to make your command lines more concise.
+
+5. **Documentation**: Document your custom commands, widgets, and pipes for other users.
+
+6. **Testing**: Test your scripts and commands thoroughly to ensure they work as expected.
+
+7. **Security**: Be careful when executing user-provided scripts or commands, especially in multi-user environments.
+
+8. **Performance**: Be mindful of performance, especially when working with large datasets or complex operations.

--- a/website/docs/reference/diagnostic.md
+++ b/website/docs/reference/diagnostic.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 2
+---
+
+# Diagnostic
+
+When troubleshooting issues with JLine, especially when dealing with system terminals, it's helpful to run diagnostic tools to gather information about your environment. This page explains how to use JLine's diagnostic tools and interpret their output.
+
+## JLine Diagnostic Tool
+
+JLine provides a built-in diagnostic tool that can help identify issues with terminal detection and configuration. To run the JLine diagnostic tool, use the following command:
+
+```bash
+java -cp jline-3.26.1.jar org.jline.terminal.impl.Diag
+```
+
+This will output a full diagnosis for JLine. You may want to add some dependencies if you want specific providers to be loaded.
+
+## Jansi Diagnostic Tool
+
+If you're using Jansi with JLine, you can run the Jansi diagnostic tool to get information about both JLine and Jansi:
+
+```bash
+java -jar jansi-3.26.1.jar
+```
+
+This will output a full diagnosis for both JLine and Jansi.
+
+## Output Example
+
+Here's an example of the output from the diagnostic tools:
+
+```
+System properties
+=================
+os.name =         Mac OS X
+OSTYPE =          null
+MSYSTEM =         null
+PWD =             /Users/gnodet/work/git/jline3
+ConEmuPID =       null
+WSL_DISTRO_NAME = null
+WSL_INTEROP =     null
+
+OSUtils
+=================
+IS_WINDOWS = false
+IS_CYGWIN =  false
+IS_MSYSTEM = false
+IS_WSL =     false
+IS_WSL1 =    false
+IS_WSL2 =    false
+IS_CONEMU =  false
+IS_OSX =     true
+
+FFM Support
+=================
+FFM support not available: java.io.IOException: Unable to load terminal provider ffm: null
+
+JnaSupport
+=================
+JNA support not available: java.io.IOException: Unable to load terminal provider jna: null
+
+Jansi2Support
+=================
+Jansi 2 support not available: java.io.IOException: Unable to load terminal provider jansi: null
+
+JniSupport
+=================
+StdIn stream =    true
+StdOut stream =   true
+StdErr stream =   true
+StdIn stream name =     /dev/ttys007
+StdOut stream name =    /dev/ttys007
+StdErr stream name =    /dev/ttys007
+Terminal size: Size[cols=184, rows=47]
+The terminal seems to work: terminal org.jline.terminal.impl.PosixSysTerminal with pty org.jline.terminal.impl.jni.osx.OsXNativePty
+
+Exec Support
+=================
+StdIn stream =    true
+StdOut stream =   true
+StdErr stream =   true
+StdIn stream name =     /dev/ttys007
+StdOut stream name =    /dev/ttys007
+StdErr stream name =    /dev/ttys007
+Terminal size: Size[cols=184, rows=47]
+The terminal seems to work: terminal org.jline.terminal.impl.PosixSysTerminal with pty org.jline.terminal.impl.exec.ExecPty
+```
+
+## Understanding the Output
+
+The diagnostic output provides several sections of information:
+
+1. **System Properties**: Shows relevant system properties that might affect terminal behavior.
+
+2. **OSUtils**: Indicates what type of operating system you're running on.
+
+3. **Provider Support**: Shows which terminal providers are available and working:
+   - FFM Support
+   - JNA Support
+   - Jansi2 Support
+   - JNI Support
+   - Exec Support
+
+4. **Terminal Information**: For each working provider, it shows:
+   - Whether standard streams are available
+   - The names of the standard streams
+   - The terminal size
+   - The terminal implementation being used
+
+## Troubleshooting with Diagnostic Output
+
+When troubleshooting issues with JLine, pay attention to:
+
+1. **Missing Providers**: If a provider you expect to be available shows "not available," check that you have the necessary dependencies on your classpath.
+
+2. **Stream Information**: If standard streams are not available or have unexpected names, this could indicate issues with how your application is launched.
+
+3. **Terminal Size**: If the terminal size is incorrect or zero, this could indicate issues with terminal detection.
+
+4. **Terminal Implementation**: The specific implementation being used can help identify compatibility issues.
+
+## Reporting Issues
+
+When reporting issues with JLine, always include the full diagnostic output. This helps the JLine developers understand your environment and the specific configuration that's causing problems.
+
+To report an issue:
+
+1. Run the appropriate diagnostic tool
+2. Copy the full output
+3. Create a new issue on the [JLine GitHub repository](https://github.com/jline/jline3/issues)
+4. Paste the diagnostic output into your issue description
+5. Provide additional details about your problem and steps to reproduce it

--- a/website/docs/reference/glossary.md
+++ b/website/docs/reference/glossary.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 1
+---
+
+# Glossary
+
+This glossary provides definitions for common terms used in JLine and terminal-related programming.
+
+## Terminal
+
+A terminal is a device or program that takes inputs and displays output from the terminating end of communication. In modern computing, terminals are typically software implementations that emulate the behavior of hardware terminals.
+
+## Dumb Terminal
+
+A dumb terminal only shows text and takes input but doesn't process input locally. All processing is done on the other end of the communication channel. In JLine, a dumb terminal is a fallback option when more advanced terminal capabilities aren't available.
+
+## Console
+
+Originally, a console was a physical cabinet that contained a terminal. In software development, the terms "terminal" and "console" are often used interchangeably. In JLine, the console typically refers to the interactive environment where users enter commands and view output.
+
+## TTY
+
+TTY is an abbreviation for "teletypewriter," which was the first type of terminal. In modern systems, TTY refers to the device files that represent terminals in Unix-like operating systems.
+
+## Shell
+
+A shell is a command interpreter that processes commands entered in a terminal. Examples include Bash, Zsh, and PowerShell. JLine provides functionality that is often used to build shell-like applications.
+
+## PTY
+
+PTY (pseudoterminal) is a program that sits between a terminal and a shell. It allows more privileged programs to run and provides terminal emulation. JLine uses PTYs to provide advanced terminal functionality.
+
+## Parser
+
+A parser is a program, function, or method that takes input (like command lines) and formats or interprets it to make it meaningful. In JLine, parsers are used to interpret command lines, handle quoting, and support features like command completion.
+
+## ANSI
+
+ANSI (American National Standards Institute) defines standards for character encoding. In terminal programming, ANSI often refers to the ANSI escape codes used for terminal control, such as changing text colors or moving the cursor.
+
+## Escape Codes
+
+Escape codes are special sequences of characters that, when printed to a terminal, cause the terminal to perform operations beyond simply displaying text. These operations include changing text colors, moving the cursor, clearing the screen, etc.
+
+## ANSI Escape Codes
+
+ANSI escape codes are a specific set of escape codes defined by the ANSI standard. They begin with the ESC character (ASCII 27) followed by a bracket character ([) and then one or more characters that define the operation to perform.
+
+## LineReader
+
+In JLine, a LineReader is a component that reads lines of text from a terminal, providing features like line editing, history, and completion.
+
+## Completer
+
+A Completer is a component in JLine that provides tab completion functionality, suggesting possible completions for partially typed commands or arguments.
+
+## Highlighter
+
+A Highlighter is a component in JLine that provides syntax highlighting for command lines, making them more readable and easier to understand.
+
+## Widget
+
+In JLine, a Widget is a function that can be bound to a key or key sequence to perform a specific action, such as moving the cursor, deleting text, or completing a command.
+
+## REPL
+
+REPL stands for Read-Eval-Print Loop, which is a type of interactive programming environment that reads user input, evaluates it, prints the result, and then loops back to read more input. JLine provides components for building REPL environments.
+
+## Sources
+
+- [What's The Difference Between A Console, A Terminal, And A Shell?](https://www.hanselman.com/blog/WhatsTheDifferenceBetweenAConsoleATerminalAndAShell.aspx)
+- [ANSI escape code - Wikipedia](http://en.wikipedia.org/wiki/ANSI_escape_code)

--- a/website/docs/terminal.md
+++ b/website/docs/terminal.md
@@ -8,9 +8,37 @@ import CodeSnippet from '@site/src/components/CodeSnippet';
 
 The Terminal is the foundation of JLine, providing access to the underlying terminal capabilities. This page explains how to create and use Terminal objects in your applications.
 
-## Creating a Terminal
+JLine provides a terminal abstraction using the `Terminal` interface which provides the following features:
 
-You can create a Terminal using the TerminalBuilder:
+- Signals support
+- Input stream, output stream, non-blocking reader, writer
+- Terminal size and parameters
+- Infocmp capabilities
+
+There are two different types of terminals:
+
+- **System terminals** that handle an OS terminal window
+- **Virtual terminals** to support incoming connections
+
+## System Terminals
+
+There is only a single system terminal for a given JVM, the one that has been used to launch the JVM. The terminal is the same terminal which is accessible using the [`Console` JDK API](https://docs.oracle.com/javase/8/docs/api/java/io/Console.html).
+
+The easiest way to obtain such a `Terminal` object in JLine is by using the `TerminalBuilder` class:
+
+```java
+Terminal terminal = TerminalBuilder.terminal();
+```
+
+or
+
+```java
+Terminal terminal = TerminalBuilder.builder()
+                    .system(true)
+                    .build();
+```
+
+The `TerminalBuilder` will figure out the current Operating System and which actual `Terminal` implementation to use. Note that on the Windows platform you need to have either Jansi or JNA library in your classpath.
 
 <CodeSnippet name="TerminalCreationExample" />
 
@@ -32,11 +60,52 @@ You can read from the Terminal:
 
 <CodeSnippet name="TerminalInputExample" />
 
+## Virtual Terminals
+
+Virtual terminals are used when there's no OS terminal to wrap. A common use case is when setting up some kind of server with SSH or Telnet support. Each incoming connection will need a virtual terminal.
+
+Those terminals can be created using the following pattern:
+
+```java
+Terminal terminal = TerminalBuilder.builder()
+                    .system(false)
+                    .streams(input, output)
+                    .build();
+```
+
+The builder can also be given the initial size and attributes of the terminal if they are known:
+
+```java
+int columns = ...;
+int rows = ...;
+Attributes attributes = new Attributes();
+// set attributes...
+Terminal terminal = TerminalBuilder.builder()
+                    .system(false)
+                    .streams(input, output)
+                    .size(new Size(columns, rows))
+                    .attributes(attributes)
+                    .build();
+```
+
 ## Terminal Signals
 
 You can handle terminal signals:
 
 <CodeSnippet name="TerminalSignalsExample" />
+
+JLine terminals support signals. Signals can be raised and handled very easily.
+
+System terminals can be built to intercept the native signals and forward them to the default handler.
+
+```java
+Terminal terminal = TerminalBuilder.builder()
+                    .system(true)
+                    .signalHandler(Terminal.SignalHandler.SIG_IGN)
+                    .build();
+```
+
+The LineReader does support signals and handle them accordingly.
 
 ## Terminal Attributes
 
@@ -61,6 +130,38 @@ You can control the cursor position:
 You can use colors in the terminal:
 
 <CodeSnippet name="TerminalColorsExample" />
+
+## Terminal Building Options
+
+The `TerminalBuilder` supports various options for customizing the terminal:
+
+| Option | System | Virtual | Description |
+|--------|--------|---------|-------------|
+| name | x | x | Name of the terminal, defaults to `"JLine terminal"` |
+| type | x | x | Infocmp type of the terminal, defaults to `System.getenv("TERM")` |
+| encoding | x | x | Encoding of the terminal, defaults to `Charset.defaultCharset().name()` |
+| system | x | x | Forces or prohibits the use of a system terminal |
+| streams | | x | Use the given streams for the input / output streams of the terminal |
+| jna | x | x | Allow or prohibits using JNA based terminals, defaults to whether the JNA library is available or not |
+| dumb | x | | Creates a dumb terminal if known terminals are not supported, else an exception is thrown |
+| attributes | | x | Initial attributes of the terminal |
+| size | | x | Initial size of the terminal |
+| nativeSignals | x | | Handle JVM signals from the system terminal through the created terminal |
+| signalHandler | x | | Default signal handler |
+
+## Terminal Types
+
+JLine has available the following terminal types:
+
+| OS/Terminal | Infocmp terminal type |
+|-------------|------------------------|
+| ANSI | ansi |
+| Dumb | dumb, dumb-color |
+| rxvt | rxvt, rxvt-basic, rxvt-unicode, rxvt-unicode-256color |
+| Screen | screen, screen-256color |
+| Windows/ConEmu | windows-conemu |
+| Windows/cmd | windows, windows-256color, windows-vtp |
+| xterm | xterm, xterm-256color |
 
 ## Best Practices
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -51,6 +51,10 @@ const sidebars: SidebarsConfig = {
         'advanced/terminal-size',
         'advanced/screen-clearing',
         'advanced/library-integration',
+        'advanced/autosuggestions',
+        'advanced/auto-indentation-pairing',
+        'advanced/theme-system',
+        'advanced/nano-less-customization',
       ],
     },
     {
@@ -61,6 +65,7 @@ const sidebars: SidebarsConfig = {
         'modules/builtins',
         'modules/style',
         'modules/terminal-providers',
+        'modules/repl-console',
       ],
     },
     {
@@ -73,6 +78,14 @@ const sidebars: SidebarsConfig = {
         // 'api/line-reader',
         // 'api/completer',
         // 'api/history'
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Reference',
+      items: [
+        'reference/glossary',
+        'reference/diagnostic',
       ],
     },
   ],


### PR DESCRIPTION
This PR integrates valuable information from the GitHub wiki into the JLine website documentation:

- Added new pages for REPL Console, Theme System, Nano and Less Customization, Glossary, and Diagnostic
- Created working code examples for each feature
- Updated the sidebar to include all the new pages
- Organized content in logical sections

These changes make the documentation more comprehensive and accessible to users.