### PR TITLE
fix: Send BRACKETED_PASTE_OFF when option is explicitly disabled

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -685,7 +685,12 @@ public class LineReaderImpl implements LineReader, Flushable {
                     terminal.puts(Capability.keypad_xmit);
                     if (isSet(Option.AUTO_FRESH_LINE)) callWidget(FRESH_LINE);
                     if (isSet(Option.MOUSE)) terminal.trackMouse(Terminal.MouseTracking.Normal);
-                    if (isSet(Option.BRACKETED_PASTE)) terminal.writer().write(BRACKETED_PASTE_ON);
+                    if (isSet(Option.BRACKETED_PASTE)) {
+                        terminal.writer().write(BRACKETED_PASTE_ON);
+                    } else if (options.containsKey(Option.BRACKETED_PASTE)) {
+                        // Explicitly disabled: ensure terminal bracketed paste is off
+                        terminal.writer().write(BRACKETED_PASTE_OFF);
+                    }
                 } else if (isTerminalDumb() && maskingCallback != null) {
                     // Setup masking thread for dumb terminals when reading a password
                     setupMaskThread(prompt != null ? prompt : "");


### PR DESCRIPTION
## Summary

- When `Option.BRACKETED_PASTE` is explicitly set to `false`, the reader now sends `\033[?2004l` (BRACKETED_PASTE_OFF) during application mode initialization to ensure the terminal actually disables bracketed paste
- Previously, setting the option to `false` only prevented sending BRACKETED_PASTE_ON, but never actively disabled it — so the terminal could still have bracketed paste enabled from a previous session or terminal default

The fix distinguishes between "not set" (uses default `true`) and "explicitly set to `false`" by checking `options.containsKey(Option.BRACKETED_PASTE)`.

Fixes #1395

## Test plan

- [x] Reader module tests pass (195 tests, 0 failures)
- [ ] Manual: `reader.option(Option.BRACKETED_PASTE, false)` → verify no `\033[200~`/`\033[201~` wrapping on paste