### PR TITLE
fix: Use KeyMap.key() for capability-based key bindings in example (fixes #1668)

### DIFF
--- a/demo/src/main/java/org/jline/demo/examples/CustomKeyBindingsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomKeyBindingsExample.java
@@ -45,9 +45,10 @@ public class CustomKeyBindingsExample {
         reader.getKeyMaps().get(LineReader.MAIN).bind(new Reference("capitalize-word"), "\u001b\u0063"); // Alt+C
 
         // 5. Bind F5 to clear screen
+        // Use KeyMap.key() to convert the terminal capability to an actual key sequence
         reader.getKeyMaps()
                 .get(LineReader.MAIN)
-                .bind(new Reference("clear-screen"), terminal.getStringCapability(Capability.key_f5));
+                .bind(new Reference("clear-screen"), KeyMap.key(terminal, Capability.key_f5));
 
         // 6. Bind Ctrl+X Ctrl+E to edit-and-execute-command
         reader.getKeyMaps()


### PR DESCRIPTION
## Summary
- Fix incorrect key binding example that passed raw infocmp escape notation to `bind()` instead of the actual key sequence
- `terminal.getStringCapability()` returns infocmp notation (e.g., `\E[15~`), which needs conversion via `KeyMap.key(terminal, capability)` before use with `bind()`

Fixes #1668