### PR TITLE
fix: Clear auto-suggestion menu list when no completions match

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -5151,7 +5151,8 @@ public class LineReaderImpl implements LineReader, Flushable {
     }
 
     protected boolean clearChoices() {
-        return doList(new ArrayList<>(), "", false, null, false);
+        post = null;
+        return false;
     }
 
     protected boolean doList(


### PR DESCRIPTION
## Summary

- Fixes #1338: AUTO_MENU_LIST completion menu stays visible when no candidates match
- The autosuggestion flow calls `clearChoices()` then `listChoices(true)` on every keystroke. `clearChoices()` called `doList(emptyList, ...)`, but `doList()` returns early at the `possibleSize == 0` check (line 5184) **without clearing the `post` field**. The stale `post` lambda from the previous completion continued to render old candidates
- When `listChoices(true)` subsequently finds no matches, it also returns early without touching `post`
- Fix: `clearChoices()` now directly sets `post = null` instead of delegating to `doList()` with an empty list

## Test plan

- [x] Reader module compiles and all tests pass
- [ ] Manual test: enable `AUTO_MENU_LIST` + `SuggestionType.COMPLETER`, type a prefix that matches completions, then type characters that eliminate all matches — verify the menu disappears