### PR TITLE
refactor: standardize terminal dimension naming to columns/rows

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Commands.java
+++ b/builtins/src/main/java/org/jline/builtins/Commands.java
@@ -1287,7 +1287,7 @@ public class Commands {
             }
             if (!opt.isSet("view")) {
                 boolean rgb = opt.isSet("rgb");
-                int columns = terminal.getWidth() > (rgb ? 71 : 122) ? 6 : 5;
+                int columns = terminal.getColumns() > (rgb ? 71 : 122) ? 6 : 5;
                 String findName = null;
                 boolean nameTable = opt.isSet("name");
                 boolean table16 = opt.isSet("small");
@@ -1456,13 +1456,26 @@ public class Commands {
             return out;
         }
 
+        /**
+         * Prints color tables or named/RGB color listings to the terminal using the current style/format settings.
+         *
+         * <p>The method renders either a 16/256-color grid, a named-color table, or a 24-bit RGB table depending on the flags.
+         *
+         * @param name if true, render the named-color table (ignored when {@code rgb} is true)
+         * @param rgb if true, render the 24-bit RGB table instead of the name/256 tables
+         * @param small if true, use the compact 16-color presentation when applicable
+         * @param columns maximum number of columns to use when laying out the table
+         * @param findName optional filter; when non-null restricts output to names or hex strings that match (leading '#' or 'x' are accepted and ignored)
+         * @param style optional style lock applied to every cell (affects foreground/background selection)
+         * @throws IOException if writing the generated output to the terminal fails
+         */
         public void printColors(boolean name, boolean rgb, boolean small, int columns, String findName, String style)
                 throws IOException {
             this.name = !rgb && name;
             this.rgb = rgb;
             setFixedStyle(style);
             AttributedStringBuilder asb = new AttributedStringBuilder();
-            int width = terminal.getWidth();
+            int width = terminal.getColumns();
             String tableName = small ? " 16-color " : "256-color ";
             if (!name && !rgb) {
                 out.print(tableName);
@@ -1694,6 +1707,19 @@ public class Commands {
             }
         }
 
+        /**
+         * Display detailed information and a visual swatch for the specified color.
+         *
+         * <p>Interprets the `name` as one of: 24-bit hex (`RRGGBB`), prefixed hex (`#RRGGBB` or `xRRGGBB`),
+         * one of the 16-color names, a 256-color name/prefix/substring, or a hue spec `hueN`. Prints the
+         * color's HSL values, a grid of RGB variations, and—when applicable—a hue bar.
+         *
+         * @param name  the color identifier (hex, `#`/`x`-prefixed hex, 16-color name, 256-color name or
+         *              prefix/substring, or `hueN` where N is 0–360)
+         * @param style a style lock to apply when rendering (controls fixed foreground/background/style)
+         * @throws IOException if writing output to the terminal fails
+         * @throws IllegalArgumentException if the `name` cannot be resolved to a color or a `hueN` value is out of range
+         */
         public void printColor(String name, String style) throws IOException {
             setFixedStyle(style);
             int hueAngle;
@@ -1755,7 +1781,7 @@ public class Commands {
             }
             double step = 32;
             int barSize = 14;
-            int width = terminal.getWidth();
+            int width = terminal.getColumns();
             if (width > 287) {
                 step = 8;
                 barSize = 58;

--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -1326,6 +1326,14 @@ public class Less {
         return display(oneScreen, null);
     }
 
+    /**
+     * Render the current viewport to the terminal, constructing visible content lines and the status/message row.
+     *
+     * @param oneScreen if true, render without updating the pager state and return whether the file fits on a single screen
+     * @param curPos an optional cursor column index for positioning the cursor on the final status line; null to leave cursor unspecified
+     * @return {@code true} if {@code oneScreen} is true and the file fits entirely on one screen, {@code false} otherwise
+     * @throws IOException if an I/O error occurs while writing to the terminal
+     */
     synchronized boolean display(boolean oneScreen, Integer curPos) throws IOException {
         List<AttributedString> newLines = new ArrayList<>();
         int width = size.getColumns() - (printLineNumbers ? 8 : 0);
@@ -1420,7 +1428,7 @@ public class Less {
         }
         newLines.add(msg.toAttributedString());
 
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         if (curPos == null) {
             display.update(newLines, -1);
         } else {

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -1989,6 +1989,18 @@ public class Nano implements Editor {
         }
     }
 
+    /**
+     * Run the editor: initialize terminal state, open the current buffer, enter the interactive
+     * event loop, and process user operations until the editor exits.
+     *
+     * <p>This method configures terminal attributes (raw mode, keypad, optional mouse tracking),
+     * installs a WINCH handler, displays the buffer, and then continuously reads and executes
+     * editor operations (navigation, editing, file I/O, search/replace, help, etc.). On exit
+     * it restores terminal state, mouse tracking, signal handlers, and persists pattern history.
+     *
+     * @throws IOException if an I/O or terminal operation (file read/write, terminal attributes,
+     *                     or related I/O) fails during initialization or while running the editor
+     */
     public void run() throws IOException {
         if (buffers.isEmpty()) {
             buffers.add(new Buffer(null));
@@ -2033,7 +2045,7 @@ public class Nano implements Editor {
 
             display.clear();
             display.reset();
-            display.resize(size.getRows(), size.getColumns());
+            display.resize(size);
             prevHandler = terminal.handle(Signal.WINCH, this::handle);
 
             display();
@@ -3360,9 +3372,16 @@ public class Nano implements Editor {
         return title;
     }
 
+    /**
+     * Reset the terminal display and synchronize all buffers' view state to the current terminal size.
+     *
+     * Clears the display, resizes it using the editor's current Size instance, and calls each
+     * buffer's resetDisplay() to recompute offsets and view-related state so the UI reflects the
+     * new/cleared display dimensions.
+     */
     void resetDisplay() {
         display.clear();
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         for (Buffer buffer : buffers) {
             buffer.resetDisplay();
         }

--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -2046,9 +2046,22 @@ public class PosixCommands {
         }
     }
 
+    /**
+     * Lay out ANSI-encoded strings into a columnar grid and write the result to the provided output.
+     *
+     * <p>The method measures each string's display width (respecting ANSI attributes), computes a
+     * column count that fits the terminal width (uses the terminal's columns when TTY, otherwise 80),
+     * arranges items in either row-major (horizontal) or column-major order, pads entries to align
+     * columns, and emits the combined ANSI output to {@code out}.
+     *
+     * @param context   used to obtain the terminal and determine TTY state and column width
+     * @param out       destination print stream for the rendered column output
+     * @param ansi      stream of strings containing ANSI escape sequences to be placed in columns
+     * @param horizontal if {@code true}, fill rows first (horizontal layout); if {@code false}, fill columns first (vertical layout)
+     */
     private static void toColumn(Context context, PrintStream out, Stream<String> ansi, boolean horizontal) {
         Terminal terminal = context.terminal();
-        int width = context.isTty() ? terminal.getWidth() : 80;
+        int width = context.isTty() ? terminal.getColumns() : 80;
         List<AttributedString> strings = ansi.map(AttributedString::fromAnsi).collect(Collectors.toList());
         if (!strings.isEmpty()) {
             int max = strings.stream()

--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.jline.terminal.Size;
 import org.jline.utils.Colors;
 import org.jline.utils.WCWidth;
 
@@ -77,8 +78,8 @@ public class ScreenTerminal {
         }
     }
 
-    private int width;
-    private int height;
+    private int columns;
+    private int rows;
     private long attr;
     private boolean eol;
     private int cx;
@@ -133,13 +134,22 @@ public class ScreenTerminal {
 
     private boolean dirty = true;
 
+    /**
+     * Creates a ScreenTerminal using the default size of 80 columns and 24 rows.
+     */
     public ScreenTerminal() {
         this(80, 24);
     }
 
-    public ScreenTerminal(int width, int height) {
-        this.width = width;
-        this.height = height;
+    /**
+     * Creates a ScreenTerminal with the specified number of columns and rows.
+     *
+     * @param columns the number of character columns for the terminal
+     * @param rows the number of character rows for the terminal
+     */
+    public ScreenTerminal(int columns, int rows) {
+        this.columns = columns;
+        this.rows = rows;
         reset_hard();
     }
 
@@ -187,7 +197,7 @@ public class ScreenTerminal {
         attr = 0x0000000000000000L;
         // Scroll parameters
         scroll_area_y0 = 0;
-        scroll_area_y1 = height;
+        scroll_area_y1 = rows;
         // Character sets
         vt100_charset_is_single_shift = false;
         vt100_charset_is_graphical = false;
@@ -212,9 +222,9 @@ public class ScreenTerminal {
 
     private void reset_screen() {
         // Screen
-        screen = new long[height][width];
-        screen2 = new long[height][width];
-        for (int i = 0; i < height; i++) {
+        screen = new long[rows][columns];
+        screen2 = new long[rows][columns];
+        for (int i = 0; i < rows; i++) {
             Arrays.fill(screen[i], attr | 0x00000020);
             Arrays.fill(screen2[i], attr | 0x00000020);
         }
@@ -222,13 +232,13 @@ public class ScreenTerminal {
         history2.clear();
         // Scroll parameters
         scroll_area_y0 = 0;
-        scroll_area_y1 = height;
+        scroll_area_y1 = rows;
         // Cursor position
         cx = 0;
         cy = 0;
         // Tab stops
         tab_stops = new ArrayList<>();
-        for (int i = 7; i < width; i += 8) {
+        for (int i = 7; i < columns; i += 8) {
             tab_stops.add(i);
         }
     }
@@ -246,16 +256,16 @@ public class ScreenTerminal {
     //
 
     private long[] peek(int y0, int x0, int y1, int x1) {
-        int from = width * y0 + x0;
-        int to = width * (y1 - 1) + x1;
+        int from = columns * y0 + x0;
+        int to = columns * (y1 - 1) + x1;
         int newLength = to - from;
         if (newLength < 0) throw new IllegalArgumentException(from + " > " + to);
         long[] copy = new long[newLength];
         int cur = from;
         while (cur < to) {
-            int y = cur / width;
-            int x = cur % width;
-            int nb = Math.min(width - x, to - cur);
+            int y = cur / columns;
+            int x = cur % columns;
+            int nb = Math.min(columns - x, to - cur);
             System.arraycopy(screen[y], x, copy, cur - from, nb);
             cur += nb;
         }
@@ -266,7 +276,7 @@ public class ScreenTerminal {
         int cur = 0;
         int max = s.length;
         while (cur < max) {
-            int nb = Math.min(width - x, max - cur);
+            int nb = Math.min(columns - x, max - cur);
             System.arraycopy(s, cur, screen[y++], x, nb);
             x = 0;
             cur += nb;
@@ -281,7 +291,7 @@ public class ScreenTerminal {
                 setDirty();
             }
         } else if (y0 < y1 - 1) {
-            Arrays.fill(screen[y0], x0, width, c);
+            Arrays.fill(screen[y0], x0, columns, c);
             for (int i = y0 + 1; i < y1 - 1; i++) {
                 Arrays.fill(screen[i], c);
             }
@@ -304,18 +314,18 @@ public class ScreenTerminal {
 
     private void scroll_area_up(int y0, int y1, int n) {
         n = Math.min(y1 - y0, n);
-        if (y0 == 0 && y1 == height) {
+        if (y0 == 0 && y1 == rows) {
             for (int i = 0; i < n; i++) {
                 history.add(screen[i]);
             }
-            System.arraycopy(screen, n, screen, 0, height - n);
+            System.arraycopy(screen, n, screen, 0, rows - n);
             for (int i = 1; i <= n; i++) {
-                screen[y1 - i] = new long[width];
+                screen[y1 - i] = new long[columns];
                 Arrays.fill(screen[y1 - i], attr | 0x0020);
             }
         } else {
-            poke(y0, 0, peek(y0 + n, 0, y1, width));
-            clear(y1 - n, 0, y1, width);
+            poke(y0, 0, peek(y0 + n, 0, y1, columns));
+            clear(y1 - n, 0, y1, columns);
         }
     }
 
@@ -325,13 +335,13 @@ public class ScreenTerminal {
 
     private void scroll_area_down(int y0, int y1, int n) {
         n = Math.min(y1 - y0, n);
-        poke(y0 + n, 0, peek(y0, 0, y1 - n, width));
-        clear(y0, 0, y0 + n, width);
+        poke(y0 + n, 0, peek(y0, 0, y1 - n, columns));
+        clear(y0, 0, y0 + n, columns);
     }
 
     private void scroll_area_set(int y0, int y1) {
-        y0 = Math.max(0, Math.min(height - 1, y0));
-        y1 = Math.max(1, Math.min(height, y1));
+        y0 = Math.max(0, Math.min(rows - 1, y0));
+        y1 = Math.max(1, Math.min(rows, y1));
         if (y1 > y0) {
             scroll_area_y0 = y0;
             scroll_area_y1 = y1;
@@ -343,9 +353,9 @@ public class ScreenTerminal {
     }
 
     private void scroll_line_right(int y, int x, int n) {
-        if (x < width) {
-            n = Math.min(width - x, n);
-            poke(y, x + n, peek(y, x, y + 1, width - n));
+        if (x < columns) {
+            n = Math.min(columns - x, n);
+            poke(y, x + n, peek(y, x, y + 1, columns - n));
             clear(y, x, y + 1, x + n);
         }
     }
@@ -355,10 +365,10 @@ public class ScreenTerminal {
     }
 
     private void scroll_line_left(int y, int x, int n) {
-        if (x < width) {
-            n = Math.min(width - x, n);
-            poke(y, x, peek(y, x + n, y + 1, width));
-            clear(y, width - n, y + 1, width);
+        if (x < columns) {
+            n = Math.min(columns - x, n);
+            poke(y, x, peek(y, x + n, y + 1, columns));
+            clear(y, columns - n, y + 1, columns);
         }
     }
 
@@ -366,10 +376,10 @@ public class ScreenTerminal {
     // Cursor functions
     //
 
-    private int[] cursor_line_width(int next_char) {
-        int wx = utf8_charwidth(next_char);
+    private int[] cursorLineColumns(int nextChar) {
+        int wx = utf8_charwidth(nextChar);
         int lx = 0;
-        for (int x = 0; x < Math.min(cx, width); x++) {
+        for (int x = 0; x < Math.min(cx, columns); x++) {
             int c = (int) (screen[cy][x] & 0xffffffffL);
             wx += utf8_charwidth(c);
             lx += 1;
@@ -410,19 +420,19 @@ public class ScreenTerminal {
     }
 
     private void cursor_right(int n) {
-        eol = cx + n >= width;
-        cx = Math.min(width - 1, cx + n);
+        eol = cx + n >= columns;
+        cx = Math.min(columns - 1, cx + n);
         setDirty();
     }
 
     private void cursor_set_x(int x) {
         eol = false;
-        cx = Math.max(0, Math.min(width - 1, x));
+        cx = Math.max(0, Math.min(columns - 1, x));
         setDirty();
     }
 
     private void cursor_set_y(int y) {
-        cy = Math.max(0, Math.min(height - 1, y));
+        cy = Math.max(0, Math.min(rows - 1, y));
         setDirty();
     }
 
@@ -446,7 +456,7 @@ public class ScreenTerminal {
     }
 
     private void ctrl_HT(int n) {
-        if (n > 0 && cx >= width) {
+        if (n > 0 && cx >= columns) {
             return;
         }
         if (n <= 0 && cx == 0) {
@@ -462,7 +472,7 @@ public class ScreenTerminal {
         if (ts < tab_stops.size() && ts >= 0) {
             cursor_set_x(tab_stops.get(ts));
         } else {
-            cursor_set_x(width - 1);
+            cursor_set_x(columns - 1);
         }
     }
 
@@ -503,7 +513,7 @@ public class ScreenTerminal {
                 ctrl_CR();
                 ctrl_LF();
             } else {
-                cx = cursor_line_width(c)[1] - 1;
+                cx = cursorLineColumns(c)[1] - 1;
             }
         }
         if (vt100_mode_insert) {
@@ -519,7 +529,7 @@ public class ScreenTerminal {
 
         // For wide characters, fill the subsequent cells with a continuation marker
         if (charWidth > 1) {
-            for (int i = 1; i < charWidth && cx + i < width; i++) {
+            for (int i = 1; i < charWidth && cx + i < columns; i++) {
                 poke(cy, cx + i, new long[] {attr}); // Use null character as continuation marker
             }
         }
@@ -584,9 +594,9 @@ public class ScreenTerminal {
                     // DECCOLM: Column
                     if (vt100_mode_column_switch) {
                         if (state) {
-                            width = 132;
+                            columns = 132;
                         } else {
-                            width = 80;
+                            columns = 80;
                         }
                         reset_screen();
                     }
@@ -640,12 +650,12 @@ public class ScreenTerminal {
                         int c;
                         c = vt100_alternate_cx;
                         vt100_alternate_cx = cx;
-                        cx = Math.min(c, width - 1);
+                        cx = Math.min(c, columns - 1);
                         c = vt100_alternate_cy;
                         vt100_alternate_cy = cy;
-                        cy = Math.min(c, height - 1);
+                        cy = Math.min(c, rows - 1);
                         if (state) { // Alt-screen does not persist.
-                            for (int i = 0; i < height; i++) {
+                            for (int i = 0; i < rows; i++) {
                                 Arrays.fill(screen[i], attr | 0x00000020);
                             }
                             history.clear();
@@ -678,7 +688,7 @@ public class ScreenTerminal {
     }
 
     private void esc_DECALN() {
-        fill(0, 0, height, width, attr | 'E');
+        fill(0, 0, rows, columns, attr | 'E');
     }
 
     private void esc_G0_0() {
@@ -727,8 +737,8 @@ public class ScreenTerminal {
     }
 
     private void esc_DECRC() {
-        cx = Math.min(vt100_saved.cx, width - 1);
-        cy = Math.min(vt100_saved.cy, height - 1);
+        cx = Math.min(vt100_saved.cx, columns - 1);
+        cy = Math.min(vt100_saved.cy, rows - 1);
         attr = vt100_saved.attr;
         vt100_charset_g_sel = vt100_saved.charsetGSel;
         vt100_charset_g = vt100_saved.charsetG.clone();
@@ -853,11 +863,11 @@ public class ScreenTerminal {
     private void csi_ED(String p) {
         String[] ps = vt100_parse_params(p, new String[] {"0"});
         if ("0".equals(ps[0])) {
-            clear(cy, cx, height, width);
+            clear(cy, cx, rows, columns);
         } else if ("1".equals(ps[0])) {
             clear(0, 0, cy + 1, cx + 1);
         } else if ("2".equals(ps[0])) {
-            clear(0, 0, height, width);
+            clear(0, 0, rows, columns);
         } else if ("3".equals(ps[0])) {
             history.clear();
         }
@@ -866,11 +876,11 @@ public class ScreenTerminal {
     private void csi_EL(String p) {
         String[] ps = vt100_parse_params(p, new String[] {"0"});
         if ("0".equals(ps[0])) {
-            clear(cy, cx, cy + 1, width);
+            clear(cy, cx, cy + 1, columns);
         } else if ("1".equals(ps[0])) {
             clear(cy, 0, cy + 1, cx + 1);
         } else if ("2".equals(ps[0])) {
-            clear(cy, 0, cy + 1, width);
+            clear(cy, 0, cy + 1, columns);
         }
     }
 
@@ -921,7 +931,7 @@ public class ScreenTerminal {
 
     private void csi_ECH(String p) {
         int[] ps = vt100_parse_params(p, new int[] {1});
-        int n = Math.min(width - cx, Math.max(1, ps[0]));
+        int n = Math.min(columns - cx, Math.max(1, ps[0]));
         clear(cy, cx, cy + 1, cx + n);
     }
 
@@ -1106,7 +1116,7 @@ public class ScreenTerminal {
     }
 
     private void csi_DECSTBM(String p) {
-        int[] ps = vt100_parse_params(p, new int[] {1, height});
+        int[] ps = vt100_parse_params(p, new int[] {1, rows});
         scroll_area_set(ps[0] - 1, ps[1]);
         if (vt100_mode_origin) {
             cursor_set(scroll_area_y0, 0);
@@ -1121,8 +1131,8 @@ public class ScreenTerminal {
     }
 
     private void csi_RCP(String p) {
-        cx = Math.min(vt100_saved_cx, width - 1);
-        cy = Math.min(vt100_saved_cy, height - 1);
+        cx = Math.min(vt100_saved_cx, columns - 1);
+        cy = Math.min(vt100_saved_cy, rows - 1);
     }
 
     private void csi_DECREQTPARM(String p) {
@@ -1696,132 +1706,195 @@ public class ScreenTerminal {
     //
 
     /**
+     * Provide the current number of columns in the terminal.
+     *
+     * @return the current number of columns
+     */
+    public synchronized int getColumns() {
+        return columns;
+    }
+
+    /**
+     * Gets the number of rows in the terminal.
+     *
+     * @return the number of rows
+     */
+    public synchronized int getRows() {
+        return rows;
+    }
+
+    /**
      * Gets the terminal width in characters.
      *
      * @return the width in characters
+     * @deprecated Use {@link #getColumns()} instead.
      */
+    @Deprecated
+    @SuppressWarnings("java:S1133") // Intentional deprecation; removal planned for a future major version
     public synchronized int getWidth() {
-        return width;
+        return getColumns();
     }
 
     /**
      * Gets the terminal height in characters.
      *
      * @return the height in characters
+     * @deprecated Use {@link #getRows()} instead.
      */
+    @Deprecated
+    @SuppressWarnings("java:S1133") // Intentional deprecation; removal planned for a future major version
     public synchronized int getHeight() {
-        return height;
+        return getRows();
     }
 
-    public synchronized boolean setSize(int w, int h) {
-        if (w < MIN_SIZE || w > MAX_SIZE || h < MIN_SIZE || h > MAX_SIZE) {
+    /**
+     * Resize the terminal to the specified columns and rows.
+     *
+     * @param size the new Size whose columns and rows will be applied
+     * @return true if the size was set successfully, false otherwise
+     */
+    public synchronized boolean setSize(Size size) {
+        return setSize(size.getColumns(), size.getRows());
+    }
+
+    /**
+     * Resize the terminal to the given number of columns and rows.
+     *
+     * This adjusts internal screen buffers, clamps cursor and scroll-region positions
+     * to the new dimensions, and marks the terminal as dirty so callers can refresh.
+     *
+     * @param columns the target number of columns (2–256)
+     * @param rows    the target number of rows (2–256)
+     * @return        `true` if the size was changed; `false` if the requested dimensions are out of range
+     */
+    public synchronized boolean setSize(int columns, int rows) {
+        if (columns < MIN_SIZE || columns > MAX_SIZE || rows < MIN_SIZE || rows > MAX_SIZE) {
             return false;
         }
 
-        // Set width
-        for (int i = 0; i < height; i++) {
-            if (screen[i].length != w) {
-                int oldLength = screen[i].length;
-                screen[i] = Arrays.copyOf(screen[i], w);
-                for (int j = oldLength; j < w; j++) {
-                    screen[i][j] = attr | 0x00000020;
-                }
-            }
-            if (screen2[i].length != w) {
-                int oldLength = screen2[i].length;
-                screen2[i] = Arrays.copyOf(screen2[i], w);
-                for (int j = oldLength; j < w; j++) {
-                    screen2[i][j] = attr | 0x00000020;
-                }
-            }
-        }
-        if (cx >= w) {
-            cx = w - 1;
+        // Resize screen buffers
+        adjustBufferColumns(screen, columns);
+        adjustBufferColumns(screen2, columns);
+
+        if (cx >= columns) {
+            cx = columns - 1;
         }
 
-        if (h != height) {
-            adjustBufferHeight(h, w, false);
-            adjustBufferHeight(h, w, true);
+        if (rows != this.rows) {
+            adjustBufferRows(rows, columns, false);
+            adjustBufferRows(rows, columns, true);
         }
 
         // Scroll parameters
-        scroll_area_y0 = Math.min(h, scroll_area_y0);
-        scroll_area_y1 = scroll_area_y1 == height ? h : Math.min(h, scroll_area_y1);
+        scroll_area_y0 = Math.min(rows - 1, scroll_area_y0);
+        scroll_area_y1 = scroll_area_y1 == this.rows ? rows : Math.min(rows, scroll_area_y1);
         // Cursor position
-        cx = Math.min(w - 1, cx);
-        cy = Math.min(h - 1, cy);
-        vt100_alternate_cx = Math.min(w - 1, vt100_alternate_cx);
-        vt100_alternate_cy = Math.min(h - 1, vt100_alternate_cy);
+        cx = Math.min(columns - 1, cx);
+        cy = Math.min(rows - 1, cy);
+        vt100_alternate_cx = Math.min(columns - 1, vt100_alternate_cx);
+        vt100_alternate_cy = Math.min(rows - 1, vt100_alternate_cy);
 
-        width = w;
-        height = h;
+        this.columns = columns;
+        this.rows = rows;
 
         setDirty();
         return true;
     }
 
-    private void adjustBufferHeight(int h, int w, boolean alt) {
+    /**
+     * Resize each row in the given screen buffer to the specified column count and fill any newly added cells with the current blank cell value.
+     *
+     * For each row in `buffer`, if the row's length differs from `columns` this method replaces the row with a copy truncated or extended to `columns`. Newly added cells are initialized to `attr | 0x00000020` (blank with current attributes).
+     *
+     * @param buffer  the 2D screen buffer whose rows will be resized (must have at least `rows` rows)
+     * @param columns the target number of columns for each row
+     */
+    private void adjustBufferColumns(long[][] buffer, int columns) {
+        for (int i = 0; i < rows; i++) {
+            if (buffer[i].length != columns) {
+                int oldLength = buffer[i].length;
+                buffer[i] = Arrays.copyOf(buffer[i], columns);
+                for (int j = oldLength; j < columns; j++) {
+                    buffer[i][j] = attr | 0x00000020;
+                }
+            }
+        }
+    }
+
+    private void adjustBufferRows(int rows, int columns, boolean alt) {
+        if (rows < this.rows) {
+            shrinkBufferRows(rows, alt);
+        } else if (rows > this.rows) {
+            growBufferRows(rows, columns, alt);
+        }
+    }
+
+    private void shrinkBufferRows(int rows, boolean alt) {
         List<long[]> targetHistory = alt ? history2 : history;
         long[][] targetScreen = alt ? screen2 : screen;
-        if (h < height) {
-            int needed = height - h;
-            // Delete as many lines as possible from the bottom
-            int avail = height - 1 - (alt ? vt100_alternate_cy : cy);
-            if (avail > 0) {
-                if (avail > needed) {
-                    avail = needed;
-                }
-                targetScreen = Arrays.copyOfRange(targetScreen, 0, height - avail);
-            }
-            needed -= avail;
-            // Move lines to history
-            for (int i = 0; i < needed; i++) {
-                targetHistory.add(targetScreen[i]);
-            }
-            targetScreen = Arrays.copyOfRange(targetScreen, needed, targetScreen.length);
-            if (alt) {
-                vt100_alternate_cy -= needed;
-                screen2 = targetScreen;
-            } else {
-                cy -= needed;
-                screen = targetScreen;
-            }
-        } else if (h > height) {
-            int needed = h - height;
-            // Pull lines from history
-            int avail = targetHistory.size();
+        int needed = this.rows - rows;
+        // Delete as many lines as possible from the bottom
+        int avail = this.rows - 1 - (alt ? vt100_alternate_cy : cy);
+        if (avail > 0) {
             if (avail > needed) {
                 avail = needed;
             }
-            long[][] sc = new long[h][];
-            if (avail > 0) {
-                for (int i = 0; i < avail; i++) {
-                    long[] historyLine = targetHistory.remove(targetHistory.size() - avail + i);
-                    // Check if the history line needs to be resized to match the new width
-                    if (historyLine.length < w) {
-                        int oldLength = historyLine.length;
-                        historyLine = Arrays.copyOf(historyLine, w);
-                        // Fill the rest with spaces
-                        for (int j = oldLength; j < w; j++) {
-                            historyLine[j] = attr | 0x00000020;
-                        }
-                    }
-                    sc[i] = historyLine;
-                }
-            }
-            System.arraycopy(targetScreen, 0, sc, avail, targetScreen.length);
-            for (int i = avail + targetScreen.length; i < sc.length; i++) {
-                sc[i] = new long[w];
-                Arrays.fill(sc[i], attr | 0x00000020);
-            }
-            if (alt) {
-                vt100_alternate_cy += avail;
-                screen2 = sc;
-            } else {
-                cy += avail;
-                screen = sc;
+            targetScreen = Arrays.copyOfRange(targetScreen, 0, this.rows - avail);
+        }
+        needed -= avail;
+        // Move lines to history
+        for (int i = 0; i < needed; i++) {
+            targetHistory.add(targetScreen[i]);
+        }
+        targetScreen = Arrays.copyOfRange(targetScreen, needed, targetScreen.length);
+        if (alt) {
+            vt100_alternate_cy -= needed;
+            screen2 = targetScreen;
+        } else {
+            cy -= needed;
+            screen = targetScreen;
+        }
+    }
+
+    private void growBufferRows(int rows, int columns, boolean alt) {
+        List<long[]> targetHistory = alt ? history2 : history;
+        long[][] targetScreen = alt ? screen2 : screen;
+        int needed = rows - this.rows;
+        // Pull lines from history
+        int avail = targetHistory.size();
+        if (avail > needed) {
+            avail = needed;
+        }
+        long[][] sc = new long[rows][];
+        if (avail > 0) {
+            for (int i = 0; i < avail; i++) {
+                long[] historyLine = targetHistory.remove(targetHistory.size() - avail + i);
+                sc[i] = resizeHistoryLine(historyLine, columns);
             }
         }
+        System.arraycopy(targetScreen, 0, sc, avail, targetScreen.length);
+        for (int i = avail + targetScreen.length; i < sc.length; i++) {
+            sc[i] = new long[columns];
+            Arrays.fill(sc[i], attr | 0x00000020);
+        }
+        if (alt) {
+            vt100_alternate_cy += avail;
+            screen2 = sc;
+        } else {
+            cy += avail;
+            screen = sc;
+        }
+    }
+
+    private long[] resizeHistoryLine(long[] historyLine, int columns) {
+        if (historyLine.length < columns) {
+            int oldLength = historyLine.length;
+            historyLine = Arrays.copyOf(historyLine, columns);
+            for (int j = oldLength; j < columns; j++) {
+                historyLine[j] = attr | 0x00000020;
+            }
+        }
+        return historyLine;
     }
 
     public synchronized String read() {
@@ -1925,33 +1998,33 @@ public class ScreenTerminal {
     }
 
     public synchronized void dump(long[] fullscreen, int ftop, int fleft, int fheight, int fwidth, int[] cursor) {
-        int cx = Math.min(this.cx, width - 1);
-        int cy = this.cy;
-        for (int y = 0; y < Math.min(height, fheight - ftop); y++) {
-            System.arraycopy(screen[y], 0, fullscreen, (y + ftop) * fwidth + fleft, width);
+        int cursorX = Math.min(this.cx, columns - 1);
+        int cursorY = this.cy;
+        for (int y = 0; y < Math.min(rows, fheight - ftop); y++) {
+            System.arraycopy(screen[y], 0, fullscreen, (y + ftop) * fwidth + fleft, columns);
         }
         if (cursor != null) {
-            cursor[0] = cx + fleft;
-            cursor[1] = cy + ftop;
+            cursor[0] = cursorX + fleft;
+            cursor[1] = cursorY + ftop;
         }
     }
 
     /**
      * Dumps the raw screen content into a flat array.
-     * The array must be at least {@code width * height} elements long.
+     * The array must be at least {@code columns * rows} elements long.
      *
      * @param fullscreen destination array
      * @param cursor     2-element array to receive cursor [x, y], or null
      */
     public synchronized void dump(long[] fullscreen, int[] cursor) {
-        int cx = Math.min(this.cx, width - 1);
-        int cy = this.cy;
-        for (int y = 0; y < height; y++) {
-            System.arraycopy(screen[y], 0, fullscreen, y * width, width);
+        int cursorX = Math.min(this.cx, columns - 1);
+        int cursorY = this.cy;
+        for (int y = 0; y < rows; y++) {
+            System.arraycopy(screen[y], 0, fullscreen, y * columns, columns);
         }
         if (cursor != null) {
-            cursor[0] = cx;
-            cursor[1] = cy;
+            cursor[0] = cursorX;
+            cursor[1] = cursorY;
         }
     }
 
@@ -1992,7 +2065,7 @@ public class ScreenTerminal {
      *
      * @param timeout   maximum time to wait in milliseconds
      * @param forceDump if true, dump even if the screen is not dirty
-     * @param fullscreen destination array (must be at least width * height)
+     * @param fullscreen destination array (must be at least columns * rows)
      * @param cursor    2-element array to receive cursor [x, y], or null
      * @return true if the screen was dumped
      * @throws InterruptedException if interrupted
@@ -2031,21 +2104,21 @@ public class ScreenTerminal {
     public synchronized String dump() {
         boolean inverse = vt100_mode_inverse;
         boolean cursorVisible = vt100_mode_cursor;
-        int w = getWidth();
-        int h = getHeight();
-        long[] screen = new long[w * h];
+        int cols = getColumns();
+        int numRows = getRows();
+        long[] dumpBuffer = new long[cols * numRows];
         int[] cursor = new int[2];
         dump(screen, cursor);
-        int cx = cursor[0];
-        int cy = cursor[1];
+        int cursorX = cursor[0];
+        int cursorY = cursor[1];
         StringBuilder sb = new StringBuilder();
         long prevAttr = -1;
         sb.append("<div><pre class='term'>");
-        for (int y = 0; y < h; y++) {
-            for (int x = 0; x < w; x++) {
-                long d = screen[y * w + x];
+        for (int y = 0; y < numRows; y++) {
+            for (int x = 0; x < cols; x++) {
+                long d = dumpBuffer[y * cols + x];
                 int c = (int) (d & 0xffffffffL);
-                long a = resolveCellAttr(d >>> 32, cursorVisible, x, y, cx, cy);
+                long a = resolveCellAttr(d >>> 32, cursorVisible, x, y, cursorX, cursorY);
                 if (a != prevAttr) {
                     if (prevAttr != -1) {
                         sb.append("</span>");
@@ -2187,8 +2260,8 @@ public class ScreenTerminal {
 
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
+        for (int y = 0; y < rows; y++) {
+            for (int x = 0; x < columns; x++) {
                 int c = (int) (screen[y][x] & 0xffffffffL);
                 if (c != 0) {
                     sb.appendCodePoint(c);

--- a/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
@@ -57,12 +57,12 @@ public class SwingTerminal extends LineDisciplineTerminal {
     /**
      * Creates a new SwingTerminal with the specified dimensions.
      *
-     * @param width  the terminal width in columns
-     * @param height the terminal height in rows
+     * @param columns the number of columns
+     * @param rows    the number of rows
      * @throws IOException if an I/O error occurs during initialization
      */
-    public SwingTerminal(int width, int height) throws IOException {
-        this("SwingTerminal", width, height);
+    public SwingTerminal(int columns, int rows) throws IOException {
+        this("SwingTerminal", columns, rows);
     }
 
     /**
@@ -77,20 +77,20 @@ public class SwingTerminal extends LineDisciplineTerminal {
     /**
      * Creates a new SwingTerminal with the specified name and dimensions.
      *
-     * @param name   the terminal name
-     * @param width  the terminal width in columns
-     * @param height the terminal height in rows
+     * @param name    the terminal name
+     * @param columns the number of columns
+     * @param rows    the number of rows
      * @throws IOException if an I/O error occurs during initialization
      */
     @SuppressWarnings("this-escape")
-    public SwingTerminal(String name, int width, int height) throws IOException {
+    public SwingTerminal(String name, int columns, int rows) throws IOException {
         super(name, "screen-256color", new SwingTerminalOutputStream(), StandardCharsets.UTF_8);
 
         // Create the terminal component
-        this.component = new TerminalComponent(width, height);
+        this.component = new TerminalComponent(columns, rows);
 
         // Initialize after construction to avoid this-escape warnings
-        initializeTerminal(width, height);
+        initializeTerminal(columns, rows);
 
         // Start a thread to read from SwingTerminal and process input
         inputThread = new Thread(
@@ -114,11 +114,15 @@ public class SwingTerminal extends LineDisciplineTerminal {
     }
 
     /**
-     * Initializes the terminal after construction to avoid this-escape issues.
+     * Finalizes terminal setup after construction by setting its logical size and wiring
+     * the UI component and output stream to this terminal.
+     *
+     * @param columns the number of columns for the terminal display
+     * @param rows    the number of rows for the terminal display
      */
-    private void initializeTerminal(int width, int height) {
+    private void initializeTerminal(int columns, int rows) {
         // Set initial size
-        setSize(new Size(width, height));
+        setSize(new Size(columns, rows));
 
         // Connect the component output to our master output and set the terminal reference
         SwingTerminalOutputStream outputStream = (SwingTerminalOutputStream) masterOutput;
@@ -457,9 +461,16 @@ public class SwingTerminal extends LineDisciplineTerminal {
         private final AtomicBoolean cursorVisible = new AtomicBoolean(true);
         private transient Timer cursorTimer;
 
+        /**
+         * Create a TerminalComponent for rendering and capturing input for a terminal with the specified
+         * character grid size.
+         *
+         * @param columns the number of character columns in the terminal
+         * @param rows    the number of character rows in the terminal
+         */
         @SuppressWarnings("this-escape")
-        public TerminalComponent(int width, int height) {
-            this.screenTerminal = new ScreenTerminal(width, height);
+        public TerminalComponent(int columns, int rows) {
+            this.screenTerminal = new ScreenTerminal(columns, rows);
 
             // Set up font directly to avoid this-escape warning
             this.terminalFont = new Font(Font.MONOSPACED, Font.PLAIN, 14);
@@ -556,12 +567,25 @@ public class SwingTerminal extends LineDisciplineTerminal {
             return terminalFont;
         }
 
+        /**
+         * Updates this component's preferred size to match the terminal grid.
+         *
+         * Calculates width as `columns * charWidth` and height as `rows * charHeight`
+         * using the associated ScreenTerminal's column/row counts and the current
+         * character cell dimensions, then sets the preferred size accordingly.
+         */
         private void updatePreferredSize() {
-            int width = screenTerminal.getWidth() * charWidth;
-            int height = screenTerminal.getHeight() * charHeight;
+            int width = screenTerminal.getColumns() * charWidth;
+            int height = screenTerminal.getRows() * charHeight;
             setPreferredSize(new Dimension(width, height));
         }
 
+        /**
+         * Paints this Swing component and its terminal contents.
+         *
+         * <p>Prepares a Graphics2D context with high-quality text rendering and the component's terminal font,
+         * then delegates actual terminal rendering to the paintTerminalContent method.
+         */
         @Override
         protected void paintComponent(Graphics g) {
             super.paintComponent(g);
@@ -583,19 +607,22 @@ public class SwingTerminal extends LineDisciplineTerminal {
             }
         }
 
+        /**
+         * Render the terminal's current screen buffer onto the given Graphics2D, painting each cell and the cursor.
+         */
         private void paintTerminalContent(Graphics2D g2d) {
-            int termWidth = screenTerminal.getWidth();
-            int termHeight = screenTerminal.getHeight();
+            int cols = screenTerminal.getColumns();
+            int rows = screenTerminal.getRows();
 
             // Get terminal screen data
-            long[] screenData = new long[termWidth * termHeight];
+            long[] screenData = new long[cols * rows];
             int[] cursor = new int[2];
             screenTerminal.dump(screenData, cursor);
 
             // Paint each character
-            for (int y = 0; y < termHeight; y++) {
-                for (int x = 0; x < termWidth; x++) {
-                    int index = y * termWidth + x;
+            for (int y = 0; y < rows; y++) {
+                for (int x = 0; x < cols; x++) {
+                    int index = y * cols + x;
                     if (index < screenData.length) {
                         long cell = screenData[index];
                         paintCell(g2d, x, y, cell, cursor[0] == x && cursor[1] == y);

--- a/builtins/src/main/java/org/jline/builtins/TTop.java
+++ b/builtins/src/main/java/org/jline/builtins/TTop.java
@@ -339,10 +339,21 @@ public class TTop {
         }
     }
 
+    /**
+     * Render the full terminal view: system headers, JVM/thread summary, formatted columns,
+     * per-thread rows with change highlighting, and push the result to the display.
+     *
+     * This method gathers system and JVM metrics, computes column widths and which
+     * statistics fit the current terminal size, formats per-thread values, applies
+     * time-based fade highlighting for changed fields, and updates the alternate
+     * screen buffer with the composed lines.
+     *
+     * @throws IOException if an I/O error occurs while resizing or updating the display
+     */
     private synchronized void display() throws IOException {
         long now = System.currentTimeMillis();
 
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
 
         List<AttributedString> lines = new ArrayList<>();
         AttributedStringBuilder sb = new AttributedStringBuilder(size.getColumns());

--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -1082,6 +1082,14 @@ public class Tmux {
     int INACTIVE_COLOR = 0x44F;
     int CLOCK_COLOR = 0x44F;
 
+    /**
+     * Render all panes and the status line into the display and update the terminal screen.
+     *
+     * Builds a composed screen from each pane's contents (or a clock string when a pane's
+     * clock mode is enabled), draws pane borders and optional pane identifiers, converts the
+     * composed buffer into attributed text lines, and submits them with the active cursor
+     * position to the Display for rendering.
+     */
     protected synchronized void redraw() {
         long[] screen = new long[size.getRows() * size.getColumns()];
         // Fill
@@ -1193,7 +1201,7 @@ public class Tmux {
             }
             lines.add(sb.toAttributedString());
         }
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         display.update(lines, size.cursorPos(cursor[1], cursor[0]));
     }
 
@@ -2022,18 +2030,38 @@ public class Tmux {
             return left() + width();
         }
 
+        /**
+         * Get the row index immediately after this pane's bottom edge.
+         *
+         * @return the one-past-last row index (top + height)
+         */
         public int bottom() {
             return top() + height();
         }
 
+        /**
+         * Get the current width of this pane in character columns.
+         *
+         * @return the pane width in columns
+         */
         public int width() {
-            return console.getWidth();
+            return console.getColumns();
         }
 
+        /**
+         * Get the current pane height in terminal rows.
+         *
+         * @return the pane height measured in character rows
+         */
         public int height() {
-            return console.getHeight();
+            return console.getRows();
         }
 
+        /**
+         * Get the LineDisciplineTerminal backing this virtual console.
+         *
+         * @return the {@link LineDisciplineTerminal} used by this pane
+         */
         public LineDisciplineTerminal getConsole() {
             return console;
         }

--- a/builtins/src/main/java/org/jline/builtins/WebTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/WebTerminal.java
@@ -73,21 +73,22 @@ public class WebTerminal extends LineDisciplineTerminal {
     }
 
     /**
-     * Creates a new WebTerminal with specified host, port, and terminal size.
+     * Initialize a WebTerminal bound to the given host and port and configured with the specified columns and rows.
      *
-     * @param host the host to bind to
-     * @param port the port to bind to
-     * @param width terminal width in characters
-     * @param height terminal height in characters
+     * @param host the host address to bind the embedded HTTP server to
+     * @param port the preferred port for the embedded HTTP server (use 0 to select an ephemeral port)
+     * @param columns the initial number of terminal columns
+     * @param rows the initial number of terminal rows
+     * @throws IOException if an I/O error occurs while initializing terminal resources
      */
     @SuppressWarnings("this-escape")
-    public WebTerminal(String host, int port, int width, int height) throws IOException {
+    public WebTerminal(String host, int port, int columns, int rows) throws IOException {
         super("WebTerminal", "screen-256color", new WebTerminalOutputStream(), StandardCharsets.UTF_8);
         this.host = host;
         this.port = port;
 
         // Create the terminal component
-        this.component = new WebTerminalComponent(width, height);
+        this.component = new WebTerminalComponent(columns, rows);
         this.component.setWebTerminal(this);
 
         // Connect the output stream to the component
@@ -207,14 +208,14 @@ public class WebTerminal extends LineDisciplineTerminal {
     }
 
     /**
-     * Sets the terminal size.
+     * Set the terminal dimensions in columns and rows.
      *
-     * @param width the new width
-     * @param height the new height
-     * @return true if successful
+     * @param columns the new number of columns
+     * @param rows the new number of rows
+     * @return `true` if the terminal was resized, `false` otherwise
      */
-    public boolean setSize(int width, int height) {
-        return component.setSize(width, height);
+    public boolean setSize(int columns, int rows) {
+        return component.setSize(columns, rows);
     }
 
     /**
@@ -496,11 +497,11 @@ public class WebTerminal extends LineDisciplineTerminal {
         /**
          * Creates a new WebTerminalComponent with the specified dimensions.
          *
-         * @param width terminal width in characters
-         * @param height terminal height in characters
+         * @param columns the number of columns
+         * @param rows the number of rows
          */
-        public WebTerminalComponent(int width, int height) {
-            super(width, height);
+        public WebTerminalComponent(int columns, int rows) {
+            super(columns, rows);
         }
 
         /**
@@ -536,18 +537,18 @@ public class WebTerminal extends LineDisciplineTerminal {
         }
 
         /**
-         * Sets the terminal size.
+         * Set the terminal size to the given columns and rows if they are within allowed bounds.
          *
-         * @param width the new width
-         * @param height the new height
-         * @return true if successful
+         * @param columns the new number of columns; must be between 10 and 200 inclusive
+         * @param rows the new number of rows; must be between 5 and 100 inclusive
+         * @return true if the size was applied, false if the provided dimensions are out of range
          */
-        public boolean setSize(int width, int height) {
-            if (width < 10 || height < 5 || width > MAX_SIZE || height > MAX_SIZE) {
+        @Override
+        public synchronized boolean setSize(int columns, int rows) {
+            if (columns < 10 || rows < 5 || columns > MAX_SIZE || rows > MAX_SIZE) {
                 return false;
             }
-            // ScreenTerminal.setSize takes width and height directly
-            return super.setSize(width, height);
+            return super.setSize(columns, rows);
         }
     }
 

--- a/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
@@ -21,8 +21,8 @@ public class ScreenTerminalTest {
 
     // Helper: get cursor position as [x, y]
     private int[] getCursor(ScreenTerminal terminal) {
-        int w = terminal.getWidth();
-        int h = terminal.getHeight();
+        int w = terminal.getColumns();
+        int h = terminal.getRows();
         long[] screen = new long[w * h];
         int[] cursor = new int[2];
         terminal.dump(screen, cursor);
@@ -31,8 +31,8 @@ public class ScreenTerminalTest {
 
     // Helper: get the character at a screen position from the raw dump
     private int getChar(ScreenTerminal terminal, int row, int col) {
-        int w = terminal.getWidth();
-        int h = terminal.getHeight();
+        int w = terminal.getColumns();
+        int h = terminal.getRows();
         long[] screen = new long[w * h];
         terminal.dump(screen, null);
         return (int) (screen[row * w + col] & 0xffffffffL);
@@ -40,8 +40,8 @@ public class ScreenTerminalTest {
 
     // Helper: get the attribute at a screen position from the raw dump
     private long getAttr(ScreenTerminal terminal, int row, int col) {
-        int w = terminal.getWidth();
-        int h = terminal.getHeight();
+        int w = terminal.getColumns();
+        int h = terminal.getRows();
         long[] screen = new long[w * h];
         terminal.dump(screen, null);
         return screen[row * w + col] >>> 32;

--- a/builtins/src/test/java/org/jline/example/Example.java
+++ b/builtins/src/test/java/org/jline/example/Example.java
@@ -145,6 +145,14 @@ public class Example {
             map.bind(Operation.EXIT, "\r");
         }
 
+        /**
+         * Displays an interactive option selector in the terminal and returns the user's choice.
+         *
+         * Blocks until the user confirms a selection. The menu shows a title (first line) followed by
+         * selectable option lines; the returned value is one of those option lines.
+         *
+         * @return the selected option line (one of the menu entries following the title)
+         */
         public String select() {
             Display display = new Display(terminal, true);
             Attributes attr = terminal.enterRawMode();
@@ -159,7 +167,7 @@ public class Example {
                 KeyMap<Operation> keyMap = new KeyMap<>();
                 bindKeys(keyMap);
                 while (true) {
-                    display.resize(size.getRows(), size.getColumns());
+                    display.resize(size);
                     display.update(
                             displayLines(selectRow),
                             size.cursorPos(0, lines.get(0).length()));
@@ -190,6 +198,23 @@ public class Example {
         }
     }
 
+    /**
+     * Runs the interactive example application and enters a configurable REPL driven by command-line options.
+     *
+     * <p>The method parses {@code args} to configure the terminal, parser/completer behavior, mouse and timer
+     * support, masking triggers, colorized prompts, and background callbacks; it then builds a {@code Terminal}
+     * and {@code LineReader}, executes any configured callbacks, and runs a command loop implementing the
+     * example commands (e.g., {@code printAbove}, {@code set}, {@code tput}, {@code nano}, {@code less},
+     * {@code history}, {@code setopt}/{@code unsetopt}, {@code ttop}, {@code help}, and {@code select}). The
+     * loop handles user interrupts, help and EOF, and prints output to the terminal.
+     *
+     * @param args command-line options controlling example behavior (examples: {@code timer}, {@code -system},
+     *             {@code +system}, {@code files}, {@code simple}, {@code quotes}, {@code brackets}, {@code status},
+     *             {@code argument}, {@code param}, {@code tree}, {@code regexp}, {@code color}, {@code mouse},
+     *             {@code mousetrack}, or a pair {@code <trigger> <maskChar>} to enable masking); if {@code args}
+     *             is null or empty the usage message is printed and the method returns.
+     * @throws IOException if an I/O error occurs while building or interacting with the terminal
+     */
     public static void main(String[] args) throws IOException {
         try {
             String prompt = "prompt> ";
@@ -421,7 +446,7 @@ public class Example {
                         Cursor cursor = terminal.getCursorPosition(c -> tsb.append((char) c));
                         reader.runMacro(tsb.toString());
                         String msg = "          " + event.toString();
-                        int w = terminal.getWidth();
+                        int w = terminal.getColumns();
                         terminal.puts(Capability.cursor_address, 0, Math.max(0, w - msg.length()));
                         terminal.writer().append(msg);
                         terminal.puts(Capability.cursor_address, cursor.getY(), cursor.getX());

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
@@ -87,19 +87,48 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
         size.copy(terminal.getSize());
     }
 
+    /**
+     * Refreshes the display so the UI is re-rendered with the specified cursor row.
+     *
+     * <p>Uses column 0 and an empty input buffer (no trailing newline) when updating the display.
+     *
+     * @param row the absolute terminal row to position the cursor for rendering
+     */
     protected void refreshDisplay(int row) {
         refreshDisplay(row, 0, null, false);
     }
 
+    /**
+     * Refreshes the UI to render items with the cursor positioned at the specified row and the given items marked as selected.
+     *
+     * Resizes the display to the current terminal size, updates the rendered lines based on the cursor row and selection set,
+     * and moves the terminal cursor to the computed position.
+     *
+     * @param row      the absolute terminal row where the cursor should appear (typically a value relative to the prompt's layout)
+     * @param selected names of items that should be rendered as selected/checked
+     */
     protected void refreshDisplay(int row, Set<String> selected) {
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         display.update(
                 displayLines(row, selected),
                 size.cursorPos(Math.min(size.getRows() - 1, firstItemRow + items.size()), 0));
     }
 
+    /**
+     * Refreshes the terminal display using the provided buffer and positions the cursor.
+     *
+     * This resizes the display to the current terminal Size, renders header/message/items
+     * together with the optional input buffer (when `newline` is true and `buffer` is
+     * non-empty the buffer is presented on its own line with a prompt marker), and moves
+     * the cursor to the computed (row, column) position.
+     *
+     * @param row the current cursor row used to determine which item/candidate is active
+     * @param column the cursor column within the buffer (column offset from the message start)
+     * @param buffer the current input text to render; may be null to omit the buffer text
+     * @param newline if true and `buffer` is non-empty, render the buffer on its own line with a prompt marker
+     */
     protected void refreshDisplay(int row, int column, String buffer, boolean newline) {
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         AttributedStringBuilder asb = new AttributedStringBuilder();
         int crow = column == 0 ? Math.min(size.getRows() - 1, firstItemRow + items.size()) : row;
         if (buffer != null) {
@@ -111,9 +140,23 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
         display.update(displayLines(row, asb.toAttributedString(), newline), size.cursorPos(crow, column));
     }
 
+    /**
+     * Resize the display to the cached terminal size, render the input buffer together with a candidate list,
+     * and position the cursor.
+     *
+     * Renders the provided buffer (if non-null) and the candidates at the candidate display coordinates,
+     * updates the display content, and moves the cursor to the specified buffer coordinates.
+     *
+     * @param buffRow   row where the input buffer's cursor should be placed after rendering
+     * @param buffCol   column where the input buffer's cursor should be placed after rendering
+     * @param buffer    the current input buffer to show; may be null to render no buffer text
+     * @param candRow   row used to position and highlight the candidate list
+     * @param candCol   column where the candidate list should start
+     * @param candidates the list of completion candidates to display alongside the buffer
+     */
     protected void refreshDisplay(
             int buffRow, int buffCol, String buffer, int candRow, int candCol, List<Candidate> candidates) {
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         AttributedStringBuilder asb = new AttributedStringBuilder();
         if (buffer != null) {
             asb.style(AttributedStyle.DEFAULT).append(buffer);

--- a/console-ui/src/main/java/org/jline/consoleui/prompt/ConsolePrompt.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/ConsolePrompt.java
@@ -103,9 +103,16 @@ public class ConsolePrompt {
         }
     }
 
+    /**
+     * Exits raw mode and restores the terminal to its previous state.
+     *
+     * <p>If the terminal is currently in raw mode, this updates the displayed header,
+     * restores the saved terminal attributes, disables keypad local mode, emits a
+     * newline to the terminal, and clears the saved raw-mode attributes.</p>
+     */
     protected void close() {
         if (terminalInRawMode()) {
-            int cursor = (terminal.getWidth() + 1) * header.size();
+            int cursor = (terminal.getColumns() + 1) * header.size();
             display.update(header, cursor);
             terminal.setAttributes(attributes);
             terminal.puts(InfoCmp.Capability.keypad_local);
@@ -416,11 +423,17 @@ public class ConsolePrompt {
     }
 
     /**
+     * Compute the number of terminal rows to use for paginated prompts.
+     *
+     * @param terminal the terminal from which to read the current row count
+     * @param pageSize when {@code sizeType} is ABSOLUTE, the requested number of rows; when treated as a percentage, the requested percent (0-100)
+     * @param sizeType determines whether {@code pageSize} is an absolute row count or a percentage of terminal rows
+     * @return the computed page size in rows; for ABSOLUTE, the smaller of the terminal's row count and {@code pageSize}; otherwise {@code pageSize} percent of the terminal's rows
      * @deprecated This method is deprecated along with the ConsolePrompt class. Use the new jline-prompt module instead.
      */
     @Deprecated(since = "4.0.0", forRemoval = true)
     public static int computePageSize(Terminal terminal, int pageSize, PageSizeType sizeType) {
-        int rows = terminal.getHeight();
+        int rows = terminal.getRows();
         return sizeType == PageSizeType.ABSOLUTE ? Math.min(rows, pageSize) : (rows * pageSize) / 100;
     }
 

--- a/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
+++ b/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
@@ -263,6 +263,19 @@ public class Shell {
         stopping.set(true);
     }
 
+    /**
+     * Start a Gogo shell or execute a script/command using the provided session and arguments.
+     *
+     * Parses the supplied argv as shell options and either launches an interactive shell
+     * or executes the specified script/command. When not run as a login shell, a child
+     * session is created and terminal/session variables are installed; recognized options
+     * include --command, --nointeractive, --nohistory, --login, --noshutdown, --xtrace,
+     * and --help.
+     *
+     * @param currentSession the current command session (used as the parent session or, if --login is set, used directly)
+     * @param argv the command-line arguments and options passed to the shell
+     * @return the result of executing the script/command or the interactive shell, or `null` if no result was produced
+     */
     public Object gosh(CommandSession currentSession, String[] argv) throws Exception {
         final String[] usage = {
             "gosh - execute script with arguments in a new session",
@@ -312,8 +325,8 @@ public class Shell {
         session.put(Shell.VAR_PROCESSOR, processor);
         session.put(Shell.VAR_SESSION, session);
         session.put("#TERM", (Function) (s, arguments) -> terminal.getType());
-        session.put("#COLUMNS", (Function) (s, arguments) -> terminal.getWidth());
-        session.put("#LINES", (Function) (s, arguments) -> terminal.getHeight());
+        session.put("#COLUMNS", (Function) (s, arguments) -> terminal.getColumns());
+        session.put("#LINES", (Function) (s, arguments) -> terminal.getRows());
         session.put("#PWD", (Function) (s, arguments) -> s.currentDir().toString());
         if (!opt.isSet("nohistory")) {
             session.put(LineReader.HISTORY_FILE, Paths.get(System.getProperty("user.home"), ".gogo.history"));
@@ -491,6 +504,22 @@ public class Shell {
         }
     }
 
+    /**
+     * Runs the interactive shell loop: reads lines from the given reader, executes them
+     * in the provided session, and displays results and errors on the terminal until
+     * the shell is requested to stop.
+     *
+     * Sets a job listener on the session and installs handlers for INT and TSTP signals,
+     * restores the original handlers on exit, and attempts to save history on end-of-file.
+     * Updates session variables: Shell.VAR_RESULT with the last execution result and
+     * Shell.VAR_EXCEPTION when an execution throws.
+     *
+     * @param session the command session used to execute parsed programs and track jobs
+     * @param terminal the terminal used for prompt rendering and status/output display
+     * @param reader the line reader used to obtain user input and parsed lines
+     * @return the last evaluated result produced by executing a parsed line, or null if none
+     * @throws InterruptedException if the thread is interrupted while waiting for job completion
+     */
     private Object doRunShell(final CommandSession session, Terminal terminal, LineReader reader)
             throws InterruptedException {
         AtomicBoolean reading = new AtomicBoolean();
@@ -499,7 +528,7 @@ public class Shell {
                     || current == Status.Background
                     || previous == Status.Suspended
                     || current == Status.Suspended) {
-                int width = terminal.getWidth();
+                int width = terminal.getColumns();
                 String status = current.name().toLowerCase();
                 terminal.writer().write(getStatusLine(job, width, status));
                 terminal.flush();

--- a/demo/src/main/java/org/jline/demo/Repl.java
+++ b/demo/src/main/java/org/jline/demo/Repl.java
@@ -265,6 +265,21 @@ public class Repl {
         }
     }
 
+    /**
+     * Starts an interactive Groovy read–eval–print loop (REPL) with command parsing,
+     * completion, syntax highlighting, and optional shell command execution.
+     *
+     * <p>The method configures the parser and terminal (including a fallback size
+     * when redirected), ensures demo configuration files exist, initializes the
+     * Groovy scripting engine and command registries, builds syntax highlighters
+     * and a LineReader with history and key bindings, installs widgets, and then
+     * runs the REPL loop. The loop handles interrupts, end-of-file (including
+     * executing a final redirected line on Windows), transient I/O conditions, and
+     * general errors; it closes resources on exit and warns if Groovy GUI threads
+     * remain running.
+     *
+     * @param args command-line arguments (not used by the REPL)
+     */
     public static void main(String[] args) {
         try {
             Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
@@ -278,7 +293,7 @@ public class Repl {
             parser.blockCommentDelims(new DefaultParser.BlockCommentDelims("/*", "*/"))
                     .lineCommentDelims(new String[] {"//"});
             Terminal terminal = TerminalBuilder.builder().build();
-            if (terminal.getWidth() == 0 || terminal.getHeight() == 0) {
+            if (terminal.getColumns() == 0 || terminal.getRows() == 0) {
                 terminal.setSize(new Size(120, 40)); // hard coded terminal size when redirecting
             }
             Thread executeThread = Thread.currentThread();

--- a/demo/src/main/java/org/jline/demo/examples/DisplayExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/DisplayExample.java
@@ -25,6 +25,16 @@ import org.jline.utils.Display;
 public class DisplayExample {
 
     // SNIPPET_START: DisplayExample
+    /**
+     * Demonstrates a simple terminal UI using JLine's Display with a periodically updating progress indicator.
+     *
+     * <p>Builds a Terminal and Display, renders initial text, updates a progress and status line once per
+     * second for ten steps, then waits for the user to press Enter before closing the terminal.</p>
+     *
+     * @param args command-line arguments (not used)
+     * @throws IOException if terminal I/O (creation, reading, or closing) fails
+     * @throws InterruptedException if the thread is interrupted while sleeping between updates
+     */
     public static void main(String[] args) throws IOException, InterruptedException {
         Terminal terminal = TerminalBuilder.builder().build();
 
@@ -40,7 +50,7 @@ public class DisplayExample {
         lines.add(new AttributedString("The content will update every second."));
 
         // Display the initial content
-        display.resize(terminal.getHeight(), terminal.getWidth());
+        display.resize(terminal.getSize());
         display.update(lines, 0);
 
         // Update the display with a progress indicator

--- a/demo/src/main/java/org/jline/demo/examples/GraphemeClusterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/GraphemeClusterExample.java
@@ -203,8 +203,15 @@ public class GraphemeClusterExample {
     }
 
     /**
-     * Diagnostic mode — tests the rendering paths to identify where ZWJ
-     * combining breaks.
+     * Run a multi-step diagnostic that exercises various terminal rendering paths to
+     * identify where ZWJ (zero-width joiner) grapheme-cluster combining breaks.
+     *
+     * <p>The diagnostic performs numbered tests that emit the configured family emoji
+     * sequence via different output paths (direct writer, AttributedString.print/toAnsi,
+     * flush-separated writes, per-code-point writes), simulates Display diffs and updates,
+     * and compares reported column widths with and without grapheme-cluster mode enabled.
+     *
+     * @throws IOException if opening or communicating with the terminal fails
      */
     public static void diagMode() throws IOException {
         try (Terminal terminal = TerminalBuilder.builder().build()) {
@@ -302,7 +309,7 @@ public class GraphemeClusterExample {
             writer.println("8. Actual Display.update():");
             {
                 Display display = new Display(terminal, false);
-                display.resize(terminal.getHeight(), terminal.getWidth());
+                display.resize(terminal.getSize());
                 // First update: just the prompt
                 display.update(Collections.singletonList(new AttributedString("emoji> ")), 7, true);
                 writer.println();

--- a/demo/src/main/java/org/jline/demo/examples/MultiSegmentStatusExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MultiSegmentStatusExample.java
@@ -24,6 +24,16 @@ import org.jline.utils.Status;
 public class MultiSegmentStatusExample {
 
     // SNIPPET_START: MultiSegmentStatusExample
+    /**
+     * Demonstrates creating a multi-segment status line (left, centered padding, right) and running a simple REPL that exits on "exit".
+     *
+     * Sets up a Terminal and LineReader, obtains a Status for the terminal, builds a colored status line with a left
+     * segment ("Server: Connected"), a centered padding region, and a right segment ("Users: 42"), updates the status,
+     * then reads lines from the user printing each entry until "exit" is entered.
+     *
+     * @param args command-line arguments
+     * @throws Exception if terminal or reader creation or I/O operations fail
+     */
     public static void main(String[] args) throws Exception {
         Terminal terminal = TerminalBuilder.builder().build();
         LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
@@ -39,7 +49,7 @@ public class MultiSegmentStatusExample {
             asb.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE)).append("Server: Connected");
 
             // Center segment (with padding)
-            int width = terminal.getWidth();
+            int width = terminal.getColumns();
             int leftLen = "Server: Connected".length();
             int rightLen = "Users: 42".length();
             int padding = (width - leftLen - rightLen) / 2;

--- a/demo/src/main/java/org/jline/demo/examples/RemoteTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/RemoteTerminalExample.java
@@ -111,6 +111,19 @@ public class RemoteTerminalExample {
 
     // SNIPPET_START: RemoteShellExample
     public static class RemoteShell implements Telnet.ShellProvider {
+        /**
+         * Provide an interactive, command-driven shell on the given Terminal.
+         *
+         * <p>The shell presents a short welcome banner, accepts line input with the prompt
+         * "shell> ", and supports the commands: "help" (lists available commands),
+         * "info" (prints terminal type, columns×rows, and encoding), and "exit"
+         * (closes the session). Blank lines are ignored; unrecognized input produces
+         * an "Unknown command" message. The session ends after "exit" or when the
+         * input stream is closed, and the shell prints a goodbye message before returning.
+         *
+         * @param terminal the Terminal to interact with for input/output
+         * @param environment a map of environment variables available to the shell implementation
+         */
         @Override
         public void shell(Terminal terminal, Map<String, String> environment) {
             try {
@@ -139,7 +152,7 @@ public class RemoteTerminalExample {
                             terminal.writer().println("  exit - Exit the shell");
                         } else if ("info".equals(line)) {
                             terminal.writer().println("Terminal type: " + terminal.getType());
-                            terminal.writer().println("Size: " + terminal.getWidth() + "x" + terminal.getHeight());
+                            terminal.writer().println("Size: " + terminal.getColumns() + "x" + terminal.getRows());
                             terminal.writer().println("Encoding: " + terminal.encoding());
                         } else {
                             terminal.writer().println("Unknown command: " + line);

--- a/demo/src/main/java/org/jline/demo/examples/ResponsiveUIExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ResponsiveUIExample.java
@@ -25,6 +25,16 @@ import org.jline.utils.Display;
 public class ResponsiveUIExample {
 
     // SNIPPET_START: ResponsiveUIExample
+    /**
+     * Launches an interactive example that displays a responsive terminal UI and exits when Enter is pressed.
+     *
+     * Sets up a JLine Terminal and Display, renders content based on the current terminal size, registers a
+     * window-resize handler to recompute and re-render content when the terminal is resized, and blocks until
+     * the user presses Enter.
+     *
+     * @throws IOException if an I/O error occurs while building, updating, or interacting with the terminal
+     * @throws InterruptedException if the thread is interrupted while waiting for user input
+     */
     public static void main(String[] args) throws IOException, InterruptedException {
         Terminal terminal = TerminalBuilder.builder().build();
 
@@ -38,7 +48,7 @@ public class ResponsiveUIExample {
         List<AttributedString> content = createContent(size);
 
         // Update the display
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         display.update(content, -1);
 
         // Register a signal handler for window resize events
@@ -49,7 +59,7 @@ public class ResponsiveUIExample {
             List<AttributedString> newContent = createContent(newSize);
 
             // Update the display
-            display.resize(newSize.getRows(), newSize.getColumns());
+            display.resize(newSize);
             display.update(newContent, -1);
         });
 

--- a/demo/src/main/java/org/jline/demo/examples/SwingTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SwingTerminalExample.java
@@ -119,9 +119,18 @@ public class SwingTerminalExample {
 
     // SNIPPET_START: SwingTerminalReplExample
     /**
-     * Runs a simple REPL loop using the given terminal.
-     * Demonstrates that SwingTerminal works with LineReader for
-     * line editing, tab completion, and history.
+     * Start an interactive REPL on the supplied Terminal for demonstration purposes.
+     *
+     * The loop reads lines, offers tab completion for `help`, `info`, `clear`, and `exit`,
+     * echoes unknown input, and handles the following commands:
+     * - `help`: prints available commands
+     * - `info`: prints terminal name, type, size (columns x rows), and encoding
+     * - `clear`: clears the screen
+     * - `exit`: prints a goodbye message and exits the REPL
+     *
+     * Ctrl+C is ignored (continues the loop) and Ctrl+D ends the REPL.
+     *
+     * @param terminal the Terminal to use for input/output (for example, a SwingTerminal)
      */
     private static void runRepl(Terminal terminal) {
         LineReader reader = LineReaderBuilder.builder()
@@ -156,7 +165,7 @@ public class SwingTerminalExample {
                     case "info":
                         terminal.writer().println("Terminal: " + terminal.getName());
                         terminal.writer().println("Type:     " + terminal.getType());
-                        terminal.writer().println("Size:     " + terminal.getWidth() + "x" + terminal.getHeight());
+                        terminal.writer().println("Size:     " + terminal.getColumns() + "x" + terminal.getRows());
                         terminal.writer().println("Encoding: " + terminal.encoding());
                         break;
                     case "clear":

--- a/demo/src/main/java/org/jline/demo/examples/TerminalCursorExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalCursorExample.java
@@ -20,6 +20,13 @@ import org.jline.utils.InfoCmp.Capability;
 public class TerminalCursorExample {
 
     // SNIPPET_START: TerminalCursorExample
+    /**
+     * Demonstrates terminal cursor control by clearing the screen, moving the cursor to several positions,
+     * saving and restoring the cursor position, and waiting for the user to press Enter before exiting.
+     *
+     * @throws IOException if an I/O error occurs interacting with the terminal
+     * @throws InterruptedException if the thread is interrupted while sleeping
+     */
     public static void main(String[] args) throws IOException, InterruptedException {
         Terminal terminal = TerminalBuilder.builder().build();
 
@@ -58,7 +65,7 @@ public class TerminalCursorExample {
         Thread.sleep(2000);
 
         // Move cursor to bottom
-        terminal.puts(Capability.cursor_address, terminal.getHeight() - 1, 0);
+        terminal.puts(Capability.cursor_address, terminal.getRows() - 1, 0);
         terminal.writer().println("Press Enter to exit");
         terminal.flush();
 

--- a/demo/src/main/java/org/jline/demo/examples/WebTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/WebTerminalExample.java
@@ -74,9 +74,16 @@ public class WebTerminalExample {
 
     // SNIPPET_START: WebTerminalReplExample
     /**
-     * Runs a simple REPL loop using the given terminal.
-     * Demonstrates that WebTerminal works with LineReader for
-     * line editing, tab completion, and history.
+     * Run an interactive REPL on the provided terminal.
+     *
+     * The REPL reads lines from a "web> " prompt and handles the following commands:
+     * "exit" (terminate session), "help" (show available commands), "info" (print terminal
+     * name, type, size, and encoding), "clear" (clear the screen), and "colors" (show ANSI
+     * color demo). Empty input is ignored; other input is echoed back.
+     *
+     * Ctrl+C is ignored and the REPL continues; Ctrl+D ends the REPL.
+     *
+     * @param terminal the Terminal used for input and output
      */
     private static void runRepl(Terminal terminal) {
         LineReader reader = LineReaderBuilder.builder()
@@ -112,7 +119,7 @@ public class WebTerminalExample {
                     case "info":
                         terminal.writer().println("Terminal: " + terminal.getName());
                         terminal.writer().println("Type:     " + terminal.getType());
-                        terminal.writer().println("Size:     " + terminal.getWidth() + "x" + terminal.getHeight());
+                        terminal.writer().println("Size:     " + terminal.getColumns() + "x" + terminal.getRows());
                         terminal.writer().println("Encoding: " + terminal.encoding());
                         break;
                     case "clear":

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
@@ -227,6 +227,18 @@ public class AnsiConsole {
         }
     }
 
+    /**
+     * Creates an AnsiPrintStream configured for either standard output or standard error using the current
+     * terminal's capabilities and relevant system properties/environment variables.
+     *
+     * The returned stream's ANSI mode, color depth, output type, and reset-on-uninstall behavior are derived
+     * from the terminal and from properties such as `jansi.mode`, `jansi.out.mode`, `jansi.err.mode`,
+     * `jansi.colors`, `jansi.out.colors`, `jansi.err.colors`, and environment variables like `COLORTERM` and `TERM`.
+     *
+     * @param stdout true to create a stream configured for standard output, false for standard error
+     * @return a configured AnsiPrintStream that writes to the terminal's output stream
+     * @throws IOException if the terminal output cannot be accessed or the underlying stream cannot be created
+     */
     private static AnsiPrintStream ansiStream(boolean stdout) throws IOException {
         final OutputStream out;
         final AnsiOutputStream.WidthSupplier width;
@@ -236,7 +248,7 @@ public class AnsiConsole {
         final AnsiOutputStream.IoRunnable uninstaller = null;
 
         out = terminal.output();
-        width = terminal::getWidth;
+        width = terminal::getColumns;
         type = terminal instanceof DumbTerminal
                 ? AnsiType.Unsupported
                 : ((TerminalExt) terminal).getSystemStream() != null ? AnsiType.Native : AnsiType.Redirected;

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
@@ -564,6 +564,21 @@ public class DefaultPrompter implements Prompter {
         }
     }
 
+    /**
+     * Run an interactive search prompt that updates results as the user types and lets the user select a result.
+     *
+     * The prompt displays the provided header and an inline input field, performs searches when the input
+     * length meets the prompt's minimum, and renders a selectable result list. The user may type characters,
+     * use backspace, navigate the results with the arrow keys, press Enter to accept the highlighted result,
+     * press Escape to cancel and return {@code null}, or trigger a cancel operation which throws
+     * {@link UserInterruptException}.
+     *
+     * @param header optional list of already-rendered lines to display above the search input
+     * @param prompt the search prompt configuration and callback functions
+     * @return the selected {@link SearchResult} containing the chosen value, or {@code null} if the prompt was cancelled via Escape
+     * @throws IOException if an I/O error occurs while interacting with the terminal
+     * @throws UserInterruptException if the user triggers a cancel operation (e.g., interrupt)
+     */
     private <T> SearchResult<T> executeSearchPrompt(List<AttributedString> header, SearchPrompt<T> prompt)
             throws IOException, UserInterruptException {
 
@@ -600,7 +615,7 @@ public class DefaultPrompter implements Prompter {
             List<AttributedString> out = buildSearchDisplay(
                     header, asb, searchTerm.toString(), currentResults, selectedIndex, prompt, startColumn);
 
-            display.resize(size.getRows(), size.getColumns());
+            display.resize(size);
             int cursorRow = (header != null ? header.size() : 0);
             int column = startColumn + searchTerm.length();
             display.update(out, size.cursorPos(cursorRow, column));
@@ -649,6 +664,20 @@ public class DefaultPrompter implements Prompter {
         }
     }
 
+    /**
+     * Prompt the user to open an external editor and return the edited content.
+     *
+     * Renders the provided header and a message instructing the user to press Enter to open
+     * the configured editor or Escape to cancel, then waits for a key binding and acts
+     * accordingly.
+     *
+     * @param header prior prompt lines to render above the editor prompt; may be null
+     * @param prompt the EditorPrompt describing editor configuration and initial text
+     * @return an EditorResult containing the text produced by the editor, or `null` if the user
+     *         cancelled/escaped or if launching the editor failed
+     * @throws IOException if an I/O error occurs while updating or interacting with the terminal
+     * @throws UserInterruptException if the user issues a cancel (e.g., Ctrl+C)
+     */
     private EditorResult executeEditorPrompt(List<AttributedString> header, EditorPrompt prompt)
             throws IOException, UserInterruptException {
 
@@ -663,7 +692,7 @@ public class DefaultPrompter implements Prompter {
         displayLines.add(asb.toAttributedString());
 
         size.copy(terminal.getSize());
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         display.update(displayLines, -1);
 
         // Wait for user input
@@ -1231,11 +1260,23 @@ public class DefaultPrompter implements Prompter {
         }
     }
 
+    /**
+     * Present a single-key choice prompt, handle interactive key input, and produce the selected choice.
+     *
+     * Renders the provided header and choice items, accepts single-character commands for selection,
+     * supports an expanded full-list view via the "h" key, applies a default when Enter is pressed,
+     * and returns to the caller when a choice is made or when the user escapes.
+     *
+     * @param header prior prompt output lines to render above the choice prompt; may be null
+     * @param prompt the ChoicePrompt describing available items and presentation options
+     * @return the chosen ChoiceResult, or `null` if the user presses Escape to cancel/go back
+     * @throws UserInterruptException if the user issues an explicit cancel operation (Ctrl+C)
+     */
     private ChoiceResult executeChoicePrompt(List<AttributedString> header, ChoicePrompt prompt)
             throws IOException, UserInterruptException {
 
         size.copy(terminal.getSize());
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
 
         List<ChoiceItem> items = prompt.getItems();
         if (items.isEmpty()) {
@@ -1290,7 +1331,7 @@ public class DefaultPrompter implements Prompter {
                 out.addAll(buildChoiceItemsDisplay(items));
                 out.add(choiceBuilder.toAttributedString());
                 size.copy(terminal.getSize());
-                display.resize(size.getRows(), size.getColumns());
+                display.resize(size);
                 display.update(out, out.size() - 1);
                 redrawNeeded = false;
             }
@@ -1353,8 +1394,14 @@ public class DefaultPrompter implements Prompter {
     }
 
     /**
-     * Execute an expanded choice prompt that shows all choices as a navigable list.
-     * This is triggered when the user presses 'h' in a choice prompt.
+     * Show all choice items as a navigable list and let the user pick one.
+     *
+     * @param header prior lines to render above the prompt; may be null
+     * @param prompt the ChoicePrompt describing the prompt message and options
+     * @param items the list of ChoiceItem entries to display
+     * @return the chosen ChoiceResult, or `null` if the user escaped/backed out
+     * @throws IOException if an I/O error occurs while updating or reading the terminal
+     * @throws UserInterruptException if the user cancels the prompt (e.g., Ctrl+C)
      */
     private ChoiceResult executeExpandedChoicePrompt(
             List<AttributedString> header, ChoicePrompt prompt, List<ChoiceItem> items)
@@ -1392,7 +1439,7 @@ public class DefaultPrompter implements Prompter {
                 out.add(buildSingleItemLine(items.get(i), i + firstItemRow == selectRow, true));
             }
 
-            display.resize(size.getRows(), size.getColumns());
+            display.resize(size);
             display.update(out, size.cursorPos(Math.min(size.getRows() - 1, firstItemRow + items.size()), 0));
 
             ListOperation op = bindingReader.readBinding(keyMap);
@@ -1434,6 +1481,19 @@ public class DefaultPrompter implements Prompter {
         display.update(out, -1);
     }
 
+    /**
+     * Prompt the user for a yes/no confirmation and return the selected result.
+     *
+     * Renders the provided header and a confirmation prompt with the prompt's message
+     * and default indicator, updates the terminal display while reading key bindings,
+     * and maps user actions to a ConfirmResult.
+     *
+     * @param header optional lines to render above the confirmation prompt; may be null
+     * @param prompt the ConfirmPrompt containing the message and default choice
+     * @return the ConfirmResult representing the chosen confirmation value, or `null` if the user pressed escape to go back
+     * @throws IOException if an I/O error occurs while interacting with the terminal
+     * @throws UserInterruptException if the user explicitly cancels the prompt (e.g., Ctrl+C)
+     */
     private ConfirmResult executeConfirmPrompt(List<AttributedString> header, ConfirmPrompt prompt)
             throws IOException, UserInterruptException {
 
@@ -1467,7 +1527,7 @@ public class DefaultPrompter implements Prompter {
             out.add(messageBuilder.toAttributedString());
 
             // Update display exactly like ConsolePrompt
-            display.resize(size.getRows(), size.getColumns());
+            display.resize(size);
             int cursorRow = out.size() - 1;
             int column = asb.columnLength(terminal) + buffer.length();
             display.update(out, size.cursorPos(cursorRow, column));
@@ -1497,6 +1557,15 @@ public class DefaultPrompter implements Prompter {
         }
     }
 
+    /**
+     * Renders the provided header followed by the text prompt's lines to the terminal display.
+     *
+     * @param header prior output lines to render above the prompt; may be {@code null}
+     * @param prompt the text prompt whose lines will be displayed
+     * @return {@code NoResult.INSTANCE} indicating the prompt produces no user-entered value
+     * @throws IOException if an I/O error occurs while updating the display
+     * @throws UserInterruptException if the user interrupts the prompt (e.g., Ctrl+C)
+     */
     private PromptResult<? extends Prompt> executeTextPrompt(List<AttributedString> header, TextPrompt prompt)
             throws IOException, UserInterruptException {
 
@@ -1511,13 +1580,21 @@ public class DefaultPrompter implements Prompter {
 
         // Update size and display using Display system
         size.copy(terminal.getSize());
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         display.update(displayLines, -1);
 
         // Text prompts don't require user input, just display
         return NoResult.INSTANCE;
     }
 
+    /**
+     * Display a toggle prompt, allow the user to switch between the active and inactive labels, and return the chosen state.
+     *
+     * @param header optional lines to render above the prompt (may be null)
+     * @param prompt the toggle prompt configuration and labels
+     * @return a {@code ToggleResult} containing the chosen boolean state, or {@code null} if the user cancelled via escape
+     * @throws UserInterruptException if the user issues an interrupt (e.g., Ctrl+C)
+     */
     private ToggleResult executeTogglePrompt(List<AttributedString> header, TogglePrompt prompt)
             throws IOException, UserInterruptException {
 
@@ -1553,7 +1630,7 @@ public class DefaultPrompter implements Prompter {
             }
             out.add(asb.toAttributedString());
 
-            display.resize(size.getRows(), size.getColumns());
+            display.resize(size);
             display.update(out, size.cursorPos(out.size() - 1, asb.columnLength(terminal)));
 
             ConfirmOperation op = bindingReader.readBinding(keyMap);
@@ -1573,6 +1650,19 @@ public class DefaultPrompter implements Prompter {
         }
     }
 
+    /**
+     * Reads one key press from the terminal and produces a KeyPressResult for that key.
+     *
+     * Renders the provided header and prompt message, consumes multi-byte escape sequences
+     * (arrow/function keys) so they do not leak into subsequent prompts, and maps special
+     * controls: Escape returns `null`, Ctrl+C raises a user interrupt.
+     *
+     * @param header optional lines rendered above the prompt; may be null
+     * @param prompt the KeyPressPrompt describing the prompt message and hint
+     * @return the pressed key as a KeyPressResult, or `null` if the user pressed Escape
+     * @throws IOException if an I/O error occurs while reading key bindings
+     * @throws UserInterruptException if the user cancels the prompt (Ctrl+C)
+     */
     private KeyPressResult executeKeyPressPrompt(List<AttributedString> header, KeyPressPrompt prompt)
             throws IOException, UserInterruptException {
 
@@ -1587,7 +1677,7 @@ public class DefaultPrompter implements Prompter {
         asb.styled(config.style(PrompterConfig.ME), prompt.getHint());
         out.add(asb.toAttributedString());
 
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         display.update(out, -1);
 
         // Use a KeyMap to properly consume multi-byte escape sequences (arrow keys, function keys)
@@ -1629,11 +1719,20 @@ public class DefaultPrompter implements Prompter {
         }
     }
 
+    /**
+     * Restore the terminal to normal mode and render the final header if the prompter is in raw mode.
+     *
+     * If the terminal is currently in raw mode, update the display with the accumulated header (ignoring
+     * possible ArithmeticException), restore saved terminal attributes, enable keypad-local mode, print a
+     * trailing newline and flush the terminal output, and clear the cached attributes marker.
+     *
+     * @throws IOException if restoring terminal attributes or writing to the terminal fails
+     */
     private void close() throws IOException {
         if (terminalInRawMode()) {
             // Update display with final header state
             try {
-                int cursor = (terminal.getWidth() + 1) * header.size();
+                int cursor = (terminal.getColumns() + 1) * header.size();
                 display.update(header, cursor);
             } catch (ArithmeticException e) {
                 // Ignore division by zero errors in display update (can happen with test terminals)
@@ -1676,12 +1775,23 @@ public class DefaultPrompter implements Prompter {
     }
 
     /**
-     * Refresh the display for list prompts using JLine's Display class.
+     * Update the terminal display to show a paginated list prompt composed of the given header,
+     * message, and items.
+     *
+     * Renders header and list lines, resizes the display to the current terminal size, and
+     * positions the cursor to the row corresponding to the provided cursorRow (relative to
+     * firstItemRow).
+     *
+     * @param header    previously rendered prompt output lines to display above the list
+     * @param message   the prompt message line shown above the items (may include filter text)
+     * @param items     the list of items to render
+     * @param cursorRow the index of the currently highlighted item within {@code items}
+     * @param prompt    configuration and metadata for rendering the list prompt
      */
     private void refreshListDisplay(
             List<AttributedString> header, String message, List<ListItem> items, int cursorRow, ListPrompt prompt) {
         size.copy(terminal.getSize());
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         display.update(
                 buildListDisplayLines(header, message, items, cursorRow, prompt),
                 size.cursorPos(Math.min(size.getRows() - 1, firstItemRow + items.size()), 0));
@@ -1814,7 +1924,17 @@ public class DefaultPrompter implements Prompter {
     }
 
     /**
-     * Refresh the display for checkbox prompts using JLine's Display class.
+     * Update the terminal view to show the current checkbox prompt state.
+     *
+     * Renders the provided header, the prompt message, and the checkbox items (with pagination and styles),
+     * and places the cursor on the line identified by cursorRow.
+     *
+     * @param header      lines shown above the prompt (previous prompt outputs)
+     * @param message     the message line for this prompt
+     * @param items       list of checkbox items to display (may include separators and disabled items)
+     * @param cursorRow   index of the currently highlighted item (relative to firstItemRow)
+     * @param selectedIds set of item names that are currently selected
+     * @param prompt      the CheckboxPrompt containing display-related options (hints, limits, styles)
      */
     private void refreshCheckboxDisplay(
             List<AttributedString> header,
@@ -1824,7 +1944,7 @@ public class DefaultPrompter implements Prompter {
             Set<String> selectedIds,
             CheckboxPrompt prompt) {
         size.copy(terminal.getSize());
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         display.update(
                 buildCheckboxDisplayLines(header, message, items, cursorRow, selectedIds, prompt),
                 size.cursorPos(Math.min(size.getRows() - 1, firstItemRow + items.size()), 0));

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -831,13 +831,20 @@ public class LineReaderImpl implements LineReader, Flushable {
         return Terminal.TYPE_DUMB.equals(terminal.getType()) || Terminal.TYPE_DUMB_COLOR.equals(terminal.getType());
     }
 
+    /**
+     * Initialize the display using the current terminal buffer size.
+     *
+     * Caches the terminal's buffer size into the reader's size, creates a new
+     * Display bound to the terminal, applies the cached size to the Display,
+     * and enables delayed line wrapping when the DELAY_LINE_WRAP option is set.
+     */
     private void doDisplay() {
         // Cache terminal size for the duration of the call to readLine()
         // It will eventually be updated with WINCH signals
         size.copy(terminal.getBufferSize());
 
         display = new Display(terminal, false);
-        display.resize(size.getRows(), size.getColumns());
+        display.resize(size);
         if (isSet(Option.DELAY_LINE_WRAP)) display.setDelayLineWrap(true);
     }
 
@@ -1269,6 +1276,21 @@ public class LineReaderImpl implements LineReader, Flushable {
         return str;
     }
 
+    /**
+     * Handle terminal signals that affect the reader's display and terminal state.
+     *
+     * <p>For SIGWINCH (window change) this checks whether the terminal's character
+     * grid (rows/columns) changed and, if so, recreates the display, resizes the
+     * status bar, resets the cursor to column 0, and triggers a redisplay.
+     *
+     * <p>For SIGCONT (continue) this re-enters raw mode, updates the cached size,
+     * resizes the active display, enables keypad transmit, redraws the current
+     * prompt/line and triggers a redisplay.
+     *
+     * <p>Autosuggestions are disabled when any handled signal is received.
+     *
+     * @param signal the received terminal signal (e.g. WINCH or CONT)
+     */
     protected synchronized void handleSignal(Signal signal) {
         doAutosuggestion = false;
         if (signal == Signal.WINCH) {
@@ -1293,7 +1315,7 @@ public class LineReaderImpl implements LineReader, Flushable {
         } else if (signal == Signal.CONT) {
             terminal.enterRawMode();
             size.copy(terminal.getBufferSize());
-            display.resize(size.getRows(), size.getColumns());
+            display.resize(size);
             terminal.puts(Capability.keypad_xmit);
             redrawLine();
             redisplay();
@@ -5484,6 +5506,19 @@ public class LineReaderImpl implements LineReader, Flushable {
         return doList(possible, completed, runLoop, escaper, false);
     }
 
+    /**
+     * Displays an interactive list of completion candidates and processes user interaction
+     * (filtering, paging, and switching to the menu) for the current buffer state.
+     *
+     * @param possible   the candidate list to display
+     * @param completed  the already-completed prefix to prepend to filtered candidates
+     * @param runLoop    when true, enter the interactive listing loop; when false, only prepares listing state
+     * @param escaper    function that returns the escaped display form for a candidate fragment;
+     *                   receives the fragment and a boolean indicating whether to escape for insertion
+     * @param forSuggestion  true when listing is being requested for an inline autosuggestion (suppresses prompts)
+     * @return `false` if the listing was not shown or the user aborted the listing (no candidates, user declined,
+     *         or listing suppressed); `true` if the listing was shown and consumed control.
+     */
     protected boolean doList(
             List<Candidate> possible,
             String completed,
@@ -5557,7 +5592,7 @@ public class LineReaderImpl implements LineReader, Flushable {
                     List<AttributedString> ls =
                             pr.post.columnSplitLength(size.getColumns(), false, display.delayLineWrap());
                     Display d = new Display(terminal, false);
-                    d.resize(size.getRows(), size.getColumns());
+                    d.resize(size);
                     d.update(ls, -1);
                     println();
                     redrawLine();

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
@@ -141,6 +141,25 @@ public class Ssh {
         this.clientBuilder = clientBuilder;
     }
 
+    /**
+     * Connects to an SSH server and either executes a remote command or opens an interactive shell.
+     *
+     * Parses connection target from argv (optionally containing user and port), establishes an SSH
+     * client session, and forwards local stdin/stdout/stderr to the remote side. In interactive mode
+     * configures a PTY from the provided Terminal, installs signal handlers for window changes and
+     * job-control signals, and restores terminal state on exit.
+     *
+     * @param terminal the Terminal used for raw-mode control, PTY geometry, and signal handling
+     * @param reader   a LineReader used for user interaction (passwords/prompts)
+     * @param user     the default username to use if not specified in argv
+     * @param stdin    input stream to forward to the remote session
+     * @param stdout   output stream to receive remote standard output
+     * @param stderr   output stream to receive remote standard error and interaction errors
+     * @param argv     command-line arguments; first positional is target ([user@]host[:port]) and
+     *                 remaining tokens form an optional remote command; supports --help
+     * @throws Exception for SSH, authentication, or I/O errors that occur while connecting or during
+     *                   remote command/shell execution
+     */
     public void ssh(
             Terminal terminal,
             LineReader reader,
@@ -247,8 +266,8 @@ public class Ssh {
                         setMode(modes, PtyMode.ONOCR, getFlag(attributes, Attributes.OutputFlag.ONOCR));
                         setMode(modes, PtyMode.ONLRET, getFlag(attributes, Attributes.OutputFlag.ONLRET));
                         channel.setPtyModes(modes);
-                        channel.setPtyColumns(terminal.getWidth());
-                        channel.setPtyLines(terminal.getHeight());
+                        channel.setPtyColumns(terminal.getColumns());
+                        channel.setPtyLines(terminal.getRows());
                         channel.setAgentForwarding(true);
                         channel.setEnv("TERM", terminal.getType());
                         // TODO: channel.setEnv("LC_CTYPE", terminal.encoding().toString());

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionData.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionData.java
@@ -239,17 +239,14 @@ public class ConnectionData {
     } // setWarned
 
     /**
-     * Sets the terminal geometry data.<br>
-     * <em>This method should not be called explicitly
-     * by the application (i.e. the its here for the io subsystem).</em><br>
-     * A call will set the terminal geometry changed flag.
+     * Update the stored terminal dimensions and mark the geometry as changed.
      *
-     * @param width  of the terminal in columns.
-     * @param height of the terminal in rows.
+     * @param columns the number of columns
+     * @param rows    the number of rows
      */
-    public void setTerminalGeometry(int width, int height) {
-        terminalGeometry[0] = width;
-        terminalGeometry[1] = height;
+    public void setTerminalGeometry(int columns, int rows) {
+        terminalGeometry[0] = columns;
+        terminalGeometry[1] = rows;
         terminalGeometryChanged = true;
     } // setTerminalGeometry
 

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
@@ -587,27 +587,6 @@ public class TelnetIO {
         connection.processConnectionEvent(new ConnectionEvent(connection, ConnectionEvent.Type.CONNECTION_BREAK));
     } // nvtBreak
 
-    /**
-     * Method that checks reported terminal sizes and sets the
-     * asserted values in the ConnectionData instance associated with
-     * the connection.
-     *
-     * @param width  Integer that represents the Window width in chars
-     * @param height Integer that represents the Window height in chars
-     */
-    private void setTerminalGeometry(int width, int height) {
-        if (width < SMALLEST_BELIEVABLE_WIDTH) {
-            width = DEFAULT_WIDTH;
-        }
-        if (height < SMALLEST_BELIEVABLE_HEIGHT) {
-            height = DEFAULT_HEIGHT;
-        }
-        // DEBUG: write("[New Window Size " + window_width + "x" + window_height + "]");
-        connectionData.setTerminalGeometry(width, height);
-        connection.processConnectionEvent(
-                new ConnectionEvent(connection, ConnectionEvent.Type.CONNECTION_TERMINAL_GEOMETRY_CHANGED));
-    } // setTerminalGeometry
-
     public void setEcho(boolean b) {} // setEcho
 
     /**
@@ -885,7 +864,19 @@ public class TelnetIO {
             }
             skipToSE();
             setTerminalGeometry(width, height);
-        } // handleNAWS
+        }
+
+        private void setTerminalGeometry(int columns, int rows) {
+            if (columns < SMALLEST_BELIEVABLE_WIDTH) {
+                columns = DEFAULT_WIDTH;
+            }
+            if (rows < SMALLEST_BELIEVABLE_HEIGHT) {
+                rows = DEFAULT_HEIGHT;
+            }
+            connectionData.setTerminalGeometry(columns, rows);
+            connection.processConnectionEvent(
+                    new ConnectionEvent(connection, ConnectionEvent.Type.CONNECTION_TERMINAL_GEOMETRY_CHANGED));
+        }
 
         /**
          * Method that reads a TTYPE Subnegotiation String that ends up with a IAC SE

--- a/terminal/src/main/java/org/jline/terminal/Size.java
+++ b/terminal/src/main/java/org/jline/terminal/Size.java
@@ -63,11 +63,9 @@ public class Size {
     public Size() {}
 
     /**
-     * Creates a new Size instance with the specified dimensions.
+     * Constructs a Size with the specified number of columns and rows.
      *
-     * <p>
-     * This constructor creates a Size object with the specified number of columns and rows.
-     * </p>
+     * <p>Input values are truncated to a 16-bit signed range when stored.</p>
      *
      * @param columns the number of columns (width)
      * @param rows the number of rows (height)
@@ -77,6 +75,15 @@ public class Size {
         this();
         setColumns(columns);
         setRows(rows);
+    }
+
+    /**
+     * Constructs a new Size with the same columns and rows as the given size.
+     *
+     * @param size the source Size from which to copy columns and rows
+     */
+    public Size(Size size) {
+        this(size.getColumns(), size.getRows());
     }
 
     /**

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -749,51 +749,61 @@ public interface Terminal extends Closeable, Flushable {
     Size getSize();
 
     /**
-     * Sets the size of the terminal.
+     * Requests that the terminal adopt the specified window dimensions.
      *
-     * <p>
-     * This method attempts to resize the terminal to the specified dimensions. Note that
-     * not all terminals support resizing, and the actual size after this operation may
-     * differ from the requested size depending on terminal capabilities and constraints.
-     * </p>
+     * Implementations may apply constraints or ignore the request if resizing is unsupported; callers should use {@link #getSize()} to observe the effective size after calling this method.
      *
-     * <p>
-     * For virtual terminals or terminal emulators, this may update the internal size
-     * representation. For physical terminals, this may send appropriate escape sequences
-     * to adjust the viewable area.
-     * </p>
-     *
-     * @param size the new terminal size (columns and rows)
+     * @param size the desired terminal size (columns and rows)
      * @see #getSize()
      */
     void setSize(Size size);
 
     /**
-     * Returns the width (number of columns) of the terminal.
-     *
-     * <p>
-     * This is a convenience method equivalent to {@code getSize().getColumns()}.
-     * </p>
+     * Get the terminal's column count.
      *
      * @return the number of columns in the terminal
      * @see #getSize()
      */
-    default int getWidth() {
+    default int getColumns() {
         return getSize().getColumns();
     }
 
     /**
-     * Returns the height (number of rows) of the terminal.
+     * Get the terminal's visible row count.
      *
-     * <p>
-     * This is a convenience method equivalent to {@code getSize().getRows()}.
-     * </p>
+     * <p>Convenience method for {@code getSize().getRows()}.</p>
      *
      * @return the number of rows in the terminal
      * @see #getSize()
      */
-    default int getHeight() {
+    default int getRows() {
         return getSize().getRows();
+    }
+
+    /**
+     * Get the terminal width in columns.
+     *
+     * @return the number of columns in the terminal
+     * @see #getColumns()
+     * @deprecated Use {@link #getColumns()} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("java:S1133") // Intentional deprecation; removal planned for a future major version
+    default int getWidth() {
+        return getColumns();
+    }
+
+    /**
+     * Get the terminal height in rows.
+     *
+     * @return the number of rows in the terminal
+     * @see #getRows()
+     * @deprecated Use {@link #getRows()} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("java:S1133") // Intentional deprecation; removal planned for a future major version
+    default int getHeight() {
+        return getRows();
     }
 
     /**

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.utils.InfoCmp.Capability;
 
@@ -142,10 +143,38 @@ public class Display {
         return delayLineWrap;
     }
 
+    /**
+     * Enable or disable delayed line wrapping when the cursor reaches the right margin.
+     *
+     * @param v `true` to delay wrapping at end-of-line, `false` to disable delayed wrapping
+     */
     public void setDelayLineWrap(boolean v) {
         delayLineWrap = v;
     }
 
+    /**
+     * Resize the display to the dimensions specified by the given Size.
+     *
+     * @param size the target display dimensions; its rows and columns are applied to the display
+     */
+    public void resize(Size size) {
+        resize(size.getRows(), size.getColumns());
+    }
+
+    /**
+     * Resize the display to the specified number of rows and columns.
+     *
+     * This updates the display geometry, rewraps previously rendered lines to the new
+     * width, and adjusts wrap-at-EOL behavior based on the terminal's buffer width.
+     * If either dimension is zero the method treats it as a special case (sets rows
+     * to 1 and columns to a very large internal value) to avoid a zero-sized display.
+     *
+     * @param rows    the number of display rows
+     * @param columns the number of display columns
+     * @deprecated Use {@link #resize(Size)} instead to avoid parameter order confusion.
+     */
+    @Deprecated
+    @SuppressWarnings("java:S1133") // Intentional deprecation; removal planned for a future major version
     public void resize(int rows, int columns) {
         if (rows == 0 || columns == 0) {
             columns = Integer.MAX_VALUE - 1;
@@ -171,6 +200,32 @@ public class Display {
         }
     }
 
+    /**
+     * Get the current display width in character cells.
+     *
+     * @return the number of columns (display width)
+     */
+    public int getColumns() {
+        return columns;
+    }
+
+    /**
+     * The current display height in character rows.
+     *
+     * @return the current number of rows
+     */
+    public int getRows() {
+        return rows;
+    }
+
+    /**
+     * Clears the cached model of previously rendered lines.
+     *
+     * <p>The next {@link #update} call will treat all content as new and repaint
+     * every line via the diff algorithm. This does <em>not</em> issue a terminal
+     * {@code clear_screen}; to also clear the physical screen, call {@link #clear()}
+     * before {@code reset()}.</p>
+     */
     public void reset() {
         oldLines = Collections.emptyList();
     }

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -115,12 +115,22 @@ public class Status {
         resize(terminal.getSize());
     }
 
+    /**
+     * Resize the status display to the provided terminal character-grid size and adjust terminal state accordingly.
+     *
+     * <p>If the status feature is supported and the supplied size is valid, this updates the internal display
+     * dimensions, recomputes and applies the scroll region reserved for the status area, and clears any leftover
+     * status output that may remain after the resize. The terminal cursor position is preserved across these changes.
+     * If the status feature is not supported or the size is invalid, this method is a no-op.
+     *
+     * @param size the new terminal character-grid size to apply
+     */
     public void resize(Size size) {
         if (supported && isValid(size)) {
             int oldRows = display.rows;
             int oldColumns = display.columns;
 
-            display.resize(size.getRows(), size.getColumns());
+            display.resize(size);
 
             // Only process if the character grid size actually changed
             if (display.rows != oldRows || display.columns != oldColumns) {

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -41,10 +41,10 @@ public class DisplayTest {
         try (VirtualTerminal terminal = new VirtualTerminal("jline", "xterm", StandardCharsets.UTF_8, cols, rows)) {
             Attributes savedAttributes = terminal.enterRawMode();
             terminal.puts(enter_ca_mode);
-            int height = terminal.getHeight();
+            int height = terminal.getRows();
 
             Display display = new Display(terminal, true);
-            display.resize(height, terminal.getWidth());
+            display.resize(terminal.getSize());
 
             // Build Strings to displayed
             List<AttributedString> lines1 = new ArrayList<>();
@@ -188,10 +188,10 @@ public class DisplayTest {
         try (Terminal terminal = TerminalBuilder.builder().build()) {
             Attributes savedAttributes = terminal.enterRawMode();
             terminal.puts(enter_ca_mode);
-            int height = terminal.getHeight();
+            int height = terminal.getRows();
 
             Display display = new Display(terminal, true);
-            display.resize(height, terminal.getWidth());
+            display.resize(terminal.getSize());
 
             // Build Strings to displayed
             List<AttributedString> lines1 = new ArrayList<>();

--- a/terminal/src/test/java/org/jline/utils/ScreenTerminal.java
+++ b/terminal/src/test/java/org/jline/utils/ScreenTerminal.java
@@ -89,13 +89,24 @@ public class ScreenTerminal {
 
     private AtomicBoolean dirty = new AtomicBoolean(true);
 
+    /**
+     * Creates a ScreenTerminal initialized to 80 columns by 24 rows.
+     */
     public ScreenTerminal() {
         this(80, 24);
     }
 
-    public ScreenTerminal(int width, int height) {
-        this.width = width;
-        this.height = height;
+    /**
+     * Create a ScreenTerminal with the specified number of columns and rows.
+     *
+     * Initializes internal terminal state and screen buffers by performing a hard reset.
+     *
+     * @param columns the number of character columns (width)
+     * @param rows the number of character rows (height)
+     */
+    public ScreenTerminal(int columns, int rows) {
+        this.width = columns;
+        this.height = rows;
         reset_hard();
     }
 


### PR DESCRIPTION
## Summary

Standardize terminal dimension naming across the JLine API to use `columns`/`rows` consistently, aligning with the convention used by POSIX (`ws_col`/`ws_row`), ncurses, Lanterna, crossterm, xterm.js, and Node.js.

Inspired by the discussion in #1731.

### API additions (non-breaking)

| Class | New methods |
|-------|------------|
| `Size` | `Size(Size)` copy constructor |
| `Terminal` | `default int getColumns()`, `default int getRows()` |
| `Display` | `getColumns()`, `getRows()`, `resize(Size)` |
| `ScreenTerminal` | `getColumns()`, `getRows()`, `setSize(Size)` |

### Deprecations

| Class | Deprecated | Replacement |
|-------|-----------|-------------|
| `Terminal` | `getWidth()` | `getColumns()` |
| `Terminal` | `getHeight()` | `getRows()` |
| `ScreenTerminal` | `getWidth()` | `getColumns()` |
| `ScreenTerminal` | `getHeight()` | `getRows()` |
| `Display` | `resize(int rows, int columns)` | `resize(Size)` |

### Caller migrations

- All `display.resize(size.getRows(), size.getColumns())` → `display.resize(size)`
- All `terminal.getWidth()`/`getHeight()` → `terminal.getColumns()`/`getRows()`
- Renamed `width`/`height` parameters to `columns`/`rows` in constructors and methods across `ScreenTerminal`, `SwingTerminal`, `WebTerminal`, `ConnectionData`, `TelnetIO`

### Not changed

- `TerminalGraphics.ImageOptions.size(int width, int height)` — pixel dimensions, not terminal cells
- `SwingTerminal.dump(...)` / `Tmux.VirtualConsole.resize(...)` — viewport rectangles
- No existing public method signatures were removed or changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized sizing across the UI to use "columns" and "rows" and migrated internal rendering to the new geometry model.

* **New Features**
  * Added Size-based resize overload and new accessors for columns/rows.

* **Deprecation**
  * Legacy width/height accessors preserved as deprecated aliases.

* **User-visible fixes**
  * Improved consistency for layouts, wrapping, cursor placement, status-line centering and PTY sizing.

* **Documentation**
  * Expanded Javadoc clarifying sizing, resize semantics and constructors.

* **Tests**
  * Updated tests/helpers to use columns/rows and Size-based sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->