### PR TITLE
chore: make downcall handles static final

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -435,12 +435,12 @@ class CLibrary {
         }
     }
 
-    static MethodHandle ioctl;
-    static MethodHandle isatty;
-    static MethodHandle openpty;
-    static MethodHandle tcsetattr;
-    static MethodHandle tcgetattr;
-    static MethodHandle ttyname_r;
+    static final MethodHandle ioctl;
+    static final MethodHandle isatty;
+    static final MethodHandle openpty;
+    static final MethodHandle tcsetattr;
+    static final MethodHandle tcgetattr;
+    static final MethodHandle ttyname_r;
     static LinkageError openptyError;
 
     static {


### PR DESCRIPTION
* This is (will be) helpful for GraalVM Native Image to not need to register FunctionDescriptor manually: https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/ForeignInterface.md
* It also slightly improves performance in general by avoiding to re-read those static fields on every usage.
* Other static `MethodHandle`/`VarHandle` are already `static final`.