### PR TITLE
fix: raise virtual terminal max size from 256 to 4096

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -46,6 +46,9 @@ import org.jline.utils.WCWidth;
  */
 public class ScreenTerminal {
 
+    public static final int MIN_SIZE = 2;
+    public static final int MAX_SIZE = 4096;
+
     enum State {
         None,
         Esc,
@@ -1695,7 +1698,7 @@ public class ScreenTerminal {
     }
 
     public synchronized boolean setSize(int w, int h) {
-        if (w < 2 || w > 256 || h < 2 || h > 256) {
+        if (w < MIN_SIZE || w > MAX_SIZE || h < MIN_SIZE || h > MAX_SIZE) {
             return false;
         }
 

--- a/builtins/src/main/java/org/jline/builtins/WebTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/WebTerminal.java
@@ -543,7 +543,7 @@ public class WebTerminal extends LineDisciplineTerminal {
          * @return true if successful
          */
         public boolean setSize(int width, int height) {
-            if (width < 10 || height < 5 || width > 200 || height > 100) {
+            if (width < 10 || height < 5 || width > MAX_SIZE || height > MAX_SIZE) {
                 return false;
             }
             // ScreenTerminal.setSize takes width and height directly

--- a/builtins/src/test/java/org/jline/builtins/TerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/TerminalTest.java
@@ -269,8 +269,12 @@ public class TerminalTest {
         // Test that invalid sizes are rejected
         assertFalse(webTerminal.setSize(1, 10)); // Too small width
         assertFalse(webTerminal.setSize(10, 1)); // Too small height
-        assertFalse(webTerminal.setSize(300, 10)); // Too large width
-        assertFalse(webTerminal.setSize(10, 300)); // Too large height
+        // Boundary checks at MAX_SIZE
+        int max = ScreenTerminal.MAX_SIZE;
+        assertTrue(webTerminal.setSize(max, 10)); // Exactly at max width
+        assertTrue(webTerminal.setSize(10, max)); // Exactly at max height
+        assertFalse(webTerminal.setSize(max + 1, 10)); // One past max width
+        assertFalse(webTerminal.setSize(10, max + 1)); // One past max height
 
         swingTerminal.setSize(new Size(1, 10));
         swingTerminal.setSize(new Size(10, 1));

--- a/terminal/src/test/java/org/jline/utils/ScreenTerminal.java
+++ b/terminal/src/test/java/org/jline/utils/ScreenTerminal.java
@@ -24,6 +24,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class ScreenTerminal {
 
+    public static final int MIN_SIZE = 2;
+    public static final int MAX_SIZE = 4096;
+
     enum State {
         None,
         Esc,
@@ -1588,7 +1591,7 @@ public class ScreenTerminal {
     //
 
     public synchronized boolean setSize(int w, int h) {
-        if (w < 2 || w > 256 || h < 2 || h > 256) {
+        if (w < MIN_SIZE || w > MAX_SIZE || h < MIN_SIZE || h > MAX_SIZE) {
             return false;
         }
 


### PR DESCRIPTION
## Summary

- `ScreenTerminal.setSize()` was capped at 256x256, `WebTerminal.WebTerminalComponent.setSize()` at 200x100 — too low for modern high-resolution displays and tiling window managers
- Raise the upper bound to 4096 for both width and height
- Extract `MIN_SIZE` / `MAX_SIZE` constants in `ScreenTerminal`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Terminal size limits expanded to support much larger dimensions (up to 4,096×4,096), allowing bigger terminal windows and layouts.
  * Size validation behavior made consistent across screen and web terminals to avoid unexpected accept/reject differences.
  * Tests updated to align with the new boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->