### PR TITLE
Support multi-character padding in secondary prompt pattern (%P{...})

### DIFF
--- a/reader/src/test/java/org/jline/reader/impl/LineReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderTest.java
@@ -215,6 +215,46 @@ public class LineReaderTest {
     }
 
     @Test
+    public void testSecondaryPromptMultiCharPad() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Terminal terminal = TerminalBuilder.builder().streams(in, out).build();
+        LineReaderImpl reader = new LineReaderImpl(terminal);
+
+        // Single char pad (backward compatible): %P. pads with '.'
+        AttributedString result = reader.expandPromptPattern("%P ", 10, "", 1);
+        assertEquals(10, result.columnLength());
+        assertEquals("          ", result.toString());
+
+        // Single char pad with dots
+        result = reader.expandPromptPattern("%P.", 10, "", 1);
+        assertEquals(10, result.columnLength());
+        assertEquals("..........", result.toString());
+
+        // Multi-char pad: %P{. } pads with repeating ". "
+        result = reader.expandPromptPattern("%P{. }", 10, "", 1);
+        assertEquals(10, result.columnLength());
+        assertEquals(". . . . . ", result.toString());
+
+        // Multi-char pad: %P{..} pads with repeating ".."
+        result = reader.expandPromptPattern("%P{..}", 8, "", 1);
+        assertEquals(8, result.columnLength());
+        assertEquals("........", result.toString());
+
+        // Multi-char pad with suffix: %P{. }> pads then appends ">"
+        result = reader.expandPromptPattern("%P{. }>", 10, "", 1);
+        assertEquals(10, result.columnLength());
+        assertEquals(". . . . .>", result.toString());
+
+        // Pad with line number: %N%P{. } — line number then padding
+        result = reader.expandPromptPattern("%N%P{. }", 10, "", 2);
+        assertEquals(10, result.columnLength());
+        assertEquals("2. . . . .", result.toString());
+
+        terminal.close();
+    }
+
+    @Test
     public void testNoBackspaceInOutputOnDumbTerminal() throws IOException {
         ByteArrayInputStream in = new ByteArrayInputStream(new byte[] {'\n'});
         ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
## Summary

- The `%P` pattern in secondary prompt patterns now supports multi-character pad strings using brace syntax: `%P{. }` repeats `. ` cyclically to fill the padding width
- The existing single-character syntax (`%P.`) remains backward compatible
- Also fixes the padding insertion to correctly account for character column widths

**Example usage:**
```java
reader.setVariable(LineReader.SECONDARY_PROMPT_PATTERN, "%N%P{. }> ");
```

Produces:
```
my_sql_prompt> select
2. . . . . . > 1
3. . . . . . > from
4. . . . . . > dual;
```

Fixes #375

## Test plan
- [x] New unit test `testSecondaryPromptMultiCharPad` covering single-char pad, multi-char pad, pad with suffix, pad with line number
- [x] Full reader test suite passes (199 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)