### PR TITLE
feat: modernize signal handling via Panama FFM sigaction()

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -238,6 +238,10 @@ class FfmSignalHandler {
             return null;
         }
 
+        // Install the Java handler before sigaction() so that signals arriving
+        // immediately after the native install are not lost.
+        Runnable previousHandler = handlers.put(signum, handler);
+
         Arena arena = Arena.ofShared();
         try {
             MemorySegment oldAct = arena.allocate(sigactionLayout);
@@ -248,17 +252,19 @@ class FfmSignalHandler {
             int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
             if (res != 0) {
                 logger.log(Level.FINE, "sigaction() failed for signal {0} (signum={1})", new Object[] {name, signum});
+                restoreHandler(signum, previousHandler);
                 arena.close();
                 return null;
             }
-            // Save the previous Java handler if the old native handler was our upcall stub
-            Runnable previousHandler = isOurUpcallStub(oldAct) ? handlers.get(signum) : null;
-            handlers.put(signum, handler);
             ensureDispatcherStarted();
-            return new Registration(signum, arena, oldAct, previousHandler);
+            // Only preserve previousHandler in Registration when the old native
+            // disposition was our upcall stub (otherwise it belongs to an external handler)
+            Runnable saved = isOurUpcallStub(oldAct) ? previousHandler : null;
+            return new Registration(signum, arena, oldAct, saved);
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error registering FFM signal handler for {0}", name);
             logger.log(Level.FINE, EXCEPTION_DETAILS, t);
+            restoreHandler(signum, previousHandler);
             arena.close();
             return null;
         }
@@ -321,8 +327,7 @@ class FfmSignalHandler {
                 logger.log(Level.FINE, "sigaction() restore failed for signal {0}", name);
                 return;
             }
-            // If we restored our own upcall stub, preserve the previous Java handler;
-            // otherwise the native handler is external, so remove the Java handler.
+            // Preserve the previous Java Runnable when the restored native disposition is our stub
             if (isOurUpcallStub(reg.oldAction()) && reg.previousHandler() != null) {
                 handlers.put(reg.signum(), reg.previousHandler());
             } else {
@@ -345,6 +350,7 @@ class FfmSignalHandler {
      */
     static void signalReceived(int signum) {
         if (signum >= 0 && signum < pendingSignals.length()) {
+            // Multiple rapid signals coalesce into one pending flag (standard POSIX semantics)
             pendingSignals.set(signum, 1);
         }
     }
@@ -365,6 +371,14 @@ class FfmSignalHandler {
         if (handlers.isEmpty() && dispatcherThread != null) {
             dispatcherThread.interrupt();
             dispatcherThread = null;
+        }
+    }
+
+    private static void restoreHandler(int signum, Runnable previousHandler) {
+        if (previousHandler != null) {
+            handlers.put(signum, previousHandler);
+        } else {
+            handlers.remove(signum);
         }
     }
 

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -71,8 +71,8 @@ class FfmSignalHandler {
     // --- Shared upcall stub for all signals ---
     private static final MemorySegment upcallStub;
 
-    // --- Whether FFM signal handling is available on this platform ---
-    private static final boolean available;
+    // --- Whether FFM signal handling is AVAILABLE on this platform ---
+    private static final boolean AVAILABLE;
 
     static {
         boolean avail = false;
@@ -176,7 +176,7 @@ class FfmSignalHandler {
                 }
             }
         } catch (Exception | LinkageError t) {
-            logger.log(Level.FINE, "FFM signal handler not available", t);
+            logger.log(Level.FINE, "FFM signal handler not AVAILABLE", t);
         }
 
         SIGHUP = sighup;
@@ -194,7 +194,7 @@ class FfmSignalHandler {
         sa_flags_vh = saFlags;
         sigaction_mh = sigaction;
         upcallStub = stub;
-        available = avail;
+        AVAILABLE = avail;
     }
 
     // --- Signal dispatch infrastructure ---
@@ -216,10 +216,10 @@ class FfmSignalHandler {
     // --- Public API ---
 
     /**
-     * Returns whether FFM-based signal handling is available on this platform.
+     * Returns whether FFM-based signal handling is AVAILABLE on this platform.
      */
     static boolean isAvailable() {
-        return available;
+        return AVAILABLE;
     }
 
     /**
@@ -230,7 +230,7 @@ class FfmSignalHandler {
      * @return a {@link Registration} token, or {@code null} if the signal is unsupported
      */
     static Object register(String name, Runnable handler) {
-        if (!available) {
+        if (!AVAILABLE) {
             return null;
         }
         int signum = signalNumber(name);
@@ -270,7 +270,7 @@ class FfmSignalHandler {
      * @return a {@link Registration} token, or {@code null} if the signal is unsupported
      */
     static Object registerDefault(String name) {
-        if (!available) {
+        if (!AVAILABLE) {
             return null;
         }
         int signum = signalNumber(name);

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -216,18 +216,20 @@ class FfmSignalHandler {
     // --- Public API ---
 
     /**
-     * Returns whether FFM-based signal handling is available on this platform.
+     * Indicates whether native POSIX signal handling via the FFM API is supported and initialized.
+     *
+     * @return `true` if FFM-based signal handling is available on this platform, `false` otherwise.
      */
     static boolean isAvailable() {
         return AVAILABLE;
     }
 
     /**
-     * Registers a signal handler via {@code sigaction()} with {@code SA_RESTART}.
+     * Installs the given Java Runnable as the handler for the named POSIX signal using {@code sigaction} with {@code SA_RESTART}.
      *
      * @param name    signal name (e.g. "WINCH", "INT")
-     * @param handler the Java callback
-     * @return a {@link Registration} token, or {@code null} if the signal is unsupported
+     * @param handler the Java callback to invoke when the signal is dispatched
+     * @return a {@link Registration} token encapsulating the signum, native arena and saved old action (and the previous Java handler when preserved), or {@code null} if FFM support is unavailable or the signal name is unsupported
      */
     static Object register(String name, Runnable handler) {
         if (!AVAILABLE) {
@@ -345,8 +347,10 @@ class FfmSignalHandler {
     // --- Signal upcall target (called from native signal context) ---
 
     /**
-     * Called from the native signal handler via the upcall stub.
-     * Sets an atomic flag; the dispatcher thread will invoke the Java handler.
+     * Record a received POSIX signal for deferred dispatch to the Java handler.
+     *
+     * @param signum the POSIX signal number; if it is within the handler array bounds this marks the signal as pending
+     *                so the dispatcher thread will invoke the registered Java handler, otherwise the value is ignored
      */
     static void signalReceived(int signum) {
         if (signum >= 0 && signum < pendingSignals.length()) {
@@ -355,7 +359,12 @@ class FfmSignalHandler {
         }
     }
 
-    // --- Dispatcher thread ---
+    /**
+     * Starts the signal dispatcher daemon thread if one is not already running.
+     *
+     * Creates and starts a thread named "JLine-signal-dispatcher" that runs the dispatch loop
+     * and stores the thread reference in the class field so subsequent calls are no-ops.
+     */
 
     private static synchronized void ensureDispatcherStarted() {
         if (dispatcherThread != null) {
@@ -367,6 +376,12 @@ class FfmSignalHandler {
         dispatcherThread = t;
     }
 
+    /**
+     * Stops the dispatcher thread when there are no registered signal handlers.
+     *
+     * If no handlers are registered and a dispatcher thread exists, interrupts the thread
+     * and clears the stored reference; otherwise does nothing.
+     */
     private static synchronized void stopDispatcherIfIdle() {
         if (handlers.isEmpty() && dispatcherThread != null) {
             dispatcherThread.interrupt();
@@ -374,6 +389,15 @@ class FfmSignalHandler {
         }
     }
 
+    /**
+     * Restore or remove the Java handler mapping for the given signal number.
+     *
+     * If {@code previousHandler} is non-null, associates it with {@code signum}; otherwise removes any
+     * existing mapping for that signal.
+     *
+     * @param signum the platform signal number to update
+     * @param previousHandler the handler to restore, or {@code null} to remove the mapping
+     */
     private static void restoreHandler(int signum, Runnable previousHandler) {
         if (previousHandler != null) {
             handlers.put(signum, previousHandler);
@@ -383,8 +407,10 @@ class FfmSignalHandler {
     }
 
     /**
-     * Checks whether the {@code sa_handler} field in the given sigaction struct
-     * points to our shared upcall stub.
+     * Determine whether the native sigaction struct's `sa_handler` field points to this class's shared FFM upcall stub.
+     *
+     * @param sigactionStruct a native `struct sigaction` memory segment (as laid out for the current platform)
+     * @return `true` if the `sa_handler` address equals the shared upcall stub address, `false` otherwise
      */
     private static boolean isOurUpcallStub(MemorySegment sigactionStruct) {
         MemorySegment handler = (MemorySegment) sa_handler_vh.get(sigactionStruct);
@@ -411,8 +437,14 @@ class FfmSignalHandler {
     }
 
     /**
-     * Dispatches a single pending signal to its registered handler.
-     */
+         * Invoke the registered Java handler for the given signal, if one exists.
+         *
+         * If a handler is present it will be executed on the dispatcher thread;
+         * any Exception thrown by the handler is caught and logged and will not
+         * propagate to the caller.
+         *
+         * @param signum the POSIX signal number to dispatch
+         */
     private static void dispatchSignal(int signum) {
         Runnable handler = handlers.get(signum);
         if (handler != null) {
@@ -425,7 +457,12 @@ class FfmSignalHandler {
         }
     }
 
-    // --- Signal name → number mapping ---
+    /**
+     * Map a POSIX signal short name to its platform-specific signal number.
+     *
+     * @param name the short signal name (e.g., "INT", "HUP", "WINCH")
+     * @return the platform signal number corresponding to {@code name}, or {@code -1} if the name is not recognized
+     */
 
     private static int signalNumber(String name) {
         return switch (name) {

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -245,8 +245,10 @@ class FfmSignalHandler {
         Runnable previousHandler = handlers.put(signum, handler);
 
         Arena arena = Arena.ofShared();
+        MemorySegment oldAct = null;
+        boolean nativeInstalled = false;
         try {
-            MemorySegment oldAct = arena.allocate(sigactionLayout);
+            oldAct = arena.allocate(sigactionLayout);
             MemorySegment newAct = arena.allocate(sigactionLayout);
             sa_handler_vh.set(newAct, upcallStub);
             sa_flags_vh.set(newAct, SA_RESTART);
@@ -258,24 +260,18 @@ class FfmSignalHandler {
                 arena.close();
                 return null;
             }
-            try {
-                ensureDispatcherStarted();
-                // Only preserve previousHandler in Registration when the old native
-                // disposition was our upcall stub (otherwise it belongs to an external handler)
-                Runnable saved = isOurUpcallStub(oldAct) ? previousHandler : null;
-                return new Registration(signum, arena, oldAct, saved);
-            } catch (Throwable t2) {
-                // sigaction succeeded but post-install setup failed; restore native disposition
-                try {
-                    sigaction_mh.invoke(signum, oldAct, MemorySegment.NULL);
-                } catch (Throwable ignore) {
-                    // best-effort restore
-                }
-                throw t2;
-            }
+            nativeInstalled = true;
+            ensureDispatcherStarted();
+            // Only preserve previousHandler in Registration when the old native
+            // disposition was our upcall stub (otherwise it belongs to an external handler)
+            Runnable saved = isOurUpcallStub(oldAct) ? previousHandler : null;
+            return new Registration(signum, arena, oldAct, saved);
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error registering FFM signal handler for {0}", name);
             logger.log(Level.FINE, EXCEPTION_DETAILS, t);
+            if (nativeInstalled) {
+                bestEffortRestore(signum, oldAct);
+            }
             restoreHandler(signum, previousHandler);
             arena.close();
             return null;
@@ -408,6 +404,15 @@ class FfmSignalHandler {
      * @param signum the platform signal number to update
      * @param previousHandler the handler to restore, or {@code null} to remove the mapping
      */
+    @SuppressWarnings("java:S1181") // MethodHandle.invoke throws Throwable
+    private static void bestEffortRestore(int signum, MemorySegment oldAct) {
+        try {
+            sigaction_mh.invoke(signum, oldAct, MemorySegment.NULL);
+        } catch (Throwable ignore) {
+            // best-effort native handler restore
+        }
+    }
+
     private static void restoreHandler(int signum, Runnable previousHandler) {
         if (previousHandler != null) {
             handlers.put(signum, previousHandler);

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -41,6 +41,11 @@ class FfmSignalHandler {
 
     private static final Logger logger = Logger.getLogger("org.jline");
 
+    // --- Struct field name constants (shared across platform layouts) ---
+    private static final String SA_HANDLER = "sa_handler";
+    private static final String SA_MASK = "sa_mask";
+    private static final String SA_FLAGS = "sa_flags";
+
     // --- Platform-specific signal constants ---
     private static final int SIGHUP;
     private static final int SIGINT;
@@ -74,8 +79,14 @@ class FfmSignalHandler {
         MethodHandle sigaction = null;
         MemorySegment stub = null;
 
-        int sighup = -1, sigint = -1, sigquit = -1, sigterm = -1;
-        int sigtstp = -1, sigcont = -1, siginfo = -1, sigwinch = -1;
+        int sighup = -1;
+        int sigint = -1;
+        int sigquit = -1;
+        int sigterm = -1;
+        int sigtstp = -1;
+        int sigcont = -1;
+        int siginfo = -1;
+        int sigwinch = -1;
         int saRestart = 0;
 
         try {
@@ -93,9 +104,9 @@ class FfmSignalHandler {
                 saRestart = 0x0002;
 
                 layout = MemoryLayout.structLayout(
-                        ValueLayout.ADDRESS.withName("sa_handler"),
-                        ValueLayout.JAVA_INT.withName("sa_mask"),
-                        ValueLayout.JAVA_INT.withName("sa_flags"));
+                        ValueLayout.ADDRESS.withName(SA_HANDLER),
+                        ValueLayout.JAVA_INT.withName(SA_MASK),
+                        ValueLayout.JAVA_INT.withName(SA_FLAGS));
             } else if (osName.startsWith("Linux")) {
                 sighup = 1;
                 sigint = 2;
@@ -108,9 +119,9 @@ class FfmSignalHandler {
                 saRestart = 0x10000000;
 
                 layout = MemoryLayout.structLayout(
-                        ValueLayout.ADDRESS.withName("sa_handler"),
-                        MemoryLayout.sequenceLayout(128, ValueLayout.JAVA_BYTE).withName("sa_mask"),
-                        ValueLayout.JAVA_INT.withName("sa_flags"),
+                        ValueLayout.ADDRESS.withName(SA_HANDLER),
+                        MemoryLayout.sequenceLayout(128, ValueLayout.JAVA_BYTE).withName(SA_MASK),
+                        ValueLayout.JAVA_INT.withName(SA_FLAGS),
                         MemoryLayout.paddingLayout(4),
                         ValueLayout.ADDRESS.withName("sa_restorer"));
             } else if (osName.startsWith("FreeBSD")) {
@@ -125,17 +136,16 @@ class FfmSignalHandler {
                 saRestart = 0x0002;
 
                 layout = MemoryLayout.structLayout(
-                        ValueLayout.ADDRESS.withName("sa_handler"),
-                        ValueLayout.JAVA_INT.withName("sa_flags"),
-                        MemoryLayout.sequenceLayout(16, ValueLayout.JAVA_BYTE).withName("sa_mask"),
+                        ValueLayout.ADDRESS.withName(SA_HANDLER),
+                        ValueLayout.JAVA_INT.withName(SA_FLAGS),
+                        MemoryLayout.sequenceLayout(16, ValueLayout.JAVA_BYTE).withName(SA_MASK),
                         MemoryLayout.paddingLayout(4));
             }
 
             if (layout != null) {
-                saHandler = FfmTerminalProvider.lookupVarHandle(
-                        layout, MemoryLayout.PathElement.groupElement("sa_handler"));
-                saFlags =
-                        FfmTerminalProvider.lookupVarHandle(layout, MemoryLayout.PathElement.groupElement("sa_flags"));
+                saHandler =
+                        FfmTerminalProvider.lookupVarHandle(layout, MemoryLayout.PathElement.groupElement(SA_HANDLER));
+                saFlags = FfmTerminalProvider.lookupVarHandle(layout, MemoryLayout.PathElement.groupElement(SA_FLAGS));
 
                 Linker linker = Linker.nativeLinker();
                 SymbolLookup lookup = SymbolLookup.loaderLookup().or(linker.defaultLookup());
@@ -162,7 +172,7 @@ class FfmSignalHandler {
                     avail = true;
                 }
             }
-        } catch (Throwable t) {
+        } catch (Exception | LinkageError t) {
             logger.log(Level.FINE, "FFM signal handler not available", t);
         }
 
@@ -236,13 +246,14 @@ class FfmSignalHandler {
 
             int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
             if (res != 0) {
-                logger.log(Level.FINE, "sigaction() failed for signal " + name + " (signum=" + signum + ")");
+                logger.log(Level.FINE, "sigaction() failed for signal {0} (signum={1})", new Object[] {name, signum});
                 handlers.remove(signum);
                 return null;
             }
             return new Registration(signum, oldAct);
         } catch (Throwable t) {
-            logger.log(Level.FINE, "Error registering FFM signal handler for " + name, t);
+            logger.log(Level.FINE, "Error registering FFM signal handler for {0}", name);
+            logger.log(Level.FINE, "Exception details", t);
             handlers.remove(signum);
             return null;
         }
@@ -273,12 +284,13 @@ class FfmSignalHandler {
 
             int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
             if (res != 0) {
-                logger.log(Level.FINE, "sigaction(SIG_DFL) failed for signal " + name);
+                logger.log(Level.FINE, "sigaction(SIG_DFL) failed for signal {0}", name);
                 return null;
             }
             return new Registration(signum, oldAct);
         } catch (Throwable t) {
-            logger.log(Level.FINE, "Error registering default handler for " + name, t);
+            logger.log(Level.FINE, "Error registering default handler for {0}", name);
+            logger.log(Level.FINE, "Exception details", t);
             return null;
         }
     }
@@ -299,10 +311,11 @@ class FfmSignalHandler {
         try {
             int res = (int) sigaction_mh.invoke(reg.signum(), reg.oldAction(), MemorySegment.NULL);
             if (res != 0) {
-                logger.log(Level.FINE, "sigaction() restore failed for signal " + name);
+                logger.log(Level.FINE, "sigaction() restore failed for signal {0}", name);
             }
         } catch (Throwable t) {
-            logger.log(Level.FINE, "Error unregistering FFM signal handler for " + name, t);
+            logger.log(Level.FINE, "Error unregistering FFM signal handler for {0}", name);
+            logger.log(Level.FINE, "Exception details", t);
         }
     }
 
@@ -340,18 +353,26 @@ class FfmSignalHandler {
             for (int i = 0; i < pendingSignals.length(); i++) {
                 if (pendingSignals.compareAndSet(i, 1, 0)) {
                     anyPending = true;
-                    Runnable handler = handlers.get(i);
-                    if (handler != null) {
-                        try {
-                            handler.run();
-                        } catch (Exception e) {
-                            logger.log(Level.WARNING, "Error in signal handler for signal " + i, e);
-                        }
-                    }
+                    dispatchSignal(i);
                 }
             }
             if (!anyPending) {
                 LockSupport.parkNanos(1_000_000L); // 1 ms
+            }
+        }
+    }
+
+    /**
+     * Dispatches a single pending signal to its registered handler.
+     */
+    private static void dispatchSignal(int signum) {
+        Runnable handler = handlers.get(signum);
+        if (handler != null) {
+            try {
+                handler.run();
+            } catch (Exception e) {
+                logger.log(Level.WARNING, "Error in signal handler for signal {0}", signum);
+                logger.log(Level.WARNING, "Exception details", e);
             }
         }
     }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -32,19 +32,22 @@ import java.util.logging.Logger;
  *   <li>Arena-scoped handler lifetime</li>
  * </ul>
  *
- * <p>Signal safety is achieved by having the native signal handler only set an atomic flag.
- * A daemon dispatcher thread polls these flags and invokes the registered Java handlers
- * in a safe context.</p>
+ * <p><b>Async-signal-safety caveat:</b> The upcall stub used as the native signal handler
+ * is not formally documented as async-signal-safe by the FFM specification. However, the
+ * callback ({@link #signalReceived(int)}) performs only a single atomic store, minimizing
+ * time spent in signal context. This is analogous to what {@code sun.misc.Signal} does
+ * internally. All substantive Java work happens on the daemon dispatcher thread.</p>
  */
 @SuppressWarnings("restricted")
 class FfmSignalHandler {
 
     private static final Logger logger = Logger.getLogger("org.jline");
 
-    // --- Struct field name constants (shared across platform layouts) ---
+    // --- Shared string constants ---
     private static final String SA_HANDLER = "sa_handler";
     private static final String SA_MASK = "sa_mask";
     private static final String SA_FLAGS = "sa_flags";
+    private static final String EXCEPTION_DETAILS = "Exception details";
 
     // --- Platform-specific signal constants ---
     private static final int SIGHUP;
@@ -208,7 +211,7 @@ class FfmSignalHandler {
     /**
      * Token returned by {@link #register} for later use with {@link #unregister}.
      */
-    record Registration(int signum, MemorySegment oldAction) {}
+    record Registration(int signum, Arena arena, MemorySegment oldAction) {}
 
     // --- Public API ---
 
@@ -236,25 +239,26 @@ class FfmSignalHandler {
         }
 
         ensureDispatcherStarted();
-        handlers.put(signum, handler);
 
+        Arena arena = Arena.ofShared();
         try {
-            MemorySegment oldAct = Arena.global().allocate(sigactionLayout);
-            MemorySegment newAct = Arena.global().allocate(sigactionLayout);
+            MemorySegment oldAct = arena.allocate(sigactionLayout);
+            MemorySegment newAct = arena.allocate(sigactionLayout);
             sa_handler_vh.set(newAct, upcallStub);
             sa_flags_vh.set(newAct, SA_RESTART);
 
             int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
             if (res != 0) {
                 logger.log(Level.FINE, "sigaction() failed for signal {0} (signum={1})", new Object[] {name, signum});
-                handlers.remove(signum);
+                arena.close();
                 return null;
             }
-            return new Registration(signum, oldAct);
+            handlers.put(signum, handler);
+            return new Registration(signum, arena, oldAct);
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error registering FFM signal handler for {0}", name);
-            logger.log(Level.FINE, "Exception details", t);
-            handlers.remove(signum);
+            logger.log(Level.FINE, EXCEPTION_DETAILS, t);
+            arena.close();
             return null;
         }
     }
@@ -274,23 +278,25 @@ class FfmSignalHandler {
             return null;
         }
 
-        handlers.remove(signum);
-
+        Arena arena = Arena.ofShared();
         try {
-            MemorySegment oldAct = Arena.global().allocate(sigactionLayout);
-            MemorySegment newAct = Arena.global().allocate(sigactionLayout);
+            MemorySegment oldAct = arena.allocate(sigactionLayout);
+            MemorySegment newAct = arena.allocate(sigactionLayout);
             // sa_handler = SIG_DFL (0) — already zero from allocate()
             // sa_flags and sa_mask also zero
 
             int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
             if (res != 0) {
                 logger.log(Level.FINE, "sigaction(SIG_DFL) failed for signal {0}", name);
+                arena.close();
                 return null;
             }
-            return new Registration(signum, oldAct);
+            handlers.remove(signum);
+            return new Registration(signum, arena, oldAct);
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error registering default handler for {0}", name);
-            logger.log(Level.FINE, "Exception details", t);
+            logger.log(Level.FINE, EXCEPTION_DETAILS, t);
+            arena.close();
             return null;
         }
     }
@@ -306,16 +312,18 @@ class FfmSignalHandler {
             return;
         }
 
-        handlers.remove(reg.signum());
-
         try {
             int res = (int) sigaction_mh.invoke(reg.signum(), reg.oldAction(), MemorySegment.NULL);
             if (res != 0) {
                 logger.log(Level.FINE, "sigaction() restore failed for signal {0}", name);
+                return;
             }
+            handlers.remove(reg.signum());
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error unregistering FFM signal handler for {0}", name);
-            logger.log(Level.FINE, "Exception details", t);
+            logger.log(Level.FINE, EXCEPTION_DETAILS, t);
+        } finally {
+            reg.arena().close();
         }
     }
 
@@ -372,7 +380,7 @@ class FfmSignalHandler {
                 handler.run();
             } catch (Exception e) {
                 logger.log(Level.WARNING, "Error in signal handler for signal {0}", signum);
-                logger.log(Level.WARNING, "Exception details", e);
+                logger.log(Level.WARNING, EXCEPTION_DETAILS, e);
             }
         }
     }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -365,7 +365,6 @@ class FfmSignalHandler {
      * Creates and starts a thread named "JLine-signal-dispatcher" that runs the dispatch loop
      * and stores the thread reference in the class field so subsequent calls are no-ops.
      */
-
     private static synchronized void ensureDispatcherStarted() {
         if (dispatcherThread != null) {
             return;
@@ -437,14 +436,14 @@ class FfmSignalHandler {
     }
 
     /**
-         * Invoke the registered Java handler for the given signal, if one exists.
-         *
-         * If a handler is present it will be executed on the dispatcher thread;
-         * any Exception thrown by the handler is caught and logged and will not
-         * propagate to the caller.
-         *
-         * @param signum the POSIX signal number to dispatch
-         */
+     * Invoke the registered Java handler for the given signal, if one exists.
+     *
+     * If a handler is present it will be executed on the dispatcher thread;
+     * any Exception thrown by the handler is caught and logged and will not
+     * propagate to the caller.
+     *
+     * @param signum the POSIX signal number to dispatch
+     */
     private static void dispatchSignal(int signum) {
         Runnable handler = handlers.get(signum);
         if (handler != null) {
@@ -463,7 +462,6 @@ class FfmSignalHandler {
      * @param name the short signal name (e.g., "INT", "HUP", "WINCH")
      * @return the platform signal number corresponding to {@code name}, or {@code -1} if the name is not recognized
      */
-
     private static int signalNumber(String name) {
         return switch (name) {
             case "HUP" -> SIGHUP;

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -176,7 +176,7 @@ class FfmSignalHandler {
                 }
             }
         } catch (Exception | LinkageError t) {
-            logger.log(Level.FINE, "FFM signal handler not AVAILABLE", t);
+            logger.log(Level.FINE, "FFM signal handler not available", t);
         }
 
         SIGHUP = sighup;
@@ -211,12 +211,12 @@ class FfmSignalHandler {
     /**
      * Token returned by {@link #register} for later use with {@link #unregister}.
      */
-    record Registration(int signum, Arena arena, MemorySegment oldAction) {}
+    record Registration(int signum, Arena arena, MemorySegment oldAction, Runnable previousHandler) {}
 
     // --- Public API ---
 
     /**
-     * Returns whether FFM-based signal handling is AVAILABLE on this platform.
+     * Returns whether FFM-based signal handling is available on this platform.
      */
     static boolean isAvailable() {
         return AVAILABLE;
@@ -238,8 +238,6 @@ class FfmSignalHandler {
             return null;
         }
 
-        ensureDispatcherStarted();
-
         Arena arena = Arena.ofShared();
         try {
             MemorySegment oldAct = arena.allocate(sigactionLayout);
@@ -253,8 +251,11 @@ class FfmSignalHandler {
                 arena.close();
                 return null;
             }
+            // Save the previous Java handler if the old native handler was our upcall stub
+            Runnable previousHandler = isOurUpcallStub(oldAct) ? handlers.get(signum) : null;
             handlers.put(signum, handler);
-            return new Registration(signum, arena, oldAct);
+            ensureDispatcherStarted();
+            return new Registration(signum, arena, oldAct, previousHandler);
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error registering FFM signal handler for {0}", name);
             logger.log(Level.FINE, EXCEPTION_DETAILS, t);
@@ -291,8 +292,10 @@ class FfmSignalHandler {
                 arena.close();
                 return null;
             }
-            handlers.remove(signum);
-            return new Registration(signum, arena, oldAct);
+            // Save the previous Java handler in case unregister() needs to restore it
+            Runnable previousHandler = handlers.remove(signum);
+            stopDispatcherIfIdle();
+            return new Registration(signum, arena, oldAct, previousHandler);
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error registering default handler for {0}", name);
             logger.log(Level.FINE, EXCEPTION_DETAILS, t);
@@ -318,7 +321,14 @@ class FfmSignalHandler {
                 logger.log(Level.FINE, "sigaction() restore failed for signal {0}", name);
                 return;
             }
-            handlers.remove(reg.signum());
+            // If we restored our own upcall stub, preserve the previous Java handler;
+            // otherwise the native handler is external, so remove the Java handler.
+            if (isOurUpcallStub(reg.oldAction()) && reg.previousHandler() != null) {
+                handlers.put(reg.signum(), reg.previousHandler());
+            } else {
+                handlers.remove(reg.signum());
+            }
+            stopDispatcherIfIdle();
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error unregistering FFM signal handler for {0}", name);
             logger.log(Level.FINE, EXCEPTION_DETAILS, t);
@@ -349,6 +359,22 @@ class FfmSignalHandler {
         t.setDaemon(true);
         t.start();
         dispatcherThread = t;
+    }
+
+    private static synchronized void stopDispatcherIfIdle() {
+        if (handlers.isEmpty() && dispatcherThread != null) {
+            dispatcherThread.interrupt();
+            dispatcherThread = null;
+        }
+    }
+
+    /**
+     * Checks whether the {@code sa_handler} field in the given sigaction struct
+     * points to our shared upcall stub.
+     */
+    private static boolean isOurUpcallStub(MemorySegment sigactionStruct) {
+        MemorySegment handler = (MemorySegment) sa_handler_vh.get(sigactionStruct);
+        return handler.address() == upcallStub.address();
     }
 
     /**

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl.ffm;
+
+import java.lang.foreign.*;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.locks.LockSupport;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Native signal handling via POSIX {@code sigaction()} using the Foreign Function &amp; Memory API.
+ *
+ * <p>This class replaces the reflection-based {@code sun.misc.Signal} approach with direct
+ * {@code sigaction()} calls, providing:</p>
+ * <ul>
+ *   <li>No dependency on internal JVM APIs ({@code sun.misc.Signal})</li>
+ *   <li>{@code SA_RESTART} flag to automatically restart interrupted system calls</li>
+ *   <li>Arena-scoped handler lifetime</li>
+ * </ul>
+ *
+ * <p>Signal safety is achieved by having the native signal handler only set an atomic flag.
+ * A daemon dispatcher thread polls these flags and invokes the registered Java handlers
+ * in a safe context.</p>
+ */
+@SuppressWarnings("restricted")
+class FfmSignalHandler {
+
+    private static final Logger logger = Logger.getLogger("org.jline");
+
+    // --- Platform-specific signal constants ---
+    private static final int SIGHUP;
+    private static final int SIGINT;
+    private static final int SIGQUIT;
+    private static final int SIGTERM;
+    private static final int SIGTSTP;
+    private static final int SIGCONT;
+    private static final int SIGINFO;
+    private static final int SIGWINCH;
+    private static final int SA_RESTART;
+
+    // --- sigaction struct layout and field accessors ---
+    private static final GroupLayout sigactionLayout;
+    private static final VarHandle sa_handler_vh;
+    private static final VarHandle sa_flags_vh;
+
+    // --- FFM method handle for sigaction() ---
+    private static final MethodHandle sigaction_mh;
+
+    // --- Shared upcall stub for all signals ---
+    private static final MemorySegment upcallStub;
+
+    // --- Whether FFM signal handling is available on this platform ---
+    private static final boolean available;
+
+    static {
+        boolean avail = false;
+        GroupLayout layout = null;
+        VarHandle saHandler = null;
+        VarHandle saFlags = null;
+        MethodHandle sigaction = null;
+        MemorySegment stub = null;
+
+        int sighup = -1, sigint = -1, sigquit = -1, sigterm = -1;
+        int sigtstp = -1, sigcont = -1, siginfo = -1, sigwinch = -1;
+        int saRestart = 0;
+
+        try {
+            String osName = System.getProperty("os.name");
+
+            if (osName.startsWith("Mac") || osName.startsWith("Darwin")) {
+                sighup = 1;
+                sigint = 2;
+                sigquit = 3;
+                sigterm = 15;
+                sigtstp = 18;
+                sigcont = 19;
+                siginfo = 29;
+                sigwinch = 28;
+                saRestart = 0x0002;
+
+                layout = MemoryLayout.structLayout(
+                        ValueLayout.ADDRESS.withName("sa_handler"),
+                        ValueLayout.JAVA_INT.withName("sa_mask"),
+                        ValueLayout.JAVA_INT.withName("sa_flags"));
+            } else if (osName.startsWith("Linux")) {
+                sighup = 1;
+                sigint = 2;
+                sigquit = 3;
+                sigterm = 15;
+                sigtstp = 20;
+                sigcont = 18;
+                siginfo = -1;
+                sigwinch = 28;
+                saRestart = 0x10000000;
+
+                layout = MemoryLayout.structLayout(
+                        ValueLayout.ADDRESS.withName("sa_handler"),
+                        MemoryLayout.sequenceLayout(128, ValueLayout.JAVA_BYTE).withName("sa_mask"),
+                        ValueLayout.JAVA_INT.withName("sa_flags"),
+                        MemoryLayout.paddingLayout(4),
+                        ValueLayout.ADDRESS.withName("sa_restorer"));
+            } else if (osName.startsWith("FreeBSD")) {
+                sighup = 1;
+                sigint = 2;
+                sigquit = 3;
+                sigterm = 15;
+                sigtstp = 18;
+                sigcont = 19;
+                siginfo = 29;
+                sigwinch = 28;
+                saRestart = 0x0002;
+
+                layout = MemoryLayout.structLayout(
+                        ValueLayout.ADDRESS.withName("sa_handler"),
+                        ValueLayout.JAVA_INT.withName("sa_flags"),
+                        MemoryLayout.sequenceLayout(16, ValueLayout.JAVA_BYTE).withName("sa_mask"),
+                        MemoryLayout.paddingLayout(4));
+            }
+
+            if (layout != null) {
+                saHandler = FfmTerminalProvider.lookupVarHandle(
+                        layout, MemoryLayout.PathElement.groupElement("sa_handler"));
+                saFlags =
+                        FfmTerminalProvider.lookupVarHandle(layout, MemoryLayout.PathElement.groupElement("sa_flags"));
+
+                Linker linker = Linker.nativeLinker();
+                SymbolLookup lookup = SymbolLookup.loaderLookup().or(linker.defaultLookup());
+
+                Optional<MemorySegment> sigactionAddr = lookup.find("sigaction");
+                if (sigactionAddr.isPresent()) {
+                    sigaction = linker.downcallHandle(
+                            sigactionAddr.get(),
+                            FunctionDescriptor.of(
+                                    ValueLayout.JAVA_INT,
+                                    ValueLayout.JAVA_INT,
+                                    ValueLayout.ADDRESS,
+                                    ValueLayout.ADDRESS));
+
+                    stub = linker.upcallStub(
+                            MethodHandles.lookup()
+                                    .findStatic(
+                                            FfmSignalHandler.class,
+                                            "signalReceived",
+                                            MethodType.methodType(void.class, int.class)),
+                            FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT),
+                            Arena.global());
+
+                    avail = true;
+                }
+            }
+        } catch (Throwable t) {
+            logger.log(Level.FINE, "FFM signal handler not available", t);
+        }
+
+        SIGHUP = sighup;
+        SIGINT = sigint;
+        SIGQUIT = sigquit;
+        SIGTERM = sigterm;
+        SIGTSTP = sigtstp;
+        SIGCONT = sigcont;
+        SIGINFO = siginfo;
+        SIGWINCH = sigwinch;
+        SA_RESTART = saRestart;
+
+        sigactionLayout = layout;
+        sa_handler_vh = saHandler;
+        sa_flags_vh = saFlags;
+        sigaction_mh = sigaction;
+        upcallStub = stub;
+        available = avail;
+    }
+
+    // --- Signal dispatch infrastructure ---
+
+    /** Atomic flags: pendingSignals[signum] == 1 means a signal is pending dispatch. */
+    private static final AtomicIntegerArray pendingSignals = new AtomicIntegerArray(64);
+
+    /** Registered Java handlers, keyed by signal number. */
+    private static final Map<Integer, Runnable> handlers = new ConcurrentHashMap<>();
+
+    /** Dispatcher thread (started lazily on first registration). */
+    private static volatile Thread dispatcherThread;
+
+    /**
+     * Token returned by {@link #register} for later use with {@link #unregister}.
+     */
+    record Registration(int signum, MemorySegment oldAction) {}
+
+    // --- Public API ---
+
+    /**
+     * Returns whether FFM-based signal handling is available on this platform.
+     */
+    static boolean isAvailable() {
+        return available;
+    }
+
+    /**
+     * Registers a signal handler via {@code sigaction()} with {@code SA_RESTART}.
+     *
+     * @param name    signal name (e.g. "WINCH", "INT")
+     * @param handler the Java callback
+     * @return a {@link Registration} token, or {@code null} if the signal is unsupported
+     */
+    static Object register(String name, Runnable handler) {
+        if (!available) {
+            return null;
+        }
+        int signum = signalNumber(name);
+        if (signum < 0) {
+            return null;
+        }
+
+        ensureDispatcherStarted();
+        handlers.put(signum, handler);
+
+        try {
+            MemorySegment oldAct = Arena.global().allocate(sigactionLayout);
+            MemorySegment newAct = Arena.global().allocate(sigactionLayout);
+            sa_handler_vh.set(newAct, upcallStub);
+            sa_flags_vh.set(newAct, SA_RESTART);
+
+            int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
+            if (res != 0) {
+                logger.log(Level.FINE, "sigaction() failed for signal " + name + " (signum=" + signum + ")");
+                handlers.remove(signum);
+                return null;
+            }
+            return new Registration(signum, oldAct);
+        } catch (Throwable t) {
+            logger.log(Level.FINE, "Error registering FFM signal handler for " + name, t);
+            handlers.remove(signum);
+            return null;
+        }
+    }
+
+    /**
+     * Registers the default (SIG_DFL) handler for the specified signal.
+     *
+     * @param name signal name
+     * @return a {@link Registration} token, or {@code null} if the signal is unsupported
+     */
+    static Object registerDefault(String name) {
+        if (!available) {
+            return null;
+        }
+        int signum = signalNumber(name);
+        if (signum < 0) {
+            return null;
+        }
+
+        handlers.remove(signum);
+
+        try {
+            MemorySegment oldAct = Arena.global().allocate(sigactionLayout);
+            MemorySegment newAct = Arena.global().allocate(sigactionLayout);
+            // sa_handler = SIG_DFL (0) — already zero from allocate()
+            // sa_flags and sa_mask also zero
+
+            int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
+            if (res != 0) {
+                logger.log(Level.FINE, "sigaction(SIG_DFL) failed for signal " + name);
+                return null;
+            }
+            return new Registration(signum, oldAct);
+        } catch (Throwable t) {
+            logger.log(Level.FINE, "Error registering default handler for " + name, t);
+            return null;
+        }
+    }
+
+    /**
+     * Restores the previous signal handler that was in place before registration.
+     *
+     * @param name     signal name
+     * @param previous the token returned by {@link #register} or {@link #registerDefault}
+     */
+    static void unregister(String name, Object previous) {
+        if (!(previous instanceof Registration reg)) {
+            return;
+        }
+
+        handlers.remove(reg.signum());
+
+        try {
+            int res = (int) sigaction_mh.invoke(reg.signum(), reg.oldAction(), MemorySegment.NULL);
+            if (res != 0) {
+                logger.log(Level.FINE, "sigaction() restore failed for signal " + name);
+            }
+        } catch (Throwable t) {
+            logger.log(Level.FINE, "Error unregistering FFM signal handler for " + name, t);
+        }
+    }
+
+    // --- Signal upcall target (called from native signal context) ---
+
+    /**
+     * Called from the native signal handler via the upcall stub.
+     * Sets an atomic flag; the dispatcher thread will invoke the Java handler.
+     */
+    static void signalReceived(int signum) {
+        if (signum >= 0 && signum < pendingSignals.length()) {
+            pendingSignals.set(signum, 1);
+        }
+    }
+
+    // --- Dispatcher thread ---
+
+    private static synchronized void ensureDispatcherStarted() {
+        if (dispatcherThread != null) {
+            return;
+        }
+        Thread t = new Thread(FfmSignalHandler::dispatchLoop, "JLine-signal-dispatcher");
+        t.setDaemon(true);
+        t.start();
+        dispatcherThread = t;
+    }
+
+    /**
+     * Polls pending signal flags and dispatches to registered Java handlers.
+     * Runs on a daemon thread; exits when interrupted.
+     */
+    private static void dispatchLoop() {
+        while (!Thread.interrupted()) {
+            boolean anyPending = false;
+            for (int i = 0; i < pendingSignals.length(); i++) {
+                if (pendingSignals.compareAndSet(i, 1, 0)) {
+                    anyPending = true;
+                    Runnable handler = handlers.get(i);
+                    if (handler != null) {
+                        try {
+                            handler.run();
+                        } catch (Exception e) {
+                            logger.log(Level.WARNING, "Error in signal handler for signal " + i, e);
+                        }
+                    }
+                }
+            }
+            if (!anyPending) {
+                LockSupport.parkNanos(1_000_000L); // 1 ms
+            }
+        }
+    }
+
+    // --- Signal name → number mapping ---
+
+    private static int signalNumber(String name) {
+        return switch (name) {
+            case "HUP" -> SIGHUP;
+            case "INT" -> SIGINT;
+            case "QUIT" -> SIGQUIT;
+            case "TERM" -> SIGTERM;
+            case "TSTP" -> SIGTSTP;
+            case "CONT" -> SIGCONT;
+            case "INFO" -> SIGINFO;
+            case "WINCH" -> SIGWINCH;
+            default -> -1;
+        };
+    }
+}

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -258,11 +258,21 @@ class FfmSignalHandler {
                 arena.close();
                 return null;
             }
-            ensureDispatcherStarted();
-            // Only preserve previousHandler in Registration when the old native
-            // disposition was our upcall stub (otherwise it belongs to an external handler)
-            Runnable saved = isOurUpcallStub(oldAct) ? previousHandler : null;
-            return new Registration(signum, arena, oldAct, saved);
+            try {
+                ensureDispatcherStarted();
+                // Only preserve previousHandler in Registration when the old native
+                // disposition was our upcall stub (otherwise it belongs to an external handler)
+                Runnable saved = isOurUpcallStub(oldAct) ? previousHandler : null;
+                return new Registration(signum, arena, oldAct, saved);
+            } catch (Throwable t2) {
+                // sigaction succeeded but post-install setup failed; restore native disposition
+                try {
+                    sigaction_mh.invoke(signum, oldAct, MemorySegment.NULL);
+                } catch (Throwable ignore) {
+                    // best-effort restore
+                }
+                throw t2;
+            }
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error registering FFM signal handler for {0}", name);
             logger.log(Level.FINE, EXCEPTION_DETAILS, t);
@@ -332,10 +342,11 @@ class FfmSignalHandler {
             // Preserve the previous Java Runnable when the restored native disposition is our stub
             if (isOurUpcallStub(reg.oldAction()) && reg.previousHandler() != null) {
                 handlers.put(reg.signum(), reg.previousHandler());
+                ensureDispatcherStarted();
             } else {
                 handlers.remove(reg.signum());
+                stopDispatcherIfIdle();
             }
-            stopDispatcherIfIdle();
         } catch (Throwable t) {
             logger.log(Level.FINE, "Error unregistering FFM signal handler for {0}", name);
             logger.log(Level.FINE, EXCEPTION_DETAILS, t);

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
@@ -52,6 +52,22 @@ public class FfmTerminalProvider implements TerminalProvider {
         return -1;
     }
 
+    /**
+     * Creates a Terminal bound to the process system streams (stdin/stdout/stderr) or an equivalent PTY-backed terminal.
+     *
+     * @param name            terminal name or identifier
+     * @param type            terminal type (TERM)
+     * @param ansiPassThrough if true, pass ANSI/VT sequences through without filtering
+     * @param encoding        overall character set for the terminal
+     * @param inputEncoding   character set used for input decoding
+     * @param outputEncoding  character set used for output encoding
+     * @param nativeSignals   if true, attempt to use native signal handling when available
+     * @param signalHandler   handler invoked for terminal signals
+     * @param paused          if true, create the terminal in a paused state (input/output suspended)
+     * @param systemStream    which system stream this terminal should be associated with
+     * @return a Terminal instance bound to the specified system stream (or an equivalent PTY-backed terminal)
+     * @throws IOException if the native PTY or system terminal cannot be created or accessed
+     */
     @Override
     public Terminal sysTerminal(
             String name,
@@ -135,11 +151,24 @@ public class FfmTerminalProvider implements TerminalProvider {
         return FfmNativePty.posixSystemStreamName(stream);
     }
 
+    /**
+     * Obtain the current width, in columns, of the specified system stream.
+     *
+     * @param stream the system stream whose width to query
+     * @return the width in columns of the given system stream
+     */
     @Override
     public int systemStreamWidth(SystemStream stream) {
         return FfmNativePty.systemStreamWidth(stream);
     }
 
+    /**
+     * Register a handler to be invoked when the specified signal is delivered.
+     *
+     * @param signal the name of the signal to handle (platform-specific string)
+     * @param handler the runnable to execute when the signal is received
+     * @return an opaque registration handle that can be passed to {@code unregisterSignal} to remove the handler
+     */
     @Override
     public Object registerSignal(String signal, Runnable handler) {
         Object reg = FfmSignalHandler.register(signal, handler);
@@ -149,6 +178,12 @@ public class FfmTerminalProvider implements TerminalProvider {
         return Signals.register(signal, handler);
     }
 
+    /**
+     * Register the default handler for the specified signal, preferring the FFM handler if available.
+     *
+     * @param signal the name of the signal (for example, "INT" or "TERM")
+     * @return an object representing the installed registration; the FFM registration if one was created, otherwise the fallback Signals registration
+     */
     @Override
     public Object registerDefaultSignal(String signal) {
         Object reg = FfmSignalHandler.registerDefault(signal);
@@ -158,6 +193,13 @@ public class FfmTerminalProvider implements TerminalProvider {
         return Signals.registerDefault(signal);
     }
 
+    /**
+     * Unregisters a previously registered signal handler; uses FFM unregistration when the
+     * provided registration is an FFM registration, otherwise uses the platform fallback.
+     *
+     * @param signal the name of the signal to unregister (e.g., "INT", "TERM")
+     * @param registration the registration token returned by a prior register call
+     */
     @Override
     public void unregisterSignal(String signal, Object registration) {
         if (registration instanceof FfmSignalHandler.Registration) {
@@ -167,6 +209,11 @@ public class FfmTerminalProvider implements TerminalProvider {
         }
     }
 
+    /**
+     * Provide a short identifying string for this terminal provider.
+     *
+     * @return a string of the form "TerminalProvider[<name>]" identifying the provider
+     */
     @Override
     public String toString() {
         return "TerminalProvider[" + name() + "]";

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
@@ -28,6 +28,7 @@ import org.jline.terminal.spi.Pty;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.OSUtils;
+import org.jline.utils.Signals;
 
 public class FfmTerminalProvider implements TerminalProvider {
 
@@ -89,7 +90,7 @@ public class FfmTerminalProvider implements TerminalProvider {
                     systemStream == SystemStream.Output ? FileDescriptor.out : FileDescriptor.err,
                     CLibrary.ttyName(0));
             return new PosixSysTerminal(
-                    name, type, pty, encoding, inputEncoding, outputEncoding, nativeSignals, signalHandler);
+                    this, name, type, pty, encoding, inputEncoding, outputEncoding, nativeSignals, signalHandler);
         }
     }
 
@@ -137,6 +138,33 @@ public class FfmTerminalProvider implements TerminalProvider {
     @Override
     public int systemStreamWidth(SystemStream stream) {
         return FfmNativePty.systemStreamWidth(stream);
+    }
+
+    @Override
+    public Object registerSignal(String signal, Runnable handler) {
+        Object reg = FfmSignalHandler.register(signal, handler);
+        if (reg != null) {
+            return reg;
+        }
+        return Signals.register(signal, handler);
+    }
+
+    @Override
+    public Object registerDefaultSignal(String signal) {
+        Object reg = FfmSignalHandler.registerDefault(signal);
+        if (reg != null) {
+            return reg;
+        }
+        return Signals.registerDefault(signal);
+    }
+
+    @Override
+    public void unregisterSignal(String signal, Object registration) {
+        if (registration instanceof FfmSignalHandler.Registration) {
+            FfmSignalHandler.unregister(signal, registration);
+        } else {
+            Signals.unregister(signal, registration);
+        }
     }
 
     @Override

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
@@ -266,6 +266,27 @@ public class JniTerminalProvider implements TerminalProvider {
                 systemStream);
     }
 
+    /**
+     * Create a POSIX system terminal backed by a native PTY.
+     *
+     * The created terminal is configured with the provided character encodings and signal handling.
+     * The output encoding is chosen from {@code stdoutEncoding} or {@code stderrEncoding}
+     * depending on {@code systemStream}.
+     *
+     * @param name human-readable terminal name
+     * @param type terminal type (TERM)
+     * @param ansiPassThrough whether ANSI sequences should be passed through unchanged
+     * @param encoding primary charset used by the terminal
+     * @param stdinEncoding charset for standard input
+     * @param stdoutEncoding charset for standard output
+     * @param stderrEncoding charset for standard error
+     * @param nativeSignals whether native signal handling is enabled
+     * @param signalHandler handler for terminal signals
+     * @param paused whether the terminal should start in a paused state
+     * @param systemStream which system stream the terminal represents (affects output encoding selection)
+     * @return a POSIX system Terminal backed by a native PTY
+     * @throws IOException if the underlying PTY cannot be opened
+     */
     public Terminal posixSysTerminal(
             String name,
             String type,
@@ -286,6 +307,23 @@ public class JniTerminalProvider implements TerminalProvider {
                 this, name, type, pty, encoding, stdinEncoding, outputEncoding, nativeSignals, signalHandler);
     }
 
+    /**
+     * Create a new terminal backed by a newly opened POSIX pseudo-terminal (PTY).
+     *
+     * @param name the terminal name for identification
+     * @param type the terminal type (TERM)
+     * @param in the input stream connected to the PTY slave
+     * @param out the output stream connected to the PTY slave
+     * @param encoding the primary charset for the terminal
+     * @param inputEncoding the charset to decode input
+     * @param outputEncoding the charset to encode output
+     * @param signalHandler handler for terminal signals
+     * @param paused if true, the terminal is created in a paused state
+     * @param attributes initial terminal attributes for the PTY
+     * @param size initial terminal size for the PTY
+     * @return a Terminal instance wrapping the opened PTY and provided streams
+     * @throws IOException if the PTY cannot be opened
+     */
     @Override
     public Terminal newTerminal(
             String name,

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
@@ -283,7 +283,7 @@ public class JniTerminalProvider implements TerminalProvider {
         // Use the appropriate output encoding based on the system stream
         Charset outputEncoding = systemStream == SystemStream.Error ? stderrEncoding : stdoutEncoding;
         return new PosixSysTerminal(
-                name, type, pty, encoding, stdinEncoding, outputEncoding, nativeSignals, signalHandler);
+                this, name, type, pty, encoding, stdinEncoding, outputEncoding, nativeSignals, signalHandler);
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -89,7 +89,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         this(null, name, type, pty, encoding, inputEncoding, outputEncoding, nativeSignals, signalHandler);
     }
 
-    @SuppressWarnings("this-escape")
+    @SuppressWarnings({"this-escape", "squid:S107"})
     public PosixSysTerminal(
             TerminalProvider provider,
             String name,

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -68,6 +68,18 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
     protected final Map<Signal, Object> nativeHandlers = new HashMap<>();
     protected final Task closer;
 
+    /**
+     * Creates a POSIX system terminal backed by the provided PTY, using the same charset for input
+     * and output, and optionally enabling native signal handling.
+     *
+     * @param name the terminal name
+     * @param type the terminal type (TERM)
+     * @param pty the pseudo-terminal providing slave input/output streams for the terminal
+     * @param encoding the charset used for both input and output encoding
+     * @param nativeSignals if true, native OS signal handlers will be registered
+     * @param signalHandler the initial handler to install for native signals
+     * @throws IOException if an I/O error occurs while initializing the terminal
+     */
     @SuppressWarnings("this-escape")
     public PosixSysTerminal(
             String name, String type, Pty pty, Charset encoding, boolean nativeSignals, SignalHandler signalHandler)
@@ -75,6 +87,20 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         this(null, name, type, pty, encoding, encoding, encoding, nativeSignals, signalHandler);
     }
 
+    /**
+     * Creates a POSIX system terminal backed by the given PTY and character encodings, without a
+     * TerminalProvider.
+     *
+     * @param name the terminal name
+     * @param type the terminal type (TERM)
+     * @param pty the pseudoterminal providing slave input/output streams
+     * @param encoding the primary charset for the terminal
+     * @param inputEncoding the charset used for input decoding
+     * @param outputEncoding the charset used for output encoding
+     * @param nativeSignals whether native signal handlers should be registered
+     * @param signalHandler the initial handler to install for native signals
+     * @throws IOException if an I/O error occurs while initializing the terminal
+     */
     @SuppressWarnings("this-escape")
     public PosixSysTerminal(
             String name,
@@ -89,6 +115,22 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         this(null, name, type, pty, encoding, inputEncoding, outputEncoding, nativeSignals, signalHandler);
     }
 
+    /**
+     * Create a POSIX system terminal backed by the provided PTY, initializing non-blocking
+     * input/output, reader/writer encodings, and optional native signal handlers.
+     *
+     * @param provider        optional TerminalProvider used for native signal registration; may be null
+     * @param name            the terminal name
+     * @param type            the terminal type (TERM)
+     * @param pty             the PTY whose slave streams back this terminal
+     * @param encoding        the primary charset for the terminal
+     * @param inputEncoding   the charset used for the terminal reader
+     * @param outputEncoding  the charset used for the terminal writer
+     * @param nativeSignals   if true, register native OS signal handlers for all signals
+     * @param signalHandler   the initial handler to install for native signals; if `SignalHandler.SIG_DFL`,
+     *                        default native handlers will be registered
+     * @throws IOException if the PTY streams or terminal I/O cannot be initialized
+     */
     @SuppressWarnings({"this-escape", "squid:S107"})
     public PosixSysTerminal(
             TerminalProvider provider,
@@ -121,6 +163,16 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         ShutdownHooks.add(closer);
     }
 
+    /**
+     * Install a new handler for the given signal and synchronize native registration when the handler changes.
+     *
+     * If the new handler differs from the previous one, registers a native default handler when the new
+     * handler is `SignalHandler.SIG_DFL`; otherwise registers a native handler that will raise the signal.
+     *
+     * @param signal the signal to update
+     * @param handler the new handler to install for the signal
+     * @return the previous handler for the signal
+     */
     @Override
     public SignalHandler handle(Signal signal, SignalHandler handler) {
         SignalHandler prev = super.handle(signal, handler);
@@ -134,14 +186,34 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         return prev;
     }
 
+    /**
+     * Register a native signal handler by name, using the configured TerminalProvider if present.
+     *
+     * @param name    the signal name (for example, "INT" or "TERM")
+     * @param handler the action to run when the signal is received
+     * @return        an opaque registration object returned by the underlying registration mechanism;
+     *                this value can be passed to the corresponding unregister method to remove the handler
+     */
     private Object doRegisterSignal(String name, Runnable handler) {
         return provider != null ? provider.registerSignal(name, handler) : Signals.register(name, handler);
     }
 
+    /**
+     * Register the default native handler for the specified signal name.
+     *
+     * @param name the platform signal name (for example, "INT")
+     * @return an opaque registration object representing the native registration; pass this to {@code unregister} when removing the handler
+     */
     private Object doRegisterDefaultSignal(String name) {
         return provider != null ? provider.registerDefaultSignal(name) : Signals.registerDefault(name);
     }
 
+    /**
+     * Unregisters the native handler associated with the specified signal.
+     *
+     * @param name         the POSIX signal name (e.g., "INT", "TERM") whose handler should be removed
+     * @param registration the registration token returned when the signal was registered
+     */
     private void doUnregisterSignal(String name, Object registration) {
         if (provider != null) {
             provider.unregisterSignal(name, registration);
@@ -150,6 +222,13 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         }
     }
 
+    /**
+     * Determine if grapheme cluster mode is supported for this terminal.
+     *
+     * @return `true` if grapheme cluster mode is supported, `false` otherwise; on Windows this always
+     *         returns `false` to avoid writing a DECRQM probe to raw stdout/stderr that may not be a
+     *         real PTY and could contaminate process output.
+     */
     @Override
     public boolean supportsGraphemeClusterMode() {
         // On Windows (Cygwin/MSYSTEM), the slave output goes to a raw
@@ -186,6 +265,12 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         return output;
     }
 
+    /**
+     * Closes the terminal and releases its resources: flushes pending output, removes the shutdown hook,
+     * unregisters any native signal handlers, performs superclass shutdown, and closes the reader.
+     *
+     * @throws IOException if an I/O error occurs while flushing or closing the terminal streams
+     */
     @Override
     protected void doClose() throws IOException {
         writer.flush();

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jline.terminal.spi.Pty;
+import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.FastBufferedOutputStream;
 import org.jline.utils.NonBlocking;
 import org.jline.utils.NonBlockingInputStream;
@@ -59,6 +60,7 @@ import org.jline.utils.Signals;
  */
 public class PosixSysTerminal extends AbstractPosixTerminal {
 
+    protected final TerminalProvider provider;
     protected final NonBlockingInputStream input;
     protected final OutputStream output;
     protected final NonBlockingReader reader;
@@ -70,7 +72,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
     public PosixSysTerminal(
             String name, String type, Pty pty, Charset encoding, boolean nativeSignals, SignalHandler signalHandler)
             throws IOException {
-        this(name, type, pty, encoding, encoding, encoding, nativeSignals, signalHandler);
+        this(null, name, type, pty, encoding, encoding, encoding, nativeSignals, signalHandler);
     }
 
     @SuppressWarnings("this-escape")
@@ -84,7 +86,23 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
             boolean nativeSignals,
             SignalHandler signalHandler)
             throws IOException {
+        this(null, name, type, pty, encoding, inputEncoding, outputEncoding, nativeSignals, signalHandler);
+    }
+
+    @SuppressWarnings("this-escape")
+    public PosixSysTerminal(
+            TerminalProvider provider,
+            String name,
+            String type,
+            Pty pty,
+            Charset encoding,
+            Charset inputEncoding,
+            Charset outputEncoding,
+            boolean nativeSignals,
+            SignalHandler signalHandler)
+            throws IOException {
         super(name, type, pty, encoding, inputEncoding, outputEncoding, signalHandler);
+        this.provider = provider;
         this.input = NonBlocking.nonBlocking(getName(), pty.getSlaveInput());
         this.output = new FastBufferedOutputStream(pty.getSlaveOutput());
         this.reader = NonBlocking.nonBlocking(getName(), input, inputEncoding());
@@ -93,9 +111,9 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         if (nativeSignals) {
             for (final Signal signal : Signal.values()) {
                 if (signalHandler == SignalHandler.SIG_DFL) {
-                    nativeHandlers.put(signal, Signals.registerDefault(signal.name()));
+                    nativeHandlers.put(signal, doRegisterDefaultSignal(signal.name()));
                 } else {
-                    nativeHandlers.put(signal, Signals.register(signal.name(), () -> raise(signal)));
+                    nativeHandlers.put(signal, doRegisterSignal(signal.name(), () -> raise(signal)));
                 }
             }
         }
@@ -108,12 +126,28 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         SignalHandler prev = super.handle(signal, handler);
         if (prev != handler) {
             if (handler == SignalHandler.SIG_DFL) {
-                Signals.registerDefault(signal.name());
+                doRegisterDefaultSignal(signal.name());
             } else {
-                Signals.register(signal.name(), () -> raise(signal));
+                doRegisterSignal(signal.name(), () -> raise(signal));
             }
         }
         return prev;
+    }
+
+    private Object doRegisterSignal(String name, Runnable handler) {
+        return provider != null ? provider.registerSignal(name, handler) : Signals.register(name, handler);
+    }
+
+    private Object doRegisterDefaultSignal(String name) {
+        return provider != null ? provider.registerDefaultSignal(name) : Signals.registerDefault(name);
+    }
+
+    private void doUnregisterSignal(String name, Object registration) {
+        if (provider != null) {
+            provider.unregisterSignal(name, registration);
+        } else {
+            Signals.unregister(name, registration);
+        }
     }
 
     @Override
@@ -157,7 +191,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         writer.flush();
         ShutdownHooks.remove(closer);
         for (Map.Entry<Signal, Object> entry : nativeHandlers.entrySet()) {
-            Signals.unregister(entry.getKey().name(), entry.getValue());
+            doUnregisterSignal(entry.getKey().name(), entry.getValue());
         }
         super.doClose();
         reader.close();

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -261,7 +261,7 @@ public class ExecTerminalProvider implements TerminalProvider {
             // Use the appropriate output encoding based on the system stream
             Charset outputEncoding = systemStream == SystemStream.Error ? stderrEncoding : stdoutEncoding;
             return new PosixSysTerminal(
-                    name, type, pty, encoding, stdinEncoding, outputEncoding, nativeSignals, signalHandler);
+                    this, name, type, pty, encoding, stdinEncoding, outputEncoding, nativeSignals, signalHandler);
         } else {
             return null;
         }
@@ -328,7 +328,7 @@ public class ExecTerminalProvider implements TerminalProvider {
         // Use the appropriate output encoding based on the system stream
         Charset outputEncoding = systemStream == SystemStream.Error ? stderrEncoding : stdoutEncoding;
         return new PosixSysTerminal(
-                name, type, pty, encoding, stdinEncoding, outputEncoding, nativeSignals, signalHandler);
+                this, name, type, pty, encoding, stdinEncoding, outputEncoding, nativeSignals, signalHandler);
     }
 
     /**

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -243,6 +243,22 @@ public class ExecTerminalProvider implements TerminalProvider {
                 systemStream);
     }
 
+    /**
+     * Create a POSIX-style system terminal for Windows environments that provide a POSIX layer (Cygwin/MSYS); returns null on other Windows variants.
+     *
+     * @param name the terminal name
+     * @param type the terminal type (TERM)
+     * @param ansiPassThrough whether ANSI sequences should be passed through (unused for POSIX path)
+     * @param encoding the general charset for the terminal
+     * @param stdinEncoding charset to use for stdin
+     * @param stdoutEncoding charset to use for stdout
+     * @param stderrEncoding charset to use for stderr
+     * @param nativeSignals whether native signal handling is enabled
+     * @param signalHandler handler for terminal signals
+     * @param paused whether the terminal should be created in a paused state
+     * @param systemStream the system stream to associate with the terminal; determines which output encoding (stdout vs stderr) is selected
+     * @return a configured {@code PosixSysTerminal} when running under Cygwin or MSYS, {@code null} otherwise
+     */
     public Terminal winSysTerminal(
             String name,
             String type,
@@ -311,6 +327,23 @@ public class ExecTerminalProvider implements TerminalProvider {
                 systemStream);
     }
 
+    /**
+     * Create a POSIX system terminal backed by the specified system stream.
+     *
+     * @param name the terminal name
+     * @param type the terminal type
+     * @param ansiPassThrough whether ANSI sequences should be passed through (platform-dependent)
+     * @param encoding the terminal's primary character encoding
+     * @param stdinEncoding the encoding to use for standard input
+     * @param stdoutEncoding the encoding to use for standard output (used when {@code systemStream} is not Error)
+     * @param stderrEncoding the encoding to use for standard error (used when {@code systemStream} is Error)
+     * @param nativeSignals whether native signal handling is enabled
+     * @param signalHandler handler for terminal signals
+     * @param paused whether the terminal should be created in a paused state
+     * @param systemStream the system stream to back the terminal; selects the output encoding (uses {@code stderrEncoding} when {@code SystemStream.Error}, otherwise {@code stdoutEncoding})
+     * @return a POSIX-based Terminal instance connected to the chosen system stream
+     * @throws IOException if obtaining the underlying PTY or creating the terminal fails
+     */
     public Terminal posixSysTerminal(
             String name,
             String type,

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
+import org.jline.utils.Signals;
 
 /**
  * Service provider interface for terminal implementations.
@@ -195,6 +196,44 @@ public interface TerminalProvider {
      */
     default int getConsoleCodepage() {
         return -1;
+    }
+
+    /**
+     * Registers a handler for the specified signal.
+     *
+     * <p>
+     * Terminal providers can override this method to use platform-specific signal
+     * handling mechanisms. The default implementation delegates to
+     * {@link Signals#register(String, Runnable)} which uses {@code sun.misc.Signal}
+     * via reflection.
+     * </p>
+     *
+     * @param signal the signal name (e.g., "INT", "WINCH")
+     * @param handler the callback to run when the signal is received
+     * @return an opaque registration object for use with {@link #unregisterSignal}
+     */
+    default Object registerSignal(String signal, Runnable handler) {
+        return Signals.register(signal, handler);
+    }
+
+    /**
+     * Registers the default handler for the specified signal.
+     *
+     * @param signal the signal name (e.g., "INT", "WINCH")
+     * @return an opaque registration object for use with {@link #unregisterSignal}
+     */
+    default Object registerDefaultSignal(String signal) {
+        return Signals.registerDefault(signal);
+    }
+
+    /**
+     * Unregisters a previously registered signal handler, restoring the prior handler.
+     *
+     * @param signal the signal name
+     * @param registration the object returned by {@link #registerSignal} or {@link #registerDefaultSignal}
+     */
+    default void unregisterSignal(String signal, Object registration) {
+        Signals.unregister(signal, registration);
     }
 
     /**

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -184,15 +184,12 @@ public interface TerminalProvider {
     int systemStreamWidth(SystemStream stream);
 
     /**
-     * Returns the Windows console output codepage.
+     * Retrieve the Windows console output code page.
      *
-     * <p>
-     * On Windows, this method returns the console output codepage (equivalent to
-     * {@code GetConsoleOutputCP()}). On non-Windows platforms, or if the codepage
-     * cannot be determined, this method returns {@code -1}.
-     * </p>
+     * On Windows this returns the console output code page; on non-Windows platforms or when the code page
+     * cannot be determined this returns {@code -1}.
      *
-     * @return the console output codepage, or {@code -1} if not available
+     * @return the console output code page, or {@code -1} if not available
      */
     default int getConsoleCodepage() {
         return -1;
@@ -201,16 +198,11 @@ public interface TerminalProvider {
     /**
      * Registers a handler for the specified signal.
      *
-     * <p>
-     * Terminal providers can override this method to use platform-specific signal
-     * handling mechanisms. The default implementation delegates to
-     * {@link Signals#register(String, Runnable)} which uses {@code sun.misc.Signal}
-     * via reflection.
-     * </p>
+     * Providers may override this to use platform-specific signal handling.
      *
      * @param signal the signal name (e.g., "INT", "WINCH")
      * @param handler the callback to run when the signal is received
-     * @return an opaque registration object for use with {@link #unregisterSignal}
+     * @return an opaque registration object suitable for use with {@link #unregisterSignal(String, Object)}
      */
     default Object registerSignal(String signal, Runnable handler) {
         return Signals.register(signal, handler);


### PR DESCRIPTION
## Summary

- Add provider-delegated signal handling so each `TerminalProvider` can use platform-specific mechanisms instead of relying on `sun.misc.Signal` reflection
- `FfmTerminalProvider` now installs signal handlers via native `sigaction()` with `SA_RESTART`, eliminating reflection and internal API usage when the FFM provider is active (Java 22+)
- JNI, Exec, and other providers continue using `sun.misc.Signal` through the default implementation — no behavioral change

### Key changes

- **`TerminalProvider`**: new default methods `registerSignal()` / `registerDefaultSignal()` / `unregisterSignal()` delegating to `Signals.java`
- **`FfmSignalHandler`** (new): self-contained FFM signal handler with platform-specific `struct sigaction` layouts (macOS, Linux, FreeBSD), `SA_RESTART` flag, shared upcall stub, and atomic-flag dispatcher thread for signal safety
- **`FfmTerminalProvider`**: overrides signal methods to use `FfmSignalHandler` with automatic fallback to `Signals.java`
- **`PosixSysTerminal`**: accepts optional `TerminalProvider`, delegates signal registration through it
- All providers (`FfmTerminalProvider`, `JniTerminalProvider`, `ExecTerminalProvider`) pass `this` to `PosixSysTerminal`

### Non-breaking guarantees

| | sun.misc.Signal (current) | sigaction via FFM (new) |
|---|---|---|
| API stability | Internal, may be removed | POSIX standard |
| Access method | Reflection | Direct FFM downcall |
| SA_RESTART | Not available | Enabled |
| Handler lifetime | GC-dependent | Arena-scoped |

- `Terminal.handle(Signal, SignalHandler)` public API is unchanged
- Existing constructors remain backward compatible
- Provider selection determines the mechanism transparently

Closes #1747

## Test plan

- [x] All existing terminal module tests pass
- [x] All existing terminal-ffm module tests pass
- [x] All existing terminal-jni module tests pass
- [ ] Manual verification on macOS with FFM provider active
- [ ] Manual verification on Linux with FFM provider active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional native POSIX signal handling via the Java FFM API on macOS, Linux, and FreeBSD.
  * Terminal providers can register, install default, and unregister signal handlers via the provider API.

* **Improvements**
  * Signal registration now prefers the native path with automatic fallback when native support is unavailable.
  * POSIX terminal construction accepts a provider instance so terminals can delegate signal management to the provider.
  * Safer handler lifecycle with dispatcher support and restored native dispositions on unregister.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->