### PR TITLE
fix: DefaultParser trailing empty word for non-completion contexts (#1489)

### DIFF
--- a/builtins/src/test/java/org/jline/builtins/CompletersTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CompletersTest.java
@@ -15,6 +15,7 @@ import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
 import org.jline.reader.ParsedLine;
+import org.jline.reader.Parser.ParseContext;
 import org.jline.reader.impl.DefaultParser;
 import org.junit.jupiter.api.Test;
 
@@ -37,8 +38,8 @@ public class CompletersTest {
         Completer completer = new Completers.TreeCompleter(
                 node("Command1", node("Option1", node(test)), node("Option2"), node("Option3")));
         List<Candidate> candidates = new ArrayList<>();
-        completer.complete(
-                null, new DefaultParser().parse("Command1 Option1 ", "Command1 Option1 ".length()), candidates);
+        String line = "Command1 Option1 ";
+        completer.complete(null, new DefaultParser().parse(line, line.length(), ParseContext.COMPLETE), candidates);
         assertEquals(2, candidates.size());
         assertEquals("Param1", candidates.get(0).value());
         assertEquals("Param2", candidates.get(1).value());


### PR DESCRIPTION
## Summary

- DefaultParser no longer emits a trailing empty word when the cursor is at the end of a line ending with whitespace, unless parsing for tab-completion (`ParseContext.COMPLETE`)
- Explicitly quoted empty strings (`""`) are now correctly preserved in all contexts, both mid-line and at end-of-line
- Added guard against empty word list when cursor is at end of line

Fixes #1489

## Details

The root cause was the post-loop condition in `DefaultParser.parse()`:

```java
// Before (always adds empty word when cursor is at end)
if (current.length() > 0 || cursor == line.length()) {

// After (only adds for completion, or when word was explicitly started via quotes)
if (current.length() > 0 || wordStarted || (cursor == line.length() && context == ParseContext.COMPLETE)) {
```

A `wordStarted` flag now tracks whether a quote block was opened for the current word, distinguishing explicit empty strings (`""`) from trailing whitespace.

## Test plan

- [x] New `testTrailingSpace` test covering all scenarios:
  - Trailing space with cursor=0 and cursor=end → no empty word
  - Trailing space with `COMPLETE` context → empty word preserved
  - Explicit `""` at end of line → empty word preserved
  - `""` in middle of line → empty word preserved
  - Multiple trailing spaces → no empty word
- [x] All 196 reader module tests pass
- [x] All 3 console module tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)