### PR TITLE
add ability to ignore unknown pipe names #1393

### DIFF
--- a/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
+++ b/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
@@ -712,6 +712,7 @@ public class SystemRegistryImpl implements SystemRegistry {
                             }
                             pipe = words.get(i + 1);
                             if (!pipe.matches("\\w+") || !customPipes.containsKey(pipe)) {
+                                if (consoleOption("ignoreUnknownPipes", false)) break;
                                 throw new IllegalArgumentException("Unknown or illegal pipe name: " + pipe);
                             }
                         }


### PR DESCRIPTION
This leaves the default the same but if the option is set to `true`, more friendly parsing ensues:

<img width="182" height="116" alt="Screenshot 2025-08-14 at 4 21 17 pm" src="https://github.com/user-attachments/assets/a42715b0-c72d-4881-9d18-705b464c3731" />
