### PR TITLE
fix: Clear auto-suggestion menu list when no completions match (backport)

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -5089,7 +5089,8 @@ public class LineReaderImpl implements LineReader, Flushable {
     }
 
     protected boolean clearChoices() {
-        return doList(new ArrayList<>(), "", false, null, false);
+        post = null;
+        return false;
     }
 
     protected boolean doList(


### PR DESCRIPTION
## Summary

Backport of #1631 to jline-3.x.

- Fixes #1338: AUTO_MENU_LIST completion menu stays visible when no candidates match
- `clearChoices()` now directly sets `post = null` instead of calling `doList()` with an empty list, which returned early without clearing the display

## Test plan

- [x] Cherry-pick applies cleanly
- [x] Reader module builds and tests pass