### PR TITLE
fix: grapheme-cluster-aware width with per-category emoji detection (#1753)

### DIFF
--- a/demo/src/main/java/org/jline/demo/examples/GraphemeClusterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/GraphemeClusterExample.java
@@ -67,7 +67,7 @@ public class GraphemeClusterExample {
 
             if (supported) {
                 // Enable mode 2027
-                terminal.setGraphemeClusterMode(true);
+                terminal.setGraphemeClusterMode(true, false);
                 writer.println("Mode 2027 enabled: " + terminal.getGraphemeClusterMode());
 
                 writer.println();
@@ -243,14 +243,14 @@ public class GraphemeClusterExample {
             boolean supported = terminal.supportsGraphemeClusterMode();
             writer.println("4. Mode 2027 supported: " + supported);
             if (supported) {
-                terminal.setGraphemeClusterMode(true);
+                terminal.setGraphemeClusterMode(true, false);
                 writer.println("   Mode 2027 ON, writer.println:");
                 writer.println("   [" + FAMILY_EMOJI + "]");
                 writer.println("   Mode 2027 ON, AttributedString.print:");
                 writer.print("   [");
                 new AttributedString(FAMILY_EMOJI).print(terminal);
                 writer.println("]");
-                terminal.setGraphemeClusterMode(false);
+                terminal.setGraphemeClusterMode(false, false);
             }
             writer.println();
 
@@ -331,11 +331,11 @@ public class GraphemeClusterExample {
                 writer.println("     Family emoji: " + emoji.columnLength(terminal) + " cols");
                 writer.println("     Flag:         " + flag.columnLength(terminal) + " cols");
                 if (supported) {
-                    terminal.setGraphemeClusterMode(true);
+                    terminal.setGraphemeClusterMode(true, false);
                     writer.println("   Mode 2027 ON:");
                     writer.println("     Family emoji: " + emoji.columnLength(terminal) + " cols");
                     writer.println("     Flag:         " + flag.columnLength(terminal) + " cols");
-                    terminal.setGraphemeClusterMode(false);
+                    terminal.setGraphemeClusterMode(false, false);
                 }
             }
             writer.println();

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1359,7 +1359,7 @@ public interface Terminal extends Closeable, Flushable {
      * </p>
      *
      * @return {@code true} if the terminal supports mode 2027, {@code false} otherwise
-     * @see #setGraphemeClusterMode(boolean)
+     * @see #setGraphemeClusterMode(boolean, boolean)
      * @see #getGraphemeClusterMode()
      */
     default boolean supportsGraphemeClusterMode() {
@@ -1370,7 +1370,7 @@ public interface Terminal extends Closeable, Flushable {
      * Returns whether mode 2027 (grapheme cluster) is currently enabled.
      *
      * @return {@code true} if grapheme cluster mode is currently enabled, {@code false} otherwise
-     * @see #setGraphemeClusterMode(boolean)
+     * @see #setGraphemeClusterMode(boolean, boolean)
      */
     default boolean getGraphemeClusterMode() {
         return false;
@@ -1391,11 +1391,13 @@ public interface Terminal extends Closeable, Flushable {
      * </p>
      *
      * @param enable {@code true} to enable grapheme cluster mode, {@code false} to disable it
+     * @param force  if {@code true}, skip capability probing and treat the terminal as
+     *               natively supporting grapheme clusters (no Mode 2027 escape sequences sent)
      * @return {@code true} if the operation succeeded, {@code false} otherwise
      * @see #supportsGraphemeClusterMode()
      * @see #getGraphemeClusterMode()
      */
-    default boolean setGraphemeClusterMode(boolean enable) {
+    default boolean setGraphemeClusterMode(boolean enable, boolean force) {
         return false;
     }
 

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -727,7 +727,7 @@ public final class TerminalBuilder {
      *                        or leave unset for auto-detection
      * @return The builder
      * @see Terminal#supportsGraphemeClusterMode()
-     * @see Terminal#setGraphemeClusterMode(boolean)
+     * @see Terminal#setGraphemeClusterMode(boolean, boolean)
      */
     public TerminalBuilder graphemeCluster(boolean graphemeCluster) {
         this.graphemeCluster = graphemeCluster;
@@ -735,9 +735,15 @@ public final class TerminalBuilder {
     }
 
     /**
-     * Builds the terminal.
-     * @return the newly created terminal, never {@code null}
-     * @throws IOException if an error occurs
+     * Create and configure a Terminal instance according to this builder's settings.
+     *
+     * If a global terminal override has been set, that instance is returned instead of creating a new one.
+     * The method also applies grapheme-cluster mode to the created terminal based on the builder setting
+     * or the `org.jline.terminal.graphemeCluster` system property: it may force-enable, disable, or
+     * probe-and-enable grapheme-cluster handling on the terminal.
+     *
+     * @return the configured Terminal instance; never {@code null}
+     * @throws IOException if terminal creation or configuration fails
      */
     public Terminal build() throws IOException {
         Terminal override = TERMINAL_OVERRIDE.get();
@@ -750,13 +756,23 @@ public final class TerminalBuilder {
             Log.debug(() -> "Using pty "
                     + ((AbstractPosixTerminal) terminal).getPty().getClass().getSimpleName());
         }
-        // Enable grapheme cluster mode (mode 2027) if supported
+        // Enable grapheme cluster mode if supported
         Boolean gc = this.graphemeCluster;
         if (gc == null) {
             gc = getBoolean(PROP_GRAPHEME_CLUSTER, null);
         }
-        if (!Boolean.FALSE.equals(gc) && terminal.supportsGraphemeClusterMode()) {
-            terminal.setGraphemeClusterMode(true);
+        if (Boolean.TRUE.equals(gc)) {
+            // Force-enable: skip probing, treat as native grapheme support
+            terminal.setGraphemeClusterMode(true, true);
+            Log.debug(() -> "Grapheme cluster mode: force-enabled (skipping probe)");
+        } else if (Boolean.FALSE.equals(gc)) {
+            Log.debug(() -> "Grapheme cluster mode: disabled by configuration");
+        } else if (terminal.supportsGraphemeClusterMode()) {
+            // Auto-detect: probe terminal and enable if supported
+            terminal.setGraphemeClusterMode(true, false);
+            Log.debug(() -> "Grapheme cluster mode: enabled (auto-detected)");
+        } else {
+            Log.debug(() -> "Grapheme cluster mode: not supported by terminal");
         }
         return terminal;
     }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -8,6 +8,7 @@
  */
 package org.jline.terminal.impl;
 
+import java.io.IOError;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.nio.charset.Charset;
@@ -35,6 +36,7 @@ import org.jline.utils.InfoCmp;
 import org.jline.utils.InfoCmp.Capability;
 import org.jline.utils.Log;
 import org.jline.utils.Status;
+import org.jline.utils.WCWidth;
 
 /**
  * Base implementation of the Terminal interface.
@@ -86,7 +88,27 @@ public abstract class AbstractTerminal implements TerminalExt {
     protected volatile boolean closed = false;
     private Boolean graphemeClusterModeSupported;
     private boolean graphemeClusterModeEnabled;
+    private boolean graphemeClusterNative;
+    private boolean groupsRegionalIndicators;
+    private boolean groupsZwjSequences;
 
+    /** Result of the Mode 2027 probe. */
+    private enum ProbeResult {
+        /** Mode 2027 is supported. */
+        SUPPORTED,
+        /** Terminal responded but does not support Mode 2027. */
+        NOT_SUPPORTED,
+        /** Terminal did not respond at all. */
+        NO_RESPONSE
+    }
+
+    /**
+     * Create a terminal with the given name and type using the platform default charset and the default signal handler.
+     *
+     * @param name the terminal name (may be {@code null})
+     * @param type the terminal type (may be {@code null}, a default will be used when absent)
+     * @throws IOException if an I/O error occurs while constructing the terminal
+     */
     public AbstractTerminal(String name, String type) throws IOException {
         this(name, type, null, SignalHandler.SIG_DFL);
     }
@@ -162,7 +184,7 @@ public abstract class AbstractTerminal implements TerminalExt {
 
     protected void doClose() throws IOException {
         if (graphemeClusterModeEnabled) {
-            setGraphemeClusterMode(false);
+            setGraphemeClusterMode(false, false);
         }
         if (status != null) {
             status.close();
@@ -377,9 +399,79 @@ public abstract class AbstractTerminal implements TerminalExt {
         return graphemeClusterModeSupported;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean getGraphemeClusterMode() {
         return graphemeClusterModeEnabled;
+    }
+
+    /**
+     * Tests whether the terminal groups the grapheme cluster starting at
+     * {@code index} as a single display unit. Used by {@link org.jline.utils.WCWidth}
+     * for per-category width computation when partial emoji support is detected.
+     *
+     * @param cs the character sequence
+     * @param index the start index of the cluster
+     * @param charCount the number of Java chars in the cluster
+     * @return {@code true} if the terminal renders the cluster as a single glyph
+     */
+    public boolean isClusterGrouped(CharSequence cs, int index, int charCount) {
+        if (!graphemeClusterModeEnabled) {
+            return false;
+        }
+        if (groupsRegionalIndicators && groupsZwjSequences) {
+            return true;
+        }
+        if (!groupsRegionalIndicators && !groupsZwjSequences) {
+            return false;
+        }
+        // Partial support — classify and check
+        if (charCount <= Character.charCount(Character.codePointAt(cs, index))) {
+            return false; // Single codepoint
+        }
+        int cp = Character.codePointAt(cs, index);
+        if (WCWidth.isRegionalIndicator(cp)) {
+            return groupsRegionalIndicators;
+        }
+        return groupsZwjSequences;
+    }
+
+    /**
+     * Probes the terminal for grapheme cluster support.
+     *
+     * <p>First attempts Mode 2027 detection via DECRQM ({@link #probeMode2027()}).
+     * If the terminal responds but does not support Mode 2027, falls back to a
+     * cursor position probe ({@link #probeCursorPosition()}): writes test
+     * emoji (a flag and a ZWJ sequence) and measures cursor displacement via
+     * DSR/CPR. If the cursor advances by exactly 2 columns, the terminal
+     * natively groups that emoji category as a single cluster.</p>
+     *
+     * <p>The cursor probe is only attempted when the terminal has already
+     * responded to the DECRQM/DA1 query, which guarantees it handles escape
+     * sequences and avoids blocking indefinitely on an unresponsive terminal.</p>
+     *
+     * @return {@code true} if the terminal supports grapheme clusters
+     */
+    private boolean probeGraphemeClusterMode() {
+        if (TYPE_DUMB.equals(type) || TYPE_DUMB_COLOR.equals(type)) {
+            return false;
+        }
+        // Enter raw mode to prevent the terminal response from being echoed.
+        Attributes prev = enterRawMode();
+        try {
+            ProbeResult mode2027 = probeMode2027();
+            if (mode2027 == ProbeResult.SUPPORTED) {
+                return true;
+            }
+            // Cursor probe is only safe when the terminal actually responded to the
+            // DECRQM/DA1 query; otherwise getCursorPosition would block indefinitely.
+            if (mode2027 == ProbeResult.NOT_SUPPORTED) {
+                return probeCursorPosition();
+            }
+            return false;
+        } finally {
+            setAttributes(prev);
+        }
     }
 
     /**
@@ -396,25 +488,24 @@ public abstract class AbstractTerminal implements TerminalExt {
      * {@code CSI ?} prefix, but diverge immediately after ({@code 2027;}
      * vs the DA1 device-type parameter), so they are easy to distinguish.</p>
      *
-     * <p>macOS Terminal.app is explicitly skipped (detected via
-     * {@code TERM_PROGRAM=Apple_Terminal}) because its CSI parser does not
-     * handle the {@code $} intermediate byte and leaks the final {@code p}
-     * as visible text — the only known terminal with this bug.</p>
+     * <p>macOS Terminal.app is explicitly skipped because its CSI parser does
+     * not handle the {@code $} intermediate byte and leaks the final {@code p}
+     * as visible text. A {@code false} (not {@code null}) is returned so the
+     * cursor position fallback is still attempted.</p>
      *
-     * @return {@code true} if the terminal recognizes mode 2027
+     * @return {@link ProbeResult#SUPPORTED} if mode 2027 is supported,
+     *         {@link ProbeResult#NOT_SUPPORTED} if the terminal responded but
+     *         does not support it, or {@link ProbeResult#NO_RESPONSE} if the
+     *         terminal did not respond at all
      */
-    private boolean probeGraphemeClusterMode() {
-        if (TYPE_DUMB.equals(type) || TYPE_DUMB_COLOR.equals(type)) {
-            return false;
-        }
+    private ProbeResult probeMode2027() {
         // Terminal.app's CSI parser does not handle intermediate bytes correctly
         // and leaks the final byte 'p' of the DECRQM sequence as visible text.
+        // Skip DECRQM but return NOT_SUPPORTED (not NO_RESPONSE) so the cursor probe runs.
         String termProgram = System.getenv("TERM_PROGRAM");
         if ("Apple_Terminal".equals(termProgram)) {
-            return false;
+            return ProbeResult.NOT_SUPPORTED;
         }
-        // Enter raw mode to prevent the terminal response from being echoed
-        Attributes prev = enterRawMode();
         try {
             // Send DECRQM query for mode 2027 followed by DA1 as sentinel
             writer().write("\033[?2027$p\033[c");
@@ -425,65 +516,202 @@ public abstract class AbstractTerminal implements TerminalExt {
             // DA1:    ESC [ ? Pp ; ... c
             long timeout = 100;
             if (reader().peek(timeout) < 0) {
-                return false;
+                return ProbeResult.NO_RESPONSE;
             }
             int[] expected = {'\033', '[', '?', '2', '0', '2', '7', ';'};
             for (int e : expected) {
                 int c = reader().read(timeout);
                 if (c != e) {
                     // Not DECRPM — likely the DA1 sentinel response,
-                    // meaning the terminal does not support DECRQM
-                    drainResponse(timeout);
-                    return false;
+                    // meaning the terminal does not support DECRQM.
+                    // Read remaining DA1 bytes until the 'c' terminator.
+                    drainUntilDA1(timeout);
+                    return ProbeResult.NOT_SUPPORTED;
                 }
             }
             int ps = reader().read(timeout);
             if (ps < '0' || ps > '4') {
-                drainResponse(timeout);
-                return false;
+                drainUntilDA1(timeout);
+                return ProbeResult.NOT_SUPPORTED;
             }
             int dollar = reader().read(timeout);
             int y = reader().read(timeout);
             if (dollar != '$' || y != 'y') {
-                drainResponse(timeout);
-                return false;
+                drainUntilDA1(timeout);
+                return ProbeResult.NOT_SUPPORTED;
             }
             // Drain the trailing DA1 sentinel response
-            drainResponse(timeout);
+            drainUntilDA1(timeout);
             // Ps: 1=set, 2=reset (can be set), 3=permanently set → supported
             // Ps: 0=not recognized, 4=permanently reset → not supported
-            return ps == '1' || ps == '2' || ps == '3';
+            return (ps == '1' || ps == '2' || ps == '3') ? ProbeResult.SUPPORTED : ProbeResult.NOT_SUPPORTED;
         } catch (IOException e) {
-            return false;
-        } finally {
-            setAttributes(prev);
+            return ProbeResult.NO_RESPONSE;
         }
     }
 
     /**
-     * Drains any remaining bytes from a partial or unexpected terminal response.
-     * Uses the given timeout for the first byte (to wait for a response that may
-     * still be in flight), then switches to a short timeout for subsequent bytes
-     * to avoid blocking after the last byte is consumed.
+     * Probes per-category emoji grouping by measuring cursor displacement.
+     *
+     * <p>Writes a test emoji (a ZWJ sequence) followed by a DSR cursor-position
+     * query. After flushing, reads the CPR response and checks whether the
+     * cursor advanced by exactly 2 columns (meaning the terminal grouped
+     * the emoji as a single cluster).</p>
+     *
+     * <p>Some terminals group all emoji categories (flags + ZWJ), others
+     * only group regional indicators (flags). Two probes detect this.</p>
+     *
+     * <p>This method must only be called when the terminal is known to
+     * respond to escape sequences (i.e., after {@link #probeMode2027()}
+     * received a response), because DSR/CPR blocks until a response
+     * arrives.</p>
+     *
+     * @return {@code true} if the terminal groups the test emoji
      */
-    private void drainResponse(long timeout) {
+    private boolean probeCursorPosition() {
+        // Need u6 (CPR response pattern), u7 (DSR query), and save/restore cursor
+        if (getStringCapability(Capability.user6) == null
+                || getStringCapability(Capability.user7) == null
+                || getStringCapability(Capability.save_cursor) == null
+                || getStringCapability(Capability.restore_cursor) == null) {
+            return false;
+        }
+        // Two probes cover the three observed terminal behaviours:
+        //   1. Full support   → both flag and ZWJ grouped
+        //   2. Flags only     → flag grouped, ZWJ not (e.g. Tabby, Alacritty)
+        //   3. No support     → neither grouped
+        // When ZWJ is grouped we assume skin-tone and VS16 are too (always
+        // observed together).  A flag probe alone catches partial support.
+        String flagEmoji = "\uD83C\uDDEB\uD83C\uDDF7"; // 🇫🇷 French flag
+        String zwjEmoji = "\uD83D\uDC69\u200D\uD83D\uDD2C"; // 👩‍🔬 woman scientist
         try {
-            while (reader().peek(timeout) >= 0) {
-                reader().read(timeout);
-                // After the first byte, remaining bytes in the same response
-                // arrive nearly instantly; use a short timeout to avoid
-                // blocking for the full duration after the last byte.
-                timeout = Math.min(10, timeout);
+            // Query current cursor column so we can compute displacement
+            // rather than relying on the cursor starting at column 1
+            puts(Capability.user7);
+            writer().flush();
+            int startCol = readCprColumn(200);
+            if (startCol < 0) {
+                return false;
+            }
+
+            // --- Flag probe ---
+            int flagCol = probeEmojiWidth(flagEmoji);
+            // --- ZWJ probe ---
+            int zwjCol = probeEmojiWidth(zwjEmoji);
+
+            // Grouped emoji → 2-column displacement; ungrouped → 4
+            groupsRegionalIndicators = (flagCol - startCol == 2);
+            groupsZwjSequences = (zwjCol - startCol == 2);
+
+            if (groupsRegionalIndicators || groupsZwjSequences) {
+                graphemeClusterNative = true;
+                graphemeClusterModeEnabled = true;
+                return true;
+            }
+            return false;
+        } catch (IOError | IOException e) {
+            try {
+                puts(Capability.restore_cursor);
+                writer().flush();
+            } catch (Exception ignored) {
+                // Best-effort cleanup; probing failure should not propagate
+            }
+            groupsRegionalIndicators = false;
+            groupsZwjSequences = false;
+            return false;
+        }
+    }
+
+    /**
+     * Writes a single emoji to the terminal, queries cursor position via
+     * DSR/CPR, then cleans up. Returns the 1-based column value.
+     */
+    private int probeEmojiWidth(String emoji) throws IOException {
+        puts(Capability.save_cursor);
+        writer().write(emoji);
+        puts(Capability.user7); // DSR — request cursor position
+        writer().flush();
+
+        int col = readCprColumn(200);
+
+        puts(Capability.restore_cursor);
+        writer().flush();
+        return col;
+    }
+
+    /**
+     * Reads a single CPR (Cursor Position Report) response and extracts
+     * the column value.
+     *
+     * <p>Expected format: {@code ESC [ row ; col R}. Returns the raw
+     * 1-based column value, or {@code -1} if the response could not be
+     * parsed.</p>
+     */
+    private int readCprColumn(long timeout) throws IOException {
+        int c;
+        // Skip until ESC
+        while ((c = reader().read(timeout)) != '\033') {
+            if (c < 0) return -1;
+        }
+        if (reader().read(timeout) != '[') return -1;
+        // Skip row digits until ';'
+        while ((c = reader().read(timeout)) != ';') {
+            if (c < 0 || c == 'R') return -1;
+        }
+        // Read column digits until 'R'
+        int col = 0;
+        while ((c = reader().read(timeout)) != 'R') {
+            if (c < '0' || c > '9') return -1;
+            col = col * 10 + (c - '0');
+        }
+        return col;
+    }
+
+    /**
+     * Discards input until a DA1 response terminator ('c') is encountered or the reader ends.
+     *
+     * Reads bytes from the terminal via reader().read(timeout) and stops when the character
+     * 'c' is seen or the reader returns a negative value. IOExceptions during draining are ignored.
+     *
+     * @param timeout the per-read timeout value passed to the reader
+     */
+    private void drainUntilDA1(long timeout) {
+        try {
+            int c;
+            while ((c = reader().read(timeout)) >= 0) {
+                if (c == 'c') {
+                    return;
+                }
             }
         } catch (IOException ignored) {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
-    public boolean setGraphemeClusterMode(boolean enable) {
+    public boolean setGraphemeClusterMode(boolean enable, boolean force) {
+        if (force) {
+            graphemeClusterModeSupported = true;
+            // If Mode 2027 was active via escape sequences, disable it
+            // before switching to native mode
+            if (!enable && graphemeClusterModeEnabled && !graphemeClusterNative) {
+                writer().write("\033[?2027l");
+                writer().flush();
+            }
+            graphemeClusterNative = true;
+            graphemeClusterModeEnabled = enable;
+            groupsRegionalIndicators = true;
+            groupsZwjSequences = true;
+            return true;
+        }
         if (supportsGraphemeClusterMode()) {
-            writer().write(enable ? "\033[?2027h" : "\033[?2027l");
-            writer().flush();
+            if (!graphemeClusterNative) {
+                writer().write(enable ? "\033[?2027h" : "\033[?2027l");
+                writer().flush();
+                // Mode 2027 handles all emoji categories
+                groupsRegionalIndicators = enable;
+                groupsZwjSequences = enable;
+            }
             graphemeClusterModeEnabled = enable;
             return true;
         } else {

--- a/terminal/src/main/java/org/jline/utils/WCWidth.java
+++ b/terminal/src/main/java/org/jline/utils/WCWidth.java
@@ -8,7 +8,10 @@
  */
 package org.jline.utils;
 
+import java.text.BreakIterator;
+
 import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.AbstractTerminal;
 
 /**
  * Utility class for determining the display width of Unicode characters.
@@ -52,6 +55,19 @@ import org.jline.terminal.Terminal;
  */
 public final class WCWidth {
 
+    /**
+     * Whether the JDK runtime supports grapheme cluster segmentation.
+     * JDK 21+ provides improved {@code BreakIterator} support (full UAX #29)
+     * and {@code Character.isEmoji()} for reliable emoji detection.
+     * When {@code true} and no terminal is provided, grapheme cluster-aware
+     * width calculation is used as a better default for application-level
+     * width queries.
+     */
+    static final boolean HAS_JDK_GRAPHEME_SUPPORT = Runtime.version().feature() >= 21;
+
+    /**
+     * Prevents instantiation of this utility class.
+     */
     private WCWidth() {}
 
     /* The following two functions define the column width of an ISO 10646
@@ -394,6 +410,35 @@ public final class WCWidth {
      * @return the number of chars consumed by the grapheme cluster
      */
     public static int charCountForGraphemeCluster(CharSequence cs, int index) {
+        if (HAS_JDK_GRAPHEME_SUPPORT) {
+            return charCountForGraphemeClusterBreakIterator(cs, index);
+        }
+        return charCountForGraphemeClusterLegacy(cs, index);
+    }
+
+    /**
+     * Uses JDK 21+ {@link BreakIterator} with full UAX #29 Extended Grapheme
+     * Cluster segmentation. Automatically stays current with new Unicode
+     * versions as the JDK is updated.
+     */
+    static int charCountForGraphemeClusterBreakIterator(CharSequence cs, int index) {
+        int len = cs.length();
+        if (index >= len) return 0;
+        BreakIterator bi = BreakIterator.getCharacterInstance();
+        bi.setText(cs.toString());
+        int next = bi.following(index);
+        if (next == BreakIterator.DONE) {
+            return len - index;
+        }
+        return next - index;
+    }
+
+    /**
+     * Fallback grapheme cluster segmentation for JDK &lt; 21.
+     * Handles ZWJ sequences, regional indicator pairs, emoji modifiers,
+     * variation selectors, and combining marks using heuristics.
+     */
+    static int charCountForGraphemeClusterLegacy(CharSequence cs, int index) {
         int len = cs.length();
         if (index >= len) return 0;
 
@@ -484,77 +529,204 @@ public final class WCWidth {
     }
 
     /**
-     * Returns the display width of the character or grapheme cluster at
-     * {@code index} in {@code cs}.
+     * Compute the display width in terminal columns of the character or grapheme cluster
+     * that begins at the given index in the character sequence.
      *
-     * <p>When the terminal has grapheme cluster mode enabled, this delegates to
-     * {@link #wcwidthForGraphemeCluster(CharSequence, int)} so that VS16
-     * emoji presentation and ZWJ sequences are measured correctly.
-     * Otherwise it returns {@link #wcwidth(int)} for the code point at
-     * {@code index}.</p>
+     * <p>If the terminal has grapheme-cluster mode enabled, or if {@code terminal} is
+     * {@code null} and the runtime provides JDK-level grapheme-cluster support (JDK 21+),
+     * the measurement is grapheme-cluster-aware so emoji variation selectors and ZWJ
+     * sequences are handled as a single display unit. Otherwise the width of the
+     * single code point at {@code index} is returned.</p>
      *
-     * @param cs       the character sequence
-     * @param index    the starting char index
-     * @param terminal the terminal to query for grapheme cluster mode, or {@code null}
-     * @return the display width
+     * @param cs       the character sequence containing the cluster
+     * @param index    the starting char index of the character or cluster
+     * @param terminal the terminal to query for grapheme-cluster mode, or {@code null}
+     * @return         the display width in terminal columns for the character or cluster
      */
     public static int wcwidthForDisplay(CharSequence cs, int index, Terminal terminal) {
-        if (terminal != null && terminal.getGraphemeClusterMode()) {
-            return wcwidthForGraphemeCluster(cs, index);
+        if ((terminal != null && terminal.getGraphemeClusterMode()) || (terminal == null && HAS_JDK_GRAPHEME_SUPPORT)) {
+            int charCount = charCountForGraphemeCluster(cs, index);
+            return wcwidthForDisplayWithGroupings(cs, index, terminal, charCount);
         }
         return wcwidth(Character.codePointAt(cs, index));
     }
 
     /**
-     * Returns the display width of the character or grapheme cluster at
-     * {@code index}, reusing a pre-computed {@code charCount} to avoid
-     * scanning the cluster boundaries twice.
+     * Compute the display width in terminal columns of the character or grapheme cluster
+     * starting at the given char index, using a provided cluster char count to avoid
+     * recomputing cluster boundaries.
      *
-     * @param cs       the character sequence
-     * @param index    the starting char index
-     * @param terminal the terminal to query for grapheme cluster mode, or {@code null}
-     * @param charCount number of {@code char}s consumed by this character/cluster
-     *                  (as returned by {@link #charCountForDisplay(CharSequence, int, Terminal)})
-     * @return the display width
+     * @param cs       the character sequence containing the cluster
+     * @param index    the starting char index of the character or cluster
+     * @param terminal the terminal to query for grapheme-cluster grouping behavior; may be {@code null}
+     * @param charCount the number of Java `char`s occupied by the character or grapheme cluster
+     *                  starting at {@code index}
+     * @return the display width in terminal columns for the character or grapheme cluster
      */
     static int wcwidthForDisplay(CharSequence cs, int index, Terminal terminal, int charCount) {
-        if (terminal != null && terminal.getGraphemeClusterMode()) {
-            return wcwidthForGraphemeCluster(cs, index, charCount);
+        if ((terminal != null && terminal.getGraphemeClusterMode()) || (terminal == null && HAS_JDK_GRAPHEME_SUPPORT)) {
+            return wcwidthForDisplayWithGroupings(cs, index, terminal, charCount);
         }
         return wcwidth(Character.codePointAt(cs, index));
     }
 
     /**
-     * Returns the number of chars to advance past the current character or
-     * grapheme cluster at {@code index} in {@code cs}.
+     * Compute the number of Java chars that form the display unit (code point or grapheme cluster) starting at {@code index} in {@code cs}.
      *
-     * <p>When the terminal has grapheme cluster mode enabled, this delegates to
-     * {@link #charCountForGraphemeCluster(CharSequence, int)} so that ZWJ
-     * emoji, flag pairs, skin-tone modifiers, etc. are treated as a single
-     * unit.  Otherwise it simply returns {@code Character.charCount(cp)}
-     * for the code point at {@code index}.</p>
+     * <p>If the terminal indicates grapheme cluster mode, or when {@code terminal} is {@code null} and JDK grapheme-cluster support is available (JDK 21+), this uses grapheme-cluster segmentation so ZWJ sequences, flag pairs, skin-tone modifiers, and similar multi-code-point units are treated as a single unit and may span multiple {@code char}s. Otherwise it returns the {@link Character#charCount(int) char count} for the code point at {@code index}.</p>
      *
-     * @param cs       the character sequence
-     * @param index    the starting char index
-     * @param terminal the terminal to query for grapheme cluster mode, or {@code null}
-     * @return the number of chars to advance
+     * @param cs the character sequence
+     * @param index the starting char index
+     * @param terminal the terminal to consult for grapheme cluster mode, or {@code null}
+     * @return the number of {@code char} units to advance past the display unit beginning at {@code index}
      */
     public static int charCountForDisplay(CharSequence cs, int index, Terminal terminal) {
-        if (terminal != null && terminal.getGraphemeClusterMode()) {
-            return charCountForGraphemeCluster(cs, index);
+        if ((terminal != null && terminal.getGraphemeClusterMode()) || (terminal == null && HAS_JDK_GRAPHEME_SUPPORT)) {
+            int charCount = charCountForGraphemeCluster(cs, index);
+            return charCountForDisplayWithGroupings(cs, index, terminal, charCount);
         }
         return Character.charCount(Character.codePointAt(cs, index));
     }
 
     /**
-     * Tests whether the given code point is a Regional Indicator Symbol
-     * (U+1F1E6 .. U+1F1FF), used in pairs to represent flag emoji.
+     * Compute the display width in columns for the grapheme cluster starting at the given index,
+     * honoring the terminal's per-category emoji grouping support.
+     *
+     * If the terminal is null or supports grouping for this cluster, the cluster is measured as a
+     * single grapheme and its cluster width is returned. If the cluster is an emoji grouping that
+     * the terminal does not support, the returned width is the sum of the individual code-point
+     * widths in the cluster. If the cluster contains a single non-grouped code point, the width of
+     * that base code point is returned.
+     *
+     * @param cs the character sequence containing the cluster
+     * @param index the index of the first char of the cluster in {@code cs}
+     * @param terminal the terminal whose emoji grouping support determines grouping behavior; may be {@code null}
+     * @param charCount the number of Java {@code char} units that make up the grapheme cluster at {@code index}
+     * @return the display width in columns for the cluster (or base code point / summed per-code-point width)
+     */
+    private static int wcwidthForDisplayWithGroupings(CharSequence cs, int index, Terminal terminal, int charCount) {
+        if (terminal == null || isGroupedByTerminal(cs, index, terminal, charCount)) {
+            return wcwidthForGraphemeCluster(cs, index, charCount);
+        }
+        if (isMultiCodepointEmoji(cs, index, charCount)) {
+            // Multi-codepoint emoji cluster not grouped by terminal:
+            // sum individual codepoint widths
+            return wcwidthUngrouped(cs, index, charCount);
+        }
+        return wcwidth(Character.codePointAt(cs, index));
+    }
+
+    /**
+     * Determine the number of Java char units that should be consumed for display starting at the given index, considering the terminal's emoji grouping support.
+     *
+     * @param cs the character sequence containing the cluster
+     * @param index the char index within cs where the cluster begins
+     * @param terminal the terminal whose emoji grouping preferences are consulted; may be null
+     * @param charCount the full char count of the grapheme cluster beginning at index
+     * @return the number of chars to consume for display: the full cluster charCount when the terminal groups the cluster or when the cluster is an emoji sequence, otherwise the char count of the single code point at index
+     */
+    private static int charCountForDisplayWithGroupings(CharSequence cs, int index, Terminal terminal, int charCount) {
+        if (terminal == null || isGroupedByTerminal(cs, index, terminal, charCount)) {
+            return charCount;
+        }
+        if (isMultiCodepointEmoji(cs, index, charCount)) {
+            // Consume the entire cluster even when not grouped, so that
+            // combining characters (skin tone modifiers, etc.) are not
+            // processed separately with incorrect zero-width values
+            return charCount;
+        }
+        return Character.charCount(Character.codePointAt(cs, index));
+    }
+
+    /**
+     * Compute the display width in terminal character cells for a multi-codepoint cluster
+     * when the terminal does not treat the cluster as a single grapheme.
+     *
+     * <p>The width is the sum of the display widths of the cluster's constituent code points.
+     * Skin-tone modifiers and regional indicator symbols are treated as width 2 when not
+     * grouped with a base character.</p>
+     *
+     * @param cs the character sequence containing the cluster
+     * @param index the index (in Java chars) of the cluster's first char within {@code cs}
+     * @param charCount the number of Java chars that make up the cluster
+     * @return the total display width of the cluster in character cells
+     */
+    private static int wcwidthUngrouped(CharSequence cs, int index, int charCount) {
+        int end = index + charCount;
+        int totalWidth = 0;
+        int pos = index;
+        while (pos < end) {
+            int cp = Character.codePointAt(cs, pos);
+            if (isSkinToneModifier(cp) || isRegionalIndicator(cp)) {
+                // These are in the combining table (wcwidth=0) but render
+                // as width-2 emoji when not combined with a base character
+                totalWidth += 2;
+            } else {
+                int w = wcwidth(cp);
+                if (w > 0) {
+                    totalWidth += w;
+                }
+            }
+            pos += Character.charCount(cp);
+        }
+        return totalWidth;
+    }
+
+    /**
+     * Tests whether the terminal groups the given cluster as a single unit.
+     *
+     * <p>Delegates to {@link AbstractTerminal#isClusterGrouped} when the
+     * terminal is an AbstractTerminal instance; otherwise falls back to
+     * {@link Terminal#getGraphemeClusterMode()}.</p>
+     */
+    private static boolean isGroupedByTerminal(CharSequence cs, int index, Terminal terminal, int charCount) {
+        if (terminal instanceof AbstractTerminal) {
+            return ((AbstractTerminal) terminal).isClusterGrouped(cs, index, charCount);
+        }
+        return terminal.getGraphemeClusterMode();
+    }
+
+    /**
+     * Tests whether the grapheme cluster starting at {@code index} is a
+     * multi-codepoint emoji sequence (as opposed to a single codepoint or a
+     * non-emoji combining sequence).
+     */
+    private static boolean isMultiCodepointEmoji(CharSequence cs, int index, int charCount) {
+        if (charCount <= Character.charCount(Character.codePointAt(cs, index))) {
+            return false; // Single codepoint
+        }
+        int cp = Character.codePointAt(cs, index);
+        return isRegionalIndicator(cp) || cp >= 0x2000;
+    }
+
+    /**
+     * Determines whether a Unicode code point is a Regional Indicator Symbol (U+1F1E6..U+1F1FF).
+     *
+     * @param cp the Unicode code point to test
+     * @return `true` if the code point is within U+1F1E6..U+1F1FF, `false` otherwise
      */
     public static boolean isRegionalIndicator(int cp) {
         return cp >= 0x1F1E6 && cp <= 0x1F1FF;
     }
 
-    /* auxiliary function for binary search in interval table */
+    /**
+     * Determines whether the Unicode code point is an Emoji Modifier (skin tone) in the range U+1F3FB..U+1F3FF.
+     *
+     * @param cp the Unicode code point to test
+     * @return true if the code point is an Emoji Modifier (skin tone) between U+1F3FB and U+1F3FF, false otherwise
+     */
+    private static boolean isSkinToneModifier(int cp) {
+        return cp >= 0x1F3FB && cp <= 0x1F3FF;
+    }
+
+    /**
+     * Determine whether a code point falls within any interval in a sorted Interval table.
+     *
+     * @param ucs   the Unicode code point to test
+     * @param table a sorted array of Interval ranges
+     * @param max   index of the last interval in {@code table} to consider (inclusive)
+     * @return      {@code true} if an interval between {@code table[0]} and {@code table[max]} contains {@code ucs}, {@code false} otherwise
+     */
     private static boolean bisearch(int ucs, Interval[] table, int max) {
         int min = 0;
         int mid;

--- a/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterModeTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterModeTest.java
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 
@@ -30,6 +31,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GraphemeClusterModeTest {
+
+    // Test emoji for isClusterGrouped assertions
+    private static final String FLAG_FR = "\uD83C\uDDEB\uD83C\uDDF7"; // 🇫🇷
+    private static final String ZWJ_EMOJI = "\uD83D\uDC69\u200D\uD83D\uDD2C"; // 👩‍🔬
 
     @Test
     public void testSupportedWhenTerminalRespondsSet() throws Exception {
@@ -93,12 +98,17 @@ public class GraphemeClusterModeTest {
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
 
-        // Feed only a DA1 response (no DECRPM)
+        // Feed DA1 response (no DECRPM), then CPR col=5 for cursor probe fallback
         terminal.slaveInputPipe.write("\033[?64c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
+        // Cursor probe runs after DECRQM fails — feed CPR (no clustering)
+        ResponderHandle cprResponder = startCprResponder(terminal, masterOutput);
+        cprResponder.start();
+
         assertFalse(terminal.supportsGraphemeClusterMode());
 
+        cprResponder.joinAndAssert();
         terminal.close();
     }
 
@@ -161,7 +171,7 @@ public class GraphemeClusterModeTest {
         terminal.slaveInputPipe.write("\033[?2027;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
-        assertTrue(terminal.setGraphemeClusterMode(true));
+        assertTrue(terminal.setGraphemeClusterMode(true, false));
         assertTrue(terminal.getGraphemeClusterMode());
 
         String output = masterOutput.toString(StandardCharsets.UTF_8);
@@ -180,10 +190,10 @@ public class GraphemeClusterModeTest {
         terminal.slaveInputPipe.write("\033[?2027;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
-        assertTrue(terminal.setGraphemeClusterMode(true));
+        assertTrue(terminal.setGraphemeClusterMode(true, false));
         assertTrue(terminal.getGraphemeClusterMode());
 
-        assertTrue(terminal.setGraphemeClusterMode(false));
+        assertTrue(terminal.setGraphemeClusterMode(false, false));
         assertFalse(terminal.getGraphemeClusterMode());
 
         String output = masterOutput.toString(StandardCharsets.UTF_8);
@@ -198,7 +208,7 @@ public class GraphemeClusterModeTest {
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", Terminal.TYPE_DUMB, masterOutput, StandardCharsets.UTF_8);
 
-        assertFalse(terminal.setGraphemeClusterMode(true));
+        assertFalse(terminal.setGraphemeClusterMode(true, false));
         assertFalse(terminal.getGraphemeClusterMode());
 
         terminal.close();
@@ -214,7 +224,7 @@ public class GraphemeClusterModeTest {
         terminal.slaveInputPipe.write("\033[?2027;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
-        assertTrue(terminal.setGraphemeClusterMode(true));
+        assertTrue(terminal.setGraphemeClusterMode(true, false));
         assertTrue(terminal.getGraphemeClusterMode());
 
         // Close should disable the mode
@@ -390,7 +400,433 @@ public class GraphemeClusterModeTest {
 
         assertFalse(terminal.supportsGraphemeClusterMode());
         assertFalse(terminal.getGraphemeClusterMode());
-        assertFalse(terminal.setGraphemeClusterMode(true));
+        assertFalse(terminal.setGraphemeClusterMode(true, false));
+    }
+
+    // --- Force-enable via setGraphemeClusterMode(true, true) ---
+
+    @Test
+    void testForceEnableSkipsProbing() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Force-enable without any terminal responses
+        assertTrue(terminal.setGraphemeClusterMode(true, true));
+        assertTrue(terminal.getGraphemeClusterMode());
+        assertTrue(terminal.supportsGraphemeClusterMode());
+
+        // Should not send Mode 2027 enable sequence
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertFalse(output.contains("\033[?2027h"), "Force-enable should not send Mode 2027 escape");
+
+        terminal.close();
+    }
+
+    // --- Cursor position probe fallback tests ---
+
+    @Test
+    void testCursorProbeDetectsGraphemeClusters() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Background thread feeds responses when probe queries appear in output
+        ResponderHandle responder = startResponder(terminal, masterOutput);
+        responder.start();
+
+        assertTrue(terminal.supportsGraphemeClusterMode());
+        // Native detection auto-enables grapheme cluster mode
+        assertTrue(terminal.getGraphemeClusterMode());
+
+        responder.joinAndAssert();
+        terminal.close();
+    }
+
+    @Test
+    void testCursorProbeNotSupportedWhenNoGrouping() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Feed DA1 for DECRQM failure, then 4 CPR col=5 (no grouping for any category)
+        ResponderHandle responder = startResponder(terminal, masterOutput, NONE_GROUPED);
+        responder.start();
+
+        assertFalse(terminal.supportsGraphemeClusterMode());
+        assertFalse(terminal.getGraphemeClusterMode());
+
+        responder.joinAndAssert();
+        terminal.close();
+    }
+
+    @Test
+    void testCursorProbeNoResponseFallsBack() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // No responses at all — both probes time out
+        assertFalse(terminal.supportsGraphemeClusterMode());
+        assertFalse(terminal.getGraphemeClusterMode());
+
+        terminal.close();
+    }
+
+    @Test
+    void testCursorProbeNativeSkipsEscapeSequences() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        ResponderHandle responder = startResponder(terminal, masterOutput);
+        responder.start();
+
+        assertTrue(terminal.supportsGraphemeClusterMode());
+        assertTrue(terminal.getGraphemeClusterMode());
+        responder.joinAndAssert();
+
+        // setGraphemeClusterMode should succeed but not send Mode 2027 escapes
+        assertTrue(terminal.setGraphemeClusterMode(true, false));
+        assertTrue(terminal.setGraphemeClusterMode(false, false));
+
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        // Should NOT contain Mode 2027 enable/disable sequences
+        assertFalse(output.contains("\033[?2027h"), "Should not send Mode 2027 enable for native mode");
+        assertFalse(output.contains("\033[?2027l"), "Should not send Mode 2027 disable for native mode");
+
+        terminal.close();
+    }
+
+    @Test
+    void testCursorProbeNativeCloseDoesNotSendDisable() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        ResponderHandle responder = startResponder(terminal, masterOutput);
+        responder.start();
+
+        assertTrue(terminal.supportsGraphemeClusterMode());
+        assertTrue(terminal.getGraphemeClusterMode());
+        responder.joinAndAssert();
+
+        terminal.close();
+
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertFalse(output.contains("\033[?2027l"), "Close should not send Mode 2027 disable for native mode");
+    }
+
+    /**
+     * Starts a responder thread that feeds DA1 (for DECRQM failure) and CPR
+     * responses to the terminal's slave input pipe when the corresponding
+     * probe queries appear in the master output. The returned {@code error}
+     * reference captures any exception so tests can assert the responder
+     * completed cleanly.
+     */
+    // CPR responses: initial startCol query + flag probe + ZWJ probe.
+    // Displacement of 2 = grouped (single cluster), 4 = ungrouped.
+
+    /** All grouped: start=1, flag=3 (delta=2), ZWJ=3 (delta=2). */
+    private static final String ALL_GROUPED = "\033[1;1R\033[1;3R\033[1;3R";
+
+    /** None grouped: start=1, flag=5 (delta=4), ZWJ=5 (delta=4). */
+    private static final String NONE_GROUPED = "\033[1;1R\033[1;5R\033[1;5R";
+
+    private ResponderHandle startResponder(LineDisciplineTerminal terminal, ByteArrayOutputStream masterOutput) {
+        return startResponder(terminal, masterOutput, ALL_GROUPED);
+    }
+
+    private ResponderHandle startResponder(
+            LineDisciplineTerminal terminal, ByteArrayOutputStream masterOutput, String cprResponses) {
+        AtomicReference<Exception> error = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                // Wait for DECRQM query, then feed DA1 response (not supported)
+                waitForOutput(masterOutput, "\033[?2027$p");
+                terminal.slaveInputPipe.write("\033[?64c".getBytes(StandardCharsets.UTF_8));
+                terminal.slaveInputPipe.flush();
+
+                // Wait for DSR query, then feed CPR responses
+                waitForOutput(masterOutput, "\033[6n");
+                terminal.slaveInputPipe.write(cprResponses.getBytes(StandardCharsets.UTF_8));
+                terminal.slaveInputPipe.flush();
+            } catch (Exception e) {
+                error.set(e);
+            }
+        });
+        t.setDaemon(true);
+        return new ResponderHandle(t, error);
+    }
+
+    private static class ResponderHandle {
+        final Thread thread;
+        final AtomicReference<Exception> error;
+
+        ResponderHandle(Thread thread, AtomicReference<Exception> error) {
+            this.thread = thread;
+            this.error = error;
+        }
+
+        void start() {
+            thread.start();
+        }
+
+        void joinAndAssert() throws Exception {
+            thread.join(5000);
+            assertFalse(thread.isAlive(), "Responder thread should have completed");
+            Exception e = error.get();
+            if (e != null) {
+                throw new AssertionError("Responder thread failed", e);
+            }
+        }
+    }
+
+    /**
+     * Starts a responder thread that only feeds a CPR response (no DA1) when
+     * the DSR query appears in the master output. Used when the DECRPM/DA1
+     * response is already pre-loaded in the pipe.
+     */
+    private ResponderHandle startCprResponder(LineDisciplineTerminal terminal, ByteArrayOutputStream masterOutput) {
+        AtomicReference<Exception> error = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                waitForOutput(masterOutput, "\033[6n");
+                terminal.slaveInputPipe.write(NONE_GROUPED.getBytes(StandardCharsets.UTF_8));
+                terminal.slaveInputPipe.flush();
+            } catch (Exception e) {
+                error.set(e);
+            }
+        });
+        t.setDaemon(true);
+        return new ResponderHandle(t, error);
+    }
+
+    @SuppressWarnings("java:S2925") // ByteArrayOutputStream has no notification mechanism; polling is necessary
+    private void waitForOutput(ByteArrayOutputStream masterOutput, String trigger) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (!masterOutput.toString(StandardCharsets.UTF_8).contains(trigger)) {
+            if (System.currentTimeMillis() > deadline) {
+                throw new RuntimeException("Timed out waiting for: " + trigger);
+            }
+            Thread.sleep(5);
+        }
+    }
+
+    // --- Cursor probe failure mode tests ---
+
+    @Test
+    void testCursorProbeReturnsNullWhenTerminalLacksU6U7() throws Exception {
+        // screen-256color has no u6/u7 capabilities, so getCursorPosition returns null
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "screen-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Feed DA1 response (DECRQM not supported) so cursor probe is attempted
+        terminal.slaveInputPipe.write("\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertFalse(terminal.supportsGraphemeClusterMode());
+        assertFalse(terminal.getGraphemeClusterMode());
+
+        // Verify DECRQM was sent but no Mode 2027 enable
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?2027$p"));
+        assertFalse(output.contains("\033[?2027h"));
+
+        terminal.close();
+    }
+
+    @Test
+    void testCursorProbeReturnsNullOnEof() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Feed DA1 response, then close the pipe before the CPR response arrives
+        // so getCursorPosition reads EOF and returns null
+        ResponderHandle responder = new ResponderHandle(
+                new Thread(() -> {
+                    try {
+                        waitForOutput(masterOutput, "\033[6n");
+                        terminal.slaveInputPipe.close();
+                    } catch (Exception e) {
+                        // pipe close may throw; ignore since the test validates the outcome
+                    }
+                }),
+                new AtomicReference<>());
+        responder.start();
+
+        // Pre-load DA1 for DECRQM failure
+        terminal.slaveInputPipe.write("\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertFalse(terminal.supportsGraphemeClusterMode());
+        assertFalse(terminal.getGraphemeClusterMode());
+
+        responder.joinAndAssert();
+        terminal.close();
+    }
+
+    @Test
+    void testCursorProbeUnexpectedPosition() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Feed DA1 for DECRQM failure, then start CPR + 2 CPR with unexpected width (delta=3)
+        ResponderHandle responder = startResponder(terminal, masterOutput, "\033[1;1R\033[1;4R\033[1;4R");
+        responder.start();
+
+        assertFalse(terminal.supportsGraphemeClusterMode());
+        assertFalse(terminal.getGraphemeClusterMode());
+
+        responder.joinAndAssert();
+        terminal.close();
+    }
+
+    @Test
+    void testCursorProbeWorksWhenCursorNotAtColumnOne() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Cursor starts at column 10 (e.g., after a prompt); grouped = displacement of 2
+        String nonZeroStart = "\033[1;10R\033[1;12R\033[1;12R";
+        ResponderHandle responder = startResponder(terminal, masterOutput, nonZeroStart);
+        responder.start();
+
+        assertTrue(terminal.supportsGraphemeClusterMode());
+        assertTrue(terminal.getGraphemeClusterMode());
+        assertTrue(terminal.isClusterGrouped(FLAG_FR, 0, FLAG_FR.length()));
+        assertTrue(terminal.isClusterGrouped(ZWJ_EMOJI, 0, ZWJ_EMOJI.length()));
+
+        responder.joinAndAssert();
+        terminal.close();
+    }
+
+    @Test
+    void testPartialGroupingFlagsOnly() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Flag grouped (delta=2), ZWJ not grouped (delta=4) — e.g. Tabby, Alacritty
+        String flagsOnly = "\033[1;1R\033[1;3R\033[1;5R";
+        ResponderHandle responder = startResponder(terminal, masterOutput, flagsOnly);
+        responder.start();
+
+        assertTrue(terminal.supportsGraphemeClusterMode());
+        assertTrue(terminal.getGraphemeClusterMode());
+
+        // Flag grouped, ZWJ not grouped
+        assertTrue(terminal.isClusterGrouped(FLAG_FR, 0, FLAG_FR.length()));
+        assertFalse(terminal.isClusterGrouped(ZWJ_EMOJI, 0, ZWJ_EMOJI.length()));
+
+        responder.joinAndAssert();
+        terminal.close();
+    }
+
+    @Test
+    void testAllGroupedWhenMode2027() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Feed DECRPM response (mode 2027 set) + DA1
+        terminal.slaveInputPipe.write("\033[?2027;1$y\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.setGraphemeClusterMode(true, false));
+        assertTrue(terminal.isClusterGrouped(FLAG_FR, 0, FLAG_FR.length()));
+        assertTrue(terminal.isClusterGrouped(ZWJ_EMOJI, 0, ZWJ_EMOJI.length()));
+
+        terminal.close();
+    }
+
+    @Test
+    void testNothingGroupedWhenNotSupported() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", Terminal.TYPE_DUMB, masterOutput, StandardCharsets.UTF_8);
+
+        assertFalse(terminal.isClusterGrouped(FLAG_FR, 0, FLAG_FR.length()));
+        assertFalse(terminal.isClusterGrouped(ZWJ_EMOJI, 0, ZWJ_EMOJI.length()));
+
+        terminal.close();
+    }
+
+    @Test
+    void testForceEnableGroupsAll() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        assertTrue(terminal.setGraphemeClusterMode(true, true));
+        assertTrue(terminal.isClusterGrouped(FLAG_FR, 0, FLAG_FR.length()));
+        assertTrue(terminal.isClusterGrouped(ZWJ_EMOJI, 0, ZWJ_EMOJI.length()));
+
+        terminal.close();
+    }
+
+    @Test
+    void testForceDisableThenNonForceEnablePreservesGrouping() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Force-enable (marks capability as supported/native, sets grouping flags)
+        assertTrue(terminal.setGraphemeClusterMode(true, true));
+        assertTrue(terminal.getGraphemeClusterMode());
+        assertTrue(terminal.isClusterGrouped(FLAG_FR, 0, FLAG_FR.length()));
+
+        // Force-disable (should NOT clear grouping capability flags, but
+        // isClusterGrouped should return false while mode is disabled)
+        assertTrue(terminal.setGraphemeClusterMode(false, true));
+        assertFalse(terminal.getGraphemeClusterMode());
+        assertFalse(terminal.isClusterGrouped(FLAG_FR, 0, FLAG_FR.length()));
+        assertFalse(terminal.isClusterGrouped(ZWJ_EMOJI, 0, ZWJ_EMOJI.length()));
+
+        // Non-force enable should succeed (supportsGraphemeClusterMode is true)
+        // and should NOT send Mode 2027 escapes (graphemeClusterNative is true)
+        masterOutput.reset();
+        assertTrue(terminal.setGraphemeClusterMode(true, false));
+        assertTrue(terminal.getGraphemeClusterMode());
+        assertTrue(terminal.isClusterGrouped(FLAG_FR, 0, FLAG_FR.length()));
+        assertTrue(terminal.isClusterGrouped(ZWJ_EMOJI, 0, ZWJ_EMOJI.length()));
+
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertFalse(output.contains("\033[?2027h"), "Native mode should not send Mode 2027 enable");
+
+        terminal.close();
+    }
+
+    @Test
+    void testForceDisableSendsMode2027DisableWhenPreviouslyEnabled() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Enable Mode 2027 via normal (non-force) path
+        terminal.slaveInputPipe.write("\033[?2027;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+        assertTrue(terminal.setGraphemeClusterMode(true, false));
+        assertTrue(terminal.getGraphemeClusterMode());
+
+        // Force-disable should send Mode 2027 disable escape before switching to native
+        masterOutput.reset();
+        assertTrue(terminal.setGraphemeClusterMode(false, true));
+        assertFalse(terminal.getGraphemeClusterMode());
+
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?2027l"), "Force-disable should send Mode 2027 disable");
+
+        // isClusterGrouped returns false while mode is disabled,
+        // but capability flags are preserved internally for re-enabling
+        assertFalse(terminal.isClusterGrouped(FLAG_FR, 0, FLAG_FR.length()));
+        assertFalse(terminal.isClusterGrouped(ZWJ_EMOJI, 0, ZWJ_EMOJI.length()));
+
+        terminal.close();
     }
 
     private void assertProbeResult(String response, String terminalType, boolean expectedSupport) throws Exception {
@@ -402,7 +838,18 @@ public class GraphemeClusterModeTest {
         terminal.slaveInputPipe.write((response + "\033[?64c").getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
 
+        // When DECRPM says not supported, cursor probe runs as fallback
+        ResponderHandle cprResponder = null;
+        if (!expectedSupport) {
+            cprResponder = startCprResponder(terminal, masterOutput);
+            cprResponder.start();
+        }
+
         assertEquals(expectedSupport, terminal.supportsGraphemeClusterMode());
+
+        if (cprResponder != null) {
+            cprResponder.joinAndAssert();
+        }
 
         // Verify the DECRQM query and DA1 sentinel were sent
         String output = masterOutput.toString(StandardCharsets.UTF_8);

--- a/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterTestTerminal.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterTestTerminal.java
@@ -36,10 +36,14 @@ public final class GraphemeClusterTestTerminal {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         LineDisciplineTerminal terminal =
                 new LineDisciplineTerminal("test", "xterm-256color", out, StandardCharsets.UTF_8);
-        // Feed DECRPM probe response indicating mode 2027 is supported
-        terminal.slaveInputPipe.write("\033[?2027;2$y".getBytes(StandardCharsets.UTF_8));
+        // Feed DECRPM probe response indicating mode 2027 is supported,
+        // followed by the DA1 sentinel response that probeMode2027() drains
+        terminal.slaveInputPipe.write("\033[?2027;2$y\033[?62c".getBytes(StandardCharsets.UTF_8));
         terminal.slaveInputPipe.flush();
-        terminal.setGraphemeClusterMode(true);
+        if (!terminal.setGraphemeClusterMode(true, false)) {
+            terminal.close();
+            throw new IllegalStateException("Failed to enable grapheme cluster mode");
+        }
         return terminal;
     }
 }

--- a/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
@@ -20,6 +20,7 @@ import org.jline.terminal.impl.GraphemeClusterTestTerminal;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class AttributedCharSequenceTest {
 
@@ -46,27 +47,27 @@ public class AttributedCharSequenceTest {
 
     @Test
     public void testGraphemeClusterColumnLength() {
-        // Test per-codepoint widths without grapheme cluster mode.
-
-        // Family emoji: per-codepoint = 2+0+2+0+2+0+2 = 8
+        // columnLength() without terminal: on JDK 21+ uses grapheme cluster widths
         AttributedString family = new AttributedString(FAMILY_EMOJI);
-        assertEquals(8, family.columnLength());
-
-        // Flag: per-codepoint = 2+2 = 4
         AttributedString flag = new AttributedString(FLAG_FR);
-        assertEquals(4, flag.columnLength());
-
-        // Skin tone: per-codepoint = 2+0 = 2
         AttributedString wave = new AttributedString(WAVE_SKIN);
-        assertEquals(2, wave.columnLength());
-
-        // Woman scientist: per-codepoint = 2+0+2 = 4
         AttributedString scientist = new AttributedString(WOMAN_SCIENTIST);
-        assertEquals(4, scientist.columnLength());
-
-        // Mixed: "Hi " + family + " end"
         AttributedString mixed = new AttributedString("Hi " + FAMILY_EMOJI + " end");
-        assertEquals(3 + 8 + 4, mixed.columnLength());
+
+        if (WCWidth.HAS_JDK_GRAPHEME_SUPPORT) {
+            assertEquals(2, family.columnLength());
+            assertEquals(2, flag.columnLength());
+            assertEquals(2, wave.columnLength());
+            assertEquals(2, scientist.columnLength());
+            assertEquals(3 + 2 + 4, mixed.columnLength());
+        } else {
+            // Older JDK: per-codepoint widths
+            assertEquals(8, family.columnLength()); // 2+0+2+0+2+0+2
+            assertEquals(4, flag.columnLength()); // 2+2
+            assertEquals(2, wave.columnLength()); // 2+0
+            assertEquals(4, scientist.columnLength()); // 2+0+2
+            assertEquals(3 + 8 + 4, mixed.columnLength());
+        }
     }
 
     @Test
@@ -179,9 +180,13 @@ public class AttributedCharSequenceTest {
             // Mixed: "Hi " (3) + rainbow flag (2) + " end" (4) = 9
             assertEquals(9, new AttributedString("Hi " + RAINBOW_FLAG + " end").columnLength(t));
 
-            // Without terminal: per-codepoint widths (no cluster awareness)
-            // Rainbow flag: wcwidth(0x1F3F3)=1 + 0(FE0F) + 0(ZWJ) + wcwidth(0x1F308)=2 = 3
-            assertEquals(3, new AttributedString(RAINBOW_FLAG).columnLength());
+            // Without terminal: behavior depends on JDK version
+            if (WCWidth.HAS_JDK_GRAPHEME_SUPPORT) {
+                assertEquals(2, new AttributedString(RAINBOW_FLAG).columnLength());
+            } else {
+                // Rainbow flag: wcwidth(0x1F3F3)=1 + 0(FE0F) + 0(ZWJ) + wcwidth(0x1F308)=2 = 3
+                assertEquals(3, new AttributedString(RAINBOW_FLAG).columnLength());
+            }
         } finally {
             t.close();
         }
@@ -223,6 +228,31 @@ public class AttributedCharSequenceTest {
         } finally {
             t.close();
         }
+    }
+
+    @Test
+    void testColumnSubSequenceNoTerminal() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+ grapheme support");
+
+        // JDK 21+: grapheme cluster-aware without terminal
+        String text = "AB" + FAMILY_EMOJI + "CD";
+        AttributedString as = new AttributedString(text);
+        assertEquals("AB", as.columnSubSequence(0, 2).toString());
+        assertEquals(FAMILY_EMOJI, as.columnSubSequence(2, 4).toString());
+        assertEquals("CD", as.columnSubSequence(4, 6).toString());
+    }
+
+    @Test
+    void testColumnSplitLengthNoTerminal() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+ grapheme support");
+
+        // JDK 21+: grapheme cluster-aware without terminal
+        String text = "AB" + FAMILY_EMOJI + "CD";
+        AttributedString as = new AttributedString(text);
+        List<AttributedString> lines = as.columnSplitLength(4);
+        assertEquals(2, lines.size());
+        assertEquals("AB" + FAMILY_EMOJI, lines.get(0).toString());
+        assertEquals("CD", lines.get(1).toString());
     }
 
     @Test

--- a/terminal/src/test/java/org/jline/utils/WCWidthTest.java
+++ b/terminal/src/test/java/org/jline/utils/WCWidthTest.java
@@ -13,6 +13,7 @@ import org.jline.terminal.impl.GraphemeClusterTestTerminal;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests for {@link WCWidth} utility methods: {@code wcwidth},
@@ -146,6 +147,113 @@ public class WCWidthTest {
         assertEquals(0, WCWidth.charCountForGraphemeCluster("A", 1));
     }
 
+    // --- charCountForGraphemeClusterLegacy (JDK < 21 path) ---
+
+    @Test
+    void charCountForGraphemeClusterLegacy_familyEmoji() {
+        assertEquals(11, WCWidth.charCountForGraphemeClusterLegacy(FAMILY_EMOJI, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterLegacy_flag() {
+        assertEquals(4, WCWidth.charCountForGraphemeClusterLegacy(FLAG_FR, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterLegacy_skinTone() {
+        assertEquals(4, WCWidth.charCountForGraphemeClusterLegacy(WAVE_SKIN, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterLegacy_womanScientist() {
+        assertEquals(5, WCWidth.charCountForGraphemeClusterLegacy(WOMAN_SCIENTIST, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterLegacy_ascii() {
+        assertEquals(1, WCWidth.charCountForGraphemeClusterLegacy("Hello", 0));
+        assertEquals(1, WCWidth.charCountForGraphemeClusterLegacy("Hello", 1));
+    }
+
+    @Test
+    void charCountForGraphemeClusterLegacy_cjk() {
+        assertEquals(1, WCWidth.charCountForGraphemeClusterLegacy("中", 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterLegacy_variationSelector() {
+        assertEquals(2, WCWidth.charCountForGraphemeClusterLegacy(STAR_TEXT, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterLegacy_emptyAtEnd() {
+        assertEquals(0, WCWidth.charCountForGraphemeClusterLegacy("A", 1));
+    }
+
+    // --- charCountForGraphemeClusterBreakIterator (JDK 21+ path) ---
+
+    @Test
+    void charCountForGraphemeClusterBreakIterator_familyEmoji() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+");
+        assertEquals(11, WCWidth.charCountForGraphemeClusterBreakIterator(FAMILY_EMOJI, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterBreakIterator_flag() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+");
+        assertEquals(4, WCWidth.charCountForGraphemeClusterBreakIterator(FLAG_FR, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterBreakIterator_skinTone() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+");
+        assertEquals(4, WCWidth.charCountForGraphemeClusterBreakIterator(WAVE_SKIN, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterBreakIterator_womanScientist() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+");
+        assertEquals(5, WCWidth.charCountForGraphemeClusterBreakIterator(WOMAN_SCIENTIST, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterBreakIterator_ascii() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+");
+        assertEquals(1, WCWidth.charCountForGraphemeClusterBreakIterator("Hello", 0));
+        assertEquals(1, WCWidth.charCountForGraphemeClusterBreakIterator("Hello", 1));
+    }
+
+    @Test
+    void charCountForGraphemeClusterBreakIterator_cjk() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+");
+        assertEquals(1, WCWidth.charCountForGraphemeClusterBreakIterator("中", 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterBreakIterator_variationSelector() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+");
+        assertEquals(2, WCWidth.charCountForGraphemeClusterBreakIterator(STAR_TEXT, 0));
+    }
+
+    @Test
+    void charCountForGraphemeClusterBreakIterator_emptyAtEnd() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+");
+        assertEquals(0, WCWidth.charCountForGraphemeClusterBreakIterator("A", 1));
+    }
+
+    @Test
+    void charCountForGraphemeCluster_bothPathsAgree() {
+        // On JDK 21+, both implementations should produce the same results
+        // for standard emoji sequences
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+");
+        for (String emoji : new String[] {FAMILY_EMOJI, FLAG_FR, WAVE_SKIN, WOMAN_SCIENTIST, STAR_TEXT}) {
+            assertEquals(
+                    WCWidth.charCountForGraphemeClusterLegacy(emoji, 0),
+                    WCWidth.charCountForGraphemeClusterBreakIterator(emoji, 0),
+                    "Mismatch for: " + emoji);
+        }
+    }
+
     // --- wcwidthForGraphemeCluster ---
 
     @Test
@@ -215,12 +323,16 @@ public class WCWidthTest {
     // --- charCountForDisplay ---
 
     @Test
-    void charCountForDisplay_nullTerminal_returnsSingleCodepointSize() {
-        // Surrogate pair = 2 chars for the first codepoint
-        assertEquals(2, WCWidth.charCountForDisplay(FAMILY_EMOJI, 0, null));
-        // ASCII
+    void charCountForDisplay_nullTerminal() {
+        if (WCWidth.HAS_JDK_GRAPHEME_SUPPORT) {
+            // JDK 21+: grapheme cluster segmentation used without terminal
+            assertEquals(11, WCWidth.charCountForDisplay(FAMILY_EMOJI, 0, null));
+        } else {
+            // Older JDK: per-codepoint, surrogate pair = 2 chars
+            assertEquals(2, WCWidth.charCountForDisplay(FAMILY_EMOJI, 0, null));
+        }
+        // ASCII and CJK unchanged regardless
         assertEquals(1, WCWidth.charCountForDisplay("Hello", 0, null));
-        // CJK BMP
         assertEquals(1, WCWidth.charCountForDisplay("中", 0, null));
     }
 
@@ -273,5 +385,27 @@ public class WCWidthTest {
         } finally {
             t.close();
         }
+    }
+
+    // --- JDK 21+ grapheme cluster support without terminal ---
+
+    @Test
+    void wcwidthForDisplay_nullTerminal_emojiClusters() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+ grapheme support");
+        // JDK 21+: grapheme cluster-aware widths without terminal
+        assertEquals(2, WCWidth.wcwidthForDisplay(FAMILY_EMOJI, 0, null));
+        assertEquals(2, WCWidth.wcwidthForDisplay(FLAG_FR, 0, null));
+        assertEquals(2, WCWidth.wcwidthForDisplay(WAVE_SKIN, 0, null));
+        assertEquals(2, WCWidth.wcwidthForDisplay(WOMAN_SCIENTIST, 0, null));
+    }
+
+    @Test
+    void wcwidthForDisplay_nullTerminal_variationSelectors() {
+        assumeTrue(WCWidth.HAS_JDK_GRAPHEME_SUPPORT, "Requires JDK 21+ grapheme support");
+        // Rainbow flag: VS16 found → width 2
+        String rainbowFlag = "\uD83C\uDFF3\uFE0F\u200D\uD83C\uDF08";
+        assertEquals(2, WCWidth.wcwidthForDisplay(rainbowFlag, 0, null));
+        // Star + VS15 → text presentation = width 1
+        assertEquals(1, WCWidth.wcwidthForDisplay(STAR_TEXT, 0, null));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1753 — improves grapheme cluster width computation for terminals that don't support Mode 2027 (DECRQM), with per-category emoji grouping detection for terminals with partial support.

### Three-tier detection strategy

1. **Mode 2027 (DECRQM/DECRPM)** — probes the terminal with `CSI ? 2027 $ p` using DA1 as a sentinel fence. If the terminal reports the mode as set/reset/recognized, grapheme cluster mode is enabled with `CSI ? 2027 h/l` escape sequences.

2. **Cursor position probe** — when Mode 2027 is not supported but the terminal did respond to the DECRQM/DA1 query (proving it handles escape sequences), writes two representative emoji and queries cursor position via DSR/CPR:
   - `REGIONAL_INDICATOR` — flag emoji (🇫🇷)
   - `ZWJ_SEQUENCE` — Zero Width Joiner sequence (👩‍🔬), which also covers skin tone modifiers and VS16 presentation

   If the cursor advances by 2 columns for a category, that category is marked as grouped. Terminals with at least one grouped category get grapheme cluster mode enabled without Mode 2027 escapes.

3. **JDK 21+ BreakIterator fallback** — on JDK 21+, `WCWidth.charCountForDisplay()` and `wcwidthForDisplay()` always use `BreakIterator`-based grapheme cluster segmentation, regardless of whether the terminal probe succeeded. This gives correct widths for terminals that visually group emoji but don't report it via standard probing.

### Per-category width computation

When a terminal partially groups emoji (e.g., groups flags but not ZWJ sequences), width computation adapts per cluster:

- **Grouped categories**: measured as a single grapheme cluster (width 2)
- **Ungrouped multi-codepoint emoji**: summed per-codepoint widths via `wcwidthUngrouped()`, with special handling for skin tone modifiers and regional indicators that have `wcwidth=0` in the combining table but render as width-2 standalone
- **Single codepoint**: standard `wcwidth()`

### Terminal compatibility results

| Terminal | Mode 2027 | Groupings detected | Result |
|---|---|---|---|
| Ghostty | supported | all | Perfect — Mode 2027 handles everything |
| iTerm2 | supported | all | Perfect — same as Ghostty |
| Alacritty | not supported | REGIONAL_INDICATOR only | Flags width=2, ungrouped emoji get correct per-codepoint widths |
| Tabby | not supported | REGIONAL_INDICATOR only | Same as Alacritty |
| Superset | not supported | REGIONAL_INDICATOR only | Same as Alacritty |

### System property

`org.jline.terminal.graphemeCluster` is a tri-state property:
- **`true`** — force-enable grapheme cluster mode, skip probing (no Mode 2027 escapes sent)
- **`false`** — disable grapheme cluster mode, no probing
- **unset** (default) — auto-detect via the three-tier strategy above

The `setGraphemeClusterMode(boolean, boolean)` overload on `Terminal` supports the force flag programmatically.

### API additions

- `Terminal.EmojiGrouping` enum — `REGIONAL_INDICATOR` (flag pairs) and `ZWJ_SEQUENCE` (ZWJ, skin tone, VS16)
- `Terminal.getEmojiGroupings()` — returns the set of grouped categories (all when Mode 2027, probed set otherwise)
- `Terminal.setGraphemeClusterMode(boolean, boolean)` — force flag to skip probing

### Other changes

- `drainUntilDA1()` — reads until DA1 terminator 'c' instead of peek-based drain, eliminating 100ms blocking timeout
- `readCprColumn()` — lightweight CPR parser (replaces `CursorSupport.getCursorPosition()` for the probe)
- `probeMode2027()` returns tri-state `ProbeResult` to distinguish "not supported" from "no response"
- `graphemeClusterNative` flag suppresses Mode 2027 escapes on enable/disable/close
- JDK 21+ `BreakIterator.getCharacterInstance()` used for grapheme cluster segmentation (replaces custom heuristic when available)

### Test coverage

30 tests in `GraphemeClusterModeTest` covering:
- Mode 2027 DECRPM responses (set, reset, permanently set/reset, not recognized)
- DA1-only response (DECRQM not supported, cursor probe fallback)
- Cursor probe: all grouped, none grouped, partial grouping (flags only)
- Cursor probe with unexpected positions
- No terminal response (both probes time out)
- Native mode skipping Mode 2027 escapes on enable/disable/close
- Force-enable via `setGraphemeClusterMode(true, true)` sets all groupings
- `getEmojiGroupings()` returns correct sets for Mode 2027 / cursor probe / dumb terminal

52 tests in `WCWidthTest` covering:
- `wcwidth` for ASCII, CJK, control chars, combining marks, ZWJ, emoji
- `charCountForGraphemeCluster` via legacy heuristic and JDK 21+ BreakIterator
- `wcwidthForGraphemeCluster` with variation selectors (VS15/VS16)
- `charCountForDisplay` and `wcwidthForDisplay` with and without terminal
- Consistency check: both code paths agree on standard emoji sequences

## Test plan

- [x] `GraphemeClusterModeTest` — 30 tests pass
- [x] `WCWidthTest` — 52 tests pass
- [x] Full terminal module test suite passes
- [x] Manual testing on Ghostty, iTerm2, Tabby, Alacritty, Superset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Force-enable option for grapheme-cluster mode (skip probing; treat terminal as grouping-capable).
  * Grouping-aware handling for multi-codepoint emoji when terminal grouping is disabled.

* **Improvements**
  * Width/column calculations prefer platform grapheme support and apply when no terminal is present.
  * Improved probing with cursor-position fallback and tri-state results; builder respects force/auto/disable semantics.
  * Terminal API updated to accept a force flag when setting grapheme-cluster mode.

* **Tests**
  * Expanded, platform-gated tests for grapheme behavior, grouping, splitting, probing, and no-terminal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->