### PR TITLE
fix: Move consumer POM flattening to .mvn/maven.properties (fixes #1688)

### DIFF
--- a/.mvn/maven.properties
+++ b/.mvn/maven.properties
@@ -1,0 +1,1 @@
+maven.consumer.pom.flatten=true

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>${nisse.jgit.dateIso8601}</project.build.outputTimestamp>
-        <maven.consumer.pom.flatten>true</maven.consumer.pom.flatten>
 
         <java.build.version>22</java.build.version>
         <java.release.version>11</java.release.version>


### PR DESCRIPTION
## Summary

- Moves `maven.consumer.pom.flatten=true` from `pom.xml` `<properties>` to `.mvn/maven.properties`
- The property is a Maven configuration setting, not a project property — it was silently ignored when placed in the POM
- With this fix, child module consumer POMs are fully self-contained 4.0.0 POMs with no `<parent>` reference to `jline-parent` (which uses modelVersion 4.1.0)
- This fixes Maven 3 and Gradle compatibility

**Before** (consumer POM still had parent reference):
```xml
<modelVersion>4.0.0</modelVersion>
<parent>
  <groupId>org.jline</groupId>
  <artifactId>jline-parent</artifactId>
  <version>4.0.1</version>
</parent>
```

**After** (self-contained consumer POM):
```xml
<modelVersion>4.0.0</modelVersion>
<groupId>org.jline</groupId>
<artifactId>jline-terminal</artifactId>
<version>4.0.1</version>
```

Fixes #1688

Workaround for https://github.com/apache/maven/issues/11772