### PR TITLE
fix: update Maven wrapper to 3.9.14

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-4/apache-maven-4.0.0-rc-4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip


### PR DESCRIPTION
## Summary
- Update Maven wrapper distribution URL from 4.0.0-rc-4 to 3.9.14
- The build was reverted to Maven 3.9.x compatibility in #1699, but the wrapper properties still referenced Maven 4.0.0-rc-4
- Verified nisse versioning works correctly with Maven 3.9.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven Wrapper to use Apache Maven 3.9.14, reverting from the 4.0.0-rc-4 prerelease binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->