### PR TITLE
Fix unclear JDK requirements documentation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,8 +4,8 @@ This document provides instructions for building JLine from source.
 
 ## Requirements
 
-* Maven 3.9.7+
-* Java 8+ at runtime
+* Maven 4.0+ (JLine 4.x requires Maven 4.0+)
+* Java 11+ at runtime (JLine 4.x requires Java 11+)
 * Java 22+ at build time
 * Graal 23.1+ (for native-image builds)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ JLine is a Java library for handling console input. It's similar to [GNU Readlin
 
 ## Requirements
 
-- **Java 11 or higher**: JLine requires Java 11 as the minimum runtime version
+- **Java 11 or higher**: JLine 4.x requires Java 11 as the minimum runtime version
+- **Maven 4.0 or higher**: JLine 4.x requires Maven 4.0+ for building from source
+- **Note**: JLine 3.x supports Java 8+ and Maven 3.x+, but JLine 4.x requires Java 11+ and Maven 4.0+
 
 ## Features
 
@@ -30,14 +32,14 @@ JLine is a Java library for handling console input. It's similar to [GNU Readlin
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline</artifactId>
-    <version>3.30.0</version>
+    <version>4.0.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'org.jline:jline:3.30.0'
+implementation 'org.jline:jline:4.0.0'
 ```
 
 ## Quick Start

--- a/website/docs/contributing/version-management.md
+++ b/website/docs/contributing/version-management.md
@@ -57,7 +57,7 @@ When releasing a new version of JLine, update the version in `docusaurus.config.
 
 ```javascript
 // JLine version - update this when releasing a new version
-const jlineVersion = '3.31.0'; // Updated version
+const jlineVersion = '%%JLINE_VERSION%%'; // Updated version
 ```
 
 The build process will automatically use the new version when replacing the placeholders.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -26,7 +26,12 @@ JLine enhances your command-line applications with:
 
 ## Requirements
 
-JLine requires **Java 11 or higher** as the minimum runtime version.
+JLine 4.x requires **Java 11 or higher** as the minimum runtime version.
+
+:::note Version Requirements
+- **JLine 3.x**: Supports Java 8+, Maven 3.x+
+- **JLine 4.x**: Requires Java 11+, Maven 4.0+
+:::
 
 ## Installation
 

--- a/website/docs/modules/jpms.md
+++ b/website/docs/modules/jpms.md
@@ -183,19 +183,19 @@ When using Maven or Gradle, you can depend on individual modules:
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-terminal</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-reader</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 ```
 
 #### Gradle
 ```groovy
-implementation 'org.jline:jline-terminal:4.0.0'
-implementation 'org.jline:jline-reader:4.0.0'
+implementation 'org.jline:jline-terminal:%%JLINE_VERSION%%'
+implementation 'org.jline:jline-reader:%%JLINE_VERSION%%'
 ```
 
 ## Migration from JLine 3.x
@@ -224,17 +224,17 @@ When migrating from JLine 3.x to 4.x in a modular application:
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-terminal</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-reader</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-terminal-jni</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 ```
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,7 +6,7 @@ import path from 'path';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 // JLine version - update this when releasing a new version
-const jlineVersion = '3.30.0';
+const jlineVersion = '4.0.0';
 
 // Define build output directory - only used for production builds
 // We'll set this via CLI for development server


### PR DESCRIPTION
## Problem

The JDK requirements documentation was unclear and inconsistent across different files:

- `BUILDING.md` incorrectly stated "Java 8+ at runtime" when JLine 4.x actually requires Java 11+
- Website version was incorrectly showing `3.30.0` when this codebase represents JLine 4.x
- Maven 4.0+ requirement for JLine 4.x was not clearly documented
- Inconsistent version requirements across documentation files

## Solution

This PR fixes the documentation to clearly distinguish between JLine 3.x and 4.x requirements:

### Changes Made:

1. **Updated website version**: `3.30.0` → `4.0.0` in `docusaurus.config.ts`
2. **Fixed BUILDING.md**: 
   - Maven requirement: `3.9.7+` → `4.0+` (JLine 4.x requires Maven 4.0+)
   - Java runtime: Clarified as `11+` (JLine 4.x requires Java 11+)
3. **Enhanced README.md and intro.md**: Added clear version requirement distinctions
4. **Standardized version placeholders**: Replaced hardcoded versions with `%%JLINE_VERSION%%` placeholders
5. **Updated examples**: Version examples now use `4.0.0` instead of `3.30.0`

### Clear Requirements Now Documented:

- **JLine 3.x**: Java 8+, Maven 3.x+
- **JLine 4.x**: Java 11+, Maven 4.0+

## Testing

- ✅ Website builds successfully with new version
- ✅ All version placeholders work correctly
- ✅ Documentation is now consistent across all files

## Files Changed:

- `BUILDING.md` - Fixed Maven and Java requirements
- `README.md` - Added Maven requirement, updated examples
- `website/docusaurus.config.ts` - Updated version to 4.0.0
- `website/docs/intro.md` - Added clear version requirements note
- `website/docs/contributing/version-management.md` - Updated example
- `website/docs/modules/jpms.md` - Replaced hardcoded versions with placeholders

Fixes the unclear JDK requirements mentioned in the issue.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author