### PR TITLE
fix: guard AnsiConsole.providers() call to avoid NoSuchMethodError (fixes #1766)

### DIFF
--- a/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
@@ -195,8 +195,11 @@ public class AnsiConsole {
             if (terminal == null) {
                 TerminalBuilder builder = TerminalBuilder.builder()
                         .system(true)
-                        .name("jansi")
-                        .providers(System.getProperty(JANSI_PROVIDERS));
+                        .name("jansi");
+                String providers = System.getProperty(JANSI_PROVIDERS);
+                if (providers != null) {
+                    builder.providers(providers);
+                }
                 String graceful = System.getProperty(JANSI_GRACEFUL);
                 if (graceful != null) {
                     builder.dumb(Boolean.parseBoolean(graceful));

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
@@ -193,9 +193,7 @@ public class AnsiConsole {
     static synchronized void doInstall() {
         try {
             if (terminal == null) {
-                TerminalBuilder builder = TerminalBuilder.builder()
-                        .system(true)
-                        .name("jansi");
+                TerminalBuilder builder = TerminalBuilder.builder().system(true).name("jansi");
                 String providers = System.getProperty(JANSI_PROVIDERS);
                 if (providers != null) {
                     builder.providers(providers);


### PR DESCRIPTION
## Summary

- Guard the `TerminalBuilder.providers()` call in `AnsiConsole.doInstall()` with a null check on the `jansi.providers` system property
- Prevents `NoSuchMethodError` when an older `jline-terminal` jar (without the `providers()` method) is loaded first on the classpath
- Calling `.providers(null)` was a no-op anyway since the field defaults to null

Fixes #1766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization of the ANSI terminal provider so the app now falls back to the builder's default provider selection when no custom providers are specified via system properties.
  * Improves startup robustness and avoids unintended null/provider misconfiguration, reducing terminal-related initialization errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->