### PR TITLE
chore: add Palantir Java Format version property for Dependabot updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <ivy.version>2.5.3</ivy.version>
         <graal.version>24.2.1</graal.version>
         <graal.plugin.version>21.2.0</graal.plugin.version>
+        <palantir.version>2.38.0</palantir.version>
 
         <surefire.argLine>--add-opens java.base/java.io=ALL-UNNAMED</surefire.argLine>
     </properties>
@@ -354,6 +355,13 @@
                 <artifactId>jsr305</artifactId>
                 <version>${findbugs.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.palantir.javaformat</groupId>
+                <artifactId>palantir-java-format</artifactId>
+                <version>${palantir.version}</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -572,7 +580,7 @@
                         <java>
                             <toggleOffOn />
                             <palantirJavaFormat>
-                                <version>2.38.0</version>
+                                <version>${palantir.version}</version>
                             </palantirJavaFormat>
                             <importOrder>
                                 <order>java|javax,org,,\#</order>


### PR DESCRIPTION
This PR adds a property for the Palantir Java Format version and a fake dependency so that Dependabot can automatically update it.

Currently, the Palantir version is never updated by Dependabot because it's in a plugin configuration rather than a dependency. By adding a property and a fake dependency that uses this property, Dependabot will be able to detect and suggest updates to the Palantir Java Format version.

Changes:
1. Added a `<palantir.version>2.38.0</palantir.version>` property in the properties section
2. Updated the Palantir Java Format configuration to use this property
3. Added a fake dependency in the dependencyManagement section that uses this property

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author