### PR TITLE
fix: Alt-screen related ScreenTerminal fixes

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -1701,8 +1701,8 @@ public class ScreenTerminal {
         }
 
         if (h != height) {
-            changeHeight(h, w, false);
-            changeHeight(h, w, true);
+            adjustBufferHeight(h, w, false);
+            adjustBufferHeight(h, w, true);
         }
 
         // Scroll parameters
@@ -1721,7 +1721,7 @@ public class ScreenTerminal {
         return true;
     }
 
-    private void changeHeight(int h, int w, boolean alt) {
+    private void adjustBufferHeight(int h, int w, boolean alt) {
         List<long[]> targetHistory = alt ? history2 : history;
         long[][] targetScreen = alt ? screen2 : screen;
         if (h < height) {


### PR DESCRIPTION
Changes:
 - Added second history buffer for the alt-screen.
 - Swap history buffers to ensure main-screen data does not enter the alt-screen.
 - Clear alt-screen when going back to main screen (1049 saves cursor, clears alt-screen and then switches to it).
 - Properly resize offscreen buffer as well.
 - Clear history buffers upon reset.
Misc:
 - Rename "vt100_alternate_saved_cx/y" to "vt100_alternate_cx/y" to prevent confusion since it saves the cx/y and not the saved_cx/y state.
 - Move resize logic to its own method.
 
This fixes the following bugs:
 - Going to alt-screen and then increasing the size showing history from the main screen.
 - Running a bunch of commands in the alt-screen leaking data into the main screen when resized.
 - Alt-screen not being cleared when entering it for a second time.
 - Main-screen screen data (and partial history) being wiped when terminal size increases in alt mode.
 - History not being cleared upon screen reset (resize after reset would bring old data back).
 
 
 Considerations:
  - Mode 1049 only guarantees the main-screen cursor position being saved. A few tested terminals (e.g. Ubuntu & CentOS) indeed also retain the main-screen cursor position when switching to the alt screen regardless of where it was previously. JLine has been saving both.
  ```
Modern xterm (from late 1998) changes the behavior of the cursor save/restore operations so they apply only to the current screen. That makes it less likely to misplace your cursor.
```
 - Changing alt-screen mode has historically never called markDirty(). It feels like that would be needed, but seems to work fine without.