### PR TITLE
chore: Add DevContainer JSON

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "24",
+      "installGradle": "false",
+      "installMaven": "false"
+    }
+  },
+  "postCreateCommand": "./mvnw clean package"
+}
+


### PR DESCRIPTION
This makes the contributor experience a lot smoother, because it enables e.g. GitHub Codespaces to "just work" - with the correct more recent than default Java version already pre-installed, and the build "warmed up" (thanks to the postCreateCommand).

This is technically not specific only to GitHub Codespaces, but also useful to have a clean standard development environment in e.g. for both Visual Studio Code as well as IntelliJ, both of which nowadays also support https://containers.dev.