### PR TITLE
fix: Improve demo IOError handling and fix init.jline key resolution (backport)

### DIFF
--- a/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
+++ b/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
@@ -96,6 +96,7 @@ import org.jline.terminal.Terminal.Signal;
 import org.jline.terminal.Terminal.SignalHandler;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
+import org.jline.utils.ClosedException;
 
 public class Shell {
 
@@ -559,11 +560,11 @@ public class Shell {
                     waitJobCompletion(session);
 
                 } catch (IOError e) {
-                    if (e.getCause() instanceof IOException) {
-                        // Terminal I/O broken (e.g. Ctrl+C on some platforms), exit the loop
+                    if (e.getCause() instanceof ClosedException) {
+                        // Terminal has been closed, exit the loop
                         break;
                     }
-                    throw e;
+                    // Transient I/O error (e.g. Ctrl+C during menu completion), continue
                 } catch (UserInterruptException e) {
                     // continue;
                 } catch (EndOfFileException e) {

--- a/demo/src/main/java/org/jline/demo/Repl.java
+++ b/demo/src/main/java/org/jline/demo/Repl.java
@@ -45,6 +45,7 @@ import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.Terminal.Signal;
 import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.ClosedException;
 import org.jline.utils.InfoCmp;
 import org.jline.utils.InfoCmp.Capability;
 import org.jline.utils.OSUtils;
@@ -348,6 +349,7 @@ public class Repl {
                     .variable(LineReader.HISTORY_FILE, Paths.get(root, "history"))
                     .option(Option.INSERT_BRACKET, true)
                     .option(Option.EMPTY_WORD_OPTIONS, false)
+                    .option(Option.GROUP_PERSIST, true)
                     .option(Option.USE_FORWARD_SLASH, true) // use forward slash in directory separator
                     .option(Option.DISABLE_EVENT_EXPANSION, true)
                     .build();
@@ -392,11 +394,11 @@ public class Repl {
                     }
                     break;
                 } catch (IOError e) {
-                    if (e.getCause() instanceof IOException) {
-                        // Terminal I/O broken (e.g. Ctrl+C on some platforms), exit the loop
+                    if (e.getCause() instanceof ClosedException) {
+                        // Terminal has been closed, exit the loop
                         break;
                     }
-                    systemRegistry.trace(e);
+                    // Transient I/O error (e.g. Ctrl+C during menu completion), continue
                 } catch (Exception | Error e) {
                     systemRegistry.trace(e); // print exception and save it to console variable
                 }

--- a/demo/src/main/scripts/init.jline
+++ b/demo/src/main/scripts/init.jline
@@ -170,7 +170,7 @@ def _toggleMenuList() {
 def _getkey(name) {
     def key
     key=:tget $name
-    key.values()[0]
+    key != null ? key.values()[0] : null
 }
 _f1 = _getkey('key_f1')
 _f2 = _getkey('key_f2')


### PR DESCRIPTION
Backport of #1658 to jline-3.x.

## Summary

- **IOError handling**: Only exit the REPL loop on `ClosedException` (terminal truly closed), not on transient `IOError` from Ctrl+C during menu completion. Restores expected behavior where Ctrl+C cancels the current prompt instead of exiting. Refines #1652.
- **init.jline**: Fix `_getkey()` to handle `null` return from `tget` when the terminal lacks the requested capability (e.g. `key_f1` on ghostty).

## Test plan

- [ ] Run `./mvx demo repl` — verify no `IllegalArgumentException` on startup
- [ ] In the repl, trigger menu completion and press Ctrl+C — verify it cancels the prompt instead of exiting
- [ ] Run `./mvx demo gogo` — same Ctrl+C test

🤖 Generated with [Claude Code](https://claude.com/claude-code)