### PR TITLE
fix: close HttpURLConnection in ConsoleEngineImpl.urlExists()

### DIFF
--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -1214,13 +1214,18 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
     }
 
     private boolean urlExists(String weburl) {
+        HttpURLConnection huc = null;
         try {
             URL url = URI.create(weburl).toURL();
-            HttpURLConnection huc = (HttpURLConnection) url.openConnection();
+            huc = (HttpURLConnection) url.openConnection();
             huc.setRequestMethod("HEAD");
             return huc.getResponseCode() == HttpURLConnection.HTTP_OK;
         } catch (Exception e) {
             return false;
+        } finally {
+            if (huc != null) {
+                huc.disconnect();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix resource leak in `ConsoleEngineImpl.urlExists()` where `HttpURLConnection` is never disconnected
- Add a `finally` block to ensure `huc.disconnect()` is called after the HEAD request completes or fails