### PR TITLE
fix: Correct 4-bit to 8-bit color expansion in rgbToHex

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -2154,9 +2154,12 @@ public class ScreenTerminal {
      * @return hex color string (e.g., "#ff0000")
      */
     private static String rgbToHex(int color) {
-        int r = ((color >> 8) & 0x0f) << 4; // Expand 4-bit to 8-bit
-        int g = ((color >> 4) & 0x0f) << 4;
-        int b = ((color >> 0) & 0x0f) << 4;
+        int rn = (color >> 8) & 0x0f;
+        int gn = (color >> 4) & 0x0f;
+        int bn = (color >> 0) & 0x0f;
+        int r = (rn << 4) | rn; // Expand 4-bit to 8-bit (e.g., 0xf -> 0xff)
+        int g = (gn << 4) | gn;
+        int b = (bn << 4) | bn;
         return String.format("#%02x%02x%02x", r, g, b);
     }
 

--- a/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
@@ -113,8 +113,7 @@ public class ScreenTerminalTest {
         // Dump the terminal content
         String dump = terminal.dump(0, true);
         assertNotNull(dump);
-        assertTrue(dump.contains("<span style='color:#000000;background-color:#f0f0f0;'> </span>")
-                || dump.contains("<span style='color:#000000;background-color:#ffffff;'> </span>")); // The cursor
+        assertTrue(dump.contains("<span style='color:#000000;background-color:#ffffff;'> </span>")); // The cursor
 
         terminal = new ScreenTerminal(initialWidth, initialHeight);
         terminal.write(clearAnsi + "\033[31m" + line + clearAnsi + "\n");
@@ -122,13 +121,13 @@ public class ScreenTerminalTest {
         dump = terminal.dump(0, true);
         assertNotNull(dump);
         assertTrue(dump.contains(
-                "<span style='color:#800000;background-color:#000000;'>" + line + "\n</span>")); // Text FG
+                "<span style='color:#880000;background-color:#000000;'>" + line + "\n</span>")); // Text FG
 
         terminal = new ScreenTerminal(initialWidth, initialHeight);
         terminal.write(clearAnsi + "\033[44m" + line + clearAnsi + "\n");
 
         dump = terminal.dump(0, true);
         assertNotNull(dump);
-        assertTrue(dump.contains("background-color:#000080;'>" + line + "\n</span>")); // Text BG
+        assertTrue(dump.contains("background-color:#000088;'>" + line + "\n</span>")); // Text BG
     }
 }


### PR DESCRIPTION
Follow-up to #1725.

`rgbToHex` was using `(nibble << 4)` to expand 4-bit color components to 8-bit, which is lossy: `0xf` becomes `0xf0` instead of `0xff`. The correct expansion is `(nibble << 4) | nibble`, which matches CSS shorthand behavior (e.g., `#fff` -> `#ffffff`, not `#f0f0f0`).

Also removes a dead `|| #ffffff` branch in the test assertion that could never match with the old expansion.