### PR TITLE
[jline-3.x] fix(windows): Do not raise native signals if not enabled (#1532)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -268,7 +268,7 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
 
     protected void updateConsoleMode() {
         int mode = ENABLE_WINDOW_INPUT;
-        if (attributes.getLocalFlag(Attributes.LocalFlag.ISIG)) {
+        if (attributes.getLocalFlag(Attributes.LocalFlag.ISIG) && !nativeHandlers.isEmpty()) {
             mode |= ENABLE_PROCESSED_INPUT;
         }
         if (attributes.getLocalFlag(Attributes.LocalFlag.ECHO)) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `jline-3.x`:
 - fix(windows): Do not raise native signals if not enabled (#1532) (dd75de34)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)