### PR TITLE
Catch UnsupportedOperationException or further windows handling is ne…

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -2054,18 +2054,17 @@ public class PosixCommands {
      * Get POSIX file permissions from a file, with Windows executable handling.
      */
     private static Set<PosixFilePermission> getPermissionsFromFile(Path f) {
+        Set<PosixFilePermission> perms = new HashSet<>();
         try {
-            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(f);
-            if (OSUtils.IS_WINDOWS && isWindowsExecutable(f.getFileName().toString())) {
-                perms = new HashSet<>(perms);
-                perms.add(PosixFilePermission.OWNER_EXECUTE);
-                perms.add(PosixFilePermission.GROUP_EXECUTE);
-                perms.add(PosixFilePermission.OTHERS_EXECUTE);
-            }
-            return perms;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            perms = Files.getPosixFilePermissions(f);
+        } catch (IOException | UnsupportedOperationException ignore) {
         }
+        if (OSUtils.IS_WINDOWS && isWindowsExecutable(f.getFileName().toString())) {
+            perms.add(PosixFilePermission.OWNER_EXECUTE);
+            perms.add(PosixFilePermission.GROUP_EXECUTE);
+            perms.add(PosixFilePermission.OTHERS_EXECUTE);
+        }
+        return perms;
     }
 
     /**


### PR DESCRIPTION
…ver executed.

On windows 11, standard cmd prompt, Files.getPosixFilePermissions throws an UnsupportedOperationException.
This PR lets `ls` work on Windows 11 and other systems which don't support posix permissions but may have degraded color highlighting for files where permissions can't be determined.