### PR TITLE
fix: Skip JNI native access check on JDK < 24 (fixes #1689) [3.x backport]

### DIFF
--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
@@ -71,13 +71,26 @@ public class JniTerminalProvider implements TerminalProvider {
 
     /**
      * Checks that native access is enabled for this module.
-     * Uses reflection because {@code Module.isNativeAccessEnabled()} is only available on JDK 22+
-     * and {@code Class.getModule()} is only available on JDK 9+.
-     * On older JDKs, the check is skipped (no restrictions exist).
+     * JNI native access restrictions are only enforced from JDK 24+, so the check
+     * is skipped on earlier versions. Uses reflection because
+     * {@code Module.isNativeAccessEnabled()} is not available on all JDK versions.
      *
      * @throws UnsupportedOperationException if native access is not enabled
      */
     static void checkNativeAccess() {
+        // JNI native access restrictions are only enforced starting from JDK 24.
+        // Some JDK 21 builds (e.g. 21.0.10) backported Module.isNativeAccessEnabled(),
+        // but it returns false even though JNI works fine without --enable-native-access.
+        // See https://github.com/jline/jline3/issues/1689
+        try {
+            int version = Integer.parseInt(System.getProperty("java.specification.version"));
+            if (version < 24) {
+                return;
+            }
+        } catch (NumberFormatException e) {
+            // JDK 8 uses "1.8" format, which means JDK < 24
+            return;
+        }
         try {
             Method getModule = Class.class.getMethod("getModule");
             Object module = getModule.invoke(JniTerminalProvider.class);
@@ -88,7 +101,7 @@ public class JniTerminalProvider implements TerminalProvider {
                         "Native access is not enabled for the current module: " + module);
             }
         } catch (NoSuchMethodException e) {
-            // JDK < 9 (no modules) or JDK < 22 (no isNativeAccessEnabled), no restrictions
+            // Method not available, no native access restrictions
         } catch (UnsupportedOperationException e) {
             throw e;
         } catch (ReflectiveOperationException e) {

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -693,13 +693,26 @@ public class ExecTerminalProvider implements TerminalProvider {
 
     /**
      * Checks that native access is enabled for this module.
-     * Uses reflection because {@code Module.isNativeAccessEnabled()} is only available on JDK 22+
-     * and {@code Class.getModule()} is only available on JDK 9+.
-     * On older JDKs, the check is skipped (no restrictions exist).
+     * JNI native access restrictions are only enforced from JDK 24+, so the check
+     * is skipped on earlier versions. Uses reflection because
+     * {@code Module.isNativeAccessEnabled()} is not available on all JDK versions.
      *
      * @throws UnsupportedOperationException if native access is not enabled
      */
     static void checkNativeAccess() {
+        // JNI native access restrictions are only enforced starting from JDK 24.
+        // Some JDK 21 builds (e.g. 21.0.10) backported Module.isNativeAccessEnabled(),
+        // but it returns false even though JNI works fine without --enable-native-access.
+        // See https://github.com/jline/jline3/issues/1689
+        try {
+            int version = Integer.parseInt(System.getProperty("java.specification.version"));
+            if (version < 24) {
+                return;
+            }
+        } catch (NumberFormatException e) {
+            // JDK 8 uses "1.8" format, which means JDK < 24
+            return;
+        }
         try {
             Method getModule = Class.class.getMethod("getModule");
             Object module = getModule.invoke(ExecTerminalProvider.class);
@@ -710,7 +723,7 @@ public class ExecTerminalProvider implements TerminalProvider {
                         "Native access is not enabled for the current module: " + module);
             }
         } catch (NoSuchMethodException e) {
-            // JDK < 9 (no modules) or JDK < 22 (no isNativeAccessEnabled), no restrictions
+            // Method not available, no native access restrictions
         } catch (UnsupportedOperationException e) {
             throw e;
         } catch (ReflectiveOperationException e) {


### PR DESCRIPTION
## Summary

Backport of #1692 to the `jline-3.x` branch.

- `checkNativeAccess()` in `JniTerminalProvider` and `ExecTerminalProvider` used reflection to call `Module.isNativeAccessEnabled()`, assuming it only exists on JDK 22+
- OpenJDK 21.0.10 backported this method, causing it to return `false` and throw `UnsupportedOperationException` even though JNI works fine without `--enable-native-access` on JDK < 24
- JNI native access restrictions are only enforced from JDK 24+, so skip the check on earlier versions
- Uses `java.specification.version` system property for the version check (compatible with JDK 8+)

Fixes #1689