### PR TITLE
fix: Bind newline to EXIT in all prompts for dumb terminal support (backport)

### DIFF
--- a/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
@@ -348,7 +348,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             for (char i = 32; i < KEYMAP_LENGTH; i++) {
                 map.bind(Operation.INSERT, Character.toString(i));
             }
-            map.bind(Operation.EXIT, "\r");
+            map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
@@ -452,7 +452,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             String no = config.resourceBundle().getString("confirmation_no_key");
             map.bind(Operation.YES, yes, yes.toUpperCase());
             map.bind(Operation.NO, no, no.toUpperCase());
-            map.bind(Operation.EXIT, "\r");
+            map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
@@ -556,7 +556,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.BACKSPACE, del());
             map.bind(Operation.DELETE, ctrl('D'), key(terminal, InfoCmp.Capability.key_dc));
             map.bind(Operation.BACKSPACE, ctrl('H'));
-            map.bind(Operation.EXIT, "\r");
+            map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.RIGHT, key(terminal, InfoCmp.Capability.key_right));
             map.bind(Operation.LEFT, key(terminal, InfoCmp.Capability.key_left));
             map.bind(Operation.UP, key(terminal, InfoCmp.Capability.key_up));
@@ -844,7 +844,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             }
             map.bind(Operation.FORWARD_ONE_LINE, "e", ctrl('E'), key(terminal, InfoCmp.Capability.key_down));
             map.bind(Operation.BACKWARD_ONE_LINE, "y", ctrl('Y'), key(terminal, InfoCmp.Capability.key_up));
-            map.bind(Operation.EXIT, "\r");
+            map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
@@ -926,7 +926,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.FORWARD_ONE_LINE, "e", ctrl('E'), key(terminal, InfoCmp.Capability.key_down));
             map.bind(Operation.BACKWARD_ONE_LINE, "y", ctrl('Y'), key(terminal, InfoCmp.Capability.key_up));
             map.bind(Operation.TOGGLE, " ");
-            map.bind(Operation.EXIT, "\r");
+            map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }


### PR DESCRIPTION
## Summary

Backport of #1617 to jline-3.x.

- Fixes #1452: ConfirmPrompt (and all other prompt types) hang on dumb terminals
- On dumb terminals, pressing Enter sends `\n` (LF) rather than `\r` (CR) because the kernel's CR-to-NL translation that normally happens in raw mode doesn't apply
- All five prompt types in `AbstractPrompt.java` only bound `\r` to the EXIT operation, so `\n` was never recognized and the prompt waited forever
- Fixed by binding both `\r` and `\n` to EXIT in all prompt key maps

## Test plan

- [x] Cherry-pick applies cleanly
- [x] `console-ui` module builds and tests pass