### PR TITLE
fix: ScreenTerminal bug fixes, features, and cleanup

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -1016,17 +1016,17 @@ public class ScreenTerminal {
             } else if (m == 8) {
                 attr |= 0x04000000L << 32; // conceal
             } else if (m == 21) {
-                attr &= 0xf7ffffffL << 32; // bold off
+                attr &= ~(0x08000000L << 32); // bold off
             } else if (m == 22) {
                 attr &= ~(0x48000000L << 32); // bold and dim off (normal intensity)
             } else if (m == 23) {
                 attr &= ~(0x80000000L << 32); // italic off
             } else if (m == 24) {
-                attr &= 0xfeffffffL << 32; // underline off
+                attr &= ~(0x01000000L << 32); // underline off
             } else if (m == 27) {
-                attr &= 0xfdffffffL << 32; // negative off
+                attr &= ~(0x02000000L << 32); // negative off
             } else if (m == 28) {
-                attr &= 0xfbffffffL << 32; // conceal off
+                attr &= ~(0x04000000L << 32); // conceal off
             } else if (m >= 30 && m <= 37) {
                 attr = (attr & (0xef000fffL << 32)) | (0x10000000L << 32) | (col24(m - 30) << 44); // foreground
             } else if (m == 38) {
@@ -1681,7 +1681,7 @@ public class ScreenTerminal {
      *
      * @return the width in characters
      */
-    public int getWidth() {
+    public synchronized int getWidth() {
         return width;
     }
 
@@ -1690,7 +1690,7 @@ public class ScreenTerminal {
      *
      * @return the height in characters
      */
-    public int getHeight() {
+    public synchronized int getHeight() {
         return height;
     }
 

--- a/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
@@ -331,6 +331,110 @@ public class ScreenTerminalTest {
     }
 
     // -----------------------------------------------------------------------
+    // pipe() tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * pipe() must produce identical output for arrow keys regardless of
+     * cursor key mode, except for the prefix (\033O vs \033[).
+     * Regression guard for the switch deduplication refactoring.
+     */
+    @Test
+    public void testPipeArrowKeysNormalMode() {
+        ScreenTerminal terminal = new ScreenTerminal(80, 24);
+        // Normal mode (default): arrows use CSI (\033[)
+        String result = terminal.pipe("~A~B~C~D~F~H");
+        assertEquals("\u001b[A\u001b[B\u001b[C\u001b[D\u001b[F\u001b[H", result);
+    }
+
+    @Test
+    public void testPipeArrowKeysCursorKeyMode() {
+        ScreenTerminal terminal = new ScreenTerminal(80, 24);
+        // Enable cursor key mode via DECCKM
+        terminal.write("\033[?1h");
+        String result = terminal.pipe("~A~B~C~D~F~H");
+        assertEquals("\u001bOA\u001bOB\u001bOC\u001bOD\u001bOF\u001bOH", result);
+    }
+
+    @Test
+    public void testPipeFunctionKeys() {
+        ScreenTerminal terminal = new ScreenTerminal(80, 24);
+        // Function keys use the same sequences in both modes
+        String result = terminal.pipe("~1~2~3~4~a~b~c~d~e~f~g~h~i~j~k~l");
+        assertEquals(
+                "\u001b[5~\u001b[6~\u001b[2~\u001b[3~"
+                        + "\u001bOP\u001bOQ\u001bOR\u001bOS"
+                        + "\u001b[15~\u001b[17~\u001b[18~\u001b[19~\u001b[20~\u001b[21~\u001b[23~\u001b[24~",
+                result);
+    }
+
+    @Test
+    public void testPipeTildeEscape() {
+        ScreenTerminal terminal = new ScreenTerminal(80, 24);
+        // ~~ should produce a single ~
+        String result = terminal.pipe("~~");
+        assertEquals("~", result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Alt-screen tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * Switching to alt-screen must clear it, and switching back must
+     * restore the main screen content.
+     */
+    @Test
+    public void testAltScreenSwitchPreservesMainScreen() {
+        ScreenTerminal terminal = new ScreenTerminal(10, 5);
+        // Write content on main screen
+        terminal.write("MAIN");
+
+        // Switch to alt-screen (CSI ?1049h)
+        terminal.write("\033[?1049h");
+
+        // Alt-screen should be clear
+        assertEquals(' ', getChar(terminal, 0, 0), "Alt-screen should be cleared on entry");
+
+        // Write something on alt-screen
+        terminal.write("ALT");
+
+        // Switch back to main screen (CSI ?1049l)
+        terminal.write("\033[?1049l");
+
+        // Main screen content should be preserved
+        assertEquals('M', getChar(terminal, 0, 0), "Main screen should be restored");
+        assertEquals('A', getChar(terminal, 0, 1));
+        assertEquals('I', getChar(terminal, 0, 2));
+        assertEquals('N', getChar(terminal, 0, 3));
+    }
+
+    /**
+     * Resizing while on the alt-screen must not corrupt the main screen.
+     */
+    @Test
+    public void testResizeOnAltScreen() {
+        ScreenTerminal terminal = new ScreenTerminal(10, 5);
+        terminal.write("MAIN");
+
+        // Switch to alt-screen
+        terminal.write("\033[?1049h");
+        terminal.write("ALT");
+
+        // Resize while on alt-screen
+        terminal.setSize(20, 10);
+
+        // Switch back
+        terminal.write("\033[?1049l");
+
+        // Main screen content should still be there
+        assertEquals('M', getChar(terminal, 0, 0));
+        assertEquals('A', getChar(terminal, 0, 1));
+        assertEquals('I', getChar(terminal, 0, 2));
+        assertEquals('N', getChar(terminal, 0, 3));
+    }
+
+    // -----------------------------------------------------------------------
     // Dirty flag tests
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Comprehensive review and fixes for `ScreenTerminal`:

**Bug fixes (7):**
- Fix `scroll_area_up` filling wrong row when scrolling multiple lines (`y1-1` → `y1-i`)
- Fix `fill()` overwriting first row beyond x0 and skipping single-cell fills
- Clamp `cursor_set_x` to terminal width to prevent `ArrayIndexOutOfBoundsException`
- Fix `ctrl_BS` negative arithmetic at column 0
- Synchronize `isDirty()` to prevent race condition with `setDirty()`/`waitDirty()`
- Truncate screen rows when terminal width shrinks in `setSize()`
- Preserve alternate screen buffer contents on resize instead of clearing it

**Features (3):**
- Add true-color SGR support (`38;2;r;g;b` and `48;2;r;g;b`)
- Add SGR dim/faint (2) and italic (3) attribute support
- Add CSI 3J support to clear scrollback buffer

**Refactoring (5):**
- Replace `HashMap<String, Object>` with type-safe `SavedState` class for DECSC/DECRC
- Deduplicate `pipe()` key filtering (~140 lines of duplicated switch blocks merged)
- Replace `Array.newInstance` with direct `new long[][]` allocation
- Remove duplicate Apache license header (keep BSD per project convention)
- Optimize `cursor_line_width` to iterate screen array directly instead of per-cell `peek()`

## Test plan

- [x] Existing `ScreenTerminalTest` passes (3 tests: resize with history, space-filling on width increase, HTML dump)
- [x] Spotless formatting check passes
- [ ] Manual verification with Tmux/SwingTerminal/WebTerminal consumers