### PR TITLE
docs: Document VMIN/VTIME performance tuning for real-time applications

### DIFF
--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -295,7 +295,24 @@ If you experience performance issues with JLine:
    display.update(lines, 0);
    ```
 
-3. **Complex Completers**
+3. **Low Frame Rate in Real-Time Applications**
+
+   Applications that poll input in a tight loop (games, animations, real-time UIs) may be limited to ~10 fps.
+
+   **Cause**: JLine sets `VMIN=0, VTIME=1` by default, which means each `read()` waits up to 100ms before returning when no input is available.
+
+   **Solution**: Set both to 0 for non-blocking reads, then control the polling rate yourself:
+
+   ```java
+   Attributes attrs = terminal.getAttributes();
+   attrs.setControlChar(ControlChar.VMIN, 0);
+   attrs.setControlChar(ControlChar.VTIME, 0);
+   terminal.setAttributes(attrs);
+   ```
+
+   See [Terminal Attributes — VMIN and VTIME](./advanced/terminal-attributes.md#performance-tuning-vmin-and-vtime) for a detailed explanation of the different configurations.
+
+4. **Complex Completers**
 
    Complex tab completion logic can slow down input handling.
 


### PR DESCRIPTION
## Summary

- Add a **Performance Tuning: VMIN and VTIME** section to the terminal-attributes page explaining how these control characters affect non-canonical read behavior, with a table of all four VMIN/VTIME configurations and a code snippet for non-blocking reads
- Add a **Low Frame Rate in Real-Time Applications** troubleshooting entry explaining the 100ms bottleneck caused by the default `VMIN=0, VTIME=1` configuration, with a cross-reference to the detailed explanation

Ref: https://github.com/jline/jline3/issues/1547#issuecomment-3888124336

## Test plan

- [ ] Verify website docs render correctly