### PR TITLE
fix: Handle IOError in demo REPL loops to prevent infinite error output (backport)

### DIFF
--- a/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
+++ b/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
@@ -44,6 +44,7 @@ package org.apache.felix.gogo.jline;
  */
 
 import java.io.File;
+import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -557,6 +558,12 @@ public class Shell {
 
                     waitJobCompletion(session);
 
+                } catch (IOError e) {
+                    if (e.getCause() instanceof IOException) {
+                        // Terminal I/O broken (e.g. Ctrl+C on some platforms), exit the loop
+                        break;
+                    }
+                    throw e;
                 } catch (UserInterruptException e) {
                     // continue;
                 } catch (EndOfFileException e) {

--- a/demo/src/main/java/org/jline/demo/Repl.java
+++ b/demo/src/main/java/org/jline/demo/Repl.java
@@ -391,6 +391,12 @@ public class Repl {
                         }
                     }
                     break;
+                } catch (IOError e) {
+                    if (e.getCause() instanceof IOException) {
+                        // Terminal I/O broken (e.g. Ctrl+C on some platforms), exit the loop
+                        break;
+                    }
+                    systemRegistry.trace(e);
                 } catch (Exception | Error e) {
                     systemRegistry.trace(e); // print exception and save it to console variable
                 }


### PR DESCRIPTION
Backport of #1652 to jline-3.x.

## Summary

- When terminal I/O breaks (e.g. due to Ctrl+C on some platforms), `BindingReader.readCharacter()` throws `IOError` wrapping an `IOException`
- Both the Groovy Repl and Gogo Shell demos caught this as a generic `Error`/`Exception`, printed the stack trace, and continued looping — causing the same error to repeat indefinitely
- Fix: catch `IOError` with `IOException` cause explicitly and break the REPL loop cleanly

## Test plan

- [ ] Run `./mvx demo repl`, press Ctrl+C — verify the demo exits cleanly instead of printing stack traces in a loop
- [ ] Run `./mvx demo gogo`, press Ctrl+C — verify the same clean exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)