### PR TITLE
Remove double `docs/docs` in edit links on jline.org (fixes #1309)

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -63,7 +63,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/jline/jline3/edit/master/website/docs/',
+            'https://github.com/jline/jline3/edit/master/website/',
         },
         blog: false, // blog section disabled
         theme: {


### PR DESCRIPTION
Fixes #1309 ... hopefully. I have to admit that I have not actually taken the time to myself locally run https://docusaurus.io to verify that this indeed does the trick. But it looks about right? 🤣 