### PR TITLE
Fix compilation error with -Werror flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
                         <showWarnings>true</showWarnings>
                         <release>${java.release.version}</release>
                         <compilerArgs>
-                            <arg>-Xlint:all,-options,-processing,-restricted</arg>
+                            <arg>-Xlint:all,-options,-processing,-restricted,-requires-automatic,-requires-transitive-automatic</arg>
                             <arg>-Werror</arg>
                         </compilerArgs>
                         <fork>true</fork>


### PR DESCRIPTION
## Problem

Compilation fails with `-Werror` flag when using automatic modules (JARs without module-info.java). The compiler treats warnings about `requires` clauses referencing automatic modules as errors.

## Solution

Suppress automatic module warnings by adding `-requires-automatic` and `-requires-transitive-automatic` to the `-Xlint` exclusion list in the Maven compiler plugin configuration.

## Changes

**Before:**
```xml
<arg>-Xlint:all,-options,-processing,-restricted</arg>
```

**After:**
```xml
<arg>-Xlint:all,-options,-processing,-restricted,-requires-automatic,-requires-transitive-automatic</arg>
```

## Why This Is Safe

- Only suppresses warnings about automatic modules, not other important warnings
- All other warnings are still treated as errors due to `-Werror`
- Automatic modules are a transitional feature in the Java module system
- Many dependencies don't yet have proper module-info.java files

## Testing

Compilation succeeds:
```
mvn compile -pl builtins
```

✅ Compilation passes without errors

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author