### PR TITLE
docs: update website for JLine 4.0 release

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -2108,7 +2108,7 @@ public class ScreenTerminal {
         int numRows = getRows();
         long[] dumpBuffer = new long[cols * numRows];
         int[] cursor = new int[2];
-        dump(screen, cursor);
+        dump(dumpBuffer, cursor);
         int cursorX = cursor[0];
         int cursorY = cursor[1];
         StringBuilder sb = new StringBuilder();

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -51,20 +51,18 @@ import org.jline.utils.OSUtils;
  * <ul>
  *   <li><b>FFM</b> - Foreign Function Memory (Java 22+) based implementation</li>
  *   <li><b>JNI</b> - Java Native Interface based implementation</li>
- *   <li><b>Jansi</b> - Implementation based on the Jansi library</li>
- *   <li><b>JNA</b> - Java Native Access based implementation</li>
  *   <li><b>Exec</b> - Implementation using external commands</li>
- *   <li><b>Dumb</b> - Fallback implementation with limited capabilities</li>
+ *   <li><b>Dumb</b> - Fallback-only implementation with limited capabilities (not included in default provider order)</li>
  * </ul>
  * <p>
  * The provider selection can be controlled using the {@link #provider(String)} method or the
  * {@code org.jline.terminal.provider} system property. By default, providers are tried in the
- * order: FFM, JNI, Jansi, JNA, Exec.
+ * order: FFM, JNI, Exec.
  * </p>
  *
  * <h2>Native Library Support</h2>
  * <p>
- * When using providers that require native libraries (such as JNI, JNA, or Jansi), the appropriate
+ * When using providers that require native libraries (such as JNI), the appropriate
  * native library will be loaded automatically. The loading of these libraries is handled by
  * {@link org.jline.nativ.JLineNativeLoader} for the JNI provider.
  * </p>
@@ -909,8 +907,8 @@ public final class TerminalBuilder {
                 }
                 if (terminal == null && OSUtils.IS_WINDOWS && providers.isEmpty() && (dumb == null || !dumb)) {
                     throw new IllegalStateException(
-                            "Unable to create a system terminal. On Windows, either JLine's native libraries, JNA "
-                                    + "or Jansi library is required.  Make sure to add one of those in the classpath.",
+                            "Unable to create a system terminal. On Windows, JLine's native libraries are required. "
+                                    + "Make sure the FFM provider (Java 22+) or JNI provider is available.",
                             exception);
                 }
             }

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -37,10 +37,8 @@ import org.jline.utils.Signals;
  * <ul>
  *   <li>FFM - Foreign Function Memory (Java 22+) based implementation</li>
  *   <li>JNI - Java Native Interface based implementation</li>
- *   <li>Jansi - Implementation based on the Jansi library</li>
- *   <li>JNA - Java Native Access based implementation</li>
  *   <li>Exec - Implementation using external commands</li>
- *   <li>Dumb - Fallback implementation with limited capabilities</li>
+ *   <li>Dumb - Fallback-only implementation with limited capabilities (not included in default provider order)</li>
  * </ul>
  *
  * <p>
@@ -59,7 +57,7 @@ public interface TerminalProvider {
      * <p>
      * The provider name is a unique identifier that can be used to request this
      * specific provider when creating terminals. Common provider names include
-     * "ffm", "jni", "jansi", "exec", and "dumb".
+     * "ffm", "jni", "exec", and "dumb".
      * </p>
      *
      * @return the name of this terminal provider

--- a/website/docs/advanced/nano-less-customization.md
+++ b/website/docs/advanced/nano-less-customization.md
@@ -60,7 +60,7 @@ Note that the history log is saved in the user-specific directory, and the file 
 
 ## Theme System
 
-JLine version > 3.21.0 includes a [Theme System](theme-system.md) that allows highlight rules to be specified in terms of token type names, mixins, and parser configurations, instead of hard-coded colors in nanorc files.
+JLine includes a [Theme System](theme-system.md) that allows highlight rules to be specified in terms of token type names, mixins, and parser configurations, instead of hard-coded colors in nanorc files.
 
 Optional theme system configuration is set by adding a '**theme** theme-system-file' command in `jnanorc`/`jlessrc` configuration files.
 

--- a/website/docs/advanced/terminal-graphics.md
+++ b/website/docs/advanced/terminal-graphics.md
@@ -256,4 +256,4 @@ See the `TerminalGraphicsExample` class for complete working examples:
    -Djline.terminal.graphics.kitty.timeout=50
    -Djline.terminal.graphics.sixel.timeout=50
    ```
-6. **Escape sequences visible in terminal**: This should not happen with JLine 3.30.5+ as raw mode prevents echo during detection. If you see this, please report it as a bug.
+6. **Escape sequences visible in terminal**: This should not happen as raw mode prevents echo during detection. If you see this, please report it as a bug.

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -22,7 +22,7 @@ JLine is organized into several core components that work together to provide a 
 │                            Terminal                             │
 │                                                                 │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────┐ │
-│  │    Jansi    │  │     JNA     │  │     FFM     │  │   Exec  │ │
+│  │     JNI     │  │     FFM     │  │    Exec     │  │  Dumb   │ │
 │  │   Provider  │  │   Provider  │  │   Provider  │  │ Provider│ │
 │  └─────────────┘  └─────────────┘  └─────────────┘  └─────────┘ │
 └─────────────────────────────────────────────────────────────────┘
@@ -58,7 +58,7 @@ The `Terminal` component is the foundation of JLine. It provides:
 - Terminal size information
 - Signal handling (e.g., window resize, Ctrl+C)
 
-The Terminal layer uses different providers (Jansi, JNA, FFM, etc.) to interact with the native terminal capabilities on different platforms.
+The Terminal layer uses different providers (JNI, FFM, Exec, etc.) to interact with the native terminal capabilities on different platforms.
 
 ### LineReader
 

--- a/website/docs/modules/console-ui.md
+++ b/website/docs/modules/console-ui.md
@@ -12,7 +12,7 @@ The JLine Console UI module provides interactive prompt components for console a
 
 ## Introduction
 
-ConsoleUI is a library for prompting the user for different types of input. It provides simple UI elements on ANSI console-based terminals. ConsoleUI was initially implemented using JLine2 by Andreas Wegmann and was later upgraded to use JLine3 and merged into the JLine project.
+ConsoleUI is a library for prompting the user for different types of input. It provides simple UI elements on ANSI console-based terminals. ConsoleUI was initially implemented using JLine2 by Andreas Wegmann and was later upgraded to use JLine 3 and merged into the JLine project.
 
 ## Features
 

--- a/website/docs/modules/prompt.md
+++ b/website/docs/modules/prompt.md
@@ -6,11 +6,11 @@ sidebar_position: 6
 
 import CodeSnippet from '@site/src/components/CodeSnippet';
 
-The JLine Prompt module provides a modern, native JLine3 implementation for interactive console prompts. It offers a complete replacement for the console-ui module with enhanced features including multi-column layouts, advanced navigation, and script integration capabilities.
+The JLine Prompt module provides a modern, native JLine implementation for interactive console prompts. It offers a complete replacement for the console-ui module with enhanced features including multi-column layouts, advanced navigation, and script integration capabilities.
 
 ## Introduction
 
-The Prompt module is a comprehensive prompt system built natively on JLine3, providing all the functionality of console-ui while adding significant enhancements. It features a fluent builder API, multi-column layouts, grid-based navigation, and command-line integration for scripts and automation.
+The Prompt module is a comprehensive prompt system built natively on JLine, providing all the functionality of console-ui while adding significant enhancements. It features a fluent builder API, multi-column layouts, grid-based navigation, and command-line integration for scripts and automation.
 
 ## Key Features
 
@@ -25,7 +25,7 @@ The Prompt module offers:
 - **Pagination and scrolling** for large item lists
 - **Script integration** via PromptCommands for shell scripts and automation
 - **Terminal capability detection** with graceful fallbacks
-- **Native JLine3 implementation** with no external dependencies
+- **Native JLine implementation** with no external dependencies
 
 ## Quick Start Example
 

--- a/website/docs/whats-new.md
+++ b/website/docs/whats-new.md
@@ -1,0 +1,154 @@
+---
+sidebar_position: 1.5
+---
+
+# What's New in JLine 4
+
+JLine 4 is a major release that modernizes the library with new terminal providers, a powerful shell module, improved Unicode handling, and terminal graphics support. This page summarizes the key changes from JLine 3.x.
+
+## Requirements
+
+| | JLine 3.x | JLine 4.x |
+|---|---|---|
+| **Minimum Java** | Java 8 | **Java 11** |
+| **Build JDK** | Java 8 | Java 22 (for FFM provider) |
+| **Maven** | 3.x | 3.9+ |
+
+:::tip JDK11 Classifier
+If you're using Java 11-21 and encounter class file version errors, use the `jdk11` classifier to exclude the FFM provider (compiled with Java 22). See [Terminal Providers](./modules/terminal-providers.md) for details.
+:::
+
+## New Modules
+
+### Shell Module (`jline-shell`)
+
+A modern, clean API for building interactive command-line applications, replacing the old Console command infrastructure.
+
+- **Fluent builder API** via `Shell.builder()`
+- **Pipeline execution** with operators: `|`, `&&`, `||`, `;`, `>`, `>>`, `<`, `&`
+- **Alias system** with parameter substitution (`$1`, `$@`)
+- **Job control** — background execution, `jobs`/`fg`/`bg` commands
+- **Variable expansion** — `$VAR`, `${VAR:-default}`, `~` home expansion
+- **Script execution** — `source` / `.` commands with line continuation
+- **Subcommands** — automatic routing and tab completion
+- **Signal handling** — Ctrl-C interrupts the command, not the shell
+- **Syntax highlighting** — known commands bold, unknown commands red, operators cyan
+- **Built-in commands** — `history`, `help`, `setopt`/`unsetopt`/`setvar`
+
+See [Shell: Getting Started](./shell-getting-started.md) and [Shell: Features](./shell-features.md).
+
+### Prompt Module (`jline-prompt`)
+
+A modern replacement for the Console UI module, built natively on JLine.
+
+- **11+ prompt types**: list, checkbox, choice, input, confirm, password, number, toggle, editor, search, key press
+- **Multi-column layouts** with automatic terminal width adaptation
+- **Grid-based navigation** using arrow keys
+- **Script integration** via `PromptCommands` for shell scripts and automation
+- Full backward compatibility with the Console UI API
+
+See [Prompt Module](./modules/prompt.md).
+
+## Terminal Providers
+
+JLine 4 replaces the Jansi and JNA providers with modern alternatives.
+
+| Provider | JLine 3 | JLine 4 | Notes |
+|---|:---:|:---:|---|
+| **FFM** | -- | **New** | Foreign Function & Memory API (Java 22+), best performance |
+| **JNI** | -- | **New** | Java Native Interface, works on Java 11+ |
+| **Jansi** | Yes | **Removed** | Use JNI or FFM instead |
+| **JNA** | Yes | **Removed** | Use JNI or FFM instead |
+| **Exec** | Yes | Yes | External commands (`stty`, `tput`), no native access needed |
+| **Dumb** | Yes | Yes | Pure-Java fallback |
+
+Default provider order: **FFM, JNI, Exec** (Dumb is fallback-only).
+
+### Migrating from Jansi
+
+If you used Jansi purely for ANSI output, JLine 4's `AttributedString.toAnsi()` is a direct replacement — no `AnsiConsole.systemInstall()` needed. See [Terminal Providers: Migrating from Jansi](./modules/terminal-providers.md#migrating-from-jansi).
+
+## New Terminal Features
+
+### Terminal Graphics
+
+Display images directly in the terminal via multiple protocols:
+
+- **Sixel** — widely supported (xterm, iTerm2, foot, WezTerm)
+- **Kitty Graphics Protocol** — modern, feature-rich
+- **iTerm2 Inline Images** — iTerm2-specific
+
+A unified `TerminalGraphics` interface handles protocol detection and fallback automatically. See [Terminal Graphics](./advanced/terminal-graphics.md).
+
+### Grapheme Cluster Support
+
+Proper handling of combining characters, emoji, and complex scripts via Unicode Mode 2027 (DECRQM probing). Updated to Unicode 16.0. See [Grapheme Cluster Mode](./advanced/grapheme-cluster-mode.md).
+
+### Signal Handling via Panama FFM
+
+Modernized POSIX signal handling using Panama FFM `sigaction()`, providing better Ctrl-C and Ctrl-Z behavior without JNI overhead.
+
+### `/dev/tty` Fallback
+
+When stdin/stdout are piped (e.g., via `exec-maven-plugin`), JLine can now open `/dev/tty` directly to access the controlling terminal:
+
+```java
+TerminalBuilder.builder().devTty(true).build();
+```
+
+## JPMS Support
+
+JLine 4 provides full Java Platform Module System support with proper `module-info.java` descriptors:
+
+- `org.jline.terminal` — core terminal functionality
+- `org.jline.terminal.ffm` — FFM provider (Java 22+)
+- `org.jline.reader` — line editing
+- `org.jline.style` — styling and coloring
+- `org.jline.builtins` — built-in commands
+- `org.jline.shell` — shell framework
+- `org.jline.prompt` — prompt module
+
+See [JPMS documentation](./modules/jpms.md) for module usage and migration details.
+
+## Deprecated APIs
+
+### Console Module (`jline-console`)
+
+The old command infrastructure is deprecated but still functional. Bridge adapters are provided for migration:
+
+| Old (jline-console) | New (jline-shell) |
+|---|---|
+| `CommandRegistry` | `CommandGroup` |
+| `SystemRegistry` | `CommandDispatcher` |
+| `CommandMethods` + `CommandInput` | `Command.execute()` |
+| `CmdDesc` | `CommandDescription` |
+| `CmdLine` | `CommandLine` |
+| `ArgDesc` | `ArgumentDescription` |
+
+Use `CommandGroupAdapter` and `CommandRegistryAdapter` to bridge old and new APIs. See [Shell: Migration Guide](./shell-migration.md).
+
+### Console UI Module (`jline-console-ui`)
+
+Still functional but superseded by the [Prompt Module](./modules/prompt.md), which offers the same API with multi-column layouts, more prompt types, and better performance.
+
+## Migration Checklist
+
+1. **Update Java version** to 11 or higher
+2. **Update Maven version** to 3.9 or higher
+3. **Update dependency coordinates**:
+   ```xml
+   <dependency>
+       <groupId>org.jline</groupId>
+       <artifactId>jline</artifactId>
+       <version>4.0.0</version>
+   </dependency>
+   ```
+   Use `<classifier>jdk11</classifier>` if targeting Java 11-21.
+4. **Remove Jansi/JNA dependencies** — native access is built-in via JNI and FFM
+5. **Migrate Console API** to Shell if writing new code (or use adapters for existing code)
+6. **Migrate Console UI** to Prompt module for new prompt code
+7. **Add `--enable-native-access`** if using Java 22+ with modules:
+   ```
+   --enable-native-access=org.jline.terminal.ffm
+   ```
+8. **Test on target platforms** — provider auto-selection handles most cases

--- a/website/docs/whats-new.md
+++ b/website/docs/whats-new.md
@@ -148,7 +148,7 @@ Still functional but superseded by the [Prompt Module](./modules/prompt.md), whi
 5. **Migrate Console API** to Shell if writing new code (or use adapters for existing code)
 6. **Migrate Console UI** to Prompt module for new prompt code
 7. **Add `--enable-native-access`** if using Java 22+ with modules:
-   ```
+   ```text
    --enable-native-access=org.jline.terminal.ffm
    ```
 8. **Test on target platforms** — provider auto-selection handles most cases

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -103,8 +103,8 @@ const config: Config = {
           label: `v${jlineVersion}`,
           position: 'right',
           items: [
-            {label: '3.30.x', href: 'https://jline.org/'},
-            {label: '4.0.x', href: 'https://jline.org/versions/4.0/'},
+            {label: '4.0.x (current)', href: 'https://jline.org/'},
+            {label: '3.30.x', href: 'https://jline.org/versions/3.x/'},
           ],
         },
         {

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -15,6 +15,7 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   tutorialSidebar: [
     'intro',
+    'whats-new',
     'architecture',
     'terminal',
     'line-reader',


### PR DESCRIPTION
## Summary
- Version dropdown: make 4.0.x the current/default version, move 3.30.x to legacy URL
- Architecture diagram: update terminal providers from removed Jansi/JNA to current JNI/FFM/Exec/Dumb
- Remove outdated JLine 3.x version references in nano-less-customization and terminal-graphics docs
- Fix "JLine3" naming to "JLine" in prompt module docs

## Test plan
- [ ] Verify version dropdown renders correctly with 4.0.x as current
- [ ] Verify architecture diagram shows correct providers
- [ ] Review docs for any remaining outdated version references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated many guides for clarity: removed specific version claims, standardized JLine naming, refreshed terminal provider descriptions and navbar/version links, added a “What’s New in JLine 4” page, and updated the docs sidebar.
* **Bug Fixes**
  * Fixed terminal screen dump so exported HTML reads from the correct buffer, improving rendered terminal output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->