### PR TITLE
fix: Reduce drain timeout in grapheme cluster probe

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -473,7 +473,7 @@ public abstract class AbstractTerminal implements TerminalExt {
                 // After the first byte, remaining bytes in the same response
                 // arrive nearly instantly; use a short timeout to avoid
                 // blocking for the full duration after the last byte.
-                timeout = 10;
+                timeout = Math.min(10, timeout);
             }
         } catch (IOException ignored) {
         }


### PR DESCRIPTION
## Summary

Follow-up to #1729. Addresses [review comment](https://github.com/jline/jline3/pull/1729#discussion_r3010847225):

- `drainResponse()` now uses the given timeout only for the first `peek()`, then switches to a short 10ms timeout for subsequent bytes
- This avoids blocking for the full 100ms after the last byte is consumed, reducing probe latency on both success and failure paths
- Bytes within a single terminal response arrive nearly instantly once the first byte is available, so 10ms is more than sufficient

## Test plan

- [x] All 17 `GraphemeClusterModeTest` tests pass