### PR TITLE
fix: Suppress IOException in PosixPtyTerminal pump threads during close

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -17,6 +17,7 @@ import java.nio.charset.Charset;
 import java.util.Objects;
 
 import org.jline.terminal.spi.Pty;
+import org.jline.utils.Log;
 import org.jline.utils.NonBlocking;
 import org.jline.utils.NonBlockingInputStream;
 import org.jline.utils.NonBlockingReader;
@@ -232,7 +233,9 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
                 masterOutput.flush();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            if (!closed) {
+                Log.warn("Error in input pump", e);
+            }
         } finally {
             synchronized (lock) {
                 inputPumpThread = null;
@@ -258,7 +261,9 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
                 out.flush();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            if (!closed) {
+                Log.warn("Error in output pump", e);
+            }
         } finally {
             synchronized (lock) {
                 outputPumpThread = null;


### PR DESCRIPTION
## Summary

- Fixes #1372: SSH sessions print IOExceptions when closing
- `PosixPtyTerminal` is the correct terminal type for SSH PTY sessions (it provides real kernel line discipline), but its pump threads called `e.printStackTrace()` unconditionally when encountering IOExceptions
- When an SSH client disconnects, the SSH framework closes the channel streams, causing the pump threads to get IOExceptions — this is normal shutdown behavior, not an error
- Replace `e.printStackTrace()` with a guarded `Log.warn()` that only logs when the terminal is not already in the `closed` state; IOExceptions during expected close are silently suppressed

## Test plan

- [x] Terminal module compiles and all tests pass
- [ ] Manual test: SSH into a JLine-based server, disconnect, verify no IOException is printed to stderr