### PR TITLE
fix: Clear console input buffer to prevent phantom input (fixes #1350)

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/Kernel32.java
@@ -138,6 +138,15 @@ final class Kernel32 {
         }
     }
 
+    public static int FlushConsoleInputBuffer(MemorySegment hConsoleInput) {
+        MethodHandle mh$ = requireNonNull(FlushConsoleInputBuffer$MH, "FlushConsoleInputBuffer");
+        try {
+            return (int) mh$.invokeExact(hConsoleInput);
+        } catch (Throwable ex$) {
+            throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
     public static int SetConsoleTitleW(MemorySegment lpConsoleTitle) {
         MethodHandle mh$ = requireNonNull(SetConsoleTitleW$MH, "SetConsoleTitleW");
         try {
@@ -358,6 +367,8 @@ final class Kernel32 {
             downcallHandle("SetConsoleMode", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT, C_INT$LAYOUT));
     static final MethodHandle GetConsoleMode$MH =
             downcallHandle("GetConsoleMode", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT, C_POINTER$LAYOUT));
+    static final MethodHandle FlushConsoleInputBuffer$MH =
+            downcallHandle("FlushConsoleInputBuffer", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT));
 
     static final MethodHandle SetConsoleTitleW$MH =
             downcallHandle("SetConsoleTitleW", FunctionDescriptor.of(C_INT$LAYOUT, C_POINTER$LAYOUT));

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
@@ -138,6 +138,12 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
                     inMode.get(ValueLayout.JAVA_INT, 0),
                     console,
                     outMode.get(ValueLayout.JAVA_INT, 0));
+            // Clear any phantom input from console buffer to prevent first readLine() from
+            // returning immediately (fixes #1350)
+            long consoleInAddress = consoleIn.address();
+            if (consoleInAddress != 0 && consoleInAddress != INVALID_HANDLE_VALUE) {
+                Kernel32.FlushConsoleInputBuffer(consoleIn);
+            }
             // Start input pump thread
             if (!paused) {
                 terminal.resume();

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
@@ -132,6 +132,11 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
                 inMode[0],
                 console,
                 outMode[0]);
+        // Clear any phantom input from console buffer to prevent first readLine() from
+        // returning immediately (fixes #1350)
+        if (consoleIn != Kernel32.INVALID_HANDLE_VALUE) {
+            Kernel32.FlushConsoleInputBuffer(consoleIn);
+        }
         // Start input pump thread
         if (!paused) {
             terminal.resume();


### PR DESCRIPTION
The first readLine() call could return immediately without waiting for user input when running as a GraalVM native-image on Windows (and occasionally in regular Java).

Root cause: The Windows console input buffer can contain events from before the application starts or during initialization (focus events, mouse events, or stray keyboard events). When the pump thread starts immediately after terminal creation, it consumes these phantom events, causing the first readLine() to return prematurely.

Fix: Call FlushConsoleInputBuffer() during terminal initialization, before starting the pump thread. This clears any pre-existing console events.

Changes:
- terminal-jni: Call Kernel32.FlushConsoleInputBuffer() before resume()
- terminal-ffm: Add FlushConsoleInputBuffer() to Kernel32 API and call it before resume()

This fix applies to both JNI and FFM (Foreign Function & Memory) terminal providers on Windows.