### PR TITLE
fix: DefaultParser trailing empty word for non-completion contexts (#1489) [backport 3.x]

### DIFF
--- a/builtins/src/test/java/org/jline/builtins/CompletersTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CompletersTest.java
@@ -15,6 +15,7 @@ import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
 import org.jline.reader.ParsedLine;
+import org.jline.reader.Parser.ParseContext;
 import org.jline.reader.impl.DefaultParser;
 import org.junit.jupiter.api.Test;
 
@@ -37,8 +38,8 @@ public class CompletersTest {
         Completer completer = new Completers.TreeCompleter(
                 node("Command1", node("Option1", node(test)), node("Option2"), node("Option3")));
         List<Candidate> candidates = new ArrayList<>();
-        completer.complete(
-                null, new DefaultParser().parse("Command1 Option1 ", "Command1 Option1 ".length()), candidates);
+        String line = "Command1 Option1 ";
+        completer.complete(null, new DefaultParser().parse(line, line.length(), ParseContext.COMPLETE), candidates);
         assertEquals(2, candidates.size());
         assertEquals("Param1", candidates.get(0).value());
         assertEquals("Param2", candidates.get(1).value());

--- a/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
@@ -444,6 +444,7 @@ public class DefaultParser implements Parser {
         int rawWordStart = 0;
         BracketChecker bracketChecker = new BracketChecker(cursor);
         boolean quotedWord = false;
+        boolean wordStarted = false;
         boolean lineCommented = false;
         boolean blockCommented = false;
         boolean blockCommentInRightOrder = true;
@@ -464,6 +465,7 @@ public class DefaultParser implements Parser {
             if (quoteStart < 0 && isQuoteChar(line, i) && !lineCommented && !blockCommented) {
                 // Start a quote block
                 quoteStart = i;
+                wordStarted = true;
                 if (current.length() == 0) {
                     quotedWord = true;
                     if (context == ParseContext.SPLIT_LINE) {
@@ -492,9 +494,17 @@ public class DefaultParser implements Parser {
                     }
                 } else {
                     // Delimiter
-                    rawWordLength = handleDelimiterAndGetRawWordLength(
-                            current, words, rawWordStart, rawWordCursor, rawWordLength, i);
+                    if (wordStarted && current.length() == 0) {
+                        words.add(current.toString());
+                        if (rawWordCursor >= 0 && rawWordLength < 0) {
+                            rawWordLength = i - rawWordStart;
+                        }
+                    } else {
+                        rawWordLength = handleDelimiterAndGetRawWordLength(
+                                current, words, rawWordStart, rawWordCursor, rawWordLength, i);
+                    }
                     rawWordStart = i + 1;
+                    wordStarted = false;
                 }
             } else {
                 if (quoteStart < 0 && !blockCommented && (lineCommented || isLineCommentStarted(line, i))) {
@@ -513,6 +523,7 @@ public class DefaultParser implements Parser {
                                 current, words, rawWordStart, rawWordCursor, rawWordLength, i);
                         i += blockCommentStart == null ? 0 : blockCommentStart.length() - 1;
                         rawWordStart = i + 1;
+                        wordStarted = false;
                     }
                 } else if (quoteStart < 0 && !lineCommented && isCommentDelim(line, i, blockCommentEnd)) {
                     current.append(line.charAt(i));
@@ -528,7 +539,7 @@ public class DefaultParser implements Parser {
             }
         }
 
-        if (current.length() > 0 || cursor == line.length()) {
+        if (current.length() > 0 || wordStarted || (cursor == line.length() && context == ParseContext.COMPLETE)) {
             words.add(current.toString());
             if (rawWordCursor >= 0 && rawWordLength < 0) {
                 rawWordLength = line.length() - rawWordStart;
@@ -536,6 +547,9 @@ public class DefaultParser implements Parser {
         }
 
         if (cursor == line.length()) {
+            if (words.isEmpty()) {
+                words.add("");
+            }
             wordIndex = words.size() - 1;
             wordCursor = words.get(words.size() - 1).length();
             rawWordCursor = cursor - rawWordStart;


### PR DESCRIPTION
## Summary

Backport of #1619 to `jline-3.x`.

- DefaultParser no longer emits a trailing empty word when the cursor is at the end of a line ending with whitespace, unless parsing for tab-completion (`ParseContext.COMPLETE`)
- Explicitly quoted empty strings (`""`) are now correctly preserved in all contexts
- Fixed `CompletersTest.testTreeCompleter` to use `ParseContext.COMPLETE` (it was relying on the old buggy behavior)

Fixes #1489

## Test plan

- [x] Clean cherry-pick, no conflicts
- [x] All tests verified on master branch (reader + console + builtins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)