### PR TITLE
Update version to 4.0.0-SNAPSHOT

### DIFF
--- a/builtins/pom.xml
+++ b/builtins/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-builtins</artifactId>

--- a/console-ui/pom.xml
+++ b/console-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-console-ui</artifactId>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-console</artifactId>

--- a/curses/pom.xml
+++ b/curses/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-curses</artifactId>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-demo</artifactId>

--- a/graal/pom.xml
+++ b/graal/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-graal</artifactId>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jline-groovy</artifactId>
     <name>JLine Groovy</name>

--- a/jansi-core/pom.xml
+++ b/jansi-core/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jansi-core</artifactId>

--- a/jansi/pom.xml
+++ b/jansi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jansi</artifactId>

--- a/jline/pom.xml
+++ b/jline/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline</artifactId>

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-native</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>org.jline</groupId>
     <artifactId>jline-parent</artifactId>
-    <version>3.30.5-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>JLine</name>
     <description>JLine</description>

--- a/reader/pom.xml
+++ b/reader/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-reader</artifactId>

--- a/remote-ssh/pom.xml
+++ b/remote-ssh/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-remote-ssh</artifactId>

--- a/remote-telnet/pom.xml
+++ b/remote-telnet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-remote-telnet</artifactId>

--- a/style/pom.xml
+++ b/style/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-style</artifactId>

--- a/terminal-ffm/pom.xml
+++ b/terminal-ffm/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-terminal-ffm</artifactId>

--- a/terminal-jansi/pom.xml
+++ b/terminal-jansi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-terminal-jansi</artifactId>

--- a/terminal-jna/pom.xml
+++ b/terminal-jna/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-terminal-jna</artifactId>

--- a/terminal-jni/pom.xml
+++ b/terminal-jni/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-terminal-jni</artifactId>

--- a/terminal/pom.xml
+++ b/terminal/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>3.30.5-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jline-terminal</artifactId>


### PR DESCRIPTION
- Updated parent version from 3.30.5-SNAPSHOT to 4.0.0-SNAPSHOT
- Updated all child module versions to match parent
- Built successfully with JDK 24 and Maven 4.0.0-rc-4