### PR TITLE
Add shell next features — expansion, subcommands, I/O redirection, signals, scripts, builtins

### DIFF
--- a/builtins/pom.xml
+++ b/builtins/pom.xml
@@ -27,6 +27,11 @@
         <dependency>
             <artifactId>jline-style</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline-shell</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>com.googlecode.juniversalchardet</groupId>
@@ -66,7 +71,7 @@
                         <id>default-compile</id>
                         <configuration>
                             <compilerArgs>
-                                <arg>-Xlint:all,-options,-requires-automatic,-restricted</arg>
+                                <arg>-Xlint:all,-options,-requires-automatic,-restricted,-exports</arg>
                                 <arg>-Werror</arg>
                             </compilerArgs>
                         </configuration>

--- a/builtins/src/main/java/module-info.java
+++ b/builtins/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module org.jline.builtins {
 
     // Optional dependencies
     requires static juniversalchardet;
+    requires static org.jline.shell;
 
     // Export public API
     exports org.jline.builtins;

--- a/builtins/src/main/java/org/jline/builtins/InteractiveCommandGroup.java
+++ b/builtins/src/main/java/org/jline/builtins/InteractiveCommandGroup.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.util.*;
+
+import org.jline.shell.Command;
+import org.jline.shell.CommandGroup;
+import org.jline.shell.CommandSession;
+
+/**
+ * A {@link CommandGroup} that wraps interactive builtins ({@code nano}, {@code less},
+ * {@code tmux}, {@code ttop}) as shell {@link Command}s.
+ * <p>
+ * These commands require a terminal and are typically used in interactive sessions.
+ * <p>
+ * Example:
+ * <pre>
+ * dispatcher.addGroup(new InteractiveCommandGroup());
+ * dispatcher.execute("nano file.txt");
+ * </pre>
+ *
+ * @since 4.0
+ */
+public class InteractiveCommandGroup implements CommandGroup {
+
+    private final List<Command> commands;
+
+    /**
+     * Creates a new InteractiveCommandGroup with all available interactive commands.
+     */
+    public InteractiveCommandGroup() {
+        List<Command> cmds = new ArrayList<>();
+        cmds.add(interactiveCommand("nano", "Text editor", (session, args) -> {
+            PosixCommands.Context ctx = createContext(session);
+            String[] argv = prependName("nano", args);
+            PosixCommands.nano(ctx, argv);
+        }));
+        cmds.add(interactiveCommand("less", "File pager", (session, args) -> {
+            PosixCommands.Context ctx = createContext(session);
+            String[] argv = prependName("less", args);
+            PosixCommands.less(ctx, argv);
+        }));
+        cmds.add(interactiveCommand("ttop", "Terminal top", (session, args) -> {
+            PosixCommands.Context ctx = createContext(session);
+            String[] argv = prependName("ttop", args);
+            PosixCommands.ttop(ctx, argv);
+        }));
+        this.commands = Collections.unmodifiableList(cmds);
+    }
+
+    @Override
+    public String name() {
+        return "Interactive";
+    }
+
+    @Override
+    public Collection<Command> commands() {
+        return commands;
+    }
+
+    private static PosixCommands.Context createContext(CommandSession session) {
+        return new PosixCommands.Context(
+                session.in(),
+                session.out(),
+                session.err(),
+                session.workingDirectory(),
+                session.terminal(),
+                session::get);
+    }
+
+    private static String[] prependName(String name, String[] args) {
+        String[] argv = new String[args.length + 1];
+        argv[0] = name;
+        System.arraycopy(args, 0, argv, 1, args.length);
+        return argv;
+    }
+
+    private static Command interactiveCommand(String name, String description, InteractiveExecutor executor) {
+        return new Command() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public String description() {
+                return description;
+            }
+
+            @Override
+            public Object execute(CommandSession session, String[] args) throws Exception {
+                if (session.terminal() == null) {
+                    throw new IllegalStateException(name + " requires an interactive terminal");
+                }
+                executor.execute(session, args);
+                return null;
+            }
+        };
+    }
+
+    @FunctionalInterface
+    private interface InteractiveExecutor {
+        void execute(CommandSession session, String[] args) throws Exception;
+    }
+}

--- a/builtins/src/main/java/org/jline/builtins/PosixCommandGroup.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommandGroup.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.Consumer;
+
+import org.jline.shell.Command;
+import org.jline.shell.CommandGroup;
+import org.jline.shell.CommandSession;
+
+/**
+ * A {@link CommandGroup} that wraps {@link PosixCommands} static methods as shell {@link Command}s.
+ * <p>
+ * This provides a bridge between the builtins module's POSIX command implementations
+ * and the shell module's command API. Each command creates a {@link PosixCommands.Context}
+ * from the current {@link CommandSession}.
+ * <p>
+ * Special handling:
+ * <ul>
+ *   <li>{@code cd} — uses {@link CommandSession#setWorkingDirectory(Path)} to update the session</li>
+ * </ul>
+ * <p>
+ * Example:
+ * <pre>
+ * dispatcher.addGroup(new PosixCommandGroup());
+ * dispatcher.execute("echo hello");
+ * dispatcher.execute("ls -la");
+ * </pre>
+ *
+ * @since 4.0
+ */
+public class PosixCommandGroup implements CommandGroup {
+
+    private final List<Command> commands;
+
+    /**
+     * Creates a new PosixCommandGroup with all available POSIX commands.
+     */
+    public PosixCommandGroup() {
+        List<Command> cmds = new ArrayList<>();
+        cmds.add(posixCommand("cd", "Change working directory", (ctx, args, session) -> {
+            Consumer<Path> dirChanger = session::setWorkingDirectory;
+            PosixCommands.cd(ctx, args, dirChanger);
+        }));
+        cmds.add(posixCommand("pwd", "Print working directory", (ctx, args, session) -> PosixCommands.pwd(ctx, args)));
+        cmds.add(posixCommand("echo", "Display a line of text", (ctx, args, session) -> PosixCommands.echo(ctx, args)));
+        cmds.add(posixCommand("cat", "Concatenate files", (ctx, args, session) -> PosixCommands.cat(ctx, args)));
+        cmds.add(posixCommand("ls", "List directory contents", (ctx, args, session) -> PosixCommands.ls(ctx, args)));
+        cmds.add(posixCommand("grep", "Search text patterns", (ctx, args, session) -> PosixCommands.grep(ctx, args)));
+        cmds.add(posixCommand(
+                "head", "Output the first part of files", (ctx, args, session) -> PosixCommands.head(ctx, args)));
+        cmds.add(posixCommand(
+                "tail", "Output the last part of files", (ctx, args, session) -> PosixCommands.tail(ctx, args)));
+        cmds.add(posixCommand("wc", "Word, line, and byte count", (ctx, args, session) -> PosixCommands.wc(ctx, args)));
+        cmds.add(posixCommand(
+                "sort", "Sort lines of text files", (ctx, args, session) -> PosixCommands.sort(ctx, args)));
+        cmds.add(posixCommand("date", "Display date and time", (ctx, args, session) -> PosixCommands.date(ctx, args)));
+        cmds.add(posixCommand(
+                "sleep", "Delay for a specified time", (ctx, args, session) -> PosixCommands.sleep(ctx, args)));
+        cmds.add(posixCommand(
+                "clear", "Clear the terminal screen", (ctx, args, session) -> PosixCommands.clear(ctx, args)));
+        this.commands = Collections.unmodifiableList(cmds);
+    }
+
+    @Override
+    public String name() {
+        return "POSIX";
+    }
+
+    @Override
+    public Collection<Command> commands() {
+        return commands;
+    }
+
+    private static PosixCommands.Context createContext(CommandSession session) {
+        return new PosixCommands.Context(
+                session.in(),
+                session.out(),
+                session.err(),
+                session.workingDirectory(),
+                session.terminal(),
+                session::get);
+    }
+
+    private static Command posixCommand(String name, String description, PosixCommandExecutor executor) {
+        return new Command() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public String description() {
+                return description;
+            }
+
+            @Override
+            public Object execute(CommandSession session, String[] args) throws Exception {
+                PosixCommands.Context ctx = createContext(session);
+                // Prepend command name to args for options parsing
+                String[] argv = new String[args.length + 1];
+                argv[0] = name;
+                System.arraycopy(args, 0, argv, 1, args.length);
+                executor.execute(ctx, argv, session);
+                return null;
+            }
+        };
+    }
+
+    @FunctionalInterface
+    private interface PosixCommandExecutor {
+        void execute(PosixCommands.Context ctx, String[] args, CommandSession session) throws Exception;
+    }
+}

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandGroupTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandGroupTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jline.shell.Command;
+import org.jline.shell.CommandSession;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link PosixCommandGroup}.
+ */
+public class PosixCommandGroupTest {
+
+    private PosixCommandGroup group;
+    private Terminal terminal;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        group = new PosixCommandGroup();
+        terminal = TerminalBuilder.builder().dumb(true).build();
+    }
+
+    @Test
+    void commandsListNotEmpty() {
+        assertFalse(group.commands().isEmpty());
+    }
+
+    @Test
+    void hasEchoCommand() {
+        Command echo = group.command("echo");
+        assertNotNull(echo);
+        assertEquals("echo", echo.name());
+    }
+
+    @Test
+    void hasPwdCommand() {
+        Command pwd = group.command("pwd");
+        assertNotNull(pwd);
+    }
+
+    @Test
+    void hasCdCommand() {
+        Command cd = group.command("cd");
+        assertNotNull(cd);
+    }
+
+    @Test
+    void echoExecution() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(baos);
+        CommandSession session = new CommandSession(terminal, System.in, out, new PrintStream(terminal.output()));
+        session.setWorkingDirectory(Path.of(System.getProperty("user.dir")));
+
+        Command echo = group.command("echo");
+        echo.execute(session, new String[] {"hello", "world"});
+
+        out.flush();
+        String output = baos.toString();
+        assertTrue(output.contains("hello world"), "Expected 'hello world' in output: " + output);
+    }
+
+    @Test
+    void pwdExecution(@TempDir Path tempDir) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(baos);
+        CommandSession session = new CommandSession(terminal, System.in, out, new PrintStream(terminal.output()));
+        session.setWorkingDirectory(tempDir);
+
+        Command pwd = group.command("pwd");
+        pwd.execute(session, new String[0]);
+
+        out.flush();
+        String output = baos.toString();
+        assertTrue(output.contains(tempDir.toString()), "Expected working directory in output: " + output);
+    }
+
+    @Test
+    void cdUpdatesSessionWorkingDirectory(@TempDir Path tempDir) throws Exception {
+        Path subDir = tempDir.resolve("sub");
+        Files.createDirectories(subDir);
+
+        CommandSession session = new CommandSession(terminal);
+        session.setWorkingDirectory(tempDir);
+
+        Command cd = group.command("cd");
+        cd.execute(session, new String[] {subDir.toString()});
+
+        assertEquals(subDir, session.workingDirectory());
+    }
+
+    @Test
+    void ioStreamsPassedCorrectly() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(baos);
+        ByteArrayOutputStream errBaos = new ByteArrayOutputStream();
+        PrintStream err = new PrintStream(errBaos);
+        CommandSession session = new CommandSession(terminal, System.in, out, err);
+        session.setWorkingDirectory(Path.of(System.getProperty("user.dir")));
+
+        Command echo = group.command("echo");
+        echo.execute(session, new String[] {"test"});
+
+        out.flush();
+        assertTrue(baos.toString().contains("test"));
+    }
+
+    @Test
+    void groupName() {
+        assertEquals("POSIX", group.name());
+    }
+}

--- a/console/src/main/java/org/jline/console/impl/ConsoleLineExpander.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleLineExpander.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.console.impl;
+
+import org.jline.console.ConsoleEngine;
+import org.jline.shell.CommandSession;
+import org.jline.shell.LineExpander;
+
+/**
+ * A {@link LineExpander} backed by a {@link ConsoleEngine}'s parameter expansion.
+ * <p>
+ * This expander supports full {@code ${expression}} syntax with Groovy evaluation
+ * (or whatever script engine the ConsoleEngine is configured with), in addition
+ * to simple {@code $variable} expansion.
+ * <p>
+ * It delegates to {@link ConsoleEngine#expandCommandLine(String)} for the
+ * actual expansion logic, which supports script engine evaluation.
+ * <p>
+ * Example:
+ * <pre>
+ * ConsoleEngine engine = ...;
+ * LineExpander expander = new ConsoleLineExpander(engine);
+ * Shell.builder()
+ *     .lineExpander(expander)
+ *     .build();
+ * </pre>
+ *
+ * @since 4.0
+ */
+public class ConsoleLineExpander implements LineExpander {
+
+    private final ConsoleEngine engine;
+
+    /**
+     * Creates a new ConsoleLineExpander backed by the given engine.
+     *
+     * @param engine the console engine for parameter expansion
+     */
+    public ConsoleLineExpander(ConsoleEngine engine) {
+        this.engine = engine;
+    }
+
+    @Override
+    public String expand(String line, CommandSession session) {
+        if (line == null || line.isEmpty()) {
+            return line;
+        }
+        try {
+            return engine.expandCommandLine(line);
+        } catch (Exception e) {
+            // If expansion fails, return the original line
+            return line;
+        }
+    }
+}

--- a/console/src/main/java/org/jline/console/impl/GogoCommandGroup.java
+++ b/console/src/main/java/org/jline/console/impl/GogoCommandGroup.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.console.impl;
+
+import java.util.*;
+
+import org.jline.console.CommandRegistry;
+import org.jline.shell.Command;
+import org.jline.shell.CommandGroup;
+import org.jline.shell.CommandSession;
+
+/**
+ * A {@link CommandGroup} that wraps a legacy {@link CommandRegistry}'s commands
+ * as shell {@link Command}s.
+ * <p>
+ * This provides a migration path from the console module's {@link CommandRegistry} API
+ * to the shell module's {@link CommandGroup} API. Each command in the registry
+ * is wrapped as a shell {@code Command} that delegates to the registry's
+ * {@link CommandRegistry#invoke(CommandRegistry.CommandSession, String, Object...)} method.
+ * <p>
+ * Example:
+ * <pre>
+ * CommandRegistry registry = ...; // existing Gogo/console registry
+ * dispatcher.addGroup(new GogoCommandGroup("Gogo", registry));
+ * </pre>
+ *
+ * @since 4.0
+ */
+public class GogoCommandGroup implements CommandGroup {
+
+    private final String groupName;
+    private final CommandRegistry registry;
+    private final List<Command> commands;
+
+    /**
+     * Creates a new GogoCommandGroup wrapping the given registry.
+     *
+     * @param name the group name
+     * @param registry the command registry to wrap
+     */
+    public GogoCommandGroup(String name, CommandRegistry registry) {
+        this.groupName = name;
+        this.registry = registry;
+        List<Command> cmds = new ArrayList<>();
+        for (String cmdName : registry.commandNames()) {
+            cmds.add(new RegistryCommand(cmdName));
+        }
+        this.commands = Collections.unmodifiableList(cmds);
+    }
+
+    @Override
+    public String name() {
+        return groupName;
+    }
+
+    @Override
+    public Collection<Command> commands() {
+        return commands;
+    }
+
+    private class RegistryCommand implements Command {
+        private final String name;
+
+        RegistryCommand(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public String description() {
+            List<String> infos = registry.commandInfo(name);
+            if (infos != null && !infos.isEmpty()) {
+                return infos.get(0);
+            }
+            return "";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            CommandRegistry.CommandSession regSession =
+                    new CommandRegistry.CommandSession(session.terminal(), session.in(), session.out(), session.err());
+            Object[] objArgs = new Object[args.length];
+            System.arraycopy(args, 0, objArgs, 0, args.length);
+            return registry.invoke(regSession, name, objArgs);
+        }
+    }
+}

--- a/demo/src/main/java/org/jline/demo/examples/ShellBuilderExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellBuilderExample.java
@@ -8,54 +8,136 @@
  */
 package org.jline.demo.examples;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 
+import org.jline.builtins.PosixCommandGroup;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReader.Option;
+import org.jline.shell.Command;
 import org.jline.shell.CommandSession;
 import org.jline.shell.Shell;
-import org.jline.shell.impl.AbstractCommand;
-import org.jline.shell.impl.SimpleCommandGroup;
+import org.jline.shell.impl.*;
 
 /**
- * Example demonstrating how Shell.builder() eliminates REPL boilerplate.
+ * Example demonstrating how Shell.builder() creates a feature-rich shell.
  * <p>
- * Compare this with {@link ReplConsoleExample} to see the reduction in setup code.
+ * This example showcases:
+ * <ul>
+ *   <li>POSIX builtins (ls, cd, pwd, cat, echo, grep, head, tail, wc, sort, date, sleep, clear)</li>
+ *   <li>Variable expansion ($VAR, ${VAR}, ~)</li>
+ *   <li>Subcommands (git commit, git status)</li>
+ *   <li>Script execution (source command)</li>
+ *   <li>I/O redirection (&lt;, 2&gt;, &amp;&gt;)</li>
+ *   <li>Job control, aliases, syntax highlighting, help</li>
+ * </ul>
+ * <p>
+ * Try these commands:
+ * <pre>
+ *   echo hello world
+ *   echo $HOME
+ *   echo ~/docs
+ *   FOO=bar
+ *   echo $FOO
+ *   set NAME=world
+ *   echo ${NAME:-default}
+ *   unset NAME
+ *   echo ${NAME:-default}
+ *   ls
+ *   pwd
+ *   cd /tmp
+ *   echo hello &gt; /tmp/test.txt
+ *   cat &lt; /tmp/test.txt
+ *   git status
+ *   git commit -m "my message"
+ *   sleep 5 &amp;
+ *   jobs
+ *   help
+ * </pre>
  */
 public class ShellBuilderExample {
 
     // SNIPPET_START: ShellBuilderExample
+    /**
+     * A command with subcommands, demonstrating the subcommand routing feature.
+     */
+    static class GitCommand extends AbstractCommand {
+        private final Map<String, Command> subcommands = Map.of(
+                "commit",
+                new AbstractCommand("commit") {
+                    @Override
+                    public String description() {
+                        return "Record changes";
+                    }
+
+                    @Override
+                    public Object execute(CommandSession session, String[] args) {
+                        session.out().println("committed: " + String.join(" ", args));
+                        return null;
+                    }
+                },
+                "status",
+                new AbstractCommand("status") {
+                    @Override
+                    public String description() {
+                        return "Show working tree status";
+                    }
+
+                    @Override
+                    public Object execute(CommandSession session, String[] args) {
+                        Path wd = session.workingDirectory();
+                        session.out().println("On branch main");
+                        session.out().println("Working directory: " + wd);
+                        session.out().println("nothing to commit, working tree clean");
+                        return null;
+                    }
+                });
+
+        GitCommand() {
+            super("git");
+        }
+
+        @Override
+        public String description() {
+            return "Version control (subcommands: commit, status)";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            session.out().println("usage: git <command> [<args>]");
+            session.out().println("  commit    Record changes");
+            session.out().println("  status    Show working tree status");
+            return null;
+        }
+
+        @Override
+        public Map<String, Command> subcommands() {
+            return subcommands;
+        }
+    }
+
     public static void main(String[] args) {
         try (Shell shell = Shell.builder()
                 .prompt("demo> ")
-                .groups(new SimpleCommandGroup(
-                        "demo",
-                        new AbstractCommand("echo") {
-                            @Override
-                            public String description() {
-                                return "Echo arguments to output";
-                            }
-
-                            @Override
-                            public Object execute(CommandSession session, String[] a) {
-                                String msg = String.join(" ", a);
-                                session.out().println(msg);
-                                return msg;
-                            }
-                        },
-                        new AbstractCommand("greet") {
-                            @Override
-                            public String description() {
-                                return "Greet someone";
-                            }
-
-                            @Override
-                            public Object execute(CommandSession session, String[] a) {
-                                String name = a.length > 0 ? a[0] : "World";
-                                session.out().println("Hello, " + name + "!");
-                                return null;
-                            }
-                        }))
+                // POSIX builtins: ls, cd, pwd, cat, echo, grep, etc.
+                .groups(new PosixCommandGroup()) // HIGHLIGHT
+                // Custom commands with subcommand support
+                .groups(new SimpleCommandGroup("demo", new GitCommand())) // HIGHLIGHT
+                // Variable expansion: $VAR, ${VAR}, ~
+                .lineExpander(new DefaultLineExpander()) // HIGHLIGHT
+                // Script execution: source/. commands
+                .scriptRunner(new DefaultScriptRunner()) // HIGHLIGHT
+                .scriptCommands(true) // HIGHLIGHT
+                // Variable commands: set, unset, export + bare VAR=VALUE
+                .variableCommands(true) // HIGHLIGHT
+                // Job control, aliases, built-in commands
+                .jobManager(new DefaultJobManager())
+                .aliasManager(new DefaultAliasManager())
+                .historyCommands(true)
+                .helpCommands(true)
+                .optionCommands(true)
+                .commandHighlighter(true)
                 .variable(LineReader.HISTORY_FILE, Paths.get(System.getProperty("user.home"), ".demo_history"))
                 .option(Option.INSERT_BRACKET, true)
                 .option(Option.DISABLE_EVENT_EXPANSION, true)

--- a/shell/src/main/java/org/jline/shell/Command.java
+++ b/shell/src/main/java/org/jline/shell/Command.java
@@ -9,6 +9,7 @@
 package org.jline.shell;
 
 import java.util.List;
+import java.util.Map;
 
 import org.jline.reader.Completer;
 
@@ -97,5 +98,22 @@ public interface Command {
      */
     default List<Completer> completers() {
         return List.of();
+    }
+
+    /**
+     * Returns the subcommands of this command.
+     * <p>
+     * When a command has subcommands, the dispatcher will check if the first
+     * argument matches a subcommand name and route execution accordingly.
+     * For example, a "git" command with a "commit" subcommand would handle
+     * {@code git commit -m msg} by routing to the "commit" subcommand with
+     * args {@code [-m, msg]}.
+     * <p>
+     * The default implementation returns an empty map, meaning no subcommands.
+     *
+     * @return a map from subcommand name to command, never null
+     */
+    default Map<String, Command> subcommands() {
+        return Map.of();
     }
 }

--- a/shell/src/main/java/org/jline/shell/CommandSession.java
+++ b/shell/src/main/java/org/jline/shell/CommandSession.java
@@ -27,9 +27,9 @@ import org.jline.terminal.Terminal;
 public class CommandSession {
 
     private final Terminal terminal;
-    private final InputStream in;
+    private InputStream in;
     private PrintStream out;
-    private final PrintStream err;
+    private PrintStream err;
     private final Map<String, Object> variables;
     private Path workingDirectory;
     private int lastExitCode;
@@ -110,12 +110,30 @@ public class CommandSession {
     }
 
     /**
+     * Sets the input stream.
+     *
+     * @param in the new input stream
+     */
+    public void setIn(InputStream in) {
+        this.in = in;
+    }
+
+    /**
      * Returns the error stream.
      *
      * @return the error stream
      */
     public PrintStream err() {
         return err;
+    }
+
+    /**
+     * Sets the error stream.
+     *
+     * @param err the new error stream
+     */
+    public void setErr(PrintStream err) {
+        this.err = err;
     }
 
     /**
@@ -136,6 +154,16 @@ public class CommandSession {
      */
     public void put(String name, Object value) {
         variables.put(name, value);
+    }
+
+    /**
+     * Removes a session variable.
+     *
+     * @param name the variable name
+     * @return the previous value, or null if not set
+     */
+    public Object remove(String name) {
+        return variables.remove(name);
     }
 
     /**

--- a/shell/src/main/java/org/jline/shell/LineExpander.java
+++ b/shell/src/main/java/org/jline/shell/LineExpander.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell;
+
+/**
+ * Expands variables and other expressions in a command line before parsing.
+ * <p>
+ * A {@code LineExpander} operates on the full command line string (not per-word
+ * like {@link org.jline.reader.Expander}). It is called after alias expansion
+ * and before pipeline parsing.
+ * <p>
+ * The exact expansion syntax is controlled by the implementation. Users can
+ * provide their own {@code LineExpander} to support custom variable syntax,
+ * glob expansion, or other transformations.
+ * <p>
+ * Example:
+ * <pre>
+ * LineExpander expander = (line, session) -&gt; line.replace("$HOME", "/home/user");
+ * </pre>
+ *
+ * @see org.jline.shell.impl.DefaultLineExpander
+ * @see ShellBuilder#lineExpander(LineExpander)
+ * @since 4.0
+ */
+@FunctionalInterface
+public interface LineExpander {
+
+    /**
+     * Expands variables and expressions in the given command line.
+     *
+     * @param line the command line to expand
+     * @param session the current command session (for variable lookup)
+     * @return the expanded command line
+     */
+    String expand(String line, CommandSession session);
+}

--- a/shell/src/main/java/org/jline/shell/Pipeline.java
+++ b/shell/src/main/java/org/jline/shell/Pipeline.java
@@ -47,6 +47,14 @@ public interface Pipeline {
         REDIRECT(">"),
         /** Append redirection: append output to file ({@code >>}) */
         APPEND(">>"),
+        /** Input redirection: read stdin from file ({@code <}) */
+        INPUT_REDIRECT("<"),
+        /** Here-document: provide stdin inline ({@code <<}) */
+        HEREDOC("<<"),
+        /** Stderr redirection: redirect stderr to file ({@code 2>}) */
+        STDERR_REDIRECT("2>"),
+        /** Combined redirection: redirect both stdout and stderr to file ({@code &>}) */
+        COMBINED_REDIRECT("&>"),
         /** Sequence: execute next command unconditionally ({@code ;}) */
         SEQUENCE(";");
 
@@ -113,6 +121,15 @@ public interface Pipeline {
          * @return true if append
          */
         boolean isAppend();
+
+        /**
+         * Returns the input source path, if this stage has an INPUT_REDIRECT operator.
+         *
+         * @return the input source path, or null
+         */
+        default Path inputSource() {
+            return null;
+        }
     }
 
     /**

--- a/shell/src/main/java/org/jline/shell/PipelineBuilder.java
+++ b/shell/src/main/java/org/jline/shell/PipelineBuilder.java
@@ -142,6 +142,46 @@ public class PipelineBuilder {
     }
 
     /**
+     * Adds an input redirection ({@code <}) from the specified file.
+     *
+     * @param file the file to read input from
+     * @return this builder
+     */
+    public PipelineBuilder inputRedirect(Path file) {
+        stages.add(new DefaultPipeline.DefaultStage(currentCommand, null, null, false, file));
+        source.append(" < ").append(file);
+        // Input redirect doesn't consume the current command for the next stage
+        currentCommand = null;
+        return this;
+    }
+
+    /**
+     * Adds a stderr redirection ({@code 2>}) to the specified file.
+     *
+     * @param file the file to redirect stderr to
+     * @return this builder
+     */
+    public PipelineBuilder stderrRedirect(Path file) {
+        stages.add(new DefaultPipeline.DefaultStage(currentCommand, Pipeline.Operator.STDERR_REDIRECT, file, false));
+        source.append(" 2> ").append(file);
+        currentCommand = null;
+        return this;
+    }
+
+    /**
+     * Adds a combined stdout+stderr redirection ({@code &>}) to the specified file.
+     *
+     * @param file the file to redirect both streams to
+     * @return this builder
+     */
+    public PipelineBuilder combinedRedirect(Path file) {
+        stages.add(new DefaultPipeline.DefaultStage(currentCommand, Pipeline.Operator.COMBINED_REDIRECT, file, false));
+        source.append(" &> ").append(file);
+        currentCommand = null;
+        return this;
+    }
+
+    /**
      * Marks this pipeline for background execution.
      *
      * @return this builder

--- a/shell/src/main/java/org/jline/shell/ScriptRunner.java
+++ b/shell/src/main/java/org/jline/shell/ScriptRunner.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell;
+
+import java.nio.file.Path;
+
+/**
+ * Executes a script file line by line through a {@link CommandDispatcher}.
+ * <p>
+ * A {@code ScriptRunner} reads lines from a script file and feeds them
+ * to the dispatcher for execution. The exact behavior (comment handling,
+ * line continuation, error handling) is determined by the implementation.
+ * <p>
+ * Example:
+ * <pre>
+ * ScriptRunner runner = (script, session, dispatcher) -&gt; {
+ *     Files.readAllLines(script).forEach(line -&gt; dispatcher.execute(line));
+ * };
+ * </pre>
+ *
+ * @see org.jline.shell.impl.DefaultScriptRunner
+ * @see ShellBuilder#scriptRunner(ScriptRunner)
+ * @since 4.0
+ */
+@FunctionalInterface
+public interface ScriptRunner {
+
+    /**
+     * Executes a script file.
+     *
+     * @param script the path to the script file
+     * @param session the current command session
+     * @param dispatcher the command dispatcher to execute lines through
+     * @throws Exception if script execution fails
+     */
+    void execute(Path script, CommandSession session, CommandDispatcher dispatcher) throws Exception;
+}

--- a/shell/src/main/java/org/jline/shell/impl/DefaultLineExpander.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultLineExpander.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import org.jline.shell.CommandSession;
+import org.jline.shell.LineExpander;
+
+/**
+ * Default implementation of {@link LineExpander} that provides sane defaults
+ * for variable expansion.
+ * <p>
+ * Supported expansions:
+ * <ul>
+ *   <li>{@code $VAR} and {@code ${VAR}} — variable expansion from session
+ *       variables, then {@link System#getenv()}</li>
+ *   <li>{@code ~} at word start — expands to {@code user.home} system property</li>
+ *   <li>Single-quoted regions ({@code '...'}) are not expanded</li>
+ *   <li>Double-quoted regions ({@code "..."}) expand variables</li>
+ * </ul>
+ * <p>
+ * Advanced braced forms:
+ * <ul>
+ *   <li>{@code ${VAR:-default}} — use default if VAR is unset or empty</li>
+ *   <li>{@code ${VAR:=default}} — assign default if VAR is unset or empty</li>
+ *   <li>{@code ${VAR:+alt}} — use alt if VAR is set and non-empty</li>
+ *   <li>{@code ${VAR:?error}} — error if VAR is unset or empty</li>
+ * </ul>
+ * <p>
+ * Deliberately <b>not</b> included (subclass for these):
+ * <ul>
+ *   <li>{@code ${VAR//pattern/replacement}} — pattern substitution</li>
+ *   <li>Glob expansion ({@code *}, {@code ?})</li>
+ * </ul>
+ * <p>
+ * Subclasses can override {@link #resolve(String, CommandSession)} to customize
+ * how variable names are resolved.
+ *
+ * @see LineExpander
+ * @since 4.0
+ */
+public class DefaultLineExpander implements LineExpander {
+
+    /**
+     * Creates a new DefaultLineExpander.
+     */
+    public DefaultLineExpander() {}
+
+    @Override
+    public String expand(String line, CommandSession session) {
+        if (line == null || line.isEmpty()) {
+            return line;
+        }
+
+        StringBuilder result = new StringBuilder(line.length());
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        int i = 0;
+
+        while (i < line.length()) {
+            char c = line.charAt(i);
+
+            // Handle escape character
+            if (c == '\\' && !inSingleQuote && i + 1 < line.length()) {
+                result.append(c);
+                result.append(line.charAt(i + 1));
+                i += 2;
+                continue;
+            }
+
+            // Handle quotes
+            if (c == '\'' && !inDoubleQuote) {
+                inSingleQuote = !inSingleQuote;
+                result.append(c);
+                i++;
+                continue;
+            }
+            if (c == '"' && !inSingleQuote) {
+                inDoubleQuote = !inDoubleQuote;
+                result.append(c);
+                i++;
+                continue;
+            }
+
+            // Inside single quotes, no expansion
+            if (inSingleQuote) {
+                result.append(c);
+                i++;
+                continue;
+            }
+
+            // Tilde expansion at word start (not inside quotes)
+            if (c == '~' && !inDoubleQuote) {
+                // Check if at word start: beginning of line or preceded by whitespace
+                if (i == 0 || Character.isWhitespace(line.charAt(i - 1))) {
+                    // Check if followed by / or whitespace or end of line
+                    if (i + 1 >= line.length()
+                            || line.charAt(i + 1) == '/'
+                            || Character.isWhitespace(line.charAt(i + 1))) {
+                        result.append(System.getProperty("user.home", "~"));
+                        i++;
+                        continue;
+                    }
+                }
+                result.append(c);
+                i++;
+                continue;
+            }
+
+            // Variable expansion: $VAR or ${VAR}
+            if (c == '$' && i + 1 < line.length()) {
+                char next = line.charAt(i + 1);
+                if (next == '{') {
+                    // ${VAR} or ${VAR:-default} etc.
+                    int close = findMatchingBrace(line, i + 2);
+                    if (close > i + 2) {
+                        String expr = line.substring(i + 2, close);
+                        String expanded = expandBracedExpression(expr, session);
+                        if (expanded != null) {
+                            result.append(expanded);
+                        } else {
+                            // Unknown variable: leave as-is
+                            result.append(line, i, close + 1);
+                        }
+                        i = close + 1;
+                        continue;
+                    }
+                } else if (isVarStart(next)) {
+                    // $VAR form
+                    int start = i + 1;
+                    int end = start + 1;
+                    while (end < line.length() && isVarChar(line.charAt(end))) {
+                        end++;
+                    }
+                    String name = line.substring(start, end);
+                    String value = resolve(name, session);
+                    if (value != null) {
+                        result.append(value);
+                    } else {
+                        // Unknown variable: leave as-is
+                        result.append(line, i, end);
+                    }
+                    i = end;
+                    continue;
+                }
+            }
+
+            result.append(c);
+            i++;
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Finds the closing brace for a {@code ${...}} expression, handling nested braces.
+     *
+     * @param line the line
+     * @param start the position after {@code ${}, i.e. start of the expression
+     * @return the index of the closing {@code }}, or -1 if not found
+     */
+    private static int findMatchingBrace(String line, int start) {
+        int depth = 1;
+        for (int j = start; j < line.length(); j++) {
+            char ch = line.charAt(j);
+            if (ch == '{') {
+                depth++;
+            } else if (ch == '}') {
+                depth--;
+                if (depth == 0) {
+                    return j;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Expands a braced expression such as {@code VAR}, {@code VAR:-default},
+     * {@code VAR:=default}, {@code VAR:+alt}, or {@code VAR:?error}.
+     *
+     * @param expr the expression inside the braces (without {@code ${ }})
+     * @param session the command session
+     * @return the expanded value, or null if the variable is unknown and no modifier applies
+     */
+    protected String expandBracedExpression(String expr, CommandSession session) {
+        // Check for operator forms: :-, :=, :+, :?
+        int colonPos = expr.indexOf(':');
+        if (colonPos > 0 && colonPos + 1 < expr.length()) {
+            char op = expr.charAt(colonPos + 1);
+            if (op == '-' || op == '=' || op == '+' || op == '?') {
+                String name = expr.substring(0, colonPos);
+                String operand = expr.substring(colonPos + 2);
+                String value = resolve(name, session);
+                boolean unsetOrEmpty = value == null || value.isEmpty();
+
+                switch (op) {
+                    case '-':
+                        // ${VAR:-default}: use default if unset or empty
+                        return unsetOrEmpty ? operand : value;
+                    case '=':
+                        // ${VAR:=default}: assign default if unset or empty
+                        if (unsetOrEmpty) {
+                            if (session != null) {
+                                session.put(name, operand);
+                            }
+                            return operand;
+                        }
+                        return value;
+                    case '+':
+                        // ${VAR:+alt}: use alt if set and non-empty
+                        return unsetOrEmpty ? "" : operand;
+                    case '?':
+                        // ${VAR:?error}: error if unset or empty
+                        if (unsetOrEmpty) {
+                            throw new IllegalArgumentException(name + ": " + operand);
+                        }
+                        return value;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        // Simple ${VAR}
+        return resolve(expr, session);
+    }
+
+    /**
+     * Resolves a variable name to its value.
+     * <p>
+     * The default implementation checks session variables first, then
+     * falls back to {@link System#getenv()}.
+     * <p>
+     * Subclasses can override this to provide custom resolution (e.g.,
+     * Groovy evaluation, default values).
+     *
+     * @param name the variable name
+     * @param session the current command session
+     * @return the resolved value as a string, or null if not found
+     */
+    protected String resolve(String name, CommandSession session) {
+        // Check session variables first
+        if (session != null) {
+            Object value = session.get(name);
+            if (value != null) {
+                return value.toString();
+            }
+        }
+        // Fall back to environment variables
+        String envValue = System.getenv(name);
+        if (envValue != null) {
+            return envValue;
+        }
+        return null;
+    }
+
+    private static boolean isVarStart(char c) {
+        return Character.isLetter(c) || c == '_';
+    }
+
+    private static boolean isVarChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+}

--- a/shell/src/main/java/org/jline/shell/impl/DefaultPipeline.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultPipeline.java
@@ -69,6 +69,7 @@ public class DefaultPipeline implements Pipeline {
         private final Operator operator;
         private final Path redirectTarget;
         private final boolean append;
+        private final Path inputSource;
 
         /**
          * Creates a new stage.
@@ -79,10 +80,25 @@ public class DefaultPipeline implements Pipeline {
          * @param append whether to append (for APPEND operator)
          */
         public DefaultStage(String commandLine, Operator operator, Path redirectTarget, boolean append) {
+            this(commandLine, operator, redirectTarget, append, null);
+        }
+
+        /**
+         * Creates a new stage with input source.
+         *
+         * @param commandLine the command line for this stage
+         * @param operator the operator following this stage (null for last stage)
+         * @param redirectTarget the redirect file (for REDIRECT/APPEND/STDERR_REDIRECT/COMBINED_REDIRECT operators)
+         * @param append whether to append (for APPEND operator)
+         * @param inputSource the input source file (for INPUT_REDIRECT operator)
+         */
+        public DefaultStage(
+                String commandLine, Operator operator, Path redirectTarget, boolean append, Path inputSource) {
             this.commandLine = commandLine;
             this.operator = operator;
             this.redirectTarget = redirectTarget;
             this.append = append;
+            this.inputSource = inputSource;
         }
 
         @Override
@@ -103,6 +119,11 @@ public class DefaultPipeline implements Pipeline {
         @Override
         public boolean isAppend() {
             return append;
+        }
+
+        @Override
+        public Path inputSource() {
+            return inputSource;
         }
 
         @Override

--- a/shell/src/main/java/org/jline/shell/impl/DefaultScriptRunner.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultScriptRunner.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jline.shell.CommandDispatcher;
+import org.jline.shell.CommandSession;
+import org.jline.shell.ScriptRunner;
+
+/**
+ * Default implementation of {@link ScriptRunner} that reads a script file
+ * line by line and executes each line through the dispatcher.
+ * <p>
+ * Features:
+ * <ul>
+ *   <li>Skips blank lines and lines starting with {@code #} (comments)</li>
+ *   <li>Supports {@code \} line continuation (backslash at end of line
+ *       joins with the next line)</li>
+ *   <li>Each complete line is fed to {@link CommandDispatcher#execute(String)}</li>
+ * </ul>
+ *
+ * @see ScriptRunner
+ * @since 4.0
+ */
+public class DefaultScriptRunner implements ScriptRunner {
+
+    /**
+     * Creates a new DefaultScriptRunner.
+     */
+    public DefaultScriptRunner() {}
+
+    @Override
+    public void execute(Path script, CommandSession session, CommandDispatcher dispatcher) throws Exception {
+        if (script == null || !Files.exists(script)) {
+            throw new IllegalArgumentException("Script file not found: " + script);
+        }
+
+        List<String> lines = Files.readAllLines(script);
+        StringBuilder pending = new StringBuilder();
+
+        for (String line : lines) {
+            // Handle line continuation
+            if (pending.length() > 0) {
+                pending.append(line);
+            } else {
+                // Skip comments and blank lines
+                String trimmed = line.trim();
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                    continue;
+                }
+                pending.append(line);
+            }
+
+            // Check for line continuation
+            if (pending.length() > 0 && pending.charAt(pending.length() - 1) == '\\') {
+                pending.setLength(pending.length() - 1); // Remove trailing backslash
+                continue;
+            }
+
+            // Execute the complete line
+            String completeLine = pending.toString().trim();
+            pending.setLength(0);
+
+            if (!completeLine.isEmpty()) {
+                dispatcher.execute(completeLine);
+            }
+        }
+
+        // Execute any remaining pending line (unterminated continuation)
+        if (pending.length() > 0) {
+            String remaining = pending.toString().trim();
+            if (!remaining.isEmpty()) {
+                dispatcher.execute(remaining);
+            }
+        }
+    }
+}

--- a/shell/src/main/java/org/jline/shell/impl/ScriptCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/ScriptCommands.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+
+import org.jline.shell.*;
+
+/**
+ * Built-in commands for script execution.
+ * <p>
+ * Provides:
+ * <ul>
+ *   <li>{@code source} (alias {@code .}) — executes a script file in the current session</li>
+ * </ul>
+ *
+ * @see ScriptRunner
+ * @since 4.0
+ */
+public class ScriptCommands implements CommandGroup {
+
+    private final ScriptRunner scriptRunner;
+    private final CommandDispatcher dispatcher;
+    private final List<Command> commands;
+
+    /**
+     * Creates the script commands group.
+     *
+     * @param scriptRunner the script runner to use
+     * @param dispatcher the command dispatcher for executing script lines
+     */
+    public ScriptCommands(ScriptRunner scriptRunner, CommandDispatcher dispatcher) {
+        this.scriptRunner = scriptRunner;
+        this.dispatcher = dispatcher;
+        this.commands = List.of(new SourceCommand());
+    }
+
+    @Override
+    public String name() {
+        return "Script";
+    }
+
+    @Override
+    public Collection<Command> commands() {
+        return commands;
+    }
+
+    private class SourceCommand extends AbstractCommand {
+        SourceCommand() {
+            super("source", ".");
+        }
+
+        @Override
+        public String description() {
+            return "Execute a script file in the current session";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            if (args.length < 1) {
+                throw new IllegalArgumentException("Usage: source <file>");
+            }
+            Path scriptPath = Paths.get(args[0]);
+            if (!scriptPath.isAbsolute() && session.workingDirectory() != null) {
+                scriptPath = session.workingDirectory().resolve(scriptPath);
+            }
+            scriptRunner.execute(scriptPath, session, dispatcher);
+            return null;
+        }
+    }
+}

--- a/shell/src/main/java/org/jline/shell/impl/VariableCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/VariableCommands.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.jline.shell.*;
+
+/**
+ * Built-in commands for managing session variables: {@code set}, {@code unset}, and {@code export}.
+ * <p>
+ * <ul>
+ *   <li>{@code set} — list all session variables, or set one ({@code set NAME=VALUE} or {@code set NAME VALUE})</li>
+ *   <li>{@code unset NAME} — remove a session variable</li>
+ *   <li>{@code export NAME=VALUE} — same as {@code set NAME=VALUE}</li>
+ * </ul>
+ *
+ * @since 4.0
+ */
+public class VariableCommands implements CommandGroup {
+
+    /**
+     * Creates a new VariableCommands group.
+     */
+    public VariableCommands() {}
+
+    private final List<Command> commands = List.of(new SetCommand(), new UnsetCommand(), new ExportCommand());
+
+    @Override
+    public String name() {
+        return "Variables";
+    }
+
+    @Override
+    public List<Command> commands() {
+        return commands;
+    }
+
+    @Override
+    public Command command(String name) {
+        for (Command cmd : commands) {
+            if (cmd.name().equals(name)) {
+                return cmd;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The {@code set} command: lists all variables or sets a variable.
+     * <p>
+     * Usage:
+     * <ul>
+     *   <li>{@code set} — list all session variables</li>
+     *   <li>{@code set NAME=VALUE} — set a variable</li>
+     *   <li>{@code set NAME VALUE} — set a variable (alternative form)</li>
+     * </ul>
+     */
+    static class SetCommand extends AbstractCommand {
+
+        SetCommand() {
+            super("set");
+        }
+
+        @Override
+        public String description() {
+            return "List or set session variables";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            if (args.length == 0) {
+                // List all variables sorted by name
+                Map<String, Object> sorted = new TreeMap<>(session.variables());
+                for (Map.Entry<String, Object> entry : sorted.entrySet()) {
+                    session.out().println(entry.getKey() + "=" + entry.getValue());
+                }
+                return null;
+            }
+            // set NAME=VALUE or set NAME VALUE
+            String first = args[0];
+            int eq = first.indexOf('=');
+            if (eq >= 0) {
+                String name = first.substring(0, eq);
+                String value = first.substring(eq + 1);
+                if (value.isEmpty() && args.length > 1) {
+                    value = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
+                }
+                session.put(name, value);
+            } else if (args.length >= 2) {
+                String name = first;
+                String value = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
+                session.put(name, value);
+            } else {
+                // set NAME with no value — show the variable
+                Object value = session.get(first);
+                if (value != null) {
+                    session.out().println(first + "=" + value);
+                } else {
+                    session.out().println(first + ": not set");
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * The {@code unset} command: removes a session variable.
+     * <p>
+     * Usage: {@code unset NAME [NAME...]}
+     */
+    static class UnsetCommand extends AbstractCommand {
+
+        UnsetCommand() {
+            super("unset");
+        }
+
+        @Override
+        public String description() {
+            return "Remove session variables";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            if (args.length == 0) {
+                session.out().println("usage: unset NAME [NAME...]");
+                return null;
+            }
+            for (String name : args) {
+                session.remove(name);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * The {@code export} command: sets a session variable (alias for {@code set}).
+     * <p>
+     * Usage: {@code export NAME=VALUE} or {@code export NAME VALUE}
+     */
+    static class ExportCommand extends AbstractCommand {
+
+        ExportCommand() {
+            super("export");
+        }
+
+        @Override
+        public String description() {
+            return "Set session variables";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            if (args.length == 0) {
+                // List all variables
+                Map<String, Object> sorted = new TreeMap<>(session.variables());
+                for (Map.Entry<String, Object> entry : sorted.entrySet()) {
+                    session.out().println("export " + entry.getKey() + "=" + entry.getValue());
+                }
+                return null;
+            }
+            String first = args[0];
+            int eq = first.indexOf('=');
+            if (eq >= 0) {
+                String name = first.substring(0, eq);
+                String value = first.substring(eq + 1);
+                if (value.isEmpty() && args.length > 1) {
+                    value = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
+                }
+                session.put(name, value);
+            } else if (args.length >= 2) {
+                session.put(first, String.join(" ", Arrays.copyOfRange(args, 1, args.length)));
+            } else {
+                Object value = session.get(first);
+                if (value != null) {
+                    session.out().println("export " + first + "=" + value);
+                } else {
+                    session.out().println(first + ": not set");
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/DefaultLineExpanderTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultLineExpanderTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import org.jline.shell.CommandSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link DefaultLineExpander}.
+ */
+public class DefaultLineExpanderTest {
+
+    private DefaultLineExpander expander;
+    private CommandSession session;
+
+    @BeforeEach
+    void setUp() {
+        expander = new DefaultLineExpander();
+        session = new CommandSession();
+        session.put("NAME", "world");
+        session.put("DIR", "/home/user");
+        session.put("EMPTY", "");
+    }
+
+    @Test
+    void expandDollarVar() {
+        assertEquals("hello world", expander.expand("hello $NAME", session));
+    }
+
+    @Test
+    void expandBracedVar() {
+        assertEquals("hello world", expander.expand("hello ${NAME}", session));
+    }
+
+    @Test
+    void expandTilde() {
+        String home = System.getProperty("user.home");
+        assertEquals(home + "/docs", expander.expand("~/docs", session));
+    }
+
+    @Test
+    void tildeAlone() {
+        String home = System.getProperty("user.home");
+        assertEquals(home, expander.expand("~", session));
+    }
+
+    @Test
+    void tildeInMiddleOfWord() {
+        // ~ not at word start should not expand
+        assertEquals("foo~bar", expander.expand("foo~bar", session));
+    }
+
+    @Test
+    void tildeAfterSpace() {
+        String home = System.getProperty("user.home");
+        assertEquals("cd " + home, expander.expand("cd ~", session));
+    }
+
+    @Test
+    void singleQuoteProtection() {
+        assertEquals("hello '$NAME'", expander.expand("hello '$NAME'", session));
+    }
+
+    @Test
+    void doubleQuoteExpansion() {
+        assertEquals("hello \"world\"", expander.expand("hello \"$NAME\"", session));
+    }
+
+    @Test
+    void unknownVarLeftAsIs() {
+        assertEquals("hello $UNKNOWN", expander.expand("hello $UNKNOWN", session));
+    }
+
+    @Test
+    void unknownBracedVarLeftAsIs() {
+        assertEquals("hello ${UNKNOWN}", expander.expand("hello ${UNKNOWN}", session));
+    }
+
+    @Test
+    void dollarAtEndOfLine() {
+        // $ at end of line with no following char
+        assertEquals("hello$", expander.expand("hello$", session));
+    }
+
+    @Test
+    void envFallback() {
+        // PATH is almost certainly set in the environment
+        String path = System.getenv("PATH");
+        if (path != null) {
+            assertEquals(path, expander.expand("$PATH", session));
+        }
+    }
+
+    @Test
+    void multipleExpansions() {
+        session.put("A", "1");
+        session.put("B", "2");
+        assertEquals("1 and 2", expander.expand("$A and $B", session));
+    }
+
+    @Test
+    void bracedVarInPath() {
+        assertEquals("/home/user/file.txt", expander.expand("${DIR}/file.txt", session));
+    }
+
+    @Test
+    void emptyVarExpands() {
+        assertEquals("hello ", expander.expand("hello $EMPTY", session));
+    }
+
+    @Test
+    void nullInput() {
+        assertNull(expander.expand(null, session));
+    }
+
+    @Test
+    void emptyInput() {
+        assertEquals("", expander.expand("", session));
+    }
+
+    @Test
+    void noExpansionNeeded() {
+        assertEquals("hello world", expander.expand("hello world", session));
+    }
+
+    @Test
+    void escapedDollar() {
+        assertEquals("hello \\$NAME", expander.expand("hello \\$NAME", session));
+    }
+
+    @Test
+    void varWithUnderscore() {
+        session.put("MY_VAR", "value");
+        assertEquals("value", expander.expand("$MY_VAR", session));
+    }
+
+    @Test
+    void nullSession() {
+        // Should fall back to env-only
+        String path = System.getenv("PATH");
+        if (path != null) {
+            assertEquals(path, expander.expand("$PATH", null));
+        }
+    }
+
+    // --- Advanced braced expression tests ---
+
+    @Test
+    void defaultValueWhenUnset() {
+        assertEquals("fallback", expander.expand("${MISSING:-fallback}", session));
+    }
+
+    @Test
+    void defaultValueWhenEmpty() {
+        assertEquals("fallback", expander.expand("${EMPTY:-fallback}", session));
+    }
+
+    @Test
+    void defaultValueWhenSet() {
+        assertEquals("world", expander.expand("${NAME:-fallback}", session));
+    }
+
+    @Test
+    void assignDefaultWhenUnset() {
+        assertEquals("assigned", expander.expand("${NEWVAR:=assigned}", session));
+        assertEquals("assigned", session.get("NEWVAR"));
+    }
+
+    @Test
+    void assignDefaultWhenSet() {
+        assertEquals("world", expander.expand("${NAME:=fallback}", session));
+    }
+
+    @Test
+    void alternateValueWhenSet() {
+        assertEquals("alt", expander.expand("${NAME:+alt}", session));
+    }
+
+    @Test
+    void alternateValueWhenUnset() {
+        assertEquals("", expander.expand("${MISSING:+alt}", session));
+    }
+
+    @Test
+    void alternateValueWhenEmpty() {
+        assertEquals("", expander.expand("${EMPTY:+alt}", session));
+    }
+
+    @Test
+    void errorWhenUnset() {
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> expander.expand("${MISSING:?not found}", session));
+        assertTrue(ex.getMessage().contains("MISSING"));
+        assertTrue(ex.getMessage().contains("not found"));
+    }
+
+    @Test
+    void errorWhenSet() {
+        // Should not throw
+        assertEquals("world", expander.expand("${NAME:?not found}", session));
+    }
+
+    @Test
+    void defaultInContext() {
+        assertEquals("hello fallback end", expander.expand("hello ${MISSING:-fallback} end", session));
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jline.shell.*;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link DefaultScriptRunner}.
+ */
+public class DefaultScriptRunnerTest {
+
+    private Terminal terminal;
+    private DefaultCommandDispatcher dispatcher;
+    private DefaultScriptRunner runner;
+    private List<String> executedCommands;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        terminal = TerminalBuilder.builder().dumb(true).build();
+        dispatcher = new DefaultCommandDispatcher(terminal);
+        runner = new DefaultScriptRunner();
+        executedCommands = new ArrayList<>();
+
+        // Track which commands are executed
+        dispatcher.addGroup(new SimpleCommandGroup("test", new AbstractCommand("track") {
+            @Override
+            public Object execute(CommandSession session, String[] args) {
+                String line = String.join(" ", args);
+                executedCommands.add(line);
+                return line;
+            }
+        }));
+    }
+
+    @Test
+    void multiLineScript(@TempDir Path tempDir) throws Exception {
+        Path script = tempDir.resolve("test.sh");
+        Files.writeString(script, "track line1\ntrack line2\ntrack line3\n");
+
+        runner.execute(script, dispatcher.session(), dispatcher);
+
+        assertEquals(3, executedCommands.size());
+        assertEquals("line1", executedCommands.get(0));
+        assertEquals("line2", executedCommands.get(1));
+        assertEquals("line3", executedCommands.get(2));
+    }
+
+    @Test
+    void commentsSkipped(@TempDir Path tempDir) throws Exception {
+        Path script = tempDir.resolve("test.sh");
+        Files.writeString(script, "# This is a comment\ntrack hello\n# Another comment\ntrack world\n");
+
+        runner.execute(script, dispatcher.session(), dispatcher);
+
+        assertEquals(2, executedCommands.size());
+        assertEquals("hello", executedCommands.get(0));
+        assertEquals("world", executedCommands.get(1));
+    }
+
+    @Test
+    void blankLinesSkipped(@TempDir Path tempDir) throws Exception {
+        Path script = tempDir.resolve("test.sh");
+        Files.writeString(script, "\ntrack hello\n\n\ntrack world\n\n");
+
+        runner.execute(script, dispatcher.session(), dispatcher);
+
+        assertEquals(2, executedCommands.size());
+    }
+
+    @Test
+    void lineContinuation(@TempDir Path tempDir) throws Exception {
+        Path script = tempDir.resolve("test.sh");
+        Files.writeString(script, "track hello\\\n world\n");
+
+        runner.execute(script, dispatcher.session(), dispatcher);
+
+        assertEquals(1, executedCommands.size());
+        assertEquals("hello world", executedCommands.get(0));
+    }
+
+    @Test
+    void missingFileThrows() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> runner.execute(Path.of("/nonexistent/script.sh"), null, dispatcher));
+    }
+
+    @Test
+    void nullFileThrows() {
+        assertThrows(IllegalArgumentException.class, () -> runner.execute(null, null, dispatcher));
+    }
+
+    @Test
+    void sourceCommand(@TempDir Path tempDir) throws Exception {
+        Path script = tempDir.resolve("test.sh");
+        Files.writeString(script, "track sourced\n");
+
+        ScriptCommands cmds = new ScriptCommands(runner, dispatcher);
+        dispatcher.addGroup(cmds);
+
+        CommandSession session = dispatcher.session();
+        session.setWorkingDirectory(tempDir);
+
+        dispatcher.execute("source " + script);
+
+        assertEquals(1, executedCommands.size());
+        assertEquals("sourced", executedCommands.get(0));
+    }
+
+    @Test
+    void emptyScript(@TempDir Path tempDir) throws Exception {
+        Path script = tempDir.resolve("empty.sh");
+        Files.writeString(script, "");
+
+        runner.execute(script, dispatcher.session(), dispatcher);
+
+        assertTrue(executedCommands.isEmpty());
+    }
+
+    @Test
+    void commentOnlyScript(@TempDir Path tempDir) throws Exception {
+        Path script = tempDir.resolve("comments.sh");
+        Files.writeString(script, "# comment 1\n# comment 2\n");
+
+        runner.execute(script, dispatcher.session(), dispatcher);
+
+        assertTrue(executedCommands.isEmpty());
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jline.shell.*;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for I/O redirection operators (INPUT_REDIRECT, STDERR_REDIRECT, COMBINED_REDIRECT).
+ */
+public class IORedirectionTest {
+
+    private Terminal terminal;
+    private DefaultCommandDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        terminal = TerminalBuilder.builder().dumb(true).build();
+        dispatcher = new DefaultCommandDispatcher(terminal);
+        dispatcher.addGroup(new SimpleCommandGroup("test", new CatCommand(), new ErrCommand(), new BothCommand()));
+    }
+
+    /**
+     * Reads from session input and prints to output.
+     */
+    static class CatCommand extends AbstractCommand {
+        CatCommand() {
+            super("cat");
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            byte[] data = session.in().readAllBytes();
+            String content = new String(data).trim();
+            session.out().println(content);
+            return content;
+        }
+    }
+
+    /**
+     * Writes to stderr.
+     */
+    static class ErrCommand extends AbstractCommand {
+        ErrCommand() {
+            super("errcmd");
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            String msg = args.length > 0 ? String.join(" ", args) : "error output";
+            session.err().println(msg);
+            return null;
+        }
+    }
+
+    /**
+     * Writes to both stdout and stderr.
+     */
+    static class BothCommand extends AbstractCommand {
+        BothCommand() {
+            super("bothcmd");
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            session.out().println("stdout line");
+            session.err().println("stderr line");
+            return "done";
+        }
+    }
+
+    @Test
+    void inputRedirect(@TempDir Path tempDir) throws Exception {
+        Path inputFile = tempDir.resolve("input.txt");
+        Files.writeString(inputFile, "hello from file\n");
+
+        Object result = dispatcher.execute("cat < " + inputFile);
+        assertEquals("hello from file", result);
+    }
+
+    @Test
+    void stderrRedirect(@TempDir Path tempDir) throws Exception {
+        Path errFile = tempDir.resolve("errors.txt");
+        dispatcher.execute("errcmd some error 2> " + errFile);
+
+        String content = Files.readString(errFile);
+        assertTrue(content.contains("some error"));
+    }
+
+    @Test
+    void combinedRedirect(@TempDir Path tempDir) throws Exception {
+        Path allFile = tempDir.resolve("all.txt");
+        dispatcher.execute("bothcmd &> " + allFile);
+
+        String content = Files.readString(allFile);
+        assertTrue(content.contains("stdout line"));
+        assertTrue(content.contains("stderr line"));
+    }
+
+    @Test
+    void inputRedirectParsing() {
+        Pipeline pipeline = new PipelineParser().parse("cat < input.txt");
+        assertFalse(pipeline.stages().isEmpty());
+        Pipeline.Stage stage = pipeline.stages().get(0);
+        assertNotNull(stage.inputSource());
+        assertEquals("input.txt", stage.inputSource().toString());
+    }
+
+    @Test
+    void stderrRedirectParsing() {
+        Pipeline pipeline = new PipelineParser().parse("cmd 2> errors.txt");
+        assertFalse(pipeline.stages().isEmpty());
+        Pipeline.Stage stage = pipeline.stages().get(0);
+        assertEquals(Pipeline.Operator.STDERR_REDIRECT, stage.operator());
+        assertNotNull(stage.redirectTarget());
+    }
+
+    @Test
+    void combinedRedirectParsing() {
+        Pipeline pipeline = new PipelineParser().parse("cmd &> all.txt");
+        assertFalse(pipeline.stages().isEmpty());
+        Pipeline.Stage stage = pipeline.stages().get(0);
+        assertEquals(Pipeline.Operator.COMBINED_REDIRECT, stage.operator());
+        assertNotNull(stage.redirectTarget());
+    }
+
+    @Test
+    void pipelineBuilderInputRedirect(@TempDir Path tempDir) {
+        Path file = tempDir.resolve("in.txt");
+        Pipeline pipeline = Pipeline.of("cat").inputRedirect(file).build();
+        assertFalse(pipeline.stages().isEmpty());
+    }
+
+    @Test
+    void pipelineBuilderStderrRedirect(@TempDir Path tempDir) {
+        Path file = tempDir.resolve("err.txt");
+        Pipeline pipeline = Pipeline.of("cmd").stderrRedirect(file).build();
+        Pipeline.Stage stage = pipeline.stages().get(0);
+        assertEquals(Pipeline.Operator.STDERR_REDIRECT, stage.operator());
+    }
+
+    @Test
+    void pipelineBuilderCombinedRedirect(@TempDir Path tempDir) {
+        Path file = tempDir.resolve("all.txt");
+        Pipeline pipeline = Pipeline.of("cmd").combinedRedirect(file).build();
+        Pipeline.Stage stage = pipeline.stages().get(0);
+        assertEquals(Pipeline.Operator.COMBINED_REDIRECT, stage.operator());
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jline.shell.*;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for signal handling in {@link DefaultCommandDispatcher}.
+ */
+public class SignalHandlingTest {
+
+    private Terminal terminal;
+    private DefaultCommandDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        terminal = TerminalBuilder.builder().dumb(true).build();
+        dispatcher = new DefaultCommandDispatcher(terminal);
+        dispatcher.addGroup(new SimpleCommandGroup("test", new SleepCommand(), new EchoCommand()));
+    }
+
+    static class SleepCommand extends AbstractCommand {
+        SleepCommand() {
+            super("sleep");
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            long millis = args.length > 0 ? Long.parseLong(args[0]) : 5000;
+            Thread.sleep(millis);
+            return "slept";
+        }
+    }
+
+    static class EchoCommand extends AbstractCommand {
+        EchoCommand() {
+            super("echo");
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            String msg = String.join(" ", args);
+            session.out().println(msg);
+            return msg;
+        }
+    }
+
+    @Test
+    void interruptSleepingCommand() throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean(false);
+
+        Thread execThread = new Thread(() -> {
+            started.countDown();
+            try {
+                dispatcher.execute("sleep 10000");
+            } catch (Exception e) {
+                if (e instanceof InterruptedException
+                        || (e.getCause() != null && e.getCause() instanceof InterruptedException)) {
+                    interrupted.set(true);
+                }
+            }
+        });
+        execThread.start();
+
+        assertTrue(started.await(2, TimeUnit.SECONDS));
+        // Give the command a moment to start sleeping
+        Thread.sleep(100);
+
+        dispatcher.interruptCurrentCommand();
+
+        execThread.join(5000);
+        assertFalse(execThread.isAlive(), "Thread should have terminated");
+        assertTrue(interrupted.get(), "Command should have been interrupted");
+    }
+
+    @Test
+    void interruptWithNoRunningCommandIsNoop() {
+        // Should not throw
+        dispatcher.interruptCurrentCommand();
+    }
+
+    @Test
+    void commandContinuesAfterInterrupt() throws Exception {
+        // Execute a quick command after an interrupt to verify dispatcher is still functional
+        dispatcher.interruptCurrentCommand(); // no-op, nothing running
+        Object result = dispatcher.execute("echo hello");
+        assertEquals("hello", result);
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/SubcommandTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SubcommandTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.jline.shell.*;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for subcommand support in {@link DefaultCommandDispatcher}.
+ */
+public class SubcommandTest {
+
+    private Terminal terminal;
+    private DefaultCommandDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        terminal = TerminalBuilder.builder().dumb(true).build();
+        dispatcher = new DefaultCommandDispatcher(terminal);
+        dispatcher.addGroup(new SimpleCommandGroup("test", new GitCommand()));
+    }
+
+    /**
+     * A command with subcommands, simulating "git".
+     */
+    static class GitCommand extends AbstractCommand {
+        private final Map<String, Command> subcommands;
+
+        GitCommand() {
+            super("git");
+            subcommands = Map.of(
+                    "commit", new CommitSubcommand(),
+                    "status", new StatusSubcommand());
+        }
+
+        @Override
+        public String description() {
+            return "Version control";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            session.out().println("git: no subcommand specified");
+            return "git-main";
+        }
+
+        @Override
+        public Map<String, Command> subcommands() {
+            return subcommands;
+        }
+    }
+
+    static class CommitSubcommand extends AbstractCommand {
+        CommitSubcommand() {
+            super("commit");
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            String msg = String.join(" ", args);
+            session.out().println("committed: " + msg);
+            return "commit:" + msg;
+        }
+    }
+
+    static class StatusSubcommand extends AbstractCommand {
+        StatusSubcommand() {
+            super("status");
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            session.out().println("on branch main");
+            return "status";
+        }
+    }
+
+    @Test
+    void subcommandRouting() throws Exception {
+        Object result = dispatcher.execute("git commit -m msg");
+        assertEquals("commit:-m msg", result);
+    }
+
+    @Test
+    void parentCommandWithoutSubcommand() throws Exception {
+        Object result = dispatcher.execute("git");
+        assertEquals("git-main", result);
+    }
+
+    @Test
+    void unknownSubcommandRunsParent() throws Exception {
+        // "push" is not a registered subcommand, so it falls through to parent
+        // The parent receives ["push"] as args
+        Object result = dispatcher.execute("git push");
+        assertEquals("git-main", result);
+    }
+
+    @Test
+    void subcommandWithMultipleArgs() throws Exception {
+        Object result = dispatcher.execute("git commit -m hello world");
+        assertEquals("commit:-m hello world", result);
+    }
+
+    @Test
+    void statusSubcommand() throws Exception {
+        Object result = dispatcher.execute("git status");
+        assertEquals("status", result);
+    }
+
+    @Test
+    void completerNotNull() {
+        assertNotNull(dispatcher.completer());
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.io.IOException;
+
+import org.jline.shell.CommandSession;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link VariableCommands} and bare variable assignment in
+ * {@link DefaultCommandDispatcher}.
+ */
+public class VariableCommandsTest {
+
+    private Terminal terminal;
+    private DefaultCommandDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        terminal = TerminalBuilder.builder().dumb(true).build();
+        dispatcher = new DefaultCommandDispatcher(terminal, null, null, null, new DefaultLineExpander(), null);
+        dispatcher.addGroup(new VariableCommands());
+        // Add echo for verification
+        dispatcher.addGroup(new SimpleCommandGroup("test", new AbstractCommand("echo") {
+            @Override
+            public Object execute(CommandSession session, String[] args) {
+                String msg = String.join(" ", args);
+                session.out().println(msg);
+                return msg;
+            }
+        }));
+    }
+
+    @Test
+    void bareAssignment() throws Exception {
+        dispatcher.execute("FOO=bar");
+        assertEquals("bar", dispatcher.session().get("FOO"));
+    }
+
+    @Test
+    void bareAssignmentWithValue() throws Exception {
+        dispatcher.execute("MY_VAR=hello world");
+        // Bare assignment captures everything after '='
+        assertEquals("hello world", dispatcher.session().get("MY_VAR"));
+    }
+
+    @Test
+    void setCommand() throws Exception {
+        dispatcher.execute("set NAME=world");
+        assertEquals("world", dispatcher.session().get("NAME"));
+    }
+
+    @Test
+    void setCommandSpaceForm() throws Exception {
+        dispatcher.execute("set GREETING hello");
+        assertEquals("hello", dispatcher.session().get("GREETING"));
+    }
+
+    @Test
+    void unsetCommand() throws Exception {
+        dispatcher.session().put("TEMP", "value");
+        dispatcher.execute("unset TEMP");
+        assertNull(dispatcher.session().get("TEMP"));
+    }
+
+    @Test
+    void exportCommand() throws Exception {
+        dispatcher.execute("export COLOR=blue");
+        assertEquals("blue", dispatcher.session().get("COLOR"));
+    }
+
+    @Test
+    void variableUsedInExpansion() throws Exception {
+        dispatcher.execute("FOO=bar");
+        Object result = dispatcher.execute("echo $FOO");
+        assertEquals("bar", result);
+    }
+
+    @Test
+    void setAndExpandAdvanced() throws Exception {
+        dispatcher.execute("set NAME=world");
+        Object result = dispatcher.execute("echo ${NAME:-default}");
+        assertEquals("world", result);
+    }
+
+    @Test
+    void unsetAndExpandDefault() throws Exception {
+        dispatcher.execute("set NAME=world");
+        dispatcher.execute("unset NAME");
+        Object result = dispatcher.execute("echo ${NAME:-default}");
+        assertEquals("default", result);
+    }
+}

--- a/website/docs/shell-getting-started.md
+++ b/website/docs/shell-getting-started.md
@@ -42,6 +42,10 @@ The `Shell.builder()` API provides a fluent way to configure the shell:
 | `.optionCommands(true)` | Add `setopt`/`unsetopt`/`setvar` commands |
 | `.commandHighlighter(true)` | Enable command-aware syntax highlighting |
 | `.pipelineParser(parser)` | Custom pipeline parser with custom operators |
+| `.lineExpander(expander)` | Pluggable variable expansion (`$VAR`, `${VAR}`, `${VAR:-default}`, `~`) |
+| `.variableCommands(true)` | Add built-in `set`/`unset`/`export` commands |
+| `.scriptRunner(runner)` | Script file execution engine |
+| `.scriptCommands(true)` | Add built-in `source` / `.` commands |
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

- **Variable expansion**: pluggable `LineExpander` with `DefaultLineExpander` supporting `$VAR`, `${VAR}`, `${VAR:-default}`, `${VAR:=default}`, `${VAR:+alt}`, `${VAR:?error}`, tilde, and quote-aware parsing
- **Variable commands**: `set`/`unset`/`export` built-in commands and bare `NAME=VALUE` assignment
- **Subcommand routing**: `Command.subcommands()` with automatic dispatcher resolution and tab-completion
- **I/O redirection**: `<` (input), `2>` (stderr), `&>` (combined) operators in the pipeline parser
- **Signal handling**: INT interrupts running command, TSTP suspends foreground job
- **Script execution**: `ScriptRunner` with `source`/`.` commands, comments, and line continuation
- **Builtins integration**: `PosixCommandGroup`, `InteractiveCommandGroup` bridging builtins to shell API
- **Migration adapters**: `GogoCommandGroup` and `ConsoleLineExpander` for Gogo/Groovy migration

## Test plan

- [x] 205 shell module tests pass (including new tests for expansion, subcommands, I/O redirection, signals, scripts, variables)
- [x] 8 builtins PosixCommandGroup tests pass
- [x] Full `mvn clean install` passes across all 23 modules
- [ ] Manual testing with `ShellBuilderExample` demo