### PR TITLE
allow setting a custom classloader when building terminal

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,7 +7,7 @@ This document provides instructions for building JLine from source.
 * Maven 4.0+ (JLine 4.x requires Maven 4.0+)
 * Java 11+ at runtime (JLine 4.x requires Java 11+)
 * Java 22+ at build time
-* GNU Nano at test time
+* GNU Nano at test time (when testing on Linux)
 * Graal 23.1+ (for native-image builds)
 
 ## Basic Build Instructions

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,6 +7,7 @@ This document provides instructions for building JLine from source.
 * Maven 4.0+ (JLine 4.x requires Maven 4.0+)
 * Java 11+ at runtime (JLine 4.x requires Java 11+)
 * Java 22+ at build time
+* GNU Nano at test time
 * Graal 23.1+ (for native-image builds)
 
 ## Basic Build Instructions

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -293,6 +293,7 @@ public final class TerminalBuilder {
     private boolean nativeSignals = true;
     private Terminal.SignalHandler signalHandler = Terminal.SignalHandler.SIG_DFL;
     private boolean paused = false;
+    private ClassLoader classLoader;
 
     private TerminalBuilder() {}
 
@@ -610,6 +611,17 @@ public final class TerminalBuilder {
      */
     public TerminalBuilder paused(boolean paused) {
         this.paused = paused;
+        return this;
+    }
+
+    /**
+     * Changes the classloader which will be used to load the terminal
+     * providers.
+     * @param classLoader the new classloader
+     * @return The builder
+     */
+    public TerminalBuilder classLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
         return this;
     }
 
@@ -1001,7 +1013,7 @@ public final class TerminalBuilder {
         }
         if (doLoad) {
             try {
-                TerminalProvider prov = TerminalProvider.load(name);
+                TerminalProvider prov = TerminalProvider.load(name, classLoader);
                 prov.isSystemStream(SystemStream.Output);
                 providers.add(prov);
             } catch (Throwable t) {
@@ -1096,7 +1108,7 @@ public final class TerminalBuilder {
      * build tool uses a <code>LineReader</code> to implement an interactive shell.
      * One of its supported commands is <code>console</code> which invokes
      * the scala REPL. The scala REPL also uses a <code>LineReader</code> and it
-     * is necessary to override the {@link Terminal} used by the the REPL to
+     * is necessary to override the {@link Terminal} used by the REPL to
      * share the same {@link Terminal} instance used by sbt.
      *
      * <p>

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -191,8 +191,8 @@ public interface TerminalProvider {
      * </p>
      *
      * <p>
-     * Each provider resource file should contain a {@code class} property that
-     * specifies the fully qualified name of the provider implementation class.
+     * If {@code overrideClassloader} is specified, that classloader will be
+     * used instead.
      * </p>
      *
      * @param name the name of the provider to load
@@ -200,7 +200,39 @@ public interface TerminalProvider {
      * @throws IOException if the provider cannot be loaded
      */
     static TerminalProvider load(String name) throws IOException {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        return load(name, null);
+    }
+
+    /**
+     * Loads a terminal provider with the specified name.
+     *
+     * <p>
+     * This method loads a terminal provider implementation based on its name.
+     * Provider implementations are discovered through the Java ServiceLoader
+     * mechanism, looking for resource files in the classpath at
+     * {@code META-INF/services/org/jline/terminal/provider/[name]}.
+     * </p>
+     *
+     * <p>
+     * If {@code overrideClassloader} is specified, that classloader will be
+     * used instead.
+     * </p>
+     *
+     * <p>
+     * Each provider resource file should contain a {@code class} property that
+     * specifies the fully qualified name of the provider implementation class.
+     * </p>
+     *
+     * @param name the name of the provider to load
+     * @param overrideClassloader {@link ClassLoader} providers will be loaded with
+     * @return the loaded terminal provider
+     * @throws IOException if the provider cannot be loaded
+     */
+    static TerminalProvider load(String name, ClassLoader overrideClassloader) throws IOException {
+        ClassLoader cl = overrideClassloader;
+        if (cl == null) {
+            cl = Thread.currentThread().getContextClassLoader();
+        }
         if (cl == null) {
             cl = TerminalProvider.class.getClassLoader();
         }


### PR DESCRIPTION
Resolves #1368.

Adds `TerminalBuilder#classLoader(ClassLoader)` method to set a custom classloader alongside a few extra changes necessary to make this work.

(Also one of the tests complained that nano wasn't installed, so that's now in build requirements.)