### PR TITLE
Fix System.out not working after closing dumb terminal

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -136,7 +136,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
 
     @Override
     protected void doClose() throws IOException {
-        writer.close();
+        writer.flush();
         ShutdownHooks.remove(closer);
         for (Map.Entry<Signal, Object> entry : nativeHandlers.entrySet()) {
             Signals.unregister(entry.getKey().name(), entry.getValue());

--- a/terminal/src/test/java/org/jline/terminal/SystemOutCloseTest.java
+++ b/terminal/src/test/java/org/jline/terminal/SystemOutCloseTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for issue #1336 - System.out stops working after closing a dumb terminal.
+ */
+public class SystemOutCloseTest {
+
+    @Test
+    public void testSystemOutWorksAfterTerminalClose() throws IOException {
+        // Capture System.out to verify output
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream capturedOutput = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(capturedOutput));
+
+        try {
+            // Test output before terminal creation
+            System.out.println("Before terminal");
+
+            // Create and close a dumb terminal (this should not affect System.out)
+            try (Terminal terminal = TerminalBuilder.builder().dumb(true).build()) {
+                System.out.println("Inside terminal");
+            }
+
+            // Test output after terminal close - this should still work
+            System.out.println("After terminal");
+
+            // Verify all output was captured
+            String output = capturedOutput.toString();
+            String normalizedOutput = output.replace("\r\n", "\n");
+
+            // Check that all three lines are present
+            assertTrue(normalizedOutput.contains("Before terminal"), "Should contain 'Before terminal'");
+            assertTrue(normalizedOutput.contains("Inside terminal"), "Should contain 'Inside terminal'");
+            assertTrue(normalizedOutput.contains("After terminal"), "Should contain 'After terminal'");
+
+            // The exact format might vary, but all three messages should be there
+            assertEquals("Before terminal\nInside terminal\nAfter terminal\n", normalizedOutput);
+
+        } finally {
+            // Restore original System.out
+            System.setOut(originalOut);
+        }
+    }
+
+    @Test
+    public void testTerminalWriterFlushesOutput() throws IOException {
+        // Test that the terminal writer properly flushes output
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream capturedOutput = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(capturedOutput));
+
+        try {
+            try (Terminal terminal = TerminalBuilder.builder().dumb(true).build()) {
+                terminal.writer().println("Test output");
+                // The output should be flushed when the terminal is closed
+            }
+
+            String output = capturedOutput.toString();
+            assertTrue(output.contains("Test output"), "Terminal writer output should be flushed on close");
+
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1336

## Problem

After upgrading from JLine 3.30.2 to 3.30.3, `System.out` stops working after closing a dumb terminal. This was caused by commit d41dcb90ce4d444b514a1ca11b37dba8f2eb2e54 which added `writer.close()` to fix Apache Maven issue MNG-8733.

## Root Cause

When using a system terminal (like with `.dumb(true)`), the `ExecPty.getSlaveOutput()` returns a `FileOutputStream(FileDescriptor.out)` which wraps `System.out`. The `PosixSysTerminal` creates a `PrintWriter` that wraps this output stream. When `writer.close()` is called in `doClose()`, it closes the underlying `FileOutputStream`, effectively closing `System.out`. Subsequent `System.out.println()` calls don't produce output.

## Solution

Change `writer.close()` to `writer.flush()` in `PosixSysTerminal.doClose()`. This ensures:

1. **Fixes the original issue (MNG-8733):** The `flush()` call ensures that any buffered output is written to the terminal, which was the root cause of the missing output in the `mvnenc` command

2. **Fixes the regression (issue #1336):** By not closing the writer, we don't close the underlying `System.out` stream, so it continues to work after the terminal is closed

3. **Safe for other platforms:** This change only affects POSIX system terminals. Windows terminals use native console writers that don't wrap `System.out`, so they're unaffected

## Testing

Added comprehensive test `SystemOutCloseTest` that verifies:
- `System.out` continues working after terminal closure
- Terminal writer output is properly flushed on close

## Reproducer

```java
import org.jline.terminal.Terminal;
import org.jline.terminal.TerminalBuilder;

public class Main {
    public static void main(String[] args) throws Exception {
        try (Terminal terminal = TerminalBuilder.builder().dumb(true).build()) {
            System.out.println("System out before close");
            System.err.println("System err before close");
        }
        System.out.println("System out after close");
        System.err.println("System err after close");
    }
}
```

**With 3.30.3 (before fix):**
```
System out before close
System err before close
System err after close
```

**With this fix:**
```
System out before close
System err before close
System out after close
System err after close
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author