### PR TITLE
[jline-3.x] fix: setting line reader options via system properties does not work (#1413)

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/InputRC.java
+++ b/reader/src/main/java/org/jline/reader/impl/InputRC.java
@@ -441,7 +441,7 @@ public final class InputRC {
         }
 
         for (LineReader.Option option : LineReader.Option.values()) {
-            if (option.name().toLowerCase(Locale.ENGLISH).replace('_', '-').equals(val)) {
+            if (option.name().toLowerCase(Locale.ENGLISH).replace('_', '-').equals(key)) {
                 if ("on".equalsIgnoreCase(val)) {
                     reader.setOpt(option);
                 } else if ("off".equalsIgnoreCase(val)) {

--- a/reader/src/test/java/org/jline/reader/impl/SystemOptionsTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/SystemOptionsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2002-2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader.impl;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SystemOptionsTest {
+    @Test
+    public void testSystemOptions() {
+        LineReader reader1 = LineReaderBuilder.builder().build();
+        assertFalse(reader1.isSet(LineReader.Option.DISABLE_EVENT_EXPANSION));
+
+        System.setProperty("org.jline.reader.props.disable-event-expansion", "on");
+        try {
+            LineReader reader2 = LineReaderBuilder.builder().build();
+            assertTrue(reader2.isSet(LineReader.Option.DISABLE_EVENT_EXPANSION));
+        } finally {
+            System.clearProperty("org.jline.reader.props.disable-event-expansion");
+        }
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `jline-3.x`:
 - [fix: setting line reader options via system properties does not work (#1413)](https://github.com/jline/jline3/pull/1413)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)