### PR TITLE
fix: catch LinkageError during provider loading

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -281,7 +281,7 @@ public interface TerminalProvider {
                     try {
                         Class<?> providerClass = cl.loadClass(line);
                         return (TerminalProvider) providerClass.getConstructor().newInstance();
-                    } catch (Exception e) {
+                    } catch (Exception | LinkageError e) {
                         throw new IOException("Unable to load terminal provider " + name + ": " + e.getMessage(), e);
                     }
                 }


### PR DESCRIPTION
Fixes #1751

## Problem

When using the `jline` bundle jar on JDK 21, loading the FFM terminal provider fails with:
```
java.lang.UnsupportedClassVersionError: org/jline/terminal/impl/ffm/FfmTerminalProvider
has been compiled by a more recent version of the Java Runtime (class file version 66.0),
this version of the Java Runtime only recognizes class file versions up to 65.0
```

The FFM provider is compiled for Java 22+ (class file version 66.0). When `TerminalProvider.load()` attempts to load it on an older JDK, `ClassLoader.loadClass()` throws `UnsupportedClassVersionError`, which is a `LinkageError` (an `Error`, not an `Exception`). The catch clause only caught `Exception`, so the error escaped rather than being wrapped in an `IOException` for graceful fallback.

## Fix

Change `catch (Exception e)` to `catch (Exception | LinkageError e)` in `TerminalProvider.load()`. This catches class-loading errors like `UnsupportedClassVersionError` and `NoClassDefFoundError`, wrapping them in `IOException` so the fallback logic in `TerminalBuilder.checkProvider()` can handle them gracefully.

## Workaround

Users on JDK < 22 can avoid the issue by using the individual small jars instead of the `jline` bundle jar, and simply not including the `jline-terminal-ffm` dependency:

```xml
<dependency>
    <groupId>org.jline</groupId>
    <artifactId>jline-terminal</artifactId>
    <version>4.0.9</version>
</dependency>
<dependency>
    <groupId>org.jline</groupId>
    <artifactId>jline-terminal-jni</artifactId>
    <version>4.0.9</version>
</dependency>
<dependency>
    <groupId>org.jline</groupId>
    <artifactId>jline-reader</artifactId>
    <version>4.0.9</version>
</dependency>
<!-- Add other modules as needed, but NOT jline-terminal-ffm -->
```

Alternatively, use the `jdk11` classifier of the bundle jar which excludes FFM classes:
```xml
<dependency>
    <groupId>org.jline</groupId>
    <artifactId>jline</artifactId>
    <version>4.0.9</version>
    <classifier>jdk11</classifier>
</dependency>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for terminal provider initialization to catch additional error conditions and provide consistent error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->