### PR TITLE
Fix ASCII fallback for box-drawing chars when alt charset unsupported

### DIFF
--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -276,6 +276,17 @@ public abstract class AttributedCharSequence implements CharSequence {
                 if (oldalt ^ alt) {
                     sb.append(alt ? altIn : altOut);
                 }
+            } else {
+                // Fallback to ASCII when alternate charset mode is not supported
+                // @spotless:off
+                switch (c) {
+                    case '┘': case '┐': case '┌': case '└': c = '+'; break;
+                    case '┼': c = '+'; break;
+                    case '─': c = '-'; break;
+                    case '├': case '┤': case '┴': case '┬': c = '+'; break;
+                    case '│': c = '|'; break;
+                }
+                // @spotless:on
             }
             long s = styleCodeAt(i) & ~F_HIDDEN; // The hidden flag does not change the ansi styles
             if (style != s) {


### PR DESCRIPTION
## Summary

- When a terminal does not support alternate charset mode (`smacs`/`rmacs`), box-drawing Unicode characters were passed through as-is
- Terminals that can't render these (e.g., `TERM=screen-256color`) displayed garbled output like `qqqqqq` instead of horizontal lines
- Added ASCII fallback: `─` → `-`, `│` → `|`, corners/intersections → `+`

Fixes #1259

## Test plan

- [x] `./mvx mvn -pl terminal -am test` passes
- [ ] Manual: verify with `TERM=screen-256color` that TailTipWidgets separator renders as `------` instead of `qqqqqq`