### PR TITLE
[jline-3.x] AnsiConsole should fail on repeated uninstalls (#1525)

### DIFF
--- a/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
@@ -398,6 +398,9 @@ public class AnsiConsole {
      * it is actually uninstalled.
      */
     public static synchronized void systemUninstall() {
+        if (installed == 0) {
+            throw new IllegalStateException("Already uninstalled");
+        }
         installed--;
         if (installed == 0) {
             doUninstall();


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `jline-3.x`:
 - [AnsiConsole should fail on repeated uninstalls (#1525)](https://github.com/jline/jline3/pull/1525)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)