### PR TITLE
Fix doubled quotes when completing quoted words with multiple candidates

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4733,8 +4733,8 @@ public class LineReaderImpl implements LineReader, Flushable {
             }
 
             if (useMenu) {
-                buf.move(line.word().length() - line.wordCursor());
-                buf.backspace(line.word().length());
+                buf.move(line.rawWordLength() - line.rawWordCursor());
+                buf.backspace(line.rawWordLength());
                 doMenu(possible, line.word(), line::escape);
                 return true;
             }
@@ -4752,9 +4752,13 @@ public class LineReaderImpl implements LineReader, Flushable {
             String commonPrefix = completionMatcher.getCommonPrefix();
             boolean hasUnambiguous = commonPrefix.startsWith(current) && !commonPrefix.equals(current);
 
+            // Track raw length in buffer for correct backspace when entering menu
+            int rawLen = line.rawWordLength();
             if (hasUnambiguous) {
-                buf.backspace(line.rawWordLength());
-                buf.write(line.escape(commonPrefix, false));
+                buf.backspace(rawLen);
+                CharSequence escaped = line.escape(commonPrefix, false);
+                buf.write(escaped.toString());
+                rawLen = escaped.length();
                 callWidget(REDISPLAY);
                 current = commonPrefix;
                 if ((!isSet(Option.AUTO_LIST) && isSet(Option.AUTO_MENU))
@@ -4770,7 +4774,7 @@ public class LineReaderImpl implements LineReader, Flushable {
                 }
             }
             if (isSet(Option.AUTO_MENU)) {
-                buf.backspace(current.length());
+                buf.backspace(rawLen);
                 doMenu(possible, line.word(), line::escape);
             }
             return true;

--- a/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
@@ -33,6 +33,27 @@ public class CompletionTest extends ReaderTestSupport {
     }
 
     @Test
+    public void testCompleteQuotedWithMultipleCandidates() throws IOException {
+        // Test MENU_COMPLETE with quoted input and multiple candidates
+        reader.setCompleter(new StringsCompleter("Example1", "Example2"));
+        reader.setOpt(Option.MENU_COMPLETE);
+        // Typing "Ex then Tab should produce "Example1" (not ""Example1")
+        assertBuffer("\"Example1\"", new TestBuffer("\"Ex\t"));
+    }
+
+    @Test
+    public void testCompleteQuotedAutoMenu() throws IOException {
+        // Test AUTO_MENU with quoted input and multiple candidates
+        reader.setCompleter(new StringsCompleter("Example1", "Example2"));
+        reader.unsetOpt(Option.MENU_COMPLETE);
+        reader.setOpt(Option.AUTO_LIST);
+        reader.setOpt(Option.AUTO_MENU);
+        // First tab completes common prefix, second tab enters menu
+        // Typing "Ex then Tab Tab should produce "Example1" (not ""Example1")
+        assertBuffer("\"Example1\"", new TestBuffer("\"Ex\t\t"));
+    }
+
+    @Test
     public void testListAndMenu() throws IOException {
         reader.setCompleter(new StringsCompleter("foo", "foobar"));
 


### PR DESCRIPTION
## Summary

- When typing `"Ex` then Tab with multiple candidates (e.g., `Example1`, `Example2`), the MENU_COMPLETE and AUTO_MENU paths used `word().length()` to backspace the buffer, which excluded the opening quote character
- The subsequent `escape()` call re-added the quote, producing `""Example1"` instead of `"Example1"`
- Fix: use `rawWordLength()` which correctly includes the opening quote

Fixes #1036

## Test plan

- [x] Added `testCompleteQuotedWithMultipleCandidates` — MENU_COMPLETE with quoted input
- [x] Added `testCompleteQuotedAutoMenu` — AUTO_MENU with quoted input
- [x] All existing CompletionTest tests pass
- [x] Full reader test suite passes