### PR TITLE
fix: Disable grapheme cluster probe on Windows PosixSysTerminal

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -17,9 +17,7 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.jline.terminal.impl.exec.ExecPty;
 import org.jline.terminal.spi.Pty;
-import org.jline.terminal.spi.SystemStream;
 import org.jline.utils.FastBufferedOutputStream;
 import org.jline.utils.NonBlocking;
 import org.jline.utils.NonBlockingInputStream;
@@ -120,16 +118,14 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
 
     @Override
     public boolean supportsGraphemeClusterMode() {
-        // On Windows (Cygwin/MSYSTEM), when using ExecPty, the slave output
-        // goes to a raw FileDescriptor (stdout/stderr) rather than a real PTY
-        // device.  If that fd is piped (e.g. subprocess with captured output),
-        // writing the DECRQM probe contaminates the process output.  Guard by
-        // asking the provider whether the output stream is actually a terminal.
-        if (OSUtils.IS_WINDOWS && getPty() instanceof ExecPty) {
-            SystemStream ss = getSystemStream();
-            if (ss != null && !getPty().getProvider().isSystemStream(ss)) {
-                return false;
-            }
+        // On Windows (Cygwin/MSYSTEM), the slave output goes to a raw
+        // FileDescriptor (stdout/stderr) rather than a real PTY device.
+        // Writing the DECRQM probe to such a descriptor contaminates the
+        // process output when the fd is piped (e.g. subprocess with captured
+        // output).  Detecting whether the fd is truly a terminal is unreliable
+        // on Windows, so disable the probe entirely.
+        if (OSUtils.IS_WINDOWS) {
+            return false;
         }
         return super.supportsGraphemeClusterMode();
     }


### PR DESCRIPTION
## Summary

- The 4.0.3 fix (#1695) was insufficient — Maven CI still fails on Windows with `[?2027$p` leaking into subprocess output
- The `isSystemStream()` check is unreliable on Windows MSYSTEM environments (can return true for streams that are being captured by a parent process)
- Simplify the guard to disable the DECRQM probe entirely on Windows `PosixSysTerminal`, since the slave output always goes to a raw `FileDescriptor` which makes probing inherently risky

Fixes the remaining CI failure: https://github.com/apache/maven/actions/runs/22931697655/job/66554940328

## Test plan

- [x] All 16 `GraphemeClusterModeTest` tests pass
- [x] All 184 terminal module tests pass