### PR TITLE
fix: Match SwingTerminal color logic to new HTML color logic

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
@@ -704,7 +704,18 @@ public class SwingTerminal extends LineDisciplineTerminal {
                     || (cp >= 0x30000 && cp <= 0x3FFFD);
         }
 
-        private static Color getAnsiColor(int color) {
+        /**
+         * Converts a 12-bit packed color value to a {@link Color}.
+         * <p>
+         * Each 4-bit nibble (red, green, blue) is expanded to 8 bits using the
+         * standard duplication method: {@code (nibble << 4) | nibble}. This maps
+         * the full nibble range {@code 0x0–0xF} to {@code 0x00–0xFF}, matching
+         * CSS shorthand color expansion (e.g. {@code #FFF → #FFFFFF}).
+         *
+         * @param color a 12-bit packed RGB value (bits 11–8 = red, 7–4 = green, 3–0 = blue)
+         * @return the corresponding {@link Color}
+         */
+        static Color getAnsiColor(int color) {
             int rn = (color >> 8) & 0x0f;
             int gn = (color >> 4) & 0x0f;
             int bn = (color >> 0) & 0x0f;

--- a/builtins/src/test/java/org/jline/builtins/SwingTerminalColorTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SwingTerminalColorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.awt.Color;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link SwingTerminal.TerminalComponent#getAnsiColor(int)}.
+ */
+class SwingTerminalColorTest {
+
+    @Test
+    void testBlack() {
+        Color c = SwingTerminal.TerminalComponent.getAnsiColor(0x000);
+        assertEquals(0, c.getRed());
+        assertEquals(0, c.getGreen());
+        assertEquals(0, c.getBlue());
+    }
+
+    @Test
+    void testWhite() {
+        Color c = SwingTerminal.TerminalComponent.getAnsiColor(0xFFF);
+        assertEquals(255, c.getRed());
+        assertEquals(255, c.getGreen());
+        assertEquals(255, c.getBlue());
+    }
+
+    @Test
+    void testPureRed() {
+        Color c = SwingTerminal.TerminalComponent.getAnsiColor(0xF00);
+        assertEquals(255, c.getRed());
+        assertEquals(0, c.getGreen());
+        assertEquals(0, c.getBlue());
+    }
+
+    @Test
+    void testPureGreen() {
+        Color c = SwingTerminal.TerminalComponent.getAnsiColor(0x0F0);
+        assertEquals(0, c.getRed());
+        assertEquals(255, c.getGreen());
+        assertEquals(0, c.getBlue());
+    }
+
+    @Test
+    void testPureBlue() {
+        Color c = SwingTerminal.TerminalComponent.getAnsiColor(0x00F);
+        assertEquals(0, c.getRed());
+        assertEquals(0, c.getGreen());
+        assertEquals(255, c.getBlue());
+    }
+
+    @Test
+    void testMidGray() {
+        // 0x888 -> each nibble 0x8 -> (0x8 << 4) | 0x8 = 0x88 = 136
+        Color c = SwingTerminal.TerminalComponent.getAnsiColor(0x888);
+        assertEquals(0x88, c.getRed());
+        assertEquals(0x88, c.getGreen());
+        assertEquals(0x88, c.getBlue());
+    }
+
+    @Test
+    void testNibbleExpansion() {
+        // Verify that each nibble value 0x0–0xF expands correctly to 0x00–0xFF
+        for (int n = 0; n <= 0xF; n++) {
+            int packed = (n << 8) | (n << 4) | n;
+            Color c = SwingTerminal.TerminalComponent.getAnsiColor(packed);
+            int expected = (n << 4) | n;
+            assertEquals(expected, c.getRed(), "nibble " + n + " red");
+            assertEquals(expected, c.getGreen(), "nibble " + n + " green");
+            assertEquals(expected, c.getBlue(), "nibble " + n + " blue");
+        }
+    }
+
+    @Test
+    void testMixedColor() {
+        // 0xA3C -> R=0xA, G=0x3, B=0xC
+        Color c = SwingTerminal.TerminalComponent.getAnsiColor(0xA3C);
+        assertEquals(0xAA, c.getRed());
+        assertEquals(0x33, c.getGreen());
+        assertEquals(0xCC, c.getBlue());
+    }
+}


### PR DESCRIPTION
https://github.com/jline/jline3/pull/1732 seems to have overlooked SwingTerminal. This pull makes sure the coloring logic is matched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color rendering: corrected expansion of 12-bit packed RGB to full 8-bit channels for more accurate terminal colors.

* **Tests**
  * Added comprehensive tests covering canonical, mixed, and all-nibble cases to validate color conversion and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->