### PR TITLE
Improve console variable expansion (fixes #1370)

### DIFF
--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -274,7 +274,9 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
                     throw new IllegalArgumentException();
                 }
             } else if (args[i].startsWith("${")) {
-                out[i] = engine.execute(expandName(args[i]));
+                String expanded = expandName(args[i]);
+                String statement = expanded.startsWith("$") ? args[i].substring(2, args[i].length() - 1) : expanded;
+                out[i] = engine.execute(statement);
             } else if (args[i].startsWith("$")) {
                 out[i] = engine.get(expandName(args[i]));
             } else {


### PR DESCRIPTION
This handles the common GString idiom of expressions like `${name.toUpperCase()}` instead of just `${name}.toUpperCase()` but doesn't attempt to do full parsing and handle mixed style, e.g.  `${name.toUpperCase()}.toLowerCase()`. Existing expressions are left unchanged, i.e. still supported.