### PR TITLE
Fix pipe stdin wiring in DefaultCommandDispatcher

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -2108,7 +2108,7 @@ public class ScreenTerminal {
         int numRows = getRows();
         long[] dumpBuffer = new long[cols * numRows];
         int[] cursor = new int[2];
-        dump(screen, cursor);
+        dump(dumpBuffer, cursor);
         int cursorX = cursor[0];
         int cursorY = cursor[1];
         StringBuilder sb = new StringBuilder();

--- a/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
@@ -8,6 +8,8 @@
  */
 package org.jline.demo.examples;
 
+import java.nio.charset.StandardCharsets;
+
 import org.jline.reader.LineReader.Option;
 import org.jline.shell.CommandSession;
 import org.jline.shell.Shell;
@@ -51,13 +53,9 @@ public class ShellJobExample {
 
         @Override
         public Object execute(CommandSession session, String[] args) {
-            // Check for pipe input
-            Object pipeInput = session.get("_pipe_input");
             String msg;
             if (args.length > 0) {
                 msg = String.join(" ", args);
-            } else if (pipeInput != null) {
-                msg = pipeInput.toString();
             } else {
                 msg = "";
             }
@@ -77,14 +75,12 @@ public class ShellJobExample {
         }
 
         @Override
-        public Object execute(CommandSession session, String[] args) {
-            // Check for pipe input first
-            Object pipeInput = session.get("_pipe_input");
+        public Object execute(CommandSession session, String[] args) throws Exception {
             String input;
-            if (pipeInput != null) {
-                input = pipeInput.toString().trim();
-            } else {
+            if (args.length > 0) {
                 input = String.join(" ", args);
+            } else {
+                input = new String(session.in().readAllBytes(), StandardCharsets.UTF_8).trim();
             }
             String result = input.toUpperCase();
             session.out().println(result);

--- a/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
@@ -8,6 +8,7 @@
  */
 package org.jline.demo.examples;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.jline.shell.CommandSession;
@@ -47,12 +48,9 @@ public class ShellPipelineExample {
 
         @Override
         public Object execute(CommandSession session, String[] args) {
-            Object pipeInput = session.get("_pipe_input");
             String msg;
             if (args.length > 0) {
                 msg = String.join(" ", args);
-            } else if (pipeInput != null) {
-                msg = pipeInput.toString();
             } else {
                 msg = "";
             }
@@ -72,9 +70,13 @@ public class ShellPipelineExample {
         }
 
         @Override
-        public Object execute(CommandSession session, String[] args) {
-            Object pipeInput = session.get("_pipe_input");
-            String input = pipeInput != null ? pipeInput.toString().trim() : String.join(" ", args);
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            String input;
+            if (args.length > 0) {
+                input = String.join(" ", args);
+            } else {
+                input = new String(session.in().readAllBytes(), StandardCharsets.UTF_8).trim();
+            }
             String result = input.toUpperCase();
             session.out().println(result);
             return result;

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -9,6 +9,7 @@
 package org.jline.shell.impl;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
@@ -276,16 +277,9 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             String cmdName = parts[0];
             String argsStr = parts.length > 1 ? parts[1] : "";
 
-            // Handle pipe input: prepend to args
-            if (lastOutput != null && i > 0) {
-                Pipeline.Stage prevStage = stages.get(i - 1);
-                if (prevStage.operator() == Operator.PIPE) {
-                    // For pipe, we pass input via session variable
-                    session.put("_pipe_input", lastOutput);
-                } else if (prevStage.operator() == Operator.FLIP) {
-                    // For flip, append output as argument
-                    argsStr = argsStr.isEmpty() ? lastOutput.trim() : argsStr + " " + lastOutput.trim();
-                }
+            // Handle FLIP: append previous output as argument
+            if (lastOutput != null && i > 0 && stages.get(i - 1).operator() == Operator.FLIP) {
+                argsStr = argsStr.isEmpty() ? lastOutput.trim() : argsStr + " " + lastOutput.trim();
             }
 
             Command cmd = findCommand(cmdName);
@@ -304,9 +298,13 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 }
             }
 
-            // Handle input redirection
+            // Handle input redirection (pipe input from previous stage, or explicit < redirect)
             InputStream originalIn = session.in();
             boolean inputRedirected = false;
+            if (lastOutput != null && i > 0 && stages.get(i - 1).operator() == Operator.PIPE) {
+                session.setIn(new ByteArrayInputStream(lastOutput.getBytes(StandardCharsets.UTF_8)));
+                inputRedirected = true;
+            }
             if (stage.inputSource() != null) {
                 byte[] inputBytes = Files.readAllBytes(stage.inputSource());
                 session.setIn(new ByteArrayInputStream(inputBytes));

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -9,6 +9,7 @@
 package org.jline.shell.impl;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -81,13 +82,17 @@ public class DefaultCommandDispatcherTest {
 
         @Override
         public String description() {
-            return "Convert pipe input to upper case";
+            return "Convert stdin (or args) to upper case";
         }
 
         @Override
-        public Object execute(CommandSession session, String[] args) {
-            Object pipeInput = session.get("_pipe_input");
-            String input = pipeInput != null ? pipeInput.toString().trim() : String.join(" ", args);
+        public Object execute(CommandSession session, String[] args) throws IOException {
+            String input;
+            if (args.length > 0) {
+                input = String.join(" ", args);
+            } else {
+                input = new String(session.in().readAllBytes(), StandardCharsets.UTF_8).trim();
+            }
             String result = input.toUpperCase();
             session.out().println(result);
             return result;


### PR DESCRIPTION
Second commit fixes a bug introduced in https://github.com/jline/jline3/commit/7d21f09e65bb4305db1c87086ee7e5a2ed872215 where a variable was renamed, but not in the usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pipeline input handling in shell command execution. Commands now correctly receive and process input from previous pipeline stages.
  * Fixed HTML terminal dump functionality to ensure accurate cursor position rendering.

* **Refactor**
  * Improved internal input mechanism for pipeline commands to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->