### PR TITLE
Fix errors caused by concurrent modification exception.

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -397,7 +397,10 @@ public class Display {
     }
 
     private int cost(Capability cap) {
-        return cost.computeIfAbsent(cap, this::computeCost);
+        if (!cost.containsKey(cap)) {
+            return cost.put(cap, computeCost(cap));
+        }
+        return cost.get(cap);
     }
 
     private int computeCost(Capability cap) {


### PR DESCRIPTION
Hello,
I've been working on the curses library. One of the initial issues I've been having on WIndows is a ConcurrentModificationException on the cost map in the Display class. This simple change fixes it to allow curses window to work on Windows.  

<img width="986" height="546" alt="image" src="https://github.com/user-attachments/assets/d205a55a-d03d-4f55-bf82-5cf59be2f85e" />

I plan to continue to work on curses, but for now I am just getting my test system working so it actually runs. 