### PR TITLE
fix: compiler error in ScreenTerminal.dump()

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -2108,7 +2108,7 @@ public class ScreenTerminal {
         int numRows = getRows();
         long[] dumpBuffer = new long[cols * numRows];
         int[] cursor = new int[2];
-        dump(screen, cursor);
+        dump(dumpBuffer, cursor);
         int cursorX = cursor[0];
         int cursorY = cursor[1];
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Fixes compile error introduced in https://github.com/jline/jline3/commit/7d21f09e65bb4305db1c87086ee7e5a2ed872215
In the HTML dump method, the "screen" local variable was renamed to "dumpBuffer", but not everywhere, causing a compile error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTML rendering buffer handling in screen terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->