### PR TITLE
feat: add direct dump method for ScreenTerminal HTML string

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -1663,6 +1663,13 @@ public class ScreenTerminal {
         }
     }
 
+    /**
+     * Waits for the screen to become dirty, up to the given timeout.
+     *
+     * @param timeout maximum time to wait in milliseconds; if {@code <= 0}, returns immediately
+     * @return true if the screen is dirty
+     * @throws InterruptedException if interrupted while waiting
+     */
     public synchronized boolean waitDirty(long timeout) throws InterruptedException {
         if (!dirty && timeout > 0) {
             wait(timeout);
@@ -1939,6 +1946,20 @@ public class ScreenTerminal {
         }
     }
 
+    /**
+     * Waits for the screen to be dirty, then dumps the raw screen content into a subregion.
+     *
+     * @param timeout    maximum time to wait in milliseconds
+     * @param forceDump  if true, dump even if the screen is not dirty
+     * @param fullscreen destination array (must be at least fwidth * fheight)
+     * @param ftop       top row offset
+     * @param fleft      left column offset
+     * @param fheight    number of rows to dump
+     * @param fwidth     number of columns to dump
+     * @param cursor     2-element array to receive cursor [x, y], or null
+     * @return true if the screen was dumped
+     * @throws InterruptedException if interrupted
+     */
     public synchronized boolean dump(
             long timeout,
             boolean forceDump,
@@ -1949,7 +1970,7 @@ public class ScreenTerminal {
             int fwidth,
             int[] cursor)
             throws InterruptedException {
-        if (waitDirty(timeout) || forceDump) {
+        if (forceDump || waitDirty(timeout)) {
             dump(fullscreen, ftop, fleft, fheight, fwidth, cursor);
             return true;
         } else {
@@ -1969,7 +1990,7 @@ public class ScreenTerminal {
      */
     public synchronized boolean dump(long timeout, boolean forceDump, long[] fullscreen, int[] cursor)
             throws InterruptedException {
-        if (waitDirty(timeout) || forceDump) {
+        if (forceDump || waitDirty(timeout)) {
             dump(fullscreen, cursor);
             return true;
         } else {
@@ -1986,7 +2007,7 @@ public class ScreenTerminal {
      * @throws InterruptedException if interrupted
      */
     public synchronized String dump(long timeout, boolean forceDump) throws InterruptedException {
-        if (waitDirty(timeout) || forceDump) {
+        if (forceDump || waitDirty(timeout)) {
             return dump();
         } else {
             return null;
@@ -2015,12 +2036,7 @@ public class ScreenTerminal {
             for (int x = 0; x < w; x++) {
                 long d = screen[y * w + x];
                 int c = (int) (d & 0xffffffffL);
-                long a = d >>> 32;
-                // Apply cursor styling
-                if (cursorVisible && cy == y && cx == x) {
-                    a = (a & 0xfffff000L) | 0x20000000 | 0x0fff; // white bg for cursor
-                    a = (a & 0xff000fffL) | 0x10000000; // black fg for cursor
-                }
+                long a = resolveCellAttr(d >>> 32, cursorVisible, x, y, cx, cy);
                 if (a != prevAttr) {
                     if (prevAttr != -1) {
                         sb.append("</span>");
@@ -2028,28 +2044,45 @@ public class ScreenTerminal {
                     sb.append(generateSpanTag(a, inverse));
                     prevAttr = a;
                 }
-                switch (c) {
-                    case '&':
-                        sb.append("&amp;");
-                        break;
-                    case '<':
-                        sb.append("&lt;");
-                        break;
-                    case '>':
-                        sb.append("&gt;");
-                        break;
-                    default:
-                        if (c == 0) {
-                            break; // wide char continuation
-                        }
-                        sb.appendCodePoint(c);
-                        break;
-                }
+                appendEscapedChar(sb, c);
             }
             sb.append("\n");
         }
         sb.append("</span></pre></div>");
         return sb.toString();
+    }
+
+    /**
+     * Resolves the display attribute for a cell, applying cursor styling if the cell is at the cursor position.
+     */
+    private static long resolveCellAttr(long a, boolean cursorVisible, int x, int y, int cx, int cy) {
+        if (cursorVisible && cy == y && cx == x) {
+            a = (a & 0xfffff000L) | 0x20000000 | 0x0fff; // white bg for cursor
+            a = (a & 0xff000fffL) | 0x10000000; // black fg for cursor
+        }
+        return a;
+    }
+
+    /**
+     * Appends a character to the buffer, escaping HTML special characters.
+     */
+    private static void appendEscapedChar(StringBuilder sb, int c) {
+        switch (c) {
+            case '&':
+                sb.append("&amp;");
+                break;
+            case '<':
+                sb.append("&lt;");
+                break;
+            case '>':
+                sb.append("&gt;");
+                break;
+            case 0:
+                break; // wide char continuation
+            default:
+                sb.appendCodePoint(c);
+                break;
+        }
     }
 
     /**

--- a/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
@@ -8,6 +8,8 @@
  */
 package org.jline.builtins;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -600,7 +602,7 @@ public class ScreenTerminalTest {
      * matching the output of dump(0, true) for the same screen state.
      */
     @Test
-    public void testDirectHtmlDump() throws InterruptedException {
+    void testDirectHtmlDump() throws InterruptedException {
         ScreenTerminal terminal = new ScreenTerminal(10, 3);
         terminal.write("\033[31mHello\033[0m");
 
@@ -625,19 +627,17 @@ public class ScreenTerminalTest {
      * Regression: Object.wait(0) waits forever, so timeout==0 must skip the wait.
      */
     @Test
-    public void testWaitDirtyZeroTimeoutReturnsImmediately() throws InterruptedException {
+    void testWaitDirtyZeroTimeoutReturnsImmediately() {
         ScreenTerminal terminal = new ScreenTerminal(80, 24);
 
         // Consume the initial dirty flag
         terminal.isDirty();
 
         // waitDirty(0) on a non-dirty screen must return false immediately
-        long start = System.currentTimeMillis();
-        boolean result = terminal.waitDirty(0);
-        long elapsed = System.currentTimeMillis() - start;
-
-        assertFalse(result, "Non-dirty screen should return false");
-        assertTrue(elapsed < 1000, "waitDirty(0) should return immediately, took " + elapsed + "ms");
+        assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+            boolean result = terminal.waitDirty(0);
+            assertFalse(result, "Non-dirty screen should return false");
+        });
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Both buffer dump methods in ScreenTerminal have a direct and "checked" dump variant, the HTML dump method did not have a direct dump method.
This pull adds an HTML dump method without the wait checks, and also fixes a potential issue with ScreenTerminal.waitDirty().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an immediate HTML screen dump option so callers can obtain full HTML output without waiting.

* **Bug Fixes**
  * Fixed timeout behavior so zero-timeout does not block and waits honor non-positive timeouts.

* **Refactor**
  * Streamlined screen dump logic to remove duplicated wait handling and simplify flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->