### PR TITLE
fix: Reset history search position when search term is modified

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -2720,7 +2720,6 @@ public class LineReaderImpl implements LineReader, Flushable {
         redisplay();
         try {
             while (true) {
-                int prevSearchIndex = searchIndex;
                 Binding operation = readBinding(getKeys(), terminators);
                 String ref = (operation instanceof Reference) ? ((Reference) operation).name() : "";
                 boolean next = false;
@@ -2740,10 +2739,12 @@ public class LineReaderImpl implements LineReader, Flushable {
                     case BACKWARD_DELETE_CHAR:
                         if (searchTerm.length() > 0) {
                             searchTerm.deleteCharAt(searchTerm.length() - 1);
+                            searchIndex = -1;
                         }
                         break;
                     case SELF_INSERT:
                         searchTerm.append(getLastBinding());
+                        searchIndex = -1;
                         break;
                     default:
                         // Set buffer and cursor position to the found string.

--- a/reader/src/test/java/org/jline/reader/impl/HistorySearchTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/HistorySearchTest.java
@@ -32,6 +32,40 @@ public class HistorySearchTest extends ReaderTestSupport {
     }
 
     @Test
+    public void testBackspaceAndRetypeGivesSameResult() throws Exception {
+        setupHistory();
+
+        assertLine("faddle", new TestBuffer()
+                .ctrl('R')
+                .append("f")
+                .back()
+                .append("f")
+                .enter(), false);
+    }
+
+    @Test
+    public void testSearchTermModificationResetsPosition() throws Exception {
+        setupHistory();
+
+        var navigateToSecond = new TestBuffer()
+                .ctrl('R')
+                .append("f")
+                .ctrl('R')
+                .enter();
+
+        assertLine("fiddle", navigateToSecond, false);
+
+        var modifySearchTerm = new TestBuffer()
+                .ctrl('R')
+                .append("f")
+                .ctrl('R')
+                .append("i")
+                .enter();
+
+        assertLine("fiddle", modifySearchTerm, false);
+    }
+
+    @Test
     public void testCaseInsensitive() throws Exception {
         setupHistory();
         reader.setOpt(LineReader.Option.CASE_INSENSITIVE_SEARCH);


### PR DESCRIPTION
Previously, modifying the search term (typing or backspacing) would continue
the search from the current search history position instead of starting fresh.

I am not sure if this is the intended behavior but it is very confusing for the
user, in my opinion. 