### PR TITLE
chore: Remove years from copyright headers

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ClasspathResourceUtil.java
+++ b/builtins/src/main/java/org/jline/builtins/ClasspathResourceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/Commands.java
+++ b/builtins/src/main/java/org/jline/builtins/Commands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/Completers.java
+++ b/builtins/src/main/java/org/jline/builtins/Completers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
+++ b/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/ConsoleOptionGetter.java
+++ b/builtins/src/main/java/org/jline/builtins/ConsoleOptionGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/InputRC.java
+++ b/builtins/src/main/java/org/jline/builtins/InputRC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/InteractiveCommandGroup.java
+++ b/builtins/src/main/java/org/jline/builtins/InteractiveCommandGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/NfaMatcher.java
+++ b/builtins/src/main/java/org/jline/builtins/NfaMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/Options.java
+++ b/builtins/src/main/java/org/jline/builtins/Options.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/PosixCommandGroup.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommandGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/PosixCommandsRegistry.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommandsRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/Source.java
+++ b/builtins/src/main/java/org/jline/builtins/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/Styles.java
+++ b/builtins/src/main/java/org/jline/builtins/Styles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/SyntaxHighlighter.java
+++ b/builtins/src/main/java/org/jline/builtins/SyntaxHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/TTop.java
+++ b/builtins/src/main/java/org/jline/builtins/TTop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/main/java/org/jline/builtins/WebTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/WebTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/ClasspathConfigurationPathTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ClasspathConfigurationPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/ClasspathResourceUtil.java
+++ b/builtins/src/test/java/org/jline/builtins/ClasspathResourceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/ClasspathResourceUtilTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ClasspathResourceUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/CommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/CompletersTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CompletersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/InputRCTest.java
+++ b/builtins/src/test/java/org/jline/builtins/InputRCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/NanoClasspathConfigTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NanoClasspathConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/NanoSuggestionBoxTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NanoSuggestionBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/NanoTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NanoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/NfaMatcherTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NfaMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/OptionCompleterTest.java
+++ b/builtins/src/test/java/org/jline/builtins/OptionCompleterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/OptionsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/OptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandGroupTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/ReaderTestSupport.java
+++ b/builtins/src/test/java/org/jline/builtins/ReaderTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/SimpleTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SimpleTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/SortComparatorTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SortComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/StylesTest.java
+++ b/builtins/src/test/java/org/jline/builtins/StylesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/SwingTerminalEncodingTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SwingTerminalEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterClasspathTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterClasspathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterJimFsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterJimFsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/TerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/TerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/TmuxTest.java
+++ b/builtins/src/test/java/org/jline/builtins/TmuxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/TreeCompleterTest.java
+++ b/builtins/src/test/java/org/jline/builtins/TreeCompleterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
+++ b/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/example/ArgumentMaskCallbackReader.java
+++ b/builtins/src/test/java/org/jline/example/ArgumentMaskCallbackReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/example/Example.java
+++ b/builtins/src/test/java/org/jline/example/Example.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/example/OptionMaskCallbackReader.java
+++ b/builtins/src/test/java/org/jline/example/OptionMaskCallbackReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/builtins/src/test/java/org/jline/example/PasswordReader.java
+++ b/builtins/src/test/java/org/jline/example/PasswordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/AbstractPromptableElement.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/AbstractPromptableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/Checkbox.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/Checkbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/ConfirmChoice.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/ConfirmChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/ExpandableChoice.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/ExpandableChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/InputValue.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/InputValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/ListChoice.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/ListChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/PageSizeType.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/PageSizeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/PromptableElementIF.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/PromptableElementIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/Text.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/Text.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/items/CheckboxItemIF.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/items/CheckboxItemIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/items/ChoiceItemIF.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/items/ChoiceItemIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/items/ConsoleUIItemIF.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/items/ConsoleUIItemIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/items/ListItemIF.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/items/ListItemIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/items/impl/CheckboxItem.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/items/impl/CheckboxItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/items/impl/ChoiceItem.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/items/impl/ChoiceItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/items/impl/ListItem.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/items/impl/ListItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/elements/items/impl/Separator.java
+++ b/console-ui/src/main/java/org/jline/consoleui/elements/items/impl/Separator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/CheckboxResult.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/CheckboxResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/ConfirmResult.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/ConfirmResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/ConsolePrompt.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/ConsolePrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/ExpandableChoiceResult.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/ExpandableChoiceResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/InputResult.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/InputResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/ListResult.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/ListResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/NoResult.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/NoResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/PromptResultItemIF.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/PromptResultItemIF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/CheckboxItemBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/CheckboxItemBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/CheckboxPromptBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/CheckboxPromptBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/CheckboxSeparatorBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/CheckboxSeparatorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ConfirmPromptBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ConfirmPromptBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ExpandableChoiceItemBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ExpandableChoiceItemBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ExpandableChoicePromptBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ExpandableChoicePromptBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ExpandableChoiceSeparatorBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ExpandableChoiceSeparatorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/InputValueBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/InputValueBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ListItemBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ListItemBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ListPromptBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/ListPromptBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/PromptBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/PromptBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/builder/TextBuilder.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/builder/TextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/test/java/org/jline/consoleui/Issue1025.java
+++ b/console-ui/src/test/java/org/jline/consoleui/Issue1025.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/test/java/org/jline/consoleui/examples/Basic.java
+++ b/console-ui/src/test/java/org/jline/consoleui/examples/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/test/java/org/jline/consoleui/examples/LongList.java
+++ b/console-ui/src/test/java/org/jline/consoleui/examples/LongList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/test/java/org/jline/consoleui/examples/SimpleExample.java
+++ b/console-ui/src/test/java/org/jline/consoleui/examples/SimpleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/test/java/org/jline/consoleui/prompt/CheckboxPromptTest.java
+++ b/console-ui/src/test/java/org/jline/consoleui/prompt/CheckboxPromptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/test/java/org/jline/consoleui/prompt/ExpandableChoicePromptTest.java
+++ b/console-ui/src/test/java/org/jline/consoleui/prompt/ExpandableChoicePromptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console-ui/src/test/java/org/jline/consoleui/prompt/PromptBuilderTest.java
+++ b/console-ui/src/test/java/org/jline/consoleui/prompt/PromptBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/ArgDesc.java
+++ b/console/src/main/java/org/jline/console/ArgDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/CmdDesc.java
+++ b/console/src/main/java/org/jline/console/CmdDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/CmdLine.java
+++ b/console/src/main/java/org/jline/console/CmdLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/CommandInput.java
+++ b/console/src/main/java/org/jline/console/CommandInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/CommandMethods.java
+++ b/console/src/main/java/org/jline/console/CommandMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/CommandRegistry.java
+++ b/console/src/main/java/org/jline/console/CommandRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/ConsoleEngine.java
+++ b/console/src/main/java/org/jline/console/ConsoleEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/Printer.java
+++ b/console/src/main/java/org/jline/console/Printer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/ScriptEngine.java
+++ b/console/src/main/java/org/jline/console/ScriptEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/SystemRegistry.java
+++ b/console/src/main/java/org/jline/console/SystemRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/AbstractCommandRegistry.java
+++ b/console/src/main/java/org/jline/console/impl/AbstractCommandRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/Builtins.java
+++ b/console/src/main/java/org/jline/console/impl/Builtins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/CommandGroupAdapter.java
+++ b/console/src/main/java/org/jline/console/impl/CommandGroupAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/CommandRegistryAdapter.java
+++ b/console/src/main/java/org/jline/console/impl/CommandRegistryAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/ConsoleDispatcherBuilder.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleDispatcherBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/ConsoleLineExpander.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleLineExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
+++ b/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/DescriptionAdapter.java
+++ b/console/src/main/java/org/jline/console/impl/DescriptionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/GogoCommandGroup.java
+++ b/console/src/main/java/org/jline/console/impl/GogoCommandGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/JlineCommandRegistry.java
+++ b/console/src/main/java/org/jline/console/impl/JlineCommandRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/SimpleSystemRegistryImpl.java
+++ b/console/src/main/java/org/jline/console/impl/SimpleSystemRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/SystemHighlighter.java
+++ b/console/src/main/java/org/jline/console/impl/SystemHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
+++ b/console/src/main/java/org/jline/console/impl/SystemRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/widget/AutopairWidgets.java
+++ b/console/src/main/java/org/jline/widget/AutopairWidgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/widget/AutosuggestionWidgets.java
+++ b/console/src/main/java/org/jline/widget/AutosuggestionWidgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/widget/TailTipWidgets.java
+++ b/console/src/main/java/org/jline/widget/TailTipWidgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/main/java/org/jline/widget/Widgets.java
+++ b/console/src/main/java/org/jline/widget/Widgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/test/java/org/jline/console/impl/SystemRegistryImplTest.java
+++ b/console/src/test/java/org/jline/console/impl/SystemRegistryImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/test/java/org/jline/example/Console.java
+++ b/console/src/test/java/org/jline/example/Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/console/src/test/java/org/jline/widget/TailTipWidgetsTest.java
+++ b/console/src/test/java/org/jline/widget/TailTipWidgetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/apache/felix/gogo/jline/Posix.java
+++ b/demo/src/main/java/org/apache/felix/gogo/jline/Posix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
+++ b/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/apache/felix/gogo/runtime/Reflective.java
+++ b/demo/src/main/java/org/apache/felix/gogo/runtime/Reflective.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/FunctionConverter.java
+++ b/demo/src/main/java/org/jline/demo/FunctionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/Gogo.java
+++ b/demo/src/main/java/org/jline/demo/Gogo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/Launcher.java
+++ b/demo/src/main/java/org/jline/demo/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/PasswordMaskingDemo.java
+++ b/demo/src/main/java/org/jline/demo/PasswordMaskingDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/Repl.java
+++ b/demo/src/main/java/org/jline/demo/Repl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/consoleui/BasicDynamic.java
+++ b/demo/src/main/java/org/jline/demo/consoleui/BasicDynamic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/AggregateCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AggregateCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ArchitectureExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ArchitectureExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ArgumentCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ArgumentCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/AsyncInputExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AsyncInputExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/AttributedStringBasicsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AttributedStringBasicsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/AttributedStringBuilderExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AttributedStringBuilderExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/AttributedStringExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AttributedStringExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/AttributedStyleExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AttributedStyleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/AutoIndentationExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AutoIndentationExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/AutopairWidgetsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AutopairWidgetsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/AutosuggestionWidgetsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AutosuggestionWidgetsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/BasicCompletionExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/BasicCompletionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/BasicHighlighterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/BasicHighlighterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/BasicStylingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/BasicStylingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/BuiltinWidgetsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/BuiltinWidgetsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/BuiltinsTreeCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/BuiltinsTreeCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CallWidgetExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CallWidgetExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CandidatesWithDescriptionsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CandidatesWithDescriptionsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ColoredCompleter.java
+++ b/demo/src/main/java/org/jline/demo/examples/ColoredCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CommonsCliJLineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CommonsCliJLineExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CompletionBehaviorExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CompletionBehaviorExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ConsoleScriptExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ConsoleScriptExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ConsoleUIExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ConsoleUIExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ContextAwareCompleter.java
+++ b/demo/src/main/java/org/jline/demo/examples/ContextAwareCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ControlCharsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ControlCharsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CursorMovementExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CursorMovementExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CustomCompleter.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CustomKeyBindingsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomKeyBindingsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CustomPromptExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomPromptExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CustomTerminalBehaviorExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomTerminalBehaviorExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CustomWidgetExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomWidgetExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CustomWidgetsClassExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomWidgetsClassExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/CustomWidgetsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomWidgetsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/DirectoriesCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/DirectoriesCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/DisplayAttributedStringExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/DisplayAttributedStringExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/DisplayExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/DisplayExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/DumbTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/DumbTerminalExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/DynamicStatusExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/DynamicStatusExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/EditingModesExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/EditingModesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/EnumCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/EnumCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ErrorHighlightingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ErrorHighlightingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ExecTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ExecTerminalExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/FfmTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/FfmTerminalExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/FileNameCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/FileNameCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/FileOperationsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/FileOperationsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/FilesCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/FilesCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/GroovyScriptExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/GroovyScriptExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/HighlighterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HighlighterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/HistoryExpansionExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HistoryExpansionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/HistoryFilteringExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HistoryFilteringExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/HistorySearchExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HistorySearchExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/HistorySetupExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HistorySetupExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/HistorySizeExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HistorySizeExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/InputFlagsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/InputFlagsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/JCommanderJLineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/JCommanderJLineExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/JLineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/JLineExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/JniTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/JniTerminalExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/KeyBindingBasicsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/KeyBindingBasicsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/KeyBindingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/KeyBindingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/KeyMapsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/KeyMapsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/KeywordHighlighterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/KeywordHighlighterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/LineClearingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/LineClearingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/LineReaderCreationExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/LineReaderCreationExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/LineReaderExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/LineReaderExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/LineReaderInputExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/LineReaderInputExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/LineReaderMouseExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/LineReaderMouseExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/LineReaderOptionsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/LineReaderOptionsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/MouseEventHandlingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MouseEventHandlingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/MouseInteractiveUIExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MouseInteractiveUIExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/MouseSupportBasicsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MouseSupportBasicsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/MouseTrackingModesExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MouseTrackingModesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/MultiLineInputExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MultiLineInputExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/MultiSegmentStatusExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MultiSegmentStatusExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/NanoEditorExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/NanoEditorExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/NanoLessCustomizationExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/NanoLessCustomizationExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/NonBlockingLineReaderExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/NonBlockingLineReaderExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/NonBlockingReaderExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/NonBlockingReaderExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/NullCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/NullCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/OutputFlagsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/OutputFlagsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PartialScreenClearingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PartialScreenClearingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PersistentHistoryExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PersistentHistoryExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PicocliCompletionExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PicocliCompletionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PicocliJLineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PicocliJLineExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PosixCommandsRegistryExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PosixCommandsRegistryExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PrintAboveExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PrintAboveExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PrintAboveWriterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PrintAboveWriterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ProgrammaticHistoryAccessExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ProgrammaticHistoryAccessExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ProgressBarExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ProgressBarExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptBasicExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptBasicExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptBestPracticesExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptBestPracticesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptCheckboxExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptCheckboxExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptChoiceExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptChoiceExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptConfigExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptConfigExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptConfirmExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptConfirmExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptDisabledItemsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptDisabledItemsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptDynamicExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptDynamicExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptEditorExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptEditorExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptErrorHandlingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptErrorHandlingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptInputExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptInputExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptKeyPressExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptKeyPressExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptListExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptListExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptMixedTypesExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptMixedTypesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptMultiColumnExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptMultiColumnExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptNumberExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptNumberExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptPasswordExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptPasswordExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptPreCheckedExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptPreCheckedExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptSearchExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptSearchExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/PromptToggleExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptToggleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ProviderSelectionExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ProviderSelectionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/RawModeExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/RawModeExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/RegexCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/RegexCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/RemoteTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/RemoteTerminalExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ReplConsoleExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ReplConsoleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ResponsiveUIExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ResponsiveUIExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ScreenClearingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ScreenClearingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ShellAliasExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellAliasExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ShellBuilderExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellBuilderExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ShellCommandExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellCommandExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ShellSimpleExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellSimpleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/SimpleLineReadingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SimpleLineReadingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/SpringShellJLineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SpringShellJLineExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/StatusExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/StatusExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/StatusMessageExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/StatusMessageExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/StringsCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/StringsCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/StyleExpressionExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/StyleExpressionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/StyleResolverExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/StyleResolverExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/StylerExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/StylerExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/SwingTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SwingTerminalExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/SyntaxHighlighterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SyntaxHighlighterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/SystemCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SystemCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/SystemRegistryExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SystemRegistryExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TabCompletionExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TabCompletionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TailTipWidgetsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TailTipWidgetsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalAttributesExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalAttributesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalCapabilitiesExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalCapabilitiesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalColorsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalColorsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalCreationExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalCreationExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalCursorExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalCursorExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalGraphicsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalGraphicsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalInputExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalInputExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalModesExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalModesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalOutputExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalOutputExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalSignalsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalSignalsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalSizeExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalSizeExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TerminalSizeHandlingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalSizeHandlingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/ThemeSystemExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ThemeSystemExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TimeoutReadExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TimeoutReadExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/TreeCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TreeCompleterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/UnicodeInputExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/UnicodeInputExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/UnicodeOutputExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/UnicodeOutputExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/WebTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/WebTerminalExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/demo/src/main/java/org/jline/demo/examples/WidgetChainExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/WidgetChainExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/graal/src/main/java/org/jline/demo/graal/Graal.java
+++ b/graal/src/main/java/org/jline/demo/graal/Graal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/groovy/src/main/java/org/jline/script/GroovyCommand.java
+++ b/groovy/src/main/java/org/jline/script/GroovyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/groovy/src/main/java/org/jline/script/GroovyEngine.java
+++ b/groovy/src/main/java/org/jline/script/GroovyEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2022, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/groovy/src/main/java/org/jline/script/JrtJavaBasePackages.java
+++ b/groovy/src/main/java/org/jline/script/JrtJavaBasePackages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/groovy/src/main/java/org/jline/script/PackageHelper.java
+++ b/groovy/src/main/java/org/jline/script/PackageHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/Ansi.java
+++ b/jansi-core/src/main/java/org/jline/jansi/Ansi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiColors.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiColors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiMain.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiMode.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiPrintStream.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiPrintStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiRenderer.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiType.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/io/AnsiOutputStream.java
+++ b/jansi-core/src/main/java/org/jline/jansi/io/AnsiOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/io/AnsiProcessor.java
+++ b/jansi-core/src/main/java/org/jline/jansi/io/AnsiProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/io/Colors.java
+++ b/jansi-core/src/main/java/org/jline/jansi/io/Colors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/io/ColorsAnsiProcessor.java
+++ b/jansi-core/src/main/java/org/jline/jansi/io/ColorsAnsiProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/io/FastBufferedOutputStream.java
+++ b/jansi-core/src/main/java/org/jline/jansi/io/FastBufferedOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/main/java/org/jline/jansi/io/WindowsAnsiProcessor.java
+++ b/jansi-core/src/main/java/org/jline/jansi/io/WindowsAnsiProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/test/java/org/jline/jansi/AnsiConsoleExample.java
+++ b/jansi-core/src/test/java/org/jline/jansi/AnsiConsoleExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/test/java/org/jline/jansi/AnsiConsoleExample2.java
+++ b/jansi-core/src/test/java/org/jline/jansi/AnsiConsoleExample2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/test/java/org/jline/jansi/AnsiRendererTest.java
+++ b/jansi-core/src/test/java/org/jline/jansi/AnsiRendererTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/test/java/org/jline/jansi/AnsiStringTest.java
+++ b/jansi-core/src/test/java/org/jline/jansi/AnsiStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/test/java/org/jline/jansi/AnsiTest.java
+++ b/jansi-core/src/test/java/org/jline/jansi/AnsiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/test/java/org/jline/jansi/EncodingTest.java
+++ b/jansi-core/src/test/java/org/jline/jansi/EncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/test/java/org/jline/jansi/InstallUninstallTest.java
+++ b/jansi-core/src/test/java/org/jline/jansi/InstallUninstallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/jansi-core/src/test/java/org/jline/jansi/io/AnsiOutputStreamTest.java
+++ b/jansi-core/src/test/java/org/jline/jansi/io/AnsiOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/native/src/main/java/org/jline/nativ/CLibrary.java
+++ b/native/src/main/java/org/jline/nativ/CLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/native/src/main/java/org/jline/nativ/JLineLibrary.java
+++ b/native/src/main/java/org/jline/nativ/JLineLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
+++ b/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/native/src/main/java/org/jline/nativ/Kernel32.java
+++ b/native/src/main/java/org/jline/nativ/Kernel32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/native/src/main/java/org/jline/nativ/OSInfo.java
+++ b/native/src/main/java/org/jline/nativ/OSInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/native/src/test/java/org/jline/nativ/JLineLibraryTest.java
+++ b/native/src/test/java/org/jline/nativ/JLineLibraryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/native/src/test/java/org/jline/nativ/JLineNativeLoaderTest.java
+++ b/native/src/test/java/org/jline/nativ/JLineNativeLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/picocli/src/main/java/org/jline/picocli/PicocliCommandRegistry.java
+++ b/picocli/src/main/java/org/jline/picocli/PicocliCommandRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/picocli/src/test/java/org/jline/picocli/PicocliCommandRegistryTest.java
+++ b/picocli/src/test/java/org/jline/picocli/PicocliCommandRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
                             <removeUnusedImports />
                             <licenseHeader>
                                 <content>/*
- * Copyright (c) $YEAR, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/BaseBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/BaseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/CheckboxBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/CheckboxBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/CheckboxItem.java
+++ b/prompt/src/main/java/org/jline/prompt/CheckboxItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/CheckboxPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/CheckboxPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/CheckboxResult.java
+++ b/prompt/src/main/java/org/jline/prompt/CheckboxResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/CheckboxSeparatorBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/CheckboxSeparatorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ChoiceBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/ChoiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ChoiceItem.java
+++ b/prompt/src/main/java/org/jline/prompt/ChoiceItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ChoicePrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/ChoicePrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ChoiceResult.java
+++ b/prompt/src/main/java/org/jline/prompt/ChoiceResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ConfirmBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/ConfirmBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ConfirmItem.java
+++ b/prompt/src/main/java/org/jline/prompt/ConfirmItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ConfirmPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/ConfirmPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ConfirmResult.java
+++ b/prompt/src/main/java/org/jline/prompt/ConfirmResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/DynamicPromptHelper.java
+++ b/prompt/src/main/java/org/jline/prompt/DynamicPromptHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/EditorBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/EditorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/EditorPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/EditorPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/EditorResult.java
+++ b/prompt/src/main/java/org/jline/prompt/EditorResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/InputBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/InputBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/InputPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/InputPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/InputResult.java
+++ b/prompt/src/main/java/org/jline/prompt/InputResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/KeyPressBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/KeyPressBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/KeyPressPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/KeyPressPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/KeyPressResult.java
+++ b/prompt/src/main/java/org/jline/prompt/KeyPressResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ListBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/ListBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ListItem.java
+++ b/prompt/src/main/java/org/jline/prompt/ListItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ListPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/ListPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ListResult.java
+++ b/prompt/src/main/java/org/jline/prompt/ListResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ListSeparatorBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/ListSeparatorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/NoResult.java
+++ b/prompt/src/main/java/org/jline/prompt/NoResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/NumberBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/NumberBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/NumberPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/NumberPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/PasswordBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/PasswordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/PasswordPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/PasswordPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/Prompt.java
+++ b/prompt/src/main/java/org/jline/prompt/Prompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/PromptBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/PromptBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/PromptCommands.java
+++ b/prompt/src/main/java/org/jline/prompt/PromptCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/PromptItem.java
+++ b/prompt/src/main/java/org/jline/prompt/PromptItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/PromptResult.java
+++ b/prompt/src/main/java/org/jline/prompt/PromptResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/Prompter.java
+++ b/prompt/src/main/java/org/jline/prompt/Prompter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/PrompterConfig.java
+++ b/prompt/src/main/java/org/jline/prompt/PrompterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/PrompterFactory.java
+++ b/prompt/src/main/java/org/jline/prompt/PrompterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/SearchBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/SearchBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/SearchPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/SearchPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/SearchResult.java
+++ b/prompt/src/main/java/org/jline/prompt/SearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/SeparatorItem.java
+++ b/prompt/src/main/java/org/jline/prompt/SeparatorItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/TextBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/TextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/TextPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/TextPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ToggleBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/ToggleBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/TogglePrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/TogglePrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/ToggleResult.java
+++ b/prompt/src/main/java/org/jline/prompt/ToggleResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/examples/DynamicPromptExample.java
+++ b/prompt/src/main/java/org/jline/prompt/examples/DynamicPromptExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/examples/ImprovedDynamicPromptExample.java
+++ b/prompt/src/main/java/org/jline/prompt/examples/ImprovedDynamicPromptExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/examples/PromptCommandExample.java
+++ b/prompt/src/main/java/org/jline/prompt/examples/PromptCommandExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/AbstractPromptResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/AbstractPromptResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxItem.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxSeparatorBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxSeparatorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultChoiceBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultChoiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultChoiceItem.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultChoiceItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultChoicePrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultChoicePrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultChoiceResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultChoiceResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultConfirmBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultConfirmBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultConfirmPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultConfirmPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultConfirmResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultConfirmResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultEditorBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultEditorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultEditorPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultEditorPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultEditorResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultEditorResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultInputBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultInputBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultInputPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultInputPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultInputResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultInputResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultKeyPressBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultKeyPressBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultKeyPressPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultKeyPressPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultKeyPressResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultKeyPressResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultListBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultListBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultListItem.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultListItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultListPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultListPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultListResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultListResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultListSeparatorBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultListSeparatorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultNoResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultNoResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultNumberBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultNumberBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultNumberPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultNumberPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPasswordBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPasswordBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPasswordPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPasswordPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPromptBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPromptBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompterConfig.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultSearchBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultSearchBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultSearchPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultSearchPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultSearchResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultSearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultSeparatorItem.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultSeparatorItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultTextBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultTextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultTextPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultTextPrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultToggleBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultToggleBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultTogglePrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultTogglePrompt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultToggleResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultToggleResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/ApiTest.java
+++ b/prompt/src/test/java/org/jline/prompt/ApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/BuilderPatternsTest.java
+++ b/prompt/src/test/java/org/jline/prompt/BuilderPatternsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/DefaultPrompterTest.java
+++ b/prompt/src/test/java/org/jline/prompt/DefaultPrompterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/DynamicPromptTest.java
+++ b/prompt/src/test/java/org/jline/prompt/DynamicPromptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/IntegrationTest.java
+++ b/prompt/src/test/java/org/jline/prompt/IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/PromptCommandsTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PromptCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/PrompterExecutionTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PrompterExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/PrompterListExecutionTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PrompterListExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/examples/ConvenienceMethodsExample.java
+++ b/prompt/src/test/java/org/jline/prompt/examples/ConvenienceMethodsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/prompt/src/test/java/org/jline/prompt/examples/NewApiExample.java
+++ b/prompt/src/test/java/org/jline/prompt/examples/NewApiExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/keymap/BindingReader.java
+++ b/reader/src/main/java/org/jline/keymap/BindingReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/keymap/KeyMap.java
+++ b/reader/src/main/java/org/jline/keymap/KeyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Binding.java
+++ b/reader/src/main/java/org/jline/reader/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Buffer.java
+++ b/reader/src/main/java/org/jline/reader/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Candidate.java
+++ b/reader/src/main/java/org/jline/reader/Candidate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Completer.java
+++ b/reader/src/main/java/org/jline/reader/Completer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/CompletingParsedLine.java
+++ b/reader/src/main/java/org/jline/reader/CompletingParsedLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/CompletionMatcher.java
+++ b/reader/src/main/java/org/jline/reader/CompletionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/EOFError.java
+++ b/reader/src/main/java/org/jline/reader/EOFError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Editor.java
+++ b/reader/src/main/java/org/jline/reader/Editor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/EndOfFileException.java
+++ b/reader/src/main/java/org/jline/reader/EndOfFileException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Expander.java
+++ b/reader/src/main/java/org/jline/reader/Expander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Highlighter.java
+++ b/reader/src/main/java/org/jline/reader/Highlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/History.java
+++ b/reader/src/main/java/org/jline/reader/History.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/LineReaderBuilder.java
+++ b/reader/src/main/java/org/jline/reader/LineReaderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Macro.java
+++ b/reader/src/main/java/org/jline/reader/Macro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/MaskingCallback.java
+++ b/reader/src/main/java/org/jline/reader/MaskingCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/ParsedLine.java
+++ b/reader/src/main/java/org/jline/reader/ParsedLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Parser.java
+++ b/reader/src/main/java/org/jline/reader/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/PrintAboveWriter.java
+++ b/reader/src/main/java/org/jline/reader/PrintAboveWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Reference.java
+++ b/reader/src/main/java/org/jline/reader/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/SyntaxError.java
+++ b/reader/src/main/java/org/jline/reader/SyntaxError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/UserInterruptException.java
+++ b/reader/src/main/java/org/jline/reader/UserInterruptException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/Widget.java
+++ b/reader/src/main/java/org/jline/reader/Widget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/BufferImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/BufferImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/CompletionMatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/DefaultExpander.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/DefaultHighlighter.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/InputRC.java
+++ b/reader/src/main/java/org/jline/reader/impl/InputRC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/KillRing.java
+++ b/reader/src/main/java/org/jline/reader/impl/KillRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/ReaderUtils.java
+++ b/reader/src/main/java/org/jline/reader/impl/ReaderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/SimpleMaskingCallback.java
+++ b/reader/src/main/java/org/jline/reader/impl/SimpleMaskingCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/UndoTree.java
+++ b/reader/src/main/java/org/jline/reader/impl/UndoTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/completer/AggregateCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/AggregateCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/completer/ArgumentCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/ArgumentCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/completer/EnumCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/EnumCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/completer/NullCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/NullCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/completer/StringsCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/StringsCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/completer/SystemCompleter.java
+++ b/reader/src/main/java/org/jline/reader/impl/completer/SystemCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/keymap/BindingReaderTest.java
+++ b/reader/src/test/java/org/jline/keymap/BindingReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/keymap/KeyMapTest.java
+++ b/reader/src/test/java/org/jline/keymap/KeyMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/LineReaderBuilderTest.java
+++ b/reader/src/test/java/org/jline/reader/LineReaderBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/completer/ArgumentCompleterTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/ArgumentCompleterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/DefaultParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/completer/NullCompleterTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/NullCompleterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/completer/StringsCompleterTest.java
+++ b/reader/src/test/java/org/jline/reader/completer/StringsCompleterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/BufferTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/BufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/CandidateCustomSortTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CandidateCustomSortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/ColonCommandCompletionTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/ColonCommandCompletionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/CompletionMatcherTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/CompletionWithCustomMatcherTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionWithCustomMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/CompletionWithParserTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionWithParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/DefaultParserTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/DefaultParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/DigitArgumentTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/DigitArgumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/DumbTerminalPasswordTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/DumbTerminalPasswordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/EditLineTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/EditLineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/HistorySearchTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/HistorySearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/KillRingTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/KillRingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/MultiByteCharTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/MultiByteCharTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/ReaderTestSupport.java
+++ b/reader/src/test/java/org/jline/reader/impl/ReaderTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/SystemOptionsTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/SystemOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/ViMoveModeTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/ViMoveModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/WidgetTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/WidgetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/history/DefaultHistoryInvalidEntriesTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/DefaultHistoryInvalidEntriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/history/HistoryReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/HistoryReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/history/HistoryTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/HistoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellCommand.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-ssh/src/test/java/org/jline/builtins/ssh/SshdTest.java
+++ b/remote-ssh/src/test/java/org/jline/builtins/ssh/SshdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/Connection.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionData.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionEvent.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionFilter.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionListener.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/PortListener.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/PortListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/Telnet.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/Telnet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/AliasManager.java
+++ b/shell/src/main/java/org/jline/shell/AliasManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/ArgumentDescription.java
+++ b/shell/src/main/java/org/jline/shell/ArgumentDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/Command.java
+++ b/shell/src/main/java/org/jline/shell/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/CommandDescription.java
+++ b/shell/src/main/java/org/jline/shell/CommandDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/CommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/CommandDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/CommandGroup.java
+++ b/shell/src/main/java/org/jline/shell/CommandGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/CommandLine.java
+++ b/shell/src/main/java/org/jline/shell/CommandLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/CommandSession.java
+++ b/shell/src/main/java/org/jline/shell/CommandSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/Job.java
+++ b/shell/src/main/java/org/jline/shell/Job.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/JobListener.java
+++ b/shell/src/main/java/org/jline/shell/JobListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/JobManager.java
+++ b/shell/src/main/java/org/jline/shell/JobManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/LineExpander.java
+++ b/shell/src/main/java/org/jline/shell/LineExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/Pipeline.java
+++ b/shell/src/main/java/org/jline/shell/Pipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/PipelineBuilder.java
+++ b/shell/src/main/java/org/jline/shell/PipelineBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/ScriptRunner.java
+++ b/shell/src/main/java/org/jline/shell/ScriptRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/Shell.java
+++ b/shell/src/main/java/org/jline/shell/Shell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/ShellBuilder.java
+++ b/shell/src/main/java/org/jline/shell/ShellBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/AbstractCommand.java
+++ b/shell/src/main/java/org/jline/shell/impl/AbstractCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/AliasCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/AliasCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/CommandHighlighter.java
+++ b/shell/src/main/java/org/jline/shell/impl/CommandHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/DefaultAliasManager.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultAliasManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/DefaultJob.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/DefaultJobManager.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultJobManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/DefaultLineExpander.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultLineExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/DefaultPipeline.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/DefaultScriptRunner.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultScriptRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/HelpCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/HelpCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/HistoryCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/HistoryCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/JobCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/JobCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/OptionCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/OptionCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/PipelineParser.java
+++ b/shell/src/main/java/org/jline/shell/impl/PipelineParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/ScriptCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/ScriptCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/SimpleCommandGroup.java
+++ b/shell/src/main/java/org/jline/shell/impl/SimpleCommandGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/impl/VariableCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/VariableCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/widget/AutopairWidgets.java
+++ b/shell/src/main/java/org/jline/shell/widget/AutopairWidgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/main/java/org/jline/shell/widget/CommandTailTipWidgets.java
+++ b/shell/src/main/java/org/jline/shell/widget/CommandTailTipWidgets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/ArgumentDescriptionTest.java
+++ b/shell/src/test/java/org/jline/shell/ArgumentDescriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/CommandDescriptionTest.java
+++ b/shell/src/test/java/org/jline/shell/CommandDescriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/CommandLineTest.java
+++ b/shell/src/test/java/org/jline/shell/CommandLineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/ShellBuilderTest.java
+++ b/shell/src/test/java/org/jline/shell/ShellBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/AliasCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/AliasCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/CommandHighlighterTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/CommandHighlighterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/DefaultAliasManagerTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultAliasManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/DefaultJobManagerTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultJobManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/DefaultLineExpanderTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultLineExpanderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/HelpCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/HelpCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/HistoryCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/HistoryCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/OptionCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/OptionCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/PipelineParserTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/PipelineParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/SimpleCommandGroupTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SimpleCommandGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/SubcommandTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SubcommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/InterpolationHelper.java
+++ b/style/src/main/java/org/jline/style/InterpolationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/MemoryStyleSource.java
+++ b/style/src/main/java/org/jline/style/MemoryStyleSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/NopStyleSource.java
+++ b/style/src/main/java/org/jline/style/NopStyleSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/StyleBundle.java
+++ b/style/src/main/java/org/jline/style/StyleBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/StyleBundleInvocationHandler.java
+++ b/style/src/main/java/org/jline/style/StyleBundleInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/StyleExpression.java
+++ b/style/src/main/java/org/jline/style/StyleExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/StyleFactory.java
+++ b/style/src/main/java/org/jline/style/StyleFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/StyleResolver.java
+++ b/style/src/main/java/org/jline/style/StyleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/StyleSource.java
+++ b/style/src/main/java/org/jline/style/StyleSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/StyledWriter.java
+++ b/style/src/main/java/org/jline/style/StyledWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/main/java/org/jline/style/Styler.java
+++ b/style/src/main/java/org/jline/style/Styler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/test/java/org/jline/style/StyleBundleInvocationHandlerTest.java
+++ b/style/src/test/java/org/jline/style/StyleBundleInvocationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/test/java/org/jline/style/StyleExpressionTest.java
+++ b/style/src/test/java/org/jline/style/StyleExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/test/java/org/jline/style/StyleFactoryTest.java
+++ b/style/src/test/java/org/jline/style/StyleFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/test/java/org/jline/style/StyleResolverTest.java
+++ b/style/src/test/java/org/jline/style/StyleResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/style/src/test/java/org/jline/style/StyleTestSupport.java
+++ b/style/src/test/java/org/jline/style/StyleTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmNativePty.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmNativePty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinConsoleWriter.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinConsoleWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/WindowsAnsiWriter.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/WindowsAnsiWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
+++ b/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniNativePty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/freebsd/FreeBsdNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/freebsd/FreeBsdNativePty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/linux/LinuxNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/linux/LinuxNativePty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/osx/OsXNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/osx/OsXNativePty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/solaris/SolarisNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/solaris/SolarisNativePty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinConsoleWriter.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinConsoleWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2020, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/WindowsAnsiWriter.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/WindowsAnsiWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal-jni/src/test/java/org/jline/terminal/impl/jni/JniTerminalProviderTest.java
+++ b/terminal-jni/src/test/java/org/jline/terminal/impl/jni/JniTerminalProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2021, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/Attributes.java
+++ b/terminal/src/main/java/org/jline/terminal/Attributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/Cursor.java
+++ b/terminal/src/main/java/org/jline/terminal/Cursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/KeyEvent.java
+++ b/terminal/src/main/java/org/jline/terminal/KeyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/KeyParser.java
+++ b/terminal/src/main/java/org/jline/terminal/KeyParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/MouseEvent.java
+++ b/terminal/src/main/java/org/jline/terminal/MouseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/Size.java
+++ b/terminal/src/main/java/org/jline/terminal/Size.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsConsoleWriter.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsConsoleWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/CursorSupport.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/CursorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/Diag.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/Diag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/DoubleSizeCharacters.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DoubleSizeCharacters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/DumbTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DumbTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/ITerm2Graphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ITerm2Graphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/KittyGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/KittyGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/MouseSupport.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/MouseSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/NativeSignalHandler.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/NativeSignalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/TerminalGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/TerminalGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/TerminalGraphicsManager.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/TerminalGraphicsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecPty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/spi/Pty.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/Pty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/spi/SystemStream.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/SystemStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalExt.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/AnsiWriter.java
+++ b/terminal/src/main/java/org/jline/utils/AnsiWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/AttributedString.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/AttributedStyle.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/ClosedException.java
+++ b/terminal/src/main/java/org/jline/utils/ClosedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/ColorPalette.java
+++ b/terminal/src/main/java/org/jline/utils/ColorPalette.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/Colors.java
+++ b/terminal/src/main/java/org/jline/utils/Colors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/Curses.java
+++ b/terminal/src/main/java/org/jline/utils/Curses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/DiffHelper.java
+++ b/terminal/src/main/java/org/jline/utils/DiffHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/ExecHelper.java
+++ b/terminal/src/main/java/org/jline/utils/ExecHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/FastBufferedOutputStream.java
+++ b/terminal/src/main/java/org/jline/utils/FastBufferedOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/InfoCmp.java
+++ b/terminal/src/main/java/org/jline/utils/InfoCmp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/InputStreamReader.java
+++ b/terminal/src/main/java/org/jline/utils/InputStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/Levenshtein.java
+++ b/terminal/src/main/java/org/jline/utils/Levenshtein.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/Log.java
+++ b/terminal/src/main/java/org/jline/utils/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlocking.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlocking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReader.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/OSUtils.java
+++ b/terminal/src/main/java/org/jline/utils/OSUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/PumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/PumpReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/ShutdownHooks.java
+++ b/terminal/src/main/java/org/jline/utils/ShutdownHooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/Signals.java
+++ b/terminal/src/main/java/org/jline/utils/Signals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/StyleResolver.java
+++ b/terminal/src/main/java/org/jline/utils/StyleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/Timeout.java
+++ b/terminal/src/main/java/org/jline/utils/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/WCWidth.java
+++ b/terminal/src/main/java/org/jline/utils/WCWidth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/main/java/org/jline/utils/WriterOutputStream.java
+++ b/terminal/src/main/java/org/jline/utils/WriterOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/EncodingTest.java
+++ b/terminal/src/test/java/org/jline/terminal/EncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/MultiEncodingTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/MultiEncodingTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/SystemOutCloseTest.java
+++ b/terminal/src/test/java/org/jline/terminal/SystemOutCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/AbstractPtyTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/AbstractPtyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/AbstractWindowsTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/DoubleSizeCharactersTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/DoubleSizeCharactersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/HeldStreamReferenceTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/HeldStreamReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/SixelGraphicsTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/SixelGraphicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/StreamClosureDemonstration.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/StreamClosureDemonstration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/StrictCloseTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/StrictCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/TerminalGraphicsTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/TerminalGraphicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/exec/ExecPtyTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/exec/ExecPtyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/AttributedStringBuilderTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/ColorPaletteTest.java
+++ b/terminal/src/test/java/org/jline/utils/ColorPaletteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/ColorsTest.java
+++ b/terminal/src/test/java/org/jline/utils/ColorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/CursesTest.java
+++ b/terminal/src/test/java/org/jline/utils/CursesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
+++ b/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/NonBlockingEncodingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2024, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/PumpReaderTest.java
+++ b/terminal/src/test/java/org/jline/utils/PumpReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/ScreenTerminal.java
+++ b/terminal/src/test/java/org/jline/utils/ScreenTerminal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/StatusTest.java
+++ b/terminal/src/test/java/org/jline/utils/StatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/WriterOutputStreamTest.java
+++ b/terminal/src/test/java/org/jline/utils/WriterOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2025, the original author(s).
+ * Copyright (c) the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.


### PR DESCRIPTION
## Summary

- Remove year/year-range from all Java copyright headers (712 files)
- Update the Spotless license header template in `pom.xml` to no longer include `$YEAR`

The git history already tracks authorship dates. Removing years avoids unnecessary churn when files are modified in a new calendar year.

## Before

```java
/*
 * Copyright (c) 2002-2025, the original author(s).
 * ...
 */
```

## After

```java
/*
 * Copyright (c) the original author(s).
 * ...
 */
```

## Test plan

- [x] `./mvx mvn spotless:apply` applies cleanly with no further changes
- [x] `./mvx mvn spotless:check` passes