### PR TITLE
fix: Use standard Java SPI for terminal providers (#1523)

### DIFF
--- a/terminal-ffm/src/main/resources/META-INF/jline/providers/ffm
+++ b/terminal-ffm/src/main/resources/META-INF/jline/providers/ffm
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2026 the original author(s).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# JLine FFM Terminal Provider
+org.jline.terminal.impl.ffm.FfmTerminalProvider

--- a/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/resource-config.json
+++ b/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/resource-config.json
@@ -1,5 +1,6 @@
 {
   "resources": [
-    {"pattern": "META-INF/services/org/jline/terminal/provider/.*"}
+    {"pattern": "META-INF/services/org.jline.terminal.spi.TerminalProvider"},
+    {"pattern": "META-INF/jline/providers/ffm"}
   ]
 }

--- a/terminal-ffm/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
+++ b/terminal-ffm/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2026 the original author(s).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Standard Java SPI file for jlink and JPMS module tools.
+#
+# This file is used by jlink and other JPMS tools to discover service
+# implementations and establish proper module dependencies. It is NOT
+# used at runtime by JLine - runtime loading uses the provider-specific
+# files in META-INF/jline/providers/{name} instead.
+#
+# See TerminalProvider.load() javadoc for details.
+org.jline.terminal.impl.ffm.FfmTerminalProvider

--- a/terminal-jni/src/main/resources/META-INF/jline/providers/jni
+++ b/terminal-jni/src/main/resources/META-INF/jline/providers/jni
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 the original author(s).
+# Copyright (C) 2026 the original author(s).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class = org.jline.terminal.impl.exec.ExecTerminalProvider
+
+# JLine JNI Terminal Provider
+org.jline.terminal.impl.jni.JniTerminalProvider

--- a/terminal-jni/src/main/resources/META-INF/native-image/org.jline/jline-terminal-jni/resource-config.json
+++ b/terminal-jni/src/main/resources/META-INF/native-image/org.jline/jline-terminal-jni/resource-config.json
@@ -1,5 +1,6 @@
 {
   "resources": [
-    {"pattern": "META-INF/services/org/jline/terminal/provider/.*"}
+    {"pattern": "META-INF/services/org.jline.terminal.spi.TerminalProvider"},
+    {"pattern": "META-INF/jline/providers/jni"}
   ]
 }

--- a/terminal-jni/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
+++ b/terminal-jni/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 the original author(s).
+# Copyright (C) 2026 the original author(s).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class = org.jline.terminal.impl.ffm.FfmTerminalProvider
+
+# Standard Java SPI file for jlink and JPMS module tools.
+#
+# This file is used by jlink and other JPMS tools to discover service
+# implementations and establish proper module dependencies. It is NOT
+# used at runtime by JLine - runtime loading uses the provider-specific
+# files in META-INF/jline/providers/{name} instead.
+#
+# See TerminalProvider.load() javadoc for details.
+org.jline.terminal.impl.jni.JniTerminalProvider

--- a/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
@@ -126,6 +126,8 @@ public class DumbTerminalProvider implements TerminalProvider {
             Attributes attributes,
             Size size)
             throws IOException {
+        // DumbTerminalProvider is only used for system terminals as a fallback.
+        // Non-system terminals with custom streams should use ExecTerminalProvider instead.
         throw new UnsupportedOperationException();
     }
 

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -8,11 +8,13 @@
  */
 package org.jline.terminal.spi;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.util.Properties;
+import java.nio.charset.StandardCharsets;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
@@ -391,43 +393,96 @@ public interface TerminalProvider {
     /**
      * Loads a terminal provider with the specified name.
      *
+     * <h2>Provider Discovery Mechanism</h2>
      * <p>
-     * This method loads a terminal provider implementation based on its name.
-     * Provider implementations are discovered through the Java ServiceLoader
-     * mechanism, looking for resource files in the classpath at
-     * {@code META-INF/services/org/jline/terminal/provider/[name]}.
+     * This method loads a terminal provider implementation based on its name by reading
+     * a provider-specific resource file at {@code META-INF/jline/providers/[name]} which
+     * contains the fully qualified class name of the provider implementation.
      * </p>
      *
      * <p>
-     * Each provider resource file should contain a {@code class} property that
-     * specifies the fully qualified name of the provider implementation class.
+     * This on-demand loading approach is used instead of {@link java.util.ServiceLoader}
+     * because it allows loading a specific provider by name without instantiating all
+     * available providers. This is critical for providers that may fail to initialize
+     * due to missing native libraries (JNI, FFM) or other platform-specific dependencies.
      * </p>
      *
-     * @param name the name of the provider to load
+     * <h2>Dual-Purpose Service Files</h2>
+     * <p>
+     * JLine maintains two types of service registration files:
+     * </p>
+     * <ul>
+     *   <li><b>{@code META-INF/services/org.jline.terminal.spi.TerminalProvider}</b> -
+     *       Standard Java SPI files required by jlink and JPMS module tools to discover
+     *       service implementations and establish proper module dependencies. These files
+     *       are not used at runtime by JLine.</li>
+     *   <li><b>{@code META-INF/jline/providers/[name]}</b> -
+     *       Provider-specific files used by this method for efficient runtime loading.
+     *       Each file contains the class name of a single provider and allows loading
+     *       by provider name without scanning all available providers.</li>
+     * </ul>
+     *
+     * <h2>File Format</h2>
+     * <p>
+     * The provider file format follows standard Java SPI conventions:
+     * </p>
+     * <ul>
+     *   <li>One fully qualified class name per line</li>
+     *   <li>Comments start with {@code #} and extend to end of line</li>
+     *   <li>Blank lines and whitespace are ignored</li>
+     * </ul>
+     *
+     * <p><b>Example:</b> {@code META-INF/jline/providers/ffm}</p>
+     * <pre>
+     * # JLine FFM Terminal Provider
+     * org.jline.terminal.impl.ffm.FfmTerminalProvider
+     * </pre>
+     *
+     * @param name the name of the provider to load (e.g., "ffm", "jni", "exec", "dumb")
      * @return the loaded terminal provider
-     * @throws IOException if the provider cannot be loaded
+     * @throws IOException if the provider cannot be loaded or is not found
      */
     static TerminalProvider load(String name) throws IOException {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         if (cl == null) {
             cl = TerminalProvider.class.getClassLoader();
         }
-        InputStream is = cl.getResourceAsStream("META-INF/services/org/jline/terminal/provider/" + name);
-        if (is != null) {
-            Properties props = new Properties();
-            try {
-                props.load(is);
-                String className = props.getProperty("class");
-                if (className == null) {
-                    throw new IOException("No class defined in terminal provider file " + name);
+
+        // Read the provider-specific resource file to get the class name.
+        // We use META-INF/jline/providers/{name} instead of ServiceLoader to avoid
+        // instantiating all providers when we only need one. This is critical because
+        // some providers (JNI, FFM) may fail to load due to missing native libraries.
+        String providerResource = "META-INF/jline/providers/" + name;
+        try (InputStream is = cl.getResourceAsStream(providerResource)) {
+            if (is != null) {
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    // Remove comments and trim whitespace
+                    int commentIndex = line.indexOf('#');
+                    if (commentIndex >= 0) {
+                        line = line.substring(0, commentIndex);
+                    }
+                    line = line.trim();
+
+                    // Skip empty lines
+                    if (line.isEmpty()) {
+                        continue;
+                    }
+
+                    // Found a provider class name, try to load it
+                    try {
+                        Class<?> providerClass = cl.loadClass(line);
+                        return (TerminalProvider) providerClass.getConstructor().newInstance();
+                    } catch (Exception e) {
+                        throw new IOException("Unable to load terminal provider " + name + ": " + e.getMessage(), e);
+                    }
                 }
-                Class<?> clazz = cl.loadClass(className);
-                return (TerminalProvider) clazz.getConstructor().newInstance();
-            } catch (Exception e) {
-                throw new IOException("Unable to load terminal provider " + name + ": " + e.getMessage(), e);
             }
-        } else {
-            throw new IOException("Unable to find terminal provider " + name);
+        } catch (IOException e) {
+            throw new IOException("Error reading provider resource file: " + e.getMessage(), e);
         }
+
+        throw new IOException("Unable to find terminal provider " + name);
     }
 }

--- a/terminal/src/main/resources/META-INF/jline/README.md
+++ b/terminal/src/main/resources/META-INF/jline/README.md
@@ -1,0 +1,68 @@
+<!--
+Copyright (C) 2026 the original author(s).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# JLine Provider Loading Mechanism
+
+This directory contains provider-specific resource files used for runtime loading of terminal providers.
+
+## Directory Structure
+
+```
+META-INF/jline/providers/
+├── exec    - ExecTerminalProvider
+└── dumb    - DumbTerminalProvider
+```
+
+Additional providers are defined in other modules:
+- `terminal-ffm/META-INF/jline/providers/ffm` - FfmTerminalProvider
+- `terminal-jni/META-INF/jline/providers/jni` - JniTerminalProvider
+
+## Purpose
+
+These files enable loading terminal providers by name without instantiating all available providers.
+This is critical because some providers (JNI, FFM) may fail to initialize due to missing native
+libraries or platform-specific dependencies.
+
+## Relationship to META-INF/services
+
+JLine maintains two parallel service registration mechanisms:
+
+1. **META-INF/services/org.jline.terminal.spi.TerminalProvider** (Standard Java SPI)
+   - Used by jlink and JPMS module tools
+   - Required for proper module dependency resolution
+   - **NOT used at runtime by JLine**
+
+2. **META-INF/jline/providers/{name}** (JLine-specific)
+   - Used at runtime by `TerminalProvider.load(String name)`
+   - Allows on-demand loading of specific providers
+   - Avoids instantiation failures from unavailable providers
+
+## File Format
+
+Provider files follow standard Java SPI format:
+- One fully qualified class name per line
+- Comments start with `#` and extend to end of line
+- Blank lines and whitespace are ignored
+
+Example:
+```
+# JLine FFM Terminal Provider
+org.jline.terminal.impl.ffm.FfmTerminalProvider
+```
+
+## More Information
+
+See `TerminalProvider.load()` javadoc for detailed documentation.

--- a/terminal/src/main/resources/META-INF/jline/providers/dumb
+++ b/terminal/src/main/resources/META-INF/jline/providers/dumb
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2026 the original author(s).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# JLine Dumb Terminal Provider
+org.jline.terminal.impl.DumbTerminalProvider

--- a/terminal/src/main/resources/META-INF/jline/providers/exec
+++ b/terminal/src/main/resources/META-INF/jline/providers/exec
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 the original author(s).
+# Copyright (C) 2026 the original author(s).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-class = org.jline.terminal.impl.jni.JniTerminalProvider
+
+# JLine Exec Terminal Provider
+org.jline.terminal.impl.exec.ExecTerminalProvider

--- a/terminal/src/main/resources/META-INF/native-image/org.jline/jline-terminal/resource-config.json
+++ b/terminal/src/main/resources/META-INF/native-image/org.jline/jline-terminal/resource-config.json
@@ -1,6 +1,7 @@
 {
   "resources": [
     {"pattern": "org/jline/utils/.*"},
-    {"pattern": "META-INF/services/org/jline/terminal/provider/.*"}
+    {"pattern": "META-INF/services/org.jline.terminal.spi.TerminalProvider"},
+    {"pattern": "META-INF/jline/providers/.*"}
   ]
 }

--- a/terminal/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
+++ b/terminal/src/main/resources/META-INF/services/org.jline.terminal.spi.TerminalProvider
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2026 the original author(s).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Standard Java SPI file for jlink and JPMS module tools.
+#
+# This file is used by jlink and other JPMS tools to discover service
+# implementations and establish proper module dependencies. It is NOT
+# used at runtime by JLine - runtime loading uses the provider-specific
+# files in META-INF/jline/providers/{name} instead.
+#
+# See TerminalProvider.load() javadoc for details.
+org.jline.terminal.impl.exec.ExecTerminalProvider
+org.jline.terminal.impl.DumbTerminalProvider


### PR DESCRIPTION
Replace custom service provider loading mechanism with a dual-purpose approach to fix compatibility with jlink and module tools while avoiding runtime inefficiencies.

Changes:
- Create standard META-INF/services/org.jline.terminal.spi.TerminalProvider files for jlink and JPMS module tools (build-time only)
- Add META-INF/jline/providers/{name} files for efficient runtime loading
- Update TerminalProvider.load() to use on-demand loading instead of ServiceLoader to avoid instantiating all providers
- Remove old custom META-INF/services/org/jline/terminal/provider/* files
- Add comprehensive documentation about the dual-purpose approach
- Remove unused Properties import

The old custom loading used slash-separated paths (org/jline/terminal/provider/ffm) and Properties format which conflicts with JPMS and causes errors with badass-jlink-plugin and other module tools.

The new approach maintains standard Java SPI files (META-INF/services/) for jlink/JPMS discovery, but uses provider-specific files (META-INF/jline/providers/) at runtime. This allows loading providers by name without instantiating all providers, which is critical for providers that may fail to initialize due to missing native libraries (JNI, FFM).

Fixes #1523