### PR TITLE
Fix #1565: StringIndexOutOfBoundsException in CompletionMatcherImpl

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
@@ -128,8 +128,8 @@ public class CompletionMatcherImpl implements CompletionMatcher {
         // TODO: glob completion
         String wd = line.word();
         String wdi = caseInsensitive ? wd.toLowerCase() : wd;
-        String wp = wdi.substring(0, line.wordCursor());
         if (prefix) {
+            String wp = wdi.substring(0, Math.min(line.wordCursor(), wdi.length()));
             matchers = new ArrayList<>(Arrays.asList(
                     simpleMatcher(s -> (caseInsensitive ? s.toLowerCase() : s).startsWith(wp)),
                     simpleMatcher(s -> (caseInsensitive ? s.toLowerCase() : s).contains(wp))));
@@ -142,7 +142,8 @@ public class CompletionMatcherImpl implements CompletionMatcher {
             exact = s -> caseInsensitive ? s.equalsIgnoreCase(wd) : s.equals(wd);
         } else {
             if (LineReader.Option.COMPLETE_IN_WORD.isSet(options)) {
-                String ws = wdi.substring(line.wordCursor());
+                String wp = wdi.substring(0, Math.min(line.wordCursor(), wdi.length()));
+                String ws = wdi.substring(Math.min(line.wordCursor(), wdi.length()));
                 Pattern p1 = Pattern.compile(Pattern.quote(wp) + ".*" + Pattern.quote(ws) + ".*");
                 Pattern p2 = Pattern.compile(".*" + Pattern.quote(wp) + ".*" + Pattern.quote(ws) + ".*");
                 matchers = new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
Fixes #1565

Fixed `StringIndexOutOfBoundsException` when pressing TAB on empty line where `line.word()` is empty but `line.wordCursor() > 0`.

**Changes:**
- Added bounds checking using `Math.min()` when calculating substring positions in `defaultMatchers()`
- Moved `wp` variable calculation inside branches where it's needed
- This allows `EMPTY_WORD_OPTIONS` branch to be properly reached

**Testing:**
- Added test case `testEmptyWordWithNonZeroCursor()` to verify the fix
- All tests pass

**Note:** This is the same fix as PR #1585 but targeting the jline-3.x branch.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author