### PR TITLE
fix: Propagate Ctrl+C as UserInterruptException in console-ui prompts

### DIFF
--- a/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
@@ -315,7 +315,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
         private enum Operation {
             INSERT,
             EXIT,
-            CANCEL
+            CANCEL,
+            INTERRUPT
         }
 
         private final int startColumn;
@@ -351,6 +352,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             }
             map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
+            map.bind(Operation.INTERRUPT, ctrl('C'));
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
@@ -405,6 +407,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
                         return new ExpandableChoiceResult(selectedId);
                     case CANCEL:
                         return null;
+                    case INTERRUPT:
+                        throw new UserInterruptException("");
                 }
             }
         }
@@ -425,7 +429,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             NO,
             YES,
             EXIT,
-            CANCEL
+            CANCEL,
+            INTERRUPT
         }
 
         private final int startColumn;
@@ -462,6 +467,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.NO, no, no.toUpperCase());
             map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
+            map.bind(Operation.INTERRUPT, ctrl('C'));
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
@@ -495,6 +501,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
                         return new ConfirmResult(confirm);
                     case CANCEL:
                         return null;
+                    case INTERRUPT:
+                        throw new UserInterruptException("");
                 }
             }
         }
@@ -513,14 +521,16 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             END_OF_LINE,
             SELECT_CANDIDATE,
             EXIT,
-            CANCEL
+            CANCEL,
+            INTERRUPT
         }
 
         private enum SelectOp {
             FORWARD_ONE_LINE,
             BACKWARD_ONE_LINE,
             EXIT,
-            CANCEL
+            CANCEL,
+            INTERRUPT
         }
 
         private final int startColumn;
@@ -575,6 +585,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.LEFT, ctrl('B'));
             map.bind(Operation.SELECT_CANDIDATE, "\t");
             map.bind(Operation.CANCEL, KeyMap.esc());
+            map.bind(Operation.INTERRUPT, ctrl('C'));
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
@@ -583,6 +594,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(SelectOp.BACKWARD_ONE_LINE, "y", ctrl('Y'), key(terminal, InfoCmp.Capability.key_up));
             map.bind(SelectOp.EXIT, "\r");
             map.bind(SelectOp.CANCEL, KeyMap.esc());
+            map.bind(SelectOp.INTERRUPT, ctrl('C'));
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
@@ -689,6 +701,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
                         return new InputResult(buffer.toString(), displayBuffer.toString());
                     case CANCEL:
                         return null;
+                    case INTERRUPT:
+                        throw new UserInterruptException("");
                 }
             }
         }
@@ -724,6 +738,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
                         return selected;
                     case CANCEL:
                         return null;
+                    case INTERRUPT:
+                        throw new UserInterruptException("");
                 }
             }
         }
@@ -818,7 +834,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             BACKWARD_ONE_LINE,
             INSERT,
             EXIT,
-            CANCEL
+            CANCEL,
+            INTERRUPT
         }
 
         private final List<T> items;
@@ -854,6 +871,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.BACKWARD_ONE_LINE, "y", ctrl('Y'), key(terminal, InfoCmp.Capability.key_up));
             map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
+            map.bind(Operation.INTERRUPT, ctrl('C'));
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
@@ -891,6 +909,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
                         return new ListResult(listItem.getName());
                     case CANCEL:
                         return null;
+                    case INTERRUPT:
+                        throw new UserInterruptException("");
                 }
             }
         }
@@ -902,7 +922,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             BACKWARD_ONE_LINE,
             TOGGLE,
             EXIT,
-            CANCEL
+            CANCEL,
+            INTERRUPT
         }
 
         private final List<CheckboxItemIF> items;
@@ -936,6 +957,7 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.TOGGLE, " ");
             map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
+            map.bind(Operation.INTERRUPT, ctrl('C'));
             map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
@@ -970,6 +992,8 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
                         return new CheckboxResult(selected);
                     case CANCEL:
                         return null;
+                    case INTERRUPT:
+                        throw new UserInterruptException("");
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Fixes #1444 and #1531: Ctrl+C during `ConsolePrompt.prompt()` is now properly propagated as `UserInterruptException`
- The root cause was that Ctrl+C (byte `0x03`) was not bound to any operation in the prompt key maps, so it was silently ignored by `BindingReader.readBinding()`. If the user registered a signal handler for `Signal.INT`, it would fire on a different thread and could not propagate the exception to the prompt thread
- Added a new `INTERRUPT` operation (distinct from `CANCEL`/Escape) to all 5 prompt types plus the tab-completion selector, bound to `ctrl('C')`, which throws `UserInterruptException`
- This preserves the existing Escape behavior (navigate back to previous prompt) while giving Ctrl+C the expected interrupt semantics
- The new `jline-prompt` module already handles Ctrl+C correctly and is not affected

## Test plan

- [x] `console-ui` module compiles and all existing tests pass
- [ ] Manual test: run a list/checkbox/confirm/input prompt and verify Ctrl+C throws `UserInterruptException` to the caller
- [ ] Manual test: verify Escape still navigates back to previous prompt (unchanged behavior)