### PR TITLE
fix: Prevent child modules from appending artifactId to inherited URLs

### DIFF
--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -14,7 +14,6 @@
     <parent />
     <artifactId>jline-groovy</artifactId>
     <name>JLine Groovy</name>
-    <url>http://maven.apache.org</url>
 
     <properties>
         <automatic.module.name>org.jline.groovy</automatic.module.name>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <packaging>pom</packaging>
     <name>JLine</name>
     <description>JLine</description>
-    <url>https://github.com/jline/jline3</url>
+    <url child.project.url.inherit.append.path="false">https://github.com/jline/jline3</url>
 
     <licenses>
         <license>
@@ -48,11 +48,11 @@
         </mailingList>
     </mailingLists>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:https://github.com/jline/jline3.git</connection>
         <developerConnection>scm:git:https://github.com/jline/jline3.git</developerConnection>
         <tag>${nisse.jgit.dynamicVersion}</tag>
-        <url>http://github.com/jline/jline3</url>
+        <url>https://github.com/jline/jline3</url>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
## Summary

- Set `child.project.url.inherit.append.path="false"` on `<url>` and `child.scm.*.inherit.append.path="false"` on `<scm>` in the parent POM so child modules inherit URLs unchanged instead of appending their artifactId (which produces 404 links like `https://github.com/jline/jline3/jline-terminal`)
- Fix SCM `<url>` from `http://` to `https://`
- Remove broken placeholder `<url>http://maven.apache.org</url>` from the groovy module POM

Fixes #1522

## Test plan

- [x] Build succeeds
- [ ] Verify on Maven Central after next release that module "External Resources" links point to valid URLs