### PR TITLE
fix: guard waitDirty against spurious wakeups

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.jline.utils.Colors;
 import org.jline.utils.WCWidth;
@@ -1665,6 +1666,7 @@ public class ScreenTerminal {
 
     /**
      * Waits for the screen to become dirty, up to the given timeout.
+     * Uses a while loop to guard against spurious wakeups.
      *
      * @param timeout maximum time to wait in milliseconds; if {@code <= 0}, returns immediately
      * @return true if the screen is dirty
@@ -1672,7 +1674,14 @@ public class ScreenTerminal {
      */
     public synchronized boolean waitDirty(long timeout) throws InterruptedException {
         if (!dirty && timeout > 0) {
-            wait(timeout);
+            long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeout);
+            while (!dirty) {
+                long remainingMillis = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                if (remainingMillis <= 0) {
+                    break;
+                }
+                wait(remainingMillis);
+            }
         }
         return isDirty();
     }


### PR DESCRIPTION
## Summary

- Fix SonarCloud `java:S2274`: `Object.wait(timeout)` in `ScreenTerminal.waitDirty(long)` was not in a while loop, making it vulnerable to spurious wakeups.
- Uses a deadline-based while loop to correctly re-check the dirty flag and compute remaining timeout after each wakeup.

This was flagged as a new issue on PR #1758.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved timeout handling for screen terminal operations with refined deadline-based calculation, ensuring more reliable and precise timing behavior during screen updates and reducing potential timing-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->