### PR TITLE
[3.x] Fix Nano keypad state management

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -2199,7 +2199,9 @@ public class Nano implements Editor {
             if (!terminal.puts(Capability.exit_ca_mode)) {
                 terminal.puts(Capability.clear_screen);
             }
-            terminal.puts(Capability.keypad_local);
+            // Don't call keypad_local - leave keypad in xmit mode
+            // Most applications that use Nano (editors, prompters, TUIs) need keypad enabled.
+            // Leaving it enabled is harmless, but disabling it breaks arrow keys.
             terminal.flush();
             terminal.setAttributes(attributes);
             terminal.handle(Signal.WINCH, prevHandler);


### PR DESCRIPTION
## Backport to JLine 3.x

This is a backport of the Nano keypad fix from PR #1590 to the `jline-3.x` branch.

## Problem

Arrow keys stop working in applications that embed Nano (such as the prompt module's editor feature, or any TUI application that uses Nano as a component).

## Root Cause

Nano calls `terminal.puts(Capability.keypad_local)` when exiting, which disables application keypad mode. This prevents arrow keys from sending the expected escape sequences in the calling application.

## History

The `keypad_local` call was originally added in commit 271d9c03 (October 2, 2015) for symmetry with `keypad_xmit`, assuming Nano was a standalone application. However, this breaks applications that embed Nano.

## Solution

Remove the `keypad_local` call when Nano exits. This is the correct behavior because:

- ✅ Most applications that embed Nano need keypad mode enabled
- ✅ Leaving it enabled is harmless for standalone use
- ✅ Disabling it breaks arrow keys in the calling application
- ✅ The risk is asymmetric: breaking arrow keys is much worse than leaving them enabled

## Changes

- Remove `terminal.puts(Capability.keypad_local)` from Nano's finally block
- Add comment explaining why keypad_local is not called

## Testing

All tests pass:
```
mvn test -pl builtins
```

✅ All tests in builtins module pass

## Related

- Master branch PR: #1590

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author