### PR TITLE
[jline-3.x] Fix issue #1396: Allow single-digit options like -1 in Options parser (#1418)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Options.java
+++ b/builtins/src/main/java/org/jline/builtins/Options.java
@@ -411,7 +411,7 @@ public class Options {
                 needArg = null;
                 needOpt = null;
             } else if (!arg.startsWith("-")
-                    || (arg.length() > 1 && Character.isDigit(arg.charAt(1)))
+                    || (arg.length() > 2 && Character.isDigit(arg.charAt(1)) && Character.isDigit(arg.charAt(2)))
                     || "-".equals(oarg)) {
                 if (optionsFirst) endOpt = true;
                 xargs.add(oarg);

--- a/builtins/src/test/java/org/jline/builtins/OptionsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/OptionsTest.java
@@ -108,4 +108,32 @@ public class OptionsTest {
         AttributedString as = HelpException.highlight(String.join("\n", usage), HelpException.defaultStyle());
         as.print(terminal);
     }
+
+    @Test
+    public void testSingleDigitOptions() {
+        // Test that single digit options like -1 are recognized as options, not arguments
+        final String[] usage = {
+            "ls - list files",
+            "Usage: ls [OPTIONS] [PATTERNS...]",
+            "  -? --help                show help",
+            "  -1                       list one entry per line",
+            "  -l                       long listing",
+            "  -a                       list entries starting with ."
+        };
+
+        // Test that -1 is recognized as an option
+        Options opt = Options.compile(usage).parse("ls -1".split("\\s"));
+        assertTrue(opt.isSet("1"), "Option -1 should be recognized as an option");
+        assertEquals(Arrays.asList("ls"), opt.args());
+
+        // Test that -1 combined with other options works
+        opt = Options.compile(usage).parse("ls -1a".split("\\s"));
+        assertTrue(opt.isSet("1"), "Option -1 should be recognized in combined options");
+        assertTrue(opt.isSet("a"), "Option -a should be recognized in combined options");
+
+        // Test that multi-digit negative numbers are still treated as arguments
+        opt = Options.compile(usage).parse("ls -123".split("\\s"));
+        assertFalse(opt.isSet("1"), "Multi-digit -123 should not be treated as option -1");
+        assertEquals(Arrays.asList("ls", "-123"), opt.args());
+    }
 }

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
@@ -140,6 +140,29 @@ public class PosixCommandsTest {
     }
 
     @Test
+    void testLsOneEntryPerLine() throws Exception {
+        // Skip test on platforms that don't support POSIX file attributes
+        Assumptions.assumeTrue(isPosixSupported(), "POSIX file attributes not supported on this platform");
+
+        // Create test files
+        Files.createFile(tempDir.resolve("file1.txt"));
+        Files.createFile(tempDir.resolve("file2.txt"));
+        Files.createFile(tempDir.resolve("file3.txt"));
+
+        // Test -1 option (one entry per line)
+        PosixCommands.ls(context, new String[] {"ls", "-1"});
+
+        String output = out.toString();
+        assertTrue(output.contains("file1.txt"));
+        assertTrue(output.contains("file2.txt"));
+        assertTrue(output.contains("file3.txt"));
+
+        // Verify that each file is on its own line
+        String[] lines = output.trim().split("\\r?\\n");
+        assertTrue(lines.length >= 3, "Should have at least 3 lines for 3 files");
+    }
+
+    @Test
     void testCatWithFiles() throws Exception {
         // Create test files
         Path file1 = tempDir.resolve("file1.txt");


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `jline-3.x`:
 - [Fix issue #1396: Allow single-digit options like -1 in Options parser (#1418)](https://github.com/jline/jline3/pull/1418)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)