### PR TITLE
fix: Expand IS_MSYSTEM detection to all MSYS2 environments (fixes #1445)

### DIFF
--- a/terminal/src/main/java/org/jline/utils/OSUtils.java
+++ b/terminal/src/main/java/org/jline/utils/OSUtils.java
@@ -65,10 +65,7 @@ public class OSUtils {
             && System.getenv("MSYSTEM") != null
             && System.getenv("MSYSTEM").startsWith("MINGW");
 
-    public static final boolean IS_MSYSTEM = IS_WINDOWS
-            && System.getenv("MSYSTEM") != null
-            && (System.getenv("MSYSTEM").startsWith("MINGW")
-                    || System.getenv("MSYSTEM").equals("MSYS"));
+    public static final boolean IS_MSYSTEM = IS_WINDOWS && System.getenv("MSYSTEM") != null;
 
     public static final boolean IS_WSL = System.getenv("WSL_DISTRO_NAME") != null;
 


### PR DESCRIPTION
MSYS2 has expanded beyond MINGW32/MINGW64/MSYS to include:
- UCRT64 (Universal CRT toolchain)
- CLANG32, CLANG64, CLANGARM64 (Clang-based toolchains)

The old IS_MSYSTEM check excluded these newer environments, causing backspace and other input to fail in git-bash/MSYS2 terminals.

This fix simplifies the detection to accept any MSYSTEM environment variable value, matching all MSYS2 variants.