### PR TITLE
fix: Prevent child modules from appending artifactId to inherited URLs (backport #1615)

### DIFF
--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -18,7 +18,6 @@
     </parent>
     <artifactId>jline-groovy</artifactId>
     <name>JLine Groovy</name>
-    <url>http://maven.apache.org</url>
 
     <properties>
         <automatic.module.name>org.jline.groovy</automatic.module.name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <packaging>pom</packaging>
     <name>JLine</name>
     <description>JLine</description>
-    <url>https://github.com/jline/jline3</url>
+    <url child.project.url.inherit.append.path="false">https://github.com/jline/jline3</url>
 
     <licenses>
         <license>
@@ -71,11 +71,11 @@
         <module>jansi-core</module>
     </modules>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:https://github.com/jline/jline3.git</connection>
         <developerConnection>scm:git:https://github.com/jline/jline3.git</developerConnection>
         <tag>jline-3.30.5</tag>
-        <url>http://github.com/jline/jline3</url>
+        <url>https://github.com/jline/jline3</url>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
## Summary

Backport of #1615 to the `jline-3.x` branch.

- Set `child.project.url.inherit.append.path="false"` on `<url>` and `child.scm.*.inherit.append.path="false"` on `<scm>` in the parent POM so child modules inherit URLs unchanged instead of appending their artifactId (which produces 404 links on Maven Central)
- Fix SCM `<url>` from `http://` to `https://`
- Remove broken placeholder `<url>http://maven.apache.org</url>` from the groovy module POM

Fixes #1522

## Test plan

- [x] Build succeeds on jline-3.x
- [ ] Verify on Maven Central after next release that module "External Resources" links point to valid URLs