### PR TITLE
fix: issue #1344 Terminal resize operations cause screen clearing, content displa…

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1266,10 +1266,10 @@ public class LineReaderImpl implements LineReader, Flushable {
             Status status = Status.getStatus(terminal, false);
             if (status != null) {
                 status.resize(size);
-                status.reset();
+              //  status.reset();
             }
-            terminal.puts(Capability.carriage_return);
-            terminal.puts(Capability.clr_eos);
+           // terminal.puts(Capability.carriage_return);
+           // terminal.puts(Capability.clr_eos);
             redrawLine();
             redisplay();
         } else if (signal == Signal.CONT) {

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -193,14 +193,16 @@ public class Status {
             // We need to scroll up to grow the status bar
             terminal.puts(Capability.save_cursor);
             terminal.puts(Capability.cursor_address, scrollRegion, 0);
-            for (int i = newScrollRegion; i < scrollRegion; i++) {
-                terminal.puts(Capability.cursor_down);
-            }
+           /// bug : this causes for every resizing whinch to the scrollregion or cursor to move in uwanted direction
+            // for (int i = newScrollRegion; i < scrollRegion; i++) {
+           //     terminal.puts(Capability.cursor_down);
+           // }
             terminal.puts(Capability.change_scroll_region, 0, newScrollRegion);
             terminal.puts(Capability.restore_cursor);
-            for (int i = newScrollRegion; i < scrollRegion; i++) {
-                terminal.puts(Capability.cursor_up);
-            }
+            /// bug : this causes for every resizing whinch to the scrollregion or cursor to move in uwanted direction
+            // for (int i = newScrollRegion; i < scrollRegion; i++) {
+            //    terminal.puts(Capability.cursor_up);
+           // }
             scrollRegion = newScrollRegion;
         } else if (newScrollRegion > scrollRegion) {
             terminal.puts(Capability.save_cursor);


### PR DESCRIPTION
fixing issue : #1344 

this fix is suppose to fix this issues : 

"During terminal window resizing (both horizontal and vertical), the following issues occur with JLine's status bar implementation:

Terminal content gets cleared unexpectedly during resize operations
Previous command outputs disappear from the visible area
Screen refreshes aggressively, causing flickering or blank screens
resizing affects the statusbar sometimes
Cursor position shifts incorrectly after resize
Vertical spacing increases with each resize operation
Terminal content doesn't reflow properly to new dimensions
Previously executed commands and their outputs become inaccessible
Scrollback buffer appears to be disrupted
Users cannot scroll up to see previous command results
"