### PR TITLE
fix: remove duplicate IGNBRK flag in termios attribute conversion

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -335,7 +335,6 @@ class CLibrary {
             long c_iflag = c_iflag();
             EnumSet<Attributes.InputFlag> iflag = attr.getInputFlags();
             addFlag(c_iflag, iflag, Attributes.InputFlag.IGNBRK, IGNBRK);
-            addFlag(c_iflag, iflag, Attributes.InputFlag.IGNBRK, IGNBRK);
             addFlag(c_iflag, iflag, Attributes.InputFlag.BRKINT, BRKINT);
             addFlag(c_iflag, iflag, Attributes.InputFlag.IGNPAR, IGNPAR);
             addFlag(c_iflag, iflag, Attributes.InputFlag.PARMRK, PARMRK);

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/linux/LinuxNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/linux/LinuxNativePty.java
@@ -294,7 +294,6 @@ public class LinuxNativePty extends JniNativePty {
         // Input flags
         EnumSet<Attributes.InputFlag> iflag = attr.getInputFlags();
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IGNBRK, IGNBRK);
-        addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IGNBRK, IGNBRK);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.BRKINT, BRKINT);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IGNPAR, IGNPAR);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.PARMRK, PARMRK);

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/osx/OsXNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/osx/OsXNativePty.java
@@ -283,7 +283,6 @@ public class OsXNativePty extends JniNativePty {
         // Input flags
         EnumSet<Attributes.InputFlag> iflag = attr.getInputFlags();
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IGNBRK, IGNBRK);
-        addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IGNBRK, IGNBRK);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.BRKINT, BRKINT);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IGNPAR, IGNPAR);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.PARMRK, PARMRK);


### PR DESCRIPTION
## Summary

- Remove duplicate `addFlag` call for `IGNBRK` in the `toAttributes`/`asAttributes` termios conversion methods across three files: `CLibrary.java` (FFM), `LinuxNativePty.java`, and `OsXNativePty.java`
- The second `addFlag(IGNBRK)` was a copy-paste error — `EnumSet.add` is idempotent so it had no runtime effect, but it's dead code that should be cleaned up
- The corresponding `setFlag` direction (writing back to termios) does not have this duplication, confirming it was unintentional