### PR TITLE
fix: fix Jansi AnsiConsole broken color detection in uber jars

### DIFF
--- a/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
@@ -238,7 +238,7 @@ public class AnsiConsole {
         width = terminal::getWidth;
         type = terminal instanceof DumbTerminal
                 ? AnsiType.Unsupported
-                : ((TerminalExt) terminal).getSystemStream() != null ? AnsiType.Redirected : AnsiType.Native;
+                : ((TerminalExt) terminal).getSystemStream() != null ? AnsiType.Native : AnsiType.Redirected;
 
         AnsiMode mode;
 


### PR DESCRIPTION
## Problem

When migrating from the original Jansi library to JLine's Jansi implementation, colors stopped working in uber jars on Windows (and other platforms). This was reported in issue #1292.

## Root Cause

The issue was caused by inverted logic in the `AnsiType` detection within `AnsiConsole.ansiStream()`. The ternary operator was backwards:

```java
// WRONG (before fix):
type = terminal instanceof DumbTerminal
        ? AnsiType.Unsupported
        : ((TerminalExt) terminal).getSystemStream() != null ? AnsiType.Redirected : AnsiType.Native;

// CORRECT (after fix):
type = terminal instanceof DumbTerminal
        ? AnsiType.Unsupported
        : ((TerminalExt) terminal).getSystemStream() != null ? AnsiType.Native : AnsiType.Redirected;
```

## Technical Details

The logic should be:
- When `getSystemStream() == null`: `AnsiType.Redirected` (output is redirected to a file/pipe)
- When `getSystemStream() != null`: `AnsiType.Native` (native terminal with color support)

The inverted logic was incorrectly marking native terminals as redirected, which caused ANSI escape sequences to be stripped instead of being processed for color output.

## Impact

This simple but critical fix ensures that:
- ✅ Colors work correctly in uber jars on Windows and other platforms
- ✅ Native terminal detection works as expected
- ✅ ANSI escape sequences are properly processed instead of being stripped
- ✅ Maintains full backward compatibility with existing applications
- ✅ Resolves the migration issue from original Jansi to JLine's Jansi

## Testing

The fix has been tested with:
- Manual testing using the provided example application
- Verification that colors now work correctly in uber jar scenarios
- Confirmation that existing functionality remains unaffected

Fixes #1292

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author