### PR TITLE
fix: Improve DECRQM grapheme cluster probe robustness (fixes #1726)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -385,14 +385,21 @@ public abstract class AbstractTerminal implements TerminalExt {
     /**
      * Probes the terminal for mode 2027 support using DECRQM.
      *
-     * <p>Sends {@code CSI ? 2027 $ p} and expects a DECRPM response
-     * {@code CSI ? 2027 ; Ps $ y} where Ps indicates the mode status.</p>
+     * <p>Sends {@code CSI ? 2027 $ p} followed by a DA1 (Primary Device
+     * Attributes) query {@code CSI c} as a sentinel.  DA1 is near-universally
+     * supported, so its response acts as a fence: if we receive the DA1
+     * response without a preceding DECRPM, the terminal does not support
+     * DECRQM and we return immediately instead of waiting for a timeout.</p>
      *
-     * <p>The probe is only performed on terminals whose type starts with
-     * {@code "xterm"}, as DECRQM is a DEC private mode query that may not be
-     * understood by older or minimal terminals. Terminals that do not understand
-     * DECRQM could echo the query as visible garbage or leave partial responses
-     * in the input buffer.</p>
+     * <p>The expected DECRPM response is {@code CSI ? 2027 ; Ps $ y} where
+     * Ps indicates the mode status.  Both DECRPM and DA1 responses share the
+     * {@code CSI ?} prefix, but diverge immediately after ({@code 2027;}
+     * vs the DA1 device-type parameter), so they are easy to distinguish.</p>
+     *
+     * <p>macOS Terminal.app is explicitly skipped (detected via
+     * {@code TERM_PROGRAM=Apple_Terminal}) because its CSI parser does not
+     * handle the {@code $} intermediate byte and leaks the final {@code p}
+     * as visible text — the only known terminal with this bug.</p>
      *
      * @return {@code true} if the terminal recognizes mode 2027
      */
@@ -400,17 +407,22 @@ public abstract class AbstractTerminal implements TerminalExt {
         if (TYPE_DUMB.equals(type) || TYPE_DUMB_COLOR.equals(type)) {
             return false;
         }
-        if (!type.startsWith("xterm")) {
+        // Terminal.app's CSI parser does not handle intermediate bytes correctly
+        // and leaks the final byte 'p' of the DECRQM sequence as visible text.
+        String termProgram = System.getenv("TERM_PROGRAM");
+        if ("Apple_Terminal".equals(termProgram)) {
             return false;
         }
         // Enter raw mode to prevent the terminal response from being echoed
         Attributes prev = enterRawMode();
         try {
-            // Send DECRQM query for mode 2027
-            writer().write("\033[?2027$p");
+            // Send DECRQM query for mode 2027 followed by DA1 as sentinel
+            writer().write("\033[?2027$p\033[c");
             writer().flush();
 
-            // Read DECRPM response: ESC [ ? 2 0 2 7 ; Ps $ y
+            // Read response — both DECRPM and DA1 start with ESC [ ?
+            // DECRPM: ESC [ ? 2 0 2 7 ; Ps $ y
+            // DA1:    ESC [ ? Pp ; ... c
             long timeout = 100;
             if (reader().peek(timeout) < 0) {
                 return false;
@@ -419,8 +431,8 @@ public abstract class AbstractTerminal implements TerminalExt {
             for (int e : expected) {
                 int c = reader().read(timeout);
                 if (c != e) {
-                    // Mismatch — drain any remaining bytes from the partial
-                    // response to avoid leaving garbage in the input buffer
+                    // Not DECRPM — likely the DA1 sentinel response,
+                    // meaning the terminal does not support DECRQM
                     drainResponse(timeout);
                     return false;
                 }
@@ -436,6 +448,8 @@ public abstract class AbstractTerminal implements TerminalExt {
                 drainResponse(timeout);
                 return false;
             }
+            // Drain the trailing DA1 sentinel response
+            drainResponse(timeout);
             // Ps: 1=set, 2=reset (can be set), 3=permanently set → supported
             // Ps: 0=not recognized, 4=permanently reset → not supported
             return ps == '1' || ps == '2' || ps == '3';
@@ -447,7 +461,7 @@ public abstract class AbstractTerminal implements TerminalExt {
     }
 
     /**
-     * Drains any remaining bytes from a partial or unexpected DECRPM response.
+     * Drains any remaining bytes from a partial or unexpected terminal response.
      * Reads and discards characters until no more are available within the timeout.
      */
     private void drainResponse(long timeout) {

--- a/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterModeTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterModeTest.java
@@ -87,15 +87,32 @@ public class GraphemeClusterModeTest {
     }
 
     @Test
-    public void testNotSupportedOnNonXtermTerminal() throws Exception {
-        // Terminals that don't start with "xterm" should not be probed
+    public void testNotSupportedWhenOnlyDa1Responds() throws Exception {
+        // Terminal doesn't support DECRQM but responds to DA1 sentinel
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Feed only a DA1 response (no DECRPM)
+        terminal.slaveInputPipe.write("\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertFalse(terminal.supportsGraphemeClusterMode());
+
+        terminal.close();
+    }
+
+    @Test
+    public void testProbeSentForNonXtermTerminal() throws Exception {
+        // Non-xterm terminals should now be probed (DA1 sentinel makes it safe)
         ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", "vt100", masterOutput, StandardCharsets.UTF_8);
 
         assertFalse(terminal.supportsGraphemeClusterMode());
-        // No query should have been sent
-        assertEquals(0, masterOutput.size());
+        // Probe should have been sent
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?2027$p"));
 
         terminal.close();
     }
@@ -109,9 +126,10 @@ public class GraphemeClusterModeTest {
 
         assertFalse(terminal.supportsGraphemeClusterMode());
 
-        // Query should still have been sent
+        // Query and DA1 sentinel should have been sent
         String output = masterOutput.toString(StandardCharsets.UTF_8);
         assertTrue(output.contains("\033[?2027$p"));
+        assertTrue(output.contains("\033[c"));
 
         terminal.close();
     }
@@ -122,8 +140,8 @@ public class GraphemeClusterModeTest {
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
 
-        // Feed response
-        terminal.slaveInputPipe.write("\033[?2027;2$y".getBytes(StandardCharsets.UTF_8));
+        // Feed DECRPM response followed by mock DA1 response
+        terminal.slaveInputPipe.write("\033[?2027;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
         assertTrue(terminal.supportsGraphemeClusterMode());
@@ -139,8 +157,8 @@ public class GraphemeClusterModeTest {
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
 
-        // Feed probe response
-        terminal.slaveInputPipe.write("\033[?2027;2$y".getBytes(StandardCharsets.UTF_8));
+        // Feed DECRPM response followed by mock DA1 response
+        terminal.slaveInputPipe.write("\033[?2027;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
         assertTrue(terminal.setGraphemeClusterMode(true));
@@ -158,8 +176,8 @@ public class GraphemeClusterModeTest {
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
 
-        // Feed probe response
-        terminal.slaveInputPipe.write("\033[?2027;2$y".getBytes(StandardCharsets.UTF_8));
+        // Feed DECRPM response followed by mock DA1 response
+        terminal.slaveInputPipe.write("\033[?2027;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
         assertTrue(terminal.setGraphemeClusterMode(true));
@@ -192,8 +210,8 @@ public class GraphemeClusterModeTest {
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
 
-        // Feed probe response
-        terminal.slaveInputPipe.write("\033[?2027;2$y".getBytes(StandardCharsets.UTF_8));
+        // Feed DECRPM response followed by mock DA1 response
+        terminal.slaveInputPipe.write("\033[?2027;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
         assertTrue(terminal.setGraphemeClusterMode(true));
@@ -214,8 +232,8 @@ public class GraphemeClusterModeTest {
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
 
-        // Feed probe response but don't enable the mode
-        terminal.slaveInputPipe.write("\033[?2027;2$y".getBytes(StandardCharsets.UTF_8));
+        // Feed DECRPM response followed by mock DA1 response
+        terminal.slaveInputPipe.write("\033[?2027;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
         assertTrue(terminal.supportsGraphemeClusterMode());
@@ -380,15 +398,16 @@ public class GraphemeClusterModeTest {
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", terminalType, masterOutput, StandardCharsets.UTF_8);
 
-        // Feed the DECRPM response into the slave input pipe
-        terminal.slaveInputPipe.write(response.getBytes(StandardCharsets.UTF_8));
+        // Feed the DECRPM response followed by mock DA1 response
+        terminal.slaveInputPipe.write((response + "\033[?64c").getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
         assertEquals(expectedSupport, terminal.supportsGraphemeClusterMode());
 
-        // Verify the DECRQM query was sent
+        // Verify the DECRQM query and DA1 sentinel were sent
         String output = masterOutput.toString(StandardCharsets.UTF_8);
         assertTrue(output.contains("\033[?2027$p"));
+        assertTrue(output.contains("\033[c"));
 
         terminal.close();
     }


### PR DESCRIPTION
## Summary

Fixes #1726 — `probeGraphemeClusterMode()` outputs "p" on the screen on terminals with broken CSI parsers (macOS Terminal.app).

Three improvements to the DECRQM mode 2027 probe:

- **Skip probe on Apple Terminal.app** (`TERM_PROGRAM=Apple_Terminal`): its CSI parser does not handle the `$` intermediate byte and leaks the final `p` as visible text. This is the only known terminal with this bug — all other non-supporting terminals silently ignore the sequence per ECMA-48. This is consistent with how Neovim and Tcell handle it.

- **Remove `type.startsWith("xterm")` guard**: the previous check was both too broad (Terminal.app uses `xterm-256color`) and too narrow (modern terminals like foot, ghostty, alacritty use their own TERM values and were incorrectly skipped). With the DA1 sentinel, probing any non-dumb terminal is safe.

- **DA1 sentinel for fast negative detection**: a DA1 query (`CSI c`) is sent immediately after the DECRQM query. Since DA1 is near-universally supported and terminal responses arrive in order, receiving the DA1 response without a preceding DECRPM means DECRQM is unsupported — no need to wait for the 100ms timeout. This technique is used by Tcell and notcurses.

## Test plan

- [x] `GraphemeClusterModeTest` — all 16 tests pass
- [x] New test `testNotSupportedWhenOnlyDa1Responds` — verifies fast negative via DA1
- [x] Updated `testProbeSentForNonXtermTerminal` — verifies non-xterm terminals are now probed
- [x] Manual test on macOS Terminal.app — probe should be skipped, no "p" on screen
- [x] Manual test on a terminal that supports mode 2027 (WezTerm, foot, Ghostty) — mode should be detected and enabled