### PR TITLE
fix: restore waitDirty timeout in forced dump to prevent busy-loop spinning (fixes #1768)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -1979,7 +1979,7 @@ public class ScreenTerminal {
             int fwidth,
             int[] cursor)
             throws InterruptedException {
-        if (forceDump || waitDirty(timeout)) {
+        if (waitDirty(timeout) || forceDump) {
             dump(fullscreen, ftop, fleft, fheight, fwidth, cursor);
             return true;
         } else {
@@ -1999,7 +1999,7 @@ public class ScreenTerminal {
      */
     public synchronized boolean dump(long timeout, boolean forceDump, long[] fullscreen, int[] cursor)
             throws InterruptedException {
-        if (forceDump || waitDirty(timeout)) {
+        if (waitDirty(timeout) || forceDump) {
             dump(fullscreen, cursor);
             return true;
         } else {
@@ -2016,7 +2016,7 @@ public class ScreenTerminal {
      * @throws InterruptedException if interrupted
      */
     public synchronized String dump(long timeout, boolean forceDump) throws InterruptedException {
-        if (forceDump || waitDirty(timeout)) {
+        if (waitDirty(timeout) || forceDump) {
             return dump();
         } else {
             return null;

--- a/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
@@ -641,6 +641,33 @@ public class ScreenTerminalTest {
     }
 
     /**
+     * dump(timeout, forceDump=true) must still wait for the timeout before dumping
+     * when the screen is not dirty. This prevents busy-loop spinning when callers
+     * use forceDump in a loop.
+     * Regression: #1768 — short-circuit evaluation of (forceDump || waitDirty(timeout))
+     * skipped the wait entirely when forceDump was true.
+     */
+    @Test
+    void testForceDumpWaitsForTimeout() {
+        ScreenTerminal terminal = new ScreenTerminal(10, 3);
+        terminal.write("Hello");
+
+        // Consume the dirty flag
+        terminal.isDirty();
+
+        long minWaitMs = 200;
+        long start = System.nanoTime();
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            terminal.dump(minWaitMs, true);
+        });
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(
+                elapsedMs >= minWaitMs / 2,
+                "forceDump should still wait for timeout when not dirty, but returned in " + elapsedMs + "ms");
+    }
+
+    /**
      * waitDirty(0) must return immediately rather than blocking indefinitely.
      * Regression: Object.wait(0) waits forever, so timeout==0 must skip the wait.
      */


### PR DESCRIPTION
## Summary

Commit c2a0b89 swapped `waitDirty(timeout) || forceDump` to `forceDump || waitDirty(timeout)` in the three `dump(timeout, forceDump, ...)` overloads. Due to Java's short-circuit evaluation, when `forceDump=true`, `waitDirty(timeout)` is never called, so the method returns immediately instead of waiting up to `timeout` ms. This causes busy-loop spinning for callers that rely on the timeout for throttling redraws.

This restores the original operand order so `waitDirty(timeout)` is always evaluated first, preserving the throttling behavior.

Fixes #1768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screen terminal dump operation to respect the specified timeout duration even when force dump is enabled, ensuring the operation blocks for the full timeout period as expected.

* **Tests**
  * Added test to verify timeout behavior is correctly honored in force dump scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->