### PR TITLE
fix: Use ExternalTerminal for SSH sessions instead of PosixPtyTerminal

### DIFF
--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
@@ -183,6 +183,7 @@ public class ShellFactoryImpl implements ShellFactory {
                         .name("JLine SSH")
                         .type(env.getEnv().get("TERM"))
                         .system(false)
+                        .provider("exec")
                         .streams(in, out)
                         .attributes(attributes)
                         .size(new Size(


### PR DESCRIPTION
## Summary

- Fixes #1372: SSH sessions throw IOException when closing because the wrong terminal type is used
- The root cause is that `ShellFactoryImpl` relied on the default provider ordering (`ffm, jni, jansi, jna, exec`), so the FFM or JNI provider would be selected first — both create `PosixPtyTerminal` with a real PTY even for non-system terminals
- `PosixPtyTerminal` spawns pump threads that attempt to close the terminal on EOF, causing cascading IOExceptions when SSH channels close because the SSH framework is already tearing down the streams
- `ExternalTerminal` (created by the exec provider) is specifically designed for remote connections like SSH — it uses an embedded line discipline and handles stream closure gracefully
- Fix: add `.provider("exec")` to the `TerminalBuilder` call in `ShellFactoryImpl` to force `ExternalTerminal`

## Test plan

- [x] `remote-ssh` module compiles and all tests pass
- [ ] Manual test: SSH into a JLine-based server, verify normal operation, disconnect, verify no IOException is printed