### PR TITLE
Fix autopair inserting stray closers during multiline copy/paste

### DIFF
--- a/console/src/main/java/org/jline/widget/AutopairWidgets.java
+++ b/console/src/main/java/org/jline/widget/AutopairWidgets.java
@@ -120,6 +120,12 @@ public class AutopairWidgets extends Widgets {
      * Widgets
      */
     public boolean autopairInsert() {
+        // Skip autopair logic during bracketed paste operations
+        if (reader.getRegionActive() == LineReader.RegionType.PASTE) {
+            callWidget(LineReader.SELF_INSERT);
+            return true;
+        }
+
         if (pairs.containsKey(lastBinding())) {
             if (canSkip(lastBinding())) {
                 callWidget(LineReader.FORWARD_CHAR);
@@ -137,6 +143,12 @@ public class AutopairWidgets extends Widgets {
     }
 
     public boolean autopairClose() {
+        // Skip autopair logic during bracketed paste operations
+        if (reader.getRegionActive() == LineReader.RegionType.PASTE) {
+            callWidget(LineReader.SELF_INSERT);
+            return true;
+        }
+
         if (pairs.containsValue(lastBinding()) && currChar().equals(lastBinding())) {
             callWidget(LineReader.FORWARD_CHAR);
         } else {
@@ -146,6 +158,12 @@ public class AutopairWidgets extends Widgets {
     }
 
     public boolean autopairDelete() {
+        // Skip autopair logic during bracketed paste operations
+        if (reader.getRegionActive() == LineReader.RegionType.PASTE) {
+            callWidget(LineReader.BACKWARD_DELETE_CHAR);
+            return true;
+        }
+
         if (pairs.containsKey(prevChar()) && pairs.get(prevChar()).equals(currChar()) && canDelete(prevChar())) {
             callWidget(LineReader.DELETE_CHAR);
         }


### PR DESCRIPTION
This change prevents autopair from inserting matching closing delimiters during bracketed paste operations by checking the paste region state.

## Problem

When pasting multiline input (especially with quotes/brackets), autopair inserts matching closing delimiters. Those auto-inserted closers end up being printed after execution (e.g., `"'' } ] )"`).

## Solution

Use JLine's existing bracketed paste detection (`RegionType.PASTE`) to disable autopairing during paste operations. This is more precise than detecting multiline buffers and preserves autopair functionality for legitimate multiline editing.

## Changes

- **autopairInsert**: Skip autopairing during bracketed paste
- **autopairClose**: Skip autopairing during bracketed paste
- **autopairDelete**: Skip autopairing during bracketed paste

## Why This Approach

✅ **Precise detection** - Only disables during actual paste operations
✅ **Uses existing infrastructure** - Leverages JLine's bracketed paste mode
✅ **Preserves functionality** - Autopair still works for manual multiline editing
✅ **Clean and simple** - Single condition using the proper API
✅ **Automatic cleanup** - RegionType.PASTE is cleared automatically

Fixes #1562

Based on PR #1563 by @Abdelilah-AIT-HAMOU