### PR TITLE
support "ls /"

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -1900,6 +1900,7 @@ public class PosixCommands {
         }
         boolean listAll = opt.isSet("a");
         Predicate<Path> filter = p -> listAll
+                || p.getFileName() == null // root
                 || p.getFileName().toString().equals(".")
                 || p.getFileName().toString().equals("..")
                 || !p.getFileName().toString().startsWith(".");


### PR DESCRIPTION
When running `./mvx demo PosixCommandsRegistryExample` and invoking the `ls /` command, the following error occurs (at least on macOS):
```
Error: Cannot invoke "java.nio.file.Path.toString()" because the return value of "java.nio.file.Path.getFileName()" is null
```
The JavaDoc for Path#getFileName says it can return `null`. With this PR, the command works as expected, showing the files in the root directory.
