### PR TITLE
fix: Add release-drafter support for jline-3.x branch

### DIFF
--- a/.github/release-drafter-3x.yml
+++ b/.github/release-drafter-3x.yml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Configuration for Release Drafter for jline-3.x branch
+# This configuration is specifically for the 3.x maintenance branch
+name-template: $NEXT_PATCH_VERSION
+tag-template: $NEXT_PATCH_VERSION
+version-template: $MAJOR.$MINOR.$PATCH
+
+# Emoji reference: https://gitmoji.carloscuesta.me/
+categories:
+  - title: ":boom: Breaking changes"
+    labels:
+      - breaking
+  - title: 🚨 Removed
+    label: removed
+  - title: ":tada: Major features and improvements"
+    labels:
+      - major-enhancement
+      - major-rfe
+  - title: 🐛 Major bug fixes
+    labels:
+      - major-bug
+  - title: ⚠️ Deprecated
+    label: deprecated
+  - title: 🚀 New features and improvements
+    labels:
+      - enhancement
+      - feature
+      - rfe
+  - title: 🐛 Bug Fixes
+    labels:
+      - bug
+      - fix
+      - bugfix
+      - regression
+      - backport
+  - title: ":construction_worker: Changes for developers"
+    labels:
+      - developer
+  # Default label used by Dependabot
+  - title: 📦 Dependency updates
+    label: dependencies
+  - title: 📝 Documentation updates
+    label: documentation
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - internal
+      - maintenance
+  - title: 🔧 Build
+    label: build
+  - title: 🚦 Tests
+    labels:
+      - test
+      - tests
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+
+change-template: '- $TITLE ([#$NUMBER]($URL)) @$AUTHOR'
+
+template: |
+  <!-- Optional: add a release summary here -->
+  $CHANGES
+

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,7 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - master
+      - jline-3.x
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
@@ -36,10 +37,17 @@ jobs:
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
+      - name: Run release drafter for master branch
+        if: github.ref == 'refs/heads/master'
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Drafts your next Release notes as Pull Requests are merged into "jline-3.x"
+      - name: Run release drafter for jline-3.x branch
+        if: github.ref == 'refs/heads/jline-3.x'
+        uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter-3x.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Backport the updated release-drafter workflow from master that handles both `master` and `jline-3.x` branches with separate configurations
- Add `release-drafter-3x.yml` config file for the 3.x release draft
- The old workflow only targeted `master`, causing `Validation Failed: target_commitish` errors when PRs targeting `jline-3.x` triggered the release-drafter action

This enables separate release drafts for 4.x and 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)