### PR TITLE
Fix WCWidth for BMP emoji with Emoji_Presentation=Yes

### DIFF
--- a/terminal/src/main/java/org/jline/utils/WCWidth.java
+++ b/terminal/src/main/java/org/jline/utils/WCWidth.java
@@ -79,6 +79,55 @@ public final class WCWidth {
         /* binary search in table of non-spacing characters */
         if (bisearch(ucs, combining, combining.length - 1)) return 0;
 
+        /* BMP characters with Emoji_Presentation=Yes (Unicode 16.0).
+         * These are rendered as 2 columns by modern terminal emulators
+         * but fall outside the East Asian Wide/Fullwidth categories.
+         * See https://unicode.org/Public/16.0.0/ucd/emoji/emoji-data.txt */
+        if (ucs == 0x231a
+                || ucs == 0x231b
+                || (ucs >= 0x23e9 && ucs <= 0x23ec)
+                || ucs == 0x23f0
+                || ucs == 0x23f3
+                || ucs == 0x25fd
+                || ucs == 0x25fe
+                || ucs == 0x2614
+                || ucs == 0x2615
+                || (ucs >= 0x2648 && ucs <= 0x2653)
+                || ucs == 0x267f
+                || ucs == 0x2693
+                || ucs == 0x26a1
+                || ucs == 0x26aa
+                || ucs == 0x26ab
+                || ucs == 0x26bd
+                || ucs == 0x26be
+                || ucs == 0x26c4
+                || ucs == 0x26c5
+                || ucs == 0x26ce
+                || ucs == 0x26d4
+                || ucs == 0x26ea
+                || ucs == 0x26f2
+                || ucs == 0x26f3
+                || ucs == 0x26f5
+                || ucs == 0x26fa
+                || ucs == 0x26fd
+                || ucs == 0x2705
+                || ucs == 0x270a
+                || ucs == 0x270b
+                || ucs == 0x2728
+                || ucs == 0x274c
+                || ucs == 0x274e
+                || (ucs >= 0x2753 && ucs <= 0x2755)
+                || ucs == 0x2757
+                || (ucs >= 0x2795 && ucs <= 0x2797)
+                || ucs == 0x27b0
+                || ucs == 0x27bf
+                || ucs == 0x2b1b
+                || ucs == 0x2b1c
+                || ucs == 0x2b50
+                || ucs == 0x2b55) {
+            return 2;
+        }
+
         /* if we arrive here, ucs is not a combining or C0/C1 control character */
         return 1
                 + ((ucs >= 0x1100

--- a/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
@@ -160,4 +160,62 @@ public class AttributedStringTest {
         messageLength = message.columnLength();
         assertEquals(12, messageLength);
     }
+
+    /**
+     * BMP characters with Emoji_Presentation=Yes should have column width 2.
+     * These are legacy Unicode characters (Dingbats, Miscellaneous Symbols, etc.)
+     * that modern terminals render as 2 columns wide.
+     * See https://github.com/jline/jline3/issues/1648
+     */
+    @Test
+    public void testBmpEmojiWidth() {
+        // SMP emoji (0x1F000+) — already handled
+        assertEquals(2, new AttributedString("\uD83D\uDE00").columnLength()); // 😀 U+1F600
+        assertEquals(2, new AttributedString("\uD83D\uDD34").columnLength()); // 🔴 U+1F534
+
+        // BMP Emoji_Presentation=Yes — Miscellaneous Technical
+        assertEquals(2, new AttributedString("\u231A").columnLength()); // ⌚ U+231A
+        assertEquals(2, new AttributedString("\u231B").columnLength()); // ⌛ U+231B
+        assertEquals(2, new AttributedString("\u23E9").columnLength()); // ⏩ U+23E9
+        assertEquals(2, new AttributedString("\u23F0").columnLength()); // ⏰ U+23F0
+        assertEquals(2, new AttributedString("\u23F3").columnLength()); // ⏳ U+23F3
+
+        // BMP Emoji_Presentation=Yes — Miscellaneous Symbols
+        assertEquals(2, new AttributedString("\u2614").columnLength()); // ☔ U+2614
+        assertEquals(2, new AttributedString("\u2615").columnLength()); // ☕ U+2615
+        assertEquals(2, new AttributedString("\u267F").columnLength()); // ♿ U+267F
+        assertEquals(2, new AttributedString("\u2693").columnLength()); // ⚓ U+2693
+        assertEquals(2, new AttributedString("\u26A1").columnLength()); // ⚡ U+26A1
+        assertEquals(2, new AttributedString("\u26BD").columnLength()); // ⚽ U+26BD
+        assertEquals(2, new AttributedString("\u26D4").columnLength()); // ⛔ U+26D4
+        assertEquals(2, new AttributedString("\u26FD").columnLength()); // ⛽ U+26FD
+
+        // BMP Emoji_Presentation=Yes — Dingbats
+        assertEquals(2, new AttributedString("\u2705").columnLength()); // ✅ U+2705
+        assertEquals(2, new AttributedString("\u270A").columnLength()); // ✊ U+270A
+        assertEquals(2, new AttributedString("\u2728").columnLength()); // ✨ U+2728
+        assertEquals(2, new AttributedString("\u274C").columnLength()); // ❌ U+274C
+        assertEquals(2, new AttributedString("\u274E").columnLength()); // ❎ U+274E
+        assertEquals(2, new AttributedString("\u2753").columnLength()); // ❓ U+2753
+        assertEquals(2, new AttributedString("\u2757").columnLength()); // ❗ U+2757
+        assertEquals(2, new AttributedString("\u2795").columnLength()); // ➕ U+2795
+
+        // BMP Emoji_Presentation=Yes — Miscellaneous Symbols and Arrows
+        assertEquals(2, new AttributedString("\u2B1B").columnLength()); // ⬛ U+2B1B
+        assertEquals(2, new AttributedString("\u2B50").columnLength()); // ⭐ U+2B50
+        assertEquals(2, new AttributedString("\u2B55").columnLength()); // ⭕ U+2B55
+
+        // Non-emoji neighbors should remain width 1
+        assertEquals(1, new AttributedString("\u2713").columnLength()); // ✓ U+2713
+        assertEquals(1, new AttributedString("\u2717").columnLength()); // ✗ U+2717
+        assertEquals(1, new AttributedString("\u274B").columnLength()); // ❋ U+274B
+        assertEquals(1, new AttributedString("\u2756").columnLength()); // ❖ U+2756
+
+        // Zodiac signs (Emoji_Presentation=Yes)
+        assertEquals(2, new AttributedString("\u2648").columnLength()); // ♈ U+2648
+        assertEquals(2, new AttributedString("\u2653").columnLength()); // ♓ U+2653
+
+        // Multiple BMP emoji in one string
+        assertEquals(4, new AttributedString("\u2705\u274C").columnLength()); // ✅❌
+    }
 }


### PR DESCRIPTION
## Summary

Characters like ✅ (U+2705), ❌ (U+274C), ☕ (U+2615), ⚡ (U+26A1), and ~60 others in the BMP have `Emoji_Presentation=Yes` per Unicode 16.0 and are rendered as 2 columns by modern terminal emulators. However, `WCWidth.wcwidth()` returned 1 for these since they fall outside the East Asian Wide/Fullwidth ranges.

The 2021 fix (b9ca72d, #683) added `0x1F000-0x1FEEE` but missed these BMP codepoints in the Dingbats, Miscellaneous Symbols, and Miscellaneous Technical blocks.

This causes `Display` in fullscreen mode to mistrack cursor positions, producing rendering artifacts (ghost characters, misaligned text) in any TUI application using emoji status indicators.

## Changes

- **WCWidth.java**: Add all BMP codepoints with `Emoji_Presentation=Yes` (per [emoji-data.txt](https://unicode.org/Public/16.0.0/ucd/emoji/emoji-data.txt)) to the width-2 check, before the existing East Asian Width check
- **AttributedStringTest.java**: Add `testBmpEmojiWidth` covering representative characters from each affected block, plus non-emoji neighbors to verify no false positives

## Verification

```java
// Before fix:
new AttributedString("✅").columnLength() // returns 1, should be 2
new AttributedString("❌").columnLength() // returns 1, should be 2

// After fix: both return 2

// Non-emoji neighbors unaffected:
new AttributedString("✓").columnLength()  // still returns 1 (correct)
```

All existing tests pass. New test covers 28 affected characters + 4 non-emoji neighbors.

Fixes #1648