### PR TITLE
Optimize Display performance and fix terminal capability usage

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -217,8 +217,8 @@ public class Display {
         int numLines = Math.min(rows, Math.max(oldLines.size(), newLines.size()));
         boolean wrapNeeded = false;
         while (lineIndex < numLines) {
-            AttributedString oldLine = lineIndex < oldLines.size() ? oldLines.get(lineIndex) : AttributedString.NEWLINE;
-            AttributedString newLine = lineIndex < newLines.size() ? newLines.get(lineIndex) : AttributedString.NEWLINE;
+            AttributedString oldLine = lineIndex < oldLines.size() ? oldLines.get(lineIndex) : AttributedString.EMPTY;
+            AttributedString newLine = lineIndex < newLines.size() ? newLines.get(lineIndex) : AttributedString.EMPTY;
             currentPos = lineIndex * columns1;
             int curCol = currentPos;
             int oldLength = oldLine.length();
@@ -239,7 +239,7 @@ public class Display {
                 if (newLength == 0 || newLine.isHidden(0)) {
                     // go to next line column zero
                     rawPrint(' ');
-                    terminal.puts(Capability.key_backspace);
+                    terminal.puts(Capability.cursor_left);
                 } else {
                     AttributedString firstChar = newLine.substring(0, 1);
                     // go to next line column one
@@ -340,7 +340,7 @@ public class Display {
                 if (this.wrapAtEol) {
                     if (!fullScreen || (fullScreen && lineIndex < numLines)) {
                         rawPrint(' ');
-                        terminal.puts(Capability.key_backspace);
+                        terminal.puts(Capability.cursor_left);
                         cursorPos++;
                     }
                 } else {


### PR DESCRIPTION
This PR contains two improvements to the Display class:

## Performance Optimization
- **Replace `AttributedString.NEWLINE` with `AttributedString.EMPTY`** for missing lines
  - Avoids unnecessary newline detection and substring operations since the newlines are stripped anyway in the subsequent processing
  - More efficient when dealing with shorter line lists during display updates

## Terminal Compatibility Fix
- **Replace `Capability.key_backspace` with `Capability.cursor_left`**
  - Fixes display issues in raw mode where `key_backspace` may not be properly supported by all terminals
  - Prevents weird characters from being displayed instead of proper cursor movement
  - Uses the semantically correct cursor positioning capability since we only need to move the cursor (content is already erased by printing a space)

### Technical Details
The `key_backspace` capability can cause problems in raw mode across different terminals, leading to incorrect display rendering. Since the code already erases content by printing a space before the cursor movement, we only need reliable cursor positioning, which `cursor_left` provides consistently.

Both changes maintain the same functional behavior while improving performance and terminal compatibility.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author