### PR TITLE
fix: Suppress dumb terminal warning when no streams are TTYs

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -835,14 +835,22 @@ public final class TerminalBuilder {
             }
             if (terminal == null && (forceDumb || dumb == null || dumb)) {
                 if (!forceDumb && dumb == null) {
-                    if (Log.isDebugEnabled()) {
-                        Log.warn("input is tty: " + system.get(SystemStream.Input));
-                        Log.warn("output is tty: " + system.get(SystemStream.Output));
-                        Log.warn("error is tty: " + system.get(SystemStream.Error));
-                        Log.warn("Creating a dumb terminal", exception);
-                    } else {
-                        Log.warn(
-                                "Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)");
+                    // Only warn if providers were available but couldn't create a terminal,
+                    // or if no providers loaded at all (can't determine TTY status).
+                    // When providers detect that no streams are TTYs, dumb fallback is expected.
+                    boolean noTty = !system.get(SystemStream.Input)
+                            && !system.get(SystemStream.Output)
+                            && !system.get(SystemStream.Error);
+                    if (providers.isEmpty() || !noTty) {
+                        if (Log.isDebugEnabled()) {
+                            Log.warn("input is tty: " + system.get(SystemStream.Input));
+                            Log.warn("output is tty: " + system.get(SystemStream.Output));
+                            Log.warn("error is tty: " + system.get(SystemStream.Error));
+                            Log.warn("Creating a dumb terminal", exception);
+                        } else {
+                            Log.warn(
+                                    "Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)");
+                        }
                     }
                 }
                 type = getDumbTerminalType(dumb, systemStream);

--- a/terminal/src/test/java/org/jline/terminal/DumbTerminalWarningTest.java
+++ b/terminal/src/test/java/org/jline/terminal/DumbTerminalWarningTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that the "Unable to create a system terminal" warning is suppressed
+ * when providers are available but no streams are TTYs (e.g., CI environments),
+ * and is emitted when no providers could be loaded.
+ */
+@SuppressWarnings("missing-explicit-ctor")
+public class DumbTerminalWarningTest {
+
+    @Test
+    public void testNoWarningWhenNoTtyAndProvidersAvailable() throws IOException {
+        // In a CI/test environment, no streams are TTYs.
+        // With providers available, this is an expected dumb fallback — no warning should be emitted.
+        List<LogRecord> records = new ArrayList<>();
+        Logger logger = Logger.getLogger("org.jline");
+        Handler handler = new CapturingHandler(records);
+        logger.addHandler(handler);
+        Level oldLevel = logger.getLevel();
+        logger.setLevel(Level.WARNING);
+        try {
+            Terminal terminal = TerminalBuilder.builder().system(true).build();
+            terminal.close();
+            boolean hasWarning = records.stream()
+                    .filter(r -> r.getLevel() == Level.WARNING)
+                    .anyMatch(r -> r.getMessage().contains("Unable to create a system terminal"));
+            assertFalse(hasWarning, "Should not warn about dumb terminal fallback when no streams are TTYs");
+        } finally {
+            logger.removeHandler(handler);
+            logger.setLevel(oldLevel);
+        }
+    }
+
+    @Test
+    public void testWarningWhenNoProvidersLoaded() throws IOException {
+        // When no providers can be loaded, we can't determine TTY status,
+        // so the warning should still be emitted.
+        List<LogRecord> records = new ArrayList<>();
+        Logger logger = Logger.getLogger("org.jline");
+        Handler handler = new CapturingHandler(records);
+        logger.addHandler(handler);
+        Level oldLevel = logger.getLevel();
+        logger.setLevel(Level.WARNING);
+        try {
+            Terminal terminal = TerminalBuilder.builder()
+                    .system(true)
+                    .ffm(false)
+                    .jni(false)
+                    .exec(false)
+                    .build();
+            terminal.close();
+            boolean hasWarning = records.stream()
+                    .filter(r -> r.getLevel() == Level.WARNING)
+                    .anyMatch(r -> r.getMessage().contains("Unable to create a system terminal"));
+            assertTrue(hasWarning, "Should warn about dumb terminal fallback when no providers are loaded");
+        } finally {
+            logger.removeHandler(handler);
+            logger.setLevel(oldLevel);
+        }
+    }
+
+    private static class CapturingHandler extends Handler {
+        private final List<LogRecord> records;
+
+        CapturingHandler(List<LogRecord> records) {
+            this.records = records;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
## Summary

- Suppress the "Unable to create a system terminal" warning when providers are available but detect that no streams are TTYs (expected in CI environments)
- Keep the warning when no providers could be loaded at all (can't determine TTY status, indicates a genuine configuration issue)
- Add tests verifying both scenarios

## Context

When JLine is used in CI environments (like GitHub Actions), the warning "Unable to create a system terminal, creating a dumb terminal" is emitted even though falling back to a dumb terminal is the expected behavior when no TTY is available. This creates noise in build logs (e.g., https://github.com/apache/camel/actions/runs/23203983845/job/67434869843#step:11:68).

The fix distinguishes three cases:
- **CI (no TTY), providers loaded** → `noTty=true`, providers not empty → warning suppressed
- **Real terminal, providers failed to load** → `providers.isEmpty()=true` → warning fires
- **Real terminal, providers loaded, but terminal creation failed** → `noTty=false` → warning fires

## Test plan

- [x] `DumbTerminalWarningTest.testNoWarningWhenNoTtyAndProvidersAvailable` — verifies no warning in CI-like environments
- [x] `DumbTerminalWarningTest.testWarningWhenNoProvidersLoaded` — verifies warning when no providers are available