### PR TITLE
fix: check openpty() return code in FFM implementation

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -654,6 +654,8 @@ class CLibrary {
             String device = new String(str, 0, len);
             return new FfmNativePty(
                     provider, null, master.get(ValueLayout.JAVA_INT, 0), slave.get(ValueLayout.JAVA_INT, 0), device);
+        } catch (UncheckedIOException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call openpty()", e);
         }


### PR DESCRIPTION
## Summary

- Add a return code check after the `openpty()` call in `CLibrary.java` (FFM module). Previously, the return value was captured in `res` but never checked, so a failed `openpty()` call (non-zero return) would silently proceed to use uninitialized memory segments for the master/slave file descriptors and device name.

## Test plan

- No unit test added since `openpty()` failure requires native conditions that are difficult to simulate in tests.
- Verified compilation succeeds with `./mvx build -pl terminal-ffm -am -DskipTests`.
- Verified formatting passes with `./mvx format -pl terminal-ffm`.