### PR TITLE
AnsiConsole should fail on repeated uninstalls

### DIFF
--- a/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
@@ -398,6 +398,9 @@ public class AnsiConsole {
      * it is actually uninstalled.
      */
     public static synchronized void systemUninstall() {
+        if (installed == 0) {
+            throw new IllegalStateException("Already uninstalled");
+        }
         installed--;
         if (installed == 0) {
             doUninstall();


### PR DESCRIPTION
Otherwise, the installed counter can end up negative, breaking future install attempts. I considered just ignoring repeated uninstall calls, but that may hide bugs in clients of this library, so I'd rather fail cleanly.