### PR TITLE
fix: Use standard Java SPI for terminal providers (#1523)

### DIFF
--- a/terminal-ffm/src/main/resources/META-INF/jline/providers/ffm
+++ b/terminal-ffm/src/main/resources/META-INF/jline/providers/ffm
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2026 the original author(s).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# JLine FFM Terminal Provider
+org.jline.terminal.impl.ffm.FfmTerminalProvider

--- a/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/resource-config.json
+++ b/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/resource-config.json
@@ -1,5 +1,6 @@
 {
   "resources": [
-    {"pattern": "META-INF/services/org/jline/terminal/provider/.*"}
+    {"pattern": "META-INF/services/org.jline.terminal.spi.TerminalProvider"},
+    {"pattern": "META-INF/jline/providers/ffm"}
   ]
 }

--- a/terminal-ffm/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
+++ b/terminal-ffm/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2026 the original author(s).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Standard Java SPI file for jlink and JPMS module tools.
+#
+# This file is used by jlink and other JPMS tools to discover service
+# implementations and establish proper module dependencies. It is NOT
+# used at runtime by JLine - runtime loading uses the provider-specific
+# files in META-INF/jline/providers/{name} instead.
+#
+# See TerminalProvider.load() javadoc for details.
+org.jline.terminal.impl.ffm.FfmTerminalProvider

--- a/terminal-jni/src/main/resources/META-INF/jline/providers/jni
+++ b/terminal-jni/src/main/resources/META-INF/jline/providers/jni
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 the original author(s).
+# Copyright (C) 2026 the original author(s).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class = org.jline.terminal.impl.exec.ExecTerminalProvider
+
+# JLine JNI Terminal Provider
+org.jline.terminal.impl.jni.JniTerminalProvider

--- a/terminal-jni/src/main/resources/META-INF/native-image/org.jline/jline-terminal-jni/resource-config.json
+++ b/terminal-jni/src/main/resources/META-INF/native-image/org.jline/jline-terminal-jni/resource-config.json
@@ -1,5 +1,6 @@
 {
   "resources": [
-    {"pattern": "META-INF/services/org/jline/terminal/provider/.*"}
+    {"pattern": "META-INF/services/org.jline.terminal.spi.TerminalProvider"},
+    {"pattern": "META-INF/jline/providers/jni"}
   ]
 }

--- a/terminal-jni/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
+++ b/terminal-jni/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 the original author(s).
+# Copyright (C) 2026 the original author(s).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class = org.jline.terminal.impl.ffm.FfmTerminalProvider
+
+# Standard Java SPI file for jlink and JPMS module tools.
+#
+# This file is used by jlink and other JPMS tools to discover service
+# implementations and establish proper module dependencies. It is NOT
+# used at runtime by JLine - runtime loading uses the provider-specific
+# files in META-INF/jline/providers/{name} instead.
+#
+# See TerminalProvider.load() javadoc for details.
+org.jline.terminal.impl.jni.JniTerminalProvider

--- a/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
@@ -103,6 +103,8 @@ public class DumbTerminalProvider implements TerminalProvider {
             Attributes attributes,
             Size size)
             throws IOException {
+        // DumbTerminalProvider is only used for system terminals as a fallback.
+        // Non-system terminals with custom streams should use ExecTerminalProvider instead.
         throw new UnsupportedOperationException();
     }
 

--- a/terminal/src/main/resources/META-INF/jline/README.md
+++ b/terminal/src/main/resources/META-INF/jline/README.md
@@ -1,0 +1,68 @@
+<!--
+Copyright (C) 2026 the original author(s).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# JLine Provider Loading Mechanism
+
+This directory contains provider-specific resource files used for runtime loading of terminal providers.
+
+## Directory Structure
+
+```
+META-INF/jline/providers/
+├── exec    - ExecTerminalProvider
+└── dumb    - DumbTerminalProvider
+```
+
+Additional providers are defined in other modules:
+- `terminal-ffm/META-INF/jline/providers/ffm` - FfmTerminalProvider
+- `terminal-jni/META-INF/jline/providers/jni` - JniTerminalProvider
+
+## Purpose
+
+These files enable loading terminal providers by name without instantiating all available providers.
+This is critical because some providers (JNI, FFM) may fail to initialize due to missing native
+libraries or platform-specific dependencies.
+
+## Relationship to META-INF/services
+
+JLine maintains two parallel service registration mechanisms:
+
+1. **META-INF/services/org.jline.terminal.spi.TerminalProvider** (Standard Java SPI)
+   - Used by jlink and JPMS module tools
+   - Required for proper module dependency resolution
+   - **NOT used at runtime by JLine**
+
+2. **META-INF/jline/providers/{name}** (JLine-specific)
+   - Used at runtime by `TerminalProvider.load(String name)`
+   - Allows on-demand loading of specific providers
+   - Avoids instantiation failures from unavailable providers
+
+## File Format
+
+Provider files follow standard Java SPI format:
+- One fully qualified class name per line
+- Comments start with `#` and extend to end of line
+- Blank lines and whitespace are ignored
+
+Example:
+```
+# JLine FFM Terminal Provider
+org.jline.terminal.impl.ffm.FfmTerminalProvider
+```
+
+## More Information
+
+See `TerminalProvider.load()` javadoc for detailed documentation.

--- a/terminal/src/main/resources/META-INF/jline/providers/dumb
+++ b/terminal/src/main/resources/META-INF/jline/providers/dumb
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2026 the original author(s).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# JLine Dumb Terminal Provider
+org.jline.terminal.impl.DumbTerminalProvider

--- a/terminal/src/main/resources/META-INF/jline/providers/exec
+++ b/terminal/src/main/resources/META-INF/jline/providers/exec
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 the original author(s).
+# Copyright (C) 2026 the original author(s).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class = org.jline.terminal.impl.jni.JniTerminalProvider
+
+# JLine Exec Terminal Provider
+org.jline.terminal.impl.exec.ExecTerminalProvider

--- a/terminal/src/main/resources/META-INF/native-image/org.jline/jline-terminal/resource-config.json
+++ b/terminal/src/main/resources/META-INF/native-image/org.jline/jline-terminal/resource-config.json
@@ -1,6 +1,7 @@
 {
   "resources": [
     {"pattern": "org/jline/utils/.*"},
-    {"pattern": "META-INF/services/org/jline/terminal/provider/.*"}
+    {"pattern": "META-INF/services/org.jline.terminal.spi.TerminalProvider"},
+    {"pattern": "META-INF/jline/providers/.*"}
   ]
 }

--- a/terminal/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
+++ b/terminal/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2026 the original author(s).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Standard Java SPI file for jlink and JPMS module tools.
+#
+# This file is used by jlink and other JPMS tools to discover service
+# implementations and establish proper module dependencies. It is NOT
+# used at runtime by JLine - runtime loading uses the provider-specific
+# files in META-INF/jline/providers/{name} instead.
+#
+# See TerminalProvider.load() javadoc for details.
+org.jline.terminal.impl.exec.ExecTerminalProvider
+org.jline.terminal.impl.DumbTerminalProvider


### PR DESCRIPTION
Replace custom service provider loading mechanism with standard Java ServiceLoader to fix compatibility with jlink and module tools.

Changes:
- Create proper META-INF/services/org.jline.terminal.spi.TerminalProvider files
- Update TerminalProvider.load() to use standard ServiceLoader
- Remove old custom META-INF/services/org/jline/terminal/provider/* files
- Remove unused Properties import

The custom loading used slash-separated paths (org/jline/terminal/provider/ffm) and Properties format which conflicts with JPMS and causes errors with badass-jlink-plugin and other module tools. Standard Java SPI uses dot-separated service interface names and plain text class names.

Fixes #1523