### PR TITLE
fix: erase probe emoji after grapheme cluster width detection (fixes #1801)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -595,9 +595,9 @@ public abstract class AbstractTerminal implements TerminalExt {
             }
 
             // --- Flag probe ---
-            int flagCol = probeEmojiWidth(flagEmoji);
+            int flagCol = probeEmojiWidth(flagEmoji, startCol);
             // --- ZWJ probe ---
-            int zwjCol = probeEmojiWidth(zwjEmoji);
+            int zwjCol = probeEmojiWidth(zwjEmoji, startCol);
 
             // Grouped emoji → 2-column displacement; ungrouped → 4
             groupsRegionalIndicators = (flagCol - startCol == 2);
@@ -626,7 +626,7 @@ public abstract class AbstractTerminal implements TerminalExt {
      * Writes a single emoji to the terminal, queries cursor position via
      * DSR/CPR, then cleans up. Returns the 1-based column value.
      */
-    private int probeEmojiWidth(String emoji) throws IOException {
+    private int probeEmojiWidth(String emoji, int startCol) throws IOException {
         puts(Capability.save_cursor);
         writer().write(emoji);
         puts(Capability.user7); // DSR — request cursor position
@@ -634,7 +634,18 @@ public abstract class AbstractTerminal implements TerminalExt {
 
         int col = readCprColumn(200);
 
+        // Erase the probe glyphs: rewind, overwrite the occupied cells with
+        // spaces, then rewind again to leave the cursor in the original saved position.
         puts(Capability.restore_cursor);
+        int width = col - startCol;
+        if (width > 0) {
+            for (int i = 0; i < width; i++) {
+                writer().write(' ');
+            }
+            puts(Capability.restore_cursor);
+        } else {
+            puts(Capability.clr_eol);
+        }
         writer().flush();
         return col;
     }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -612,6 +612,7 @@ public abstract class AbstractTerminal implements TerminalExt {
         } catch (IOError | IOException e) {
             try {
                 puts(Capability.restore_cursor);
+                puts(Capability.clr_eol);
                 writer().flush();
             } catch (Exception ignored) {
                 // Best-effort cleanup; probing failure should not propagate


### PR DESCRIPTION
problem: probeEmojiWidth() left test glyphs at the top of the screen when a newline was printed as the first output

fix: after reading the CPR response, rewind to the saved position, overwrite the occupied cells with spaces, then rewind again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji width detection to account for the probe start column, ensuring wide and joined emojis render at correct positions and reducing misaligned text.
  * Temporary probe characters and their occupied spans are now reliably removed after measurement; cleanup now clears to end-of-line after restoring the cursor to prevent brief visual artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->