### PR TITLE
ConsoleEngineImpl: add which command (backport)

### DIFF
--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -1194,7 +1194,7 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
                     out.add(arg + " is an alias: " + getAlias(arg));
                 } else if (systemRegistry.hasCommand(arg)) {
                     out.add(arg + " is registered in " + systemRegistry.name());
-                } else if (scripts().keySet().contains(arg)) {
+                } else if (scripts().containsKey(arg)) {
                     Path script = findScript(arg);
                     out.add(script != null ? script.toString() : arg + ": not found");
                 } else {


### PR DESCRIPTION
## Summary

- Backport of #1358: adds a `which` command to `ConsoleEngineImpl`
- Shows whether a command name is an alias, a registered command, or a script (with its path)
- Includes fix: `scripts().containsKey()` instead of `scripts().keySet().contains()`