### PR TITLE
fix: Display.resize() handles buffer wider than visible window (#1210)

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -87,8 +87,10 @@ public class Display {
 
     protected final Map<Capability, Integer> cost = new HashMap<>();
     protected final boolean canScroll;
-    protected final boolean wrapAtEol;
-    protected final boolean delayedWrapAtEol;
+    protected final boolean terminalWrapAtEol;
+    protected final boolean terminalDelayedWrapAtEol;
+    protected boolean wrapAtEol;
+    protected boolean delayedWrapAtEol;
     protected final boolean cursorDownIsNewLine;
 
     @SuppressWarnings("this-escape")
@@ -98,8 +100,11 @@ public class Display {
 
         this.canScroll = can(Capability.insert_line, Capability.parm_insert_line)
                 && can(Capability.delete_line, Capability.parm_delete_line);
-        this.wrapAtEol = terminal.getBooleanCapability(Capability.auto_right_margin);
-        this.delayedWrapAtEol = this.wrapAtEol && terminal.getBooleanCapability(Capability.eat_newline_glitch);
+        this.terminalWrapAtEol = terminal.getBooleanCapability(Capability.auto_right_margin);
+        this.terminalDelayedWrapAtEol =
+                this.terminalWrapAtEol && terminal.getBooleanCapability(Capability.eat_newline_glitch);
+        this.wrapAtEol = this.terminalWrapAtEol;
+        this.delayedWrapAtEol = this.terminalDelayedWrapAtEol;
         this.cursorDownIsNewLine = "\n".equals(Curses.tputs(terminal.getStringCapability(Capability.cursor_down)));
     }
 
@@ -127,6 +132,17 @@ public class Display {
             this.columns1 = columns + 1;
             oldLines = AttributedString.join(AttributedString.EMPTY, oldLines)
                     .columnSplitLength(columns, true, delayLineWrap());
+        }
+        // When the terminal buffer is wider than the visible window (e.g. Windows with
+        // a wide screen buffer), auto-wrap occurs at the buffer width, not the visible
+        // width. Disable wrap-at-eol reliance since content won't reach the buffer edge.
+        int bufferColumns = terminal.getBufferSize().getColumns();
+        if (bufferColumns > columns) {
+            this.wrapAtEol = false;
+            this.delayedWrapAtEol = false;
+        } else {
+            this.wrapAtEol = this.terminalWrapAtEol;
+            this.delayedWrapAtEol = this.terminalDelayedWrapAtEol;
         }
     }
 


### PR DESCRIPTION
## Summary
- On Windows, the terminal screen buffer can be wider than the visible window (e.g., buffer=2000, window=80). The `windows-vtp` terminal declares `auto_right_margin`, so `Display` expects auto-wrap at `columns`, but wrap actually occurs at the buffer width — causing cursor tracking desync and broken display output.
- `Display.resize()` now queries `terminal.getBufferSize()` and disables `wrapAtEol`/`delayedWrapAtEol` when the buffer is wider than the visible columns, since content will never reach the buffer's right edge.
- No API changes — callers continue to pass visible width to `resize()`.

Fixes #1210

## Test plan
- [x] Existing `DisplayTest` passes
- [x] Full `terminal` module test suite passes (135 tests)
- [ ] Manual verification on Windows with wide screen buffer