### PR TITLE
fix(windows): Do not raise native signals if not enabled

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -268,7 +268,7 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
 
     protected void updateConsoleMode() {
         int mode = ENABLE_WINDOW_INPUT;
-        if (attributes.getLocalFlag(Attributes.LocalFlag.ISIG)) {
+        if (attributes.getLocalFlag(Attributes.LocalFlag.ISIG) && !nativeHandlers.isEmpty()) {
             mode |= ENABLE_PROCESSED_INPUT;
         }
         if (attributes.getLocalFlag(Attributes.LocalFlag.ECHO)) {


### PR DESCRIPTION
## Problem

When using JLine on Windows (11) with `nativeSignals(false)` + LineReader and
pressing Ctrl+C causes terminal corruption where the application and shell
prompt "fight for control," leaving the terminal in an unusable state. The user
cannot cleanly return to the shell prompt.

This is  a possible **regression** commit cc021a55

