### PR TITLE
Allow system commands to be renamed.

### DIFF
--- a/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
+++ b/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
@@ -101,6 +101,13 @@ public class SystemRegistryImpl implements SystemRegistry {
         pipeName.put(pipe, name);
     }
 
+    public void renameLocal(String command, String newName) {
+        CommandMethods old = commandExecute.remove(command);
+        if (old != null) {
+            commandExecute.put(newName, old);
+        }
+    }
+
     @Override
     public Collection<String> getPipeNames() {
         return pipeName.values();


### PR DESCRIPTION
I'd be just as happy for `commandExecute` to be protected rather than private. Let me know if you'd prefer that PR instead.