### PR TITLE
fix: Skip JNI native access check on JDK < 24 (fixes #1689)

### DIFF
--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
@@ -70,9 +70,9 @@ public class JniTerminalProvider implements TerminalProvider {
 
     /**
      * Checks that native access is enabled for this module.
-     * Uses reflection because {@code Module.isNativeAccessEnabled()} is only available on JDK 22+
-     * (though GraalVM backported it to earlier versions).
-     * On JDKs without this method, the check is skipped (no restrictions exist).
+     * JNI native access restrictions are only enforced from JDK 24+, so the check
+     * is skipped on earlier versions. Uses reflection because
+     * {@code Module.isNativeAccessEnabled()} is not available on all JDK versions.
      * In GraalVM native images, the check is also skipped since native libraries
      * are handled at build time.
      *
@@ -84,6 +84,13 @@ public class JniTerminalProvider implements TerminalProvider {
         if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
             return;
         }
+        // JNI native access restrictions are only enforced starting from JDK 24.
+        // Some JDK 21 builds (e.g. 21.0.10) backported Module.isNativeAccessEnabled(),
+        // but it returns false even though JNI works fine without --enable-native-access.
+        // See https://github.com/jline/jline3/issues/1689
+        if (Runtime.version().feature() < 24) {
+            return;
+        }
         try {
             Method m = Module.class.getMethod("isNativeAccessEnabled");
             Boolean enabled = (Boolean) m.invoke(JniTerminalProvider.class.getModule());
@@ -92,7 +99,7 @@ public class JniTerminalProvider implements TerminalProvider {
                         + JniTerminalProvider.class.getModule());
             }
         } catch (NoSuchMethodException e) {
-            // JDK < 22, no native access restrictions
+            // Method not available, no native access restrictions
         } catch (UnsupportedOperationException e) {
             throw e;
         } catch (ReflectiveOperationException e) {

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -623,12 +623,20 @@ public class ExecTerminalProvider implements TerminalProvider {
 
     /**
      * Checks that native access is enabled for this module.
-     * Uses reflection because {@code Module.isNativeAccessEnabled()} is only available on JDK 22+.
-     * On older JDKs, the check is skipped (no restrictions exist).
+     * JNI native access restrictions are only enforced from JDK 24+, so the check
+     * is skipped on earlier versions. Uses reflection because
+     * {@code Module.isNativeAccessEnabled()} is not available on all JDK versions.
      *
      * @throws UnsupportedOperationException if native access is not enabled
      */
     static void checkNativeAccess() {
+        // JNI native access restrictions are only enforced starting from JDK 24.
+        // Some JDK 21 builds (e.g. 21.0.10) backported Module.isNativeAccessEnabled(),
+        // but it returns false even though JNI works fine without --enable-native-access.
+        // See https://github.com/jline/jline3/issues/1689
+        if (Runtime.version().feature() < 24) {
+            return;
+        }
         try {
             Method m = Module.class.getMethod("isNativeAccessEnabled");
             Boolean enabled = (Boolean) m.invoke(ExecTerminalProvider.class.getModule());
@@ -637,7 +645,7 @@ public class ExecTerminalProvider implements TerminalProvider {
                         + ExecTerminalProvider.class.getModule());
             }
         } catch (NoSuchMethodException e) {
-            // JDK < 22, no native access restrictions
+            // Method not available, no native access restrictions
         } catch (UnsupportedOperationException e) {
             throw e;
         } catch (ReflectiveOperationException e) {


### PR DESCRIPTION
## Summary

- `checkNativeAccess()` in `JniTerminalProvider` and `ExecTerminalProvider` used reflection to call `Module.isNativeAccessEnabled()`, assuming it only exists on JDK 22+
- OpenJDK 21.0.10 backported this method, causing it to return `false` and throw `UnsupportedOperationException` even though JNI works fine without `--enable-native-access` on JDK < 24
- JNI native access restrictions are only enforced from JDK 24+, so skip the check on earlier versions

Fixes #1689