### PR TITLE
fix: Use ExternalTerminal for SSH sessions instead of PosixPtyTerminal (backport)

### DIFF
--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
@@ -183,6 +183,7 @@ public class ShellFactoryImpl implements ShellFactory {
                         .name("JLine SSH")
                         .type(env.getEnv().get("TERM"))
                         .system(false)
+                        .provider("exec")
                         .streams(in, out)
                         .attributes(attributes)
                         .size(new Size(


### PR DESCRIPTION
## Summary

Backport of #1627 to jline-3.x.

- Fixes #1372: SSH sessions throw IOException when closing
- Forces `.provider("exec")` in `ShellFactoryImpl` to create `ExternalTerminal` instead of `PosixPtyTerminal`

## Test plan

- [x] Cherry-pick applies cleanly
- [x] `remote-ssh` module builds and tests pass