### PR TITLE
display currentdir as dot not blank

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -1633,7 +1633,13 @@ public class PosixCommands {
 
             public PathEntry(Path abs, Path root) {
                 this.abs = abs;
-                this.path = abs.startsWith(root) ? root.relativize(abs) : abs;
+                try {
+                    this.path = Files.isSameFile(abs, root)
+                            ? Paths.get(".")
+                            : abs.startsWith(root) ? root.relativize(abs) : abs;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
                 this.attributes = readAttributes(abs);
             }
 

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
@@ -119,6 +119,8 @@ public class PosixCommandsTest {
         PosixCommands.ls(context, new String[] {"ls"});
 
         String output = out.toString();
+        assertTrue(output.contains(".\n"));
+        assertTrue(output.contains("..\n"));
         assertTrue(output.contains("file1.txt"));
         assertTrue(output.contains("file2.txt"));
         assertTrue(output.contains("subdir"));

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
@@ -119,7 +119,7 @@ public class PosixCommandsTest {
         PosixCommands.ls(context, new String[] {"ls"});
 
         String output = out.toString();
-        assertTrue(output.contains(".\n"));
+        assertTrue(output.startsWith(".\n"));
         assertTrue(output.contains("..\n"));
         assertTrue(output.contains("file1.txt"));
         assertTrue(output.contains("file2.txt"));


### PR DESCRIPTION
fixes: builtins PosixCommands ls command minor formatting glitch #1397