### PR TITLE
fix: Simplify versioning by using nisse property directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ build.rc
 
 .mvn/wrapper/maven-wrapper.jar
 .dependency-reduced-pom.xml
-.flattened-pom.xml
+.inlined-pom.xml

--- a/.mvn/nisse-translation.properties
+++ b/.mvn/nisse-translation.properties
@@ -1,2 +1,0 @@
-jgit.dynamicVersion=revision,+fallback
-jgit.dateIso8601=nisse.jgit.dateIso8601

--- a/builtins/pom.xml
+++ b/builtins/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-builtins</artifactId>

--- a/console-ui/pom.xml
+++ b/console-ui/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-console-ui</artifactId>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-console</artifactId>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-demo</artifactId>

--- a/graal/pom.xml
+++ b/graal/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-graal</artifactId>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
     <artifactId>jline-groovy</artifactId>
     <name>JLine Groovy</name>

--- a/jansi-core/pom.xml
+++ b/jansi-core/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jansi-core</artifactId>

--- a/jansi/pom.xml
+++ b/jansi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jansi</artifactId>

--- a/jline/pom.xml
+++ b/jline/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline</artifactId>

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
     <artifactId>jline-native</artifactId>
 

--- a/picocli/pom.xml
+++ b/picocli/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
     <artifactId>jline-picocli</artifactId>
     <name>JLine Picocli</name>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>org.jline</groupId>
     <artifactId>jline-parent</artifactId>
-    <version>${revision}</version>
+    <version>${nisse.jgit.dynamicVersion}</version>
     <packaging>pom</packaging>
     <name>JLine</name>
     <description>JLine</description>
@@ -652,31 +652,6 @@
                 <artifactId>spotless-maven-plugin</artifactId>
             </plugin>
 
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.6.0</version>
-                <configuration>
-                    <updatePomFile>true</updatePomFile>
-                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>flatten</id>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                    </execution>
-                    <execution>
-                        <id>flatten.clean</id>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                        <phase>clean</phase>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/prompt/pom.xml
+++ b/prompt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-prompt</artifactId>

--- a/reader/pom.xml
+++ b/reader/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-reader</artifactId>

--- a/remote-ssh/pom.xml
+++ b/remote-ssh/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-remote-ssh</artifactId>

--- a/remote-telnet/pom.xml
+++ b/remote-telnet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-remote-telnet</artifactId>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-shell</artifactId>

--- a/style/pom.xml
+++ b/style/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-style</artifactId>

--- a/terminal-ffm/pom.xml
+++ b/terminal-ffm/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-terminal-ffm</artifactId>

--- a/terminal-jni/pom.xml
+++ b/terminal-jni/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-terminal-jni</artifactId>

--- a/terminal/pom.xml
+++ b/terminal/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.jline</groupId>
         <artifactId>jline-parent</artifactId>
-        <version>${revision}</version>
+        <version>${nisse.jgit.dynamicVersion}</version>
     </parent>
 
     <artifactId>jline-terminal</artifactId>


### PR DESCRIPTION
## Summary
- Use `${nisse.jgit.dynamicVersion}` directly in POMs instead of mapping to `${revision}` via a translation table
- Nisse's built-in property inliner resolves the version in installed/deployed POMs, making `flatten-maven-plugin` unnecessary
- Removes `flatten-maven-plugin` and `.mvn/nisse-translation.properties`

Net result: 22 insertions, 49 deletions — simpler setup, same behavior.