### PR TITLE
fix: Send BRACKETED_PASTE_OFF when option is explicitly disabled (backport #1613)

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -690,7 +690,12 @@ public class LineReaderImpl implements LineReader, Flushable {
                     terminal.puts(Capability.keypad_xmit);
                     if (isSet(Option.AUTO_FRESH_LINE)) callWidget(FRESH_LINE);
                     if (isSet(Option.MOUSE)) terminal.trackMouse(Terminal.MouseTracking.Normal);
-                    if (isSet(Option.BRACKETED_PASTE)) terminal.writer().write(BRACKETED_PASTE_ON);
+                    if (isSet(Option.BRACKETED_PASTE)) {
+                        terminal.writer().write(BRACKETED_PASTE_ON);
+                    } else if (options.containsKey(Option.BRACKETED_PASTE)) {
+                        // Explicitly disabled: ensure terminal bracketed paste is off
+                        terminal.writer().write(BRACKETED_PASTE_OFF);
+                    }
                 } else if (isTerminalDumb() && maskingCallback != null) {
                     // Setup masking thread for dumb terminals when reading a password
                     setupMaskThread(prompt != null ? prompt : "");


### PR DESCRIPTION
## Summary

Backport of #1613 to the `jline-3.x` branch.

When `Option.BRACKETED_PASTE` is explicitly set to `false`, the reader now sends `\033[?2004l` (BRACKETED_PASTE_OFF) during application mode initialization to ensure the terminal actually disables bracketed paste. Previously, setting the option to `false` only prevented sending BRACKETED_PASTE_ON but never actively disabled it.

Fixes #1395

## Test plan

- [x] Reader module tests pass on jline-3.x (clean cherry-pick, no conflicts)
- [ ] Manual: `reader.option(Option.BRACKETED_PASTE, false)` → verify no bracketed paste wrapping on paste