### PR TITLE
Fix ASCII fallback for box-drawing chars when alt charset unsupported (backport)

### DIFF
--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -284,6 +284,17 @@ public abstract class AttributedCharSequence implements CharSequence {
                 if (oldalt ^ alt) {
                     sb.append(alt ? altIn : altOut);
                 }
+            } else {
+                // Fallback to ASCII when alternate charset mode is not supported
+                // @spotless:off
+                switch (c) {
+                    case '┘': case '┐': case '┌': case '└': c = '+'; break;
+                    case '┼': c = '+'; break;
+                    case '─': c = '-'; break;
+                    case '├': case '┤': case '┴': case '┬': c = '+'; break;
+                    case '│': c = '|'; break;
+                }
+                // @spotless:on
             }
             long s = styleCodeAt(i) & ~F_HIDDEN; // The hidden flag does not change the ansi styles
             if (style != s) {


### PR DESCRIPTION
## Summary

Backport of #1638. See that PR for details.

Fixes #1259