### PR TITLE
fix: Suppress IOException in PosixPtyTerminal pump threads during close (backport)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -17,6 +17,7 @@ import java.nio.charset.Charset;
 import java.util.Objects;
 
 import org.jline.terminal.spi.Pty;
+import org.jline.utils.Log;
 import org.jline.utils.NonBlocking;
 import org.jline.utils.NonBlockingInputStream;
 import org.jline.utils.NonBlockingReader;
@@ -232,7 +233,9 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
                 masterOutput.flush();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            if (!closed) {
+                Log.warn("Error in input pump", e);
+            }
         } finally {
             synchronized (lock) {
                 inputPumpThread = null;
@@ -258,7 +261,9 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
                 out.flush();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            if (!closed) {
+                Log.warn("Error in output pump", e);
+            }
         } finally {
             synchronized (lock) {
                 outputPumpThread = null;


### PR DESCRIPTION
## Summary

Backport of #1629 to jline-3.x.

- Fixes #1372: SSH sessions print IOExceptions when closing
- Replace unconditional `e.printStackTrace()` in pump threads with guarded `Log.warn()` that is suppressed when the terminal is already closed

## Test plan

- [x] Cherry-pick applies cleanly
- [x] Terminal module builds and tests pass