### PR TITLE
docs: fix javadoc redirect URL issue

### DIFF
--- a/website/src/pages/javadoc.tsx
+++ b/website/src/pages/javadoc.tsx
@@ -1,20 +1,29 @@
 import React, { useEffect } from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import { Redirect } from '@docusaurus/router';
 
 export default function JavadocPage(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   const jlineVersion = siteConfig.customFields.jlineVersion as string;
-  
+
   // Redirect to the Maven Central Javadoc
   const javadocUrl = `https://javadoc.io/doc/org.jline/jline/${jlineVersion}/index.html`;
-  
+
+  useEffect(() => {
+    // Use window.location for a proper external redirect
+    window.location.href = javadocUrl;
+  }, [javadocUrl]);
+
   return (
     <Layout
       title="Javadoc"
       description="JLine API Documentation">
-      <Redirect to={javadocUrl} />
+      <div style={{ padding: '2rem', textAlign: 'center' }}>
+        <p>Redirecting to Javadoc...</p>
+        <p>
+          <a href={javadocUrl}>Click here if you are not redirected automatically</a>
+        </p>
+      </div>
     </Layout>
   );
 }


### PR DESCRIPTION
## Problem

When visiting https://jline.org/javadoc, it redirects to an invalid URL that combines the website URL with the external javadoc URL.

This happens because the website is using Docusaurus's <Redirect> component, which is designed for internal redirects within the site, not for external URLs.

## Solution

This PR modifies the website/src/pages/javadoc.tsx file to:
- Replace the Redirect component with a client-side redirect using window.location.href
- Add a loading page with a fallback link in case the automatic redirect doesn't work
- Ensure proper redirection to the external javadoc URL at javadoc.io

## Testing

The website has been built and tested locally to verify that the javadoc link now correctly redirects to the external javadoc URL.

Fixes jline/jline3#1115