### PR TITLE
fix: Enable consumer POM flattening to fix Maven 3/Gradle compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>${nisse.jgit.dateIso8601}</project.build.outputTimestamp>
+        <maven.consumer.pom.flatten>true</maven.consumer.pom.flatten>
 
         <java.build.version>22</java.build.version>
         <java.release.version>11</java.release.version>


### PR DESCRIPTION
## Summary

- Adds `<maven.consumer.pom.flatten>true</maven.consumer.pom.flatten>` to the root parent POM properties
- Without this, child module consumer POMs retain a `<parent>` reference to `jline-parent`, which is deployed with `modelVersion` 4.1.0. Maven 3 and Gradle cannot parse 4.1.0 POMs and fail
- Enabling flattening causes child consumer POMs to use the effective model with the parent stripped, producing self-contained 4.0.0 consumer POMs

Fixes #1688

Workaround for https://github.com/apache/maven/issues/11772