### PR TITLE
feat: streaming pipes with concurrent pipeline execution

### DIFF
--- a/demo/src/main/java/org/jline/demo/examples/DemoCommands.java
+++ b/demo/src/main/java/org/jline/demo/examples/DemoCommands.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import org.jline.shell.CommandSession;
+import org.jline.shell.impl.AbstractCommand;
+
+/**
+ * Shared demo commands reused across shell examples.
+ */
+public class DemoCommands {
+
+    /**
+     * Echoes arguments to output.
+     */
+    public static class EchoCommand extends AbstractCommand {
+        public EchoCommand() {
+            super("echo");
+        }
+
+        @Override
+        public String description() {
+            return "Echo arguments to output";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            String msg = String.join(" ", args);
+            session.out().println(msg);
+            return msg;
+        }
+    }
+
+    /**
+     * Converts text to upper case, reading from arguments or stdin.
+     */
+    public static class UpperCommand extends AbstractCommand {
+        public UpperCommand() {
+            super("upper");
+        }
+
+        @Override
+        public String description() {
+            return "Convert text to upper case";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            String input;
+            if (args.length > 0) {
+                input = String.join(" ", args);
+            } else {
+                input = new String(session.in().readAllBytes()).trim();
+            }
+            String result = input.toUpperCase();
+            session.out().println(result);
+            return result;
+        }
+    }
+}

--- a/demo/src/main/java/org/jline/demo/examples/DemoCommands.java
+++ b/demo/src/main/java/org/jline/demo/examples/DemoCommands.java
@@ -16,6 +16,8 @@ import org.jline.shell.impl.AbstractCommand;
  */
 public class DemoCommands {
 
+    private DemoCommands() {}
+
     /**
      * Echoes arguments to output.
      */

--- a/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
@@ -39,69 +39,6 @@ import org.jline.shell.widget.CommandTailTipWidgets;
 public class ShellJobExample {
 
     // SNIPPET_START: ShellJobExample
-    static class EchoCommand extends AbstractCommand {
-        EchoCommand() {
-            super("echo");
-        }
-
-        @Override
-        public String description() {
-            return "Echo arguments to output";
-        }
-
-        /**
-         * Echoes the provided arguments (joined with spaces) to the session output and returns the resulting message.
-         *
-         * @param args the arguments to echo; joined with spaces to form the output
-         * @return the message that was printed
-         */
-        @Override
-        public Object execute(CommandSession session, String[] args) {
-            String msg = String.join(" ", args);
-            session.out().println(msg);
-            return msg;
-        }
-    }
-
-    static class UpperCommand extends AbstractCommand {
-        UpperCommand() {
-            super("upper");
-        }
-
-        /**
-         * Provide the command's short description.
-         *
-         * @return the command description "Convert text to upper case"
-         */
-        @Override
-        public String description() {
-            return "Convert text to upper case";
-        }
-
-        /**
-         * Convert the provided input to upper case and write it to the session output.
-         *
-         * If command-line arguments are present they are joined with spaces and used as the input;
-         * otherwise the method reads remaining bytes from the session's input and trims them before converting.
-         *
-         * @param session the command session used for reading input and writing output
-         * @param args command-line arguments to be used as input when non-empty
-         * @return the resulting upper-case string
-         */
-        @Override
-        public Object execute(CommandSession session, String[] args) throws Exception {
-            String input;
-            if (args.length > 0) {
-                input = String.join(" ", args);
-            } else {
-                input = new String(session.in().readAllBytes()).trim();
-            }
-            String result = input.toUpperCase();
-            session.out().println(result);
-            return result;
-        }
-    }
-
     static class SleepCommand extends AbstractCommand {
         SleepCommand() {
             super("sleep");
@@ -154,7 +91,11 @@ public class ShellJobExample {
                 .optionCommands(true) // HIGHLIGHT
                 .commandHighlighter(true) // HIGHLIGHT
                 .groups(new SimpleCommandGroup(
-                        "demo", new EchoCommand(), new UpperCommand(), new SleepCommand(), new CountCommand()))
+                        "demo",
+                        new DemoCommands.EchoCommand(),
+                        new DemoCommands.UpperCommand(),
+                        new SleepCommand(),
+                        new CountCommand()))
                 .option(Option.INSERT_BRACKET, true)
                 .option(Option.DISABLE_EVENT_EXPANSION, true)
                 .onReaderReady((reader, dispatcher) -> {

--- a/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
@@ -49,6 +49,12 @@ public class ShellJobExample {
             return "Echo arguments to output";
         }
 
+        /**
+         * Echoes the provided arguments (joined with spaces) to the session output and returns the resulting message.
+         *
+         * @param args the arguments to echo; joined with spaces to form the output
+         * @return the message that was printed
+         */
         @Override
         public Object execute(CommandSession session, String[] args) {
             String msg = String.join(" ", args);
@@ -62,11 +68,26 @@ public class ShellJobExample {
             super("upper");
         }
 
+        /**
+         * Provide the command's short description.
+         *
+         * @return the command description "Convert text to upper case"
+         */
         @Override
         public String description() {
             return "Convert text to upper case";
         }
 
+        /**
+         * Convert the provided input to upper case and write it to the session output.
+         *
+         * If command-line arguments are present they are joined with spaces and used as the input;
+         * otherwise the method reads remaining bytes from the session's input and trims them before converting.
+         *
+         * @param session the command session used for reading input and writing output
+         * @param args command-line arguments to be used as input when non-empty
+         * @return the resulting upper-case string
+         */
         @Override
         public Object execute(CommandSession session, String[] args) throws Exception {
             String input;

--- a/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellJobExample.java
@@ -51,16 +51,7 @@ public class ShellJobExample {
 
         @Override
         public Object execute(CommandSession session, String[] args) {
-            // Check for pipe input
-            Object pipeInput = session.get("_pipe_input");
-            String msg;
-            if (args.length > 0) {
-                msg = String.join(" ", args);
-            } else if (pipeInput != null) {
-                msg = pipeInput.toString();
-            } else {
-                msg = "";
-            }
+            String msg = String.join(" ", args);
             session.out().println(msg);
             return msg;
         }
@@ -77,14 +68,12 @@ public class ShellJobExample {
         }
 
         @Override
-        public Object execute(CommandSession session, String[] args) {
-            // Check for pipe input first
-            Object pipeInput = session.get("_pipe_input");
+        public Object execute(CommandSession session, String[] args) throws Exception {
             String input;
-            if (pipeInput != null) {
-                input = pipeInput.toString().trim();
-            } else {
+            if (args.length > 0) {
                 input = String.join(" ", args);
+            } else {
+                input = new String(session.in().readAllBytes()).trim();
             }
             String result = input.toUpperCase();
             session.out().println(result);

--- a/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
@@ -47,15 +47,7 @@ public class ShellPipelineExample {
 
         @Override
         public Object execute(CommandSession session, String[] args) {
-            Object pipeInput = session.get("_pipe_input");
-            String msg;
-            if (args.length > 0) {
-                msg = String.join(" ", args);
-            } else if (pipeInput != null) {
-                msg = pipeInput.toString();
-            } else {
-                msg = "";
-            }
+            String msg = String.join(" ", args);
             session.out().println(msg);
             return msg;
         }
@@ -72,9 +64,13 @@ public class ShellPipelineExample {
         }
 
         @Override
-        public Object execute(CommandSession session, String[] args) {
-            Object pipeInput = session.get("_pipe_input");
-            String input = pipeInput != null ? pipeInput.toString().trim() : String.join(" ", args);
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            String input;
+            if (args.length > 0) {
+                input = String.join(" ", args);
+            } else {
+                input = new String(session.in().readAllBytes()).trim();
+            }
             String result = input.toUpperCase();
             session.out().println(result);
             return result;

--- a/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
@@ -45,6 +45,13 @@ public class ShellPipelineExample {
             return "Echo arguments to output";
         }
 
+        /**
+         * Prints the command arguments joined by spaces to the session output.
+         *
+         * @param session the command session used for input/output
+         * @param args the arguments to join and print
+         * @return the joined arguments string
+         */
         @Override
         public Object execute(CommandSession session, String[] args) {
             String msg = String.join(" ", args);
@@ -58,11 +65,26 @@ public class ShellPipelineExample {
             super("upper");
         }
 
+        /**
+         * Provide the one-line help text for the command.
+         *
+         * @return the one-line help text describing the command's behavior: "Convert pipe input to upper case"
+         */
         @Override
         public String description() {
             return "Convert pipe input to upper case";
         }
 
+        /**
+         * Converts input text to uppercase, writes it to the session output, and returns it.
+         *
+         * If command arguments are provided they are joined with spaces and used as the input;
+         * otherwise all available bytes from the session's input stream are read and trimmed.
+         *
+         * @param session the command session providing input and output streams
+         * @param args    command arguments; when non-empty they are joined into the input text
+         * @return        the resulting uppercase string
+         */
         @Override
         public Object execute(CommandSession session, String[] args) throws Exception {
             String input;

--- a/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellPipelineExample.java
@@ -35,70 +35,6 @@ import org.jline.shell.impl.SimpleCommandGroup;
 public class ShellPipelineExample {
 
     // SNIPPET_START: ShellPipelineExample
-    static class EchoCommand extends AbstractCommand {
-        EchoCommand() {
-            super("echo");
-        }
-
-        @Override
-        public String description() {
-            return "Echo arguments to output";
-        }
-
-        /**
-         * Prints the command arguments joined by spaces to the session output.
-         *
-         * @param session the command session used for input/output
-         * @param args the arguments to join and print
-         * @return the joined arguments string
-         */
-        @Override
-        public Object execute(CommandSession session, String[] args) {
-            String msg = String.join(" ", args);
-            session.out().println(msg);
-            return msg;
-        }
-    }
-
-    static class UpperCommand extends AbstractCommand {
-        UpperCommand() {
-            super("upper");
-        }
-
-        /**
-         * Provide the one-line help text for the command.
-         *
-         * @return the one-line help text describing the command's behavior: "Convert pipe input to upper case"
-         */
-        @Override
-        public String description() {
-            return "Convert pipe input to upper case";
-        }
-
-        /**
-         * Converts input text to uppercase, writes it to the session output, and returns it.
-         *
-         * If command arguments are provided they are joined with spaces and used as the input;
-         * otherwise all available bytes from the session's input stream are read and trimmed.
-         *
-         * @param session the command session providing input and output streams
-         * @param args    command arguments; when non-empty they are joined into the input text
-         * @return        the resulting uppercase string
-         */
-        @Override
-        public Object execute(CommandSession session, String[] args) throws Exception {
-            String input;
-            if (args.length > 0) {
-                input = String.join(" ", args);
-            } else {
-                input = new String(session.in().readAllBytes()).trim();
-            }
-            String result = input.toUpperCase();
-            session.out().println(result);
-            return result;
-        }
-    }
-
     static class FailCommand extends AbstractCommand {
         FailCommand() {
             super("fail");
@@ -123,7 +59,8 @@ public class ShellPipelineExample {
                 .prompt("pipeline-demo> ")
                 .pipelineParser(customParser) // HIGHLIGHT
                 .helpCommands(true)
-                .groups(new SimpleCommandGroup("demo", new EchoCommand(), new UpperCommand(), new FailCommand()))
+                .groups(new SimpleCommandGroup(
+                        "demo", new DemoCommands.EchoCommand(), new DemoCommands.UpperCommand(), new FailCommand()))
                 .build()) {
             shell.run();
         }

--- a/shell/src/main/java/org/jline/shell/CommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/CommandDispatcher.java
@@ -56,7 +56,15 @@ public interface CommandDispatcher extends AutoCloseable {
      * @param name the command name or alias
      * @return the command, or null if not found
      */
-    Command findCommand(String name);
+    default Command findCommand(String name) {
+        for (CommandGroup group : groups()) {
+            Command cmd = group.command(name);
+            if (cmd != null) {
+                return cmd;
+            }
+        }
+        return null;
+    }
 
     /**
      * Executes a command line string.

--- a/shell/src/main/java/org/jline/shell/CommandSession.java
+++ b/shell/src/main/java/org/jline/shell/CommandSession.java
@@ -228,4 +228,24 @@ public class CommandSession {
     public void setForegroundJob(Job foregroundJob) {
         this.foregroundJob = foregroundJob;
     }
+
+    /**
+     * Creates a child session that shares the same terminal but uses independent I/O streams.
+     * <p>
+     * The child session gets a copy of the current variables and working directory.
+     * This is used for concurrent pipeline execution where each stage needs its own
+     * I/O streams.
+     *
+     * @param in the input stream for the child session
+     * @param out the output stream for the child session
+     * @param err the error stream for the child session
+     * @return a new child session
+     */
+    public CommandSession fork(InputStream in, PrintStream out, PrintStream err) {
+        CommandSession child = new CommandSession(this.terminal, in, out, err);
+        child.variables.putAll(this.variables);
+        child.workingDirectory = this.workingDirectory;
+        child.lastExitCode = this.lastExitCode;
+        return child;
+    }
 }

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -23,6 +23,7 @@ import org.jline.reader.impl.completer.SystemCompleter;
 import org.jline.shell.*;
 import org.jline.shell.Pipeline.Operator;
 import org.jline.terminal.Terminal;
+import org.jline.utils.NonBlockingPumpInputStream;
 
 /**
  * Default implementation of {@link CommandDispatcher} that supports pipeline execution.
@@ -250,157 +251,356 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         Object lastResult = null;
         String lastOutput = null;
 
-        for (int i = 0; i < stages.size(); i++) {
-            Pipeline.Stage stage = stages.get(i);
-            String cmdLine = stage.commandLine();
-
-            if (cmdLine == null || cmdLine.trim().isEmpty()) {
-                continue;
+        int i = 0;
+        while (i < stages.size()) {
+            // Identify pipe group: consecutive stages connected by PIPE
+            int groupStart = i;
+            while (i < stages.size() - 1 && stages.get(i).operator() == Operator.PIPE) {
+                i++;
             }
+            int groupEnd = i;
+            i++;
 
-            // Determine if this stage should be skipped based on previous operator and exit code
-            if (i > 0) {
-                Operator prevOp = stages.get(i - 1).operator();
+            // Skip based on previous group's trailing operator
+            if (groupStart > 0) {
+                Operator prevOp = stages.get(groupStart - 1).operator();
                 if (prevOp == Operator.AND && session.lastExitCode() != 0) {
-                    // AND: skip if previous failed
                     continue;
                 }
                 if (prevOp == Operator.OR && session.lastExitCode() == 0) {
-                    // OR: skip if previous succeeded
                     continue;
                 }
             }
 
-            // Parse command name and args
-            String[] parts = cmdLine.trim().split("\\s+", 2);
-            String cmdName = parts[0];
-            String argsStr = parts.length > 1 ? parts[1] : "";
-
-            // Handle pipe input: prepend to args
-            if (lastOutput != null && i > 0) {
-                Pipeline.Stage prevStage = stages.get(i - 1);
-                if (prevStage.operator() == Operator.PIPE) {
-                    // For pipe, we pass input via session variable
-                    session.put("_pipe_input", lastOutput);
-                } else if (prevStage.operator() == Operator.FLIP) {
-                    // For flip, append output as argument
-                    argsStr = argsStr.isEmpty() ? lastOutput.trim() : argsStr + " " + lastOutput.trim();
-                }
+            // FLIP: previous output becomes arguments for first stage
+            String flipArgs = null;
+            if (groupStart > 0 && stages.get(groupStart - 1).operator() == Operator.FLIP && lastOutput != null) {
+                flipArgs = lastOutput.trim();
             }
 
-            Command cmd = findCommand(cmdName);
-            if (cmd == null) {
-                throw new IllegalArgumentException("Unknown command: " + cmdName);
-            }
+            int groupSize = groupEnd - groupStart + 1;
+            Pipeline.Stage lastGroupStage = stages.get(groupEnd);
+            Operator lastGroupOp = lastGroupStage.operator();
 
-            String[] args = argsStr.isEmpty() ? new String[0] : argsStr.split("\\s+");
+            if (groupSize > 1) {
+                // Multi-stage concurrent pipe group
+                Object[] result = executePipeGroup(stages.subList(groupStart, groupEnd + 1), flipArgs);
+                lastResult = result[0];
+                lastOutput = (String) result[1];
+            } else {
+                // Single-stage execution
+                Pipeline.Stage stage = stages.get(groupStart);
+                String cmdLine = stage.commandLine();
 
-            // Subcommand routing: check if first arg matches a subcommand
-            if (args.length > 0 && !cmd.subcommands().isEmpty()) {
-                Command sub = cmd.subcommands().get(args[0]);
-                if (sub != null) {
-                    cmd = sub;
-                    args = Arrays.copyOfRange(args, 1, args.length);
-                }
-            }
-
-            // Handle input redirection
-            InputStream originalIn = session.in();
-            boolean inputRedirected = false;
-            if (stage.inputSource() != null) {
-                byte[] inputBytes = Files.readAllBytes(stage.inputSource());
-                session.setIn(new ByteArrayInputStream(inputBytes));
-                inputRedirected = true;
-            }
-
-            // If this stage pipes into the next, capture stdout instead of printing to terminal
-            Operator op = stage.operator();
-            boolean captureOutput = (op == Operator.PIPE || op == Operator.FLIP);
-
-            // For stderr/combined redirect, we redirect streams before execution
-            PrintStream originalOut = session.out();
-            PrintStream originalErr = session.err();
-            ByteArrayOutputStream capture = null;
-            boolean stderrRedirected = false;
-
-            if (captureOutput) {
-                capture = new ByteArrayOutputStream();
-                session.setOut(new PrintStream(capture));
-            } else if (op == Operator.STDERR_REDIRECT && stage.redirectTarget() != null) {
-                OutputStream errFile = Files.newOutputStream(
-                        stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-                session.setErr(new PrintStream(errFile));
-                stderrRedirected = true;
-            } else if (op == Operator.COMBINED_REDIRECT && stage.redirectTarget() != null) {
-                OutputStream combinedFile = Files.newOutputStream(
-                        stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-                PrintStream combinedStream = new PrintStream(combinedFile);
-                session.setOut(combinedStream);
-                session.setErr(combinedStream);
-                stderrRedirected = true;
-            }
-
-            try {
-                lastResult = cmd.execute(session, args);
-                if (captureOutput) {
-                    session.out().flush();
-                    String captured = capture.toString().trim();
-                    lastOutput = captured.isEmpty() ? (lastResult != null ? lastResult.toString() : null) : captured;
-                } else {
-                    lastOutput = lastResult != null ? lastResult.toString() : null;
-                }
-                session.setLastExitCode(0);
-            } catch (Exception e) {
-                session.setLastExitCode(1);
-                lastResult = null;
-                lastOutput = null;
-
-                // For conditionals and sequence, swallow the exception and continue
-                if (op == Operator.AND || op == Operator.OR || op == Operator.SEQUENCE) {
+                if (cmdLine == null || cmdLine.trim().isEmpty()) {
                     continue;
                 }
-                throw e;
-            } finally {
+
+                // Parse command name and args
+                String[] parts = cmdLine.trim().split("\\s+", 2);
+                String cmdName = parts[0];
+                String argsStr = parts.length > 1 ? parts[1] : "";
+
+                // Handle FLIP args from previous group
+                if (flipArgs != null) {
+                    argsStr = argsStr.isEmpty() ? flipArgs : argsStr + " " + flipArgs;
+                }
+
+                Command cmd = findCommand(cmdName);
+                if (cmd == null) {
+                    throw new IllegalArgumentException("Unknown command: " + cmdName);
+                }
+
+                String[] args = argsStr.isEmpty() ? new String[0] : argsStr.split("\\s+");
+
+                // Subcommand routing: check if first arg matches a subcommand
+                if (args.length > 0 && !cmd.subcommands().isEmpty()) {
+                    Command sub = cmd.subcommands().get(args[0]);
+                    if (sub != null) {
+                        cmd = sub;
+                        args = Arrays.copyOfRange(args, 1, args.length);
+                    }
+                }
+
+                // Handle input redirection
+                InputStream originalIn = session.in();
+                boolean inputRedirected = false;
+                if (stage.inputSource() != null) {
+                    byte[] inputBytes = Files.readAllBytes(stage.inputSource());
+                    session.setIn(new ByteArrayInputStream(inputBytes));
+                    inputRedirected = true;
+                }
+
+                // If this stage pipes into the next, capture stdout instead of printing to terminal
+                Operator op = stage.operator();
+                boolean captureOutput = (op == Operator.PIPE || op == Operator.FLIP);
+
+                // For stderr/combined redirect, we redirect streams before execution
+                PrintStream originalOut = session.out();
+                PrintStream originalErr = session.err();
+                ByteArrayOutputStream capture = null;
+                boolean stderrRedirected = false;
+
                 if (captureOutput) {
-                    session.setOut(originalOut);
+                    capture = new ByteArrayOutputStream();
+                    session.setOut(new PrintStream(capture));
+                } else if (op == Operator.STDERR_REDIRECT && stage.redirectTarget() != null) {
+                    OutputStream errFile = Files.newOutputStream(
+                            stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                    session.setErr(new PrintStream(errFile));
+                    stderrRedirected = true;
+                } else if (op == Operator.COMBINED_REDIRECT && stage.redirectTarget() != null) {
+                    OutputStream combinedFile = Files.newOutputStream(
+                            stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                    PrintStream combinedStream = new PrintStream(combinedFile);
+                    session.setOut(combinedStream);
+                    session.setErr(combinedStream);
+                    stderrRedirected = true;
                 }
-                if (stderrRedirected) {
-                    session.out().flush();
-                    session.err().flush();
-                    session.setOut(originalOut);
-                    session.setErr(originalErr);
-                }
-                if (inputRedirected) {
-                    session.setIn(originalIn);
+
+                try {
+                    lastResult = cmd.execute(session, args);
+                    if (captureOutput) {
+                        session.out().flush();
+                        String captured = capture.toString().trim();
+                        lastOutput =
+                                captured.isEmpty() ? (lastResult != null ? lastResult.toString() : null) : captured;
+                    } else {
+                        lastOutput = lastResult != null ? lastResult.toString() : null;
+                    }
+                    session.setLastExitCode(0);
+                } catch (Exception e) {
+                    session.setLastExitCode(1);
+                    lastResult = null;
+                    lastOutput = null;
+
+                    // For conditionals and sequence, swallow the exception and continue
+                    if (op == Operator.AND || op == Operator.OR || op == Operator.SEQUENCE) {
+                        continue;
+                    }
+                    throw e;
+                } finally {
+                    if (captureOutput) {
+                        session.setOut(originalOut);
+                    }
+                    if (stderrRedirected) {
+                        session.out().flush();
+                        session.err().flush();
+                        session.setOut(originalOut);
+                        session.setErr(originalErr);
+                    }
+                    if (inputRedirected) {
+                        session.setIn(originalIn);
+                    }
                 }
             }
 
-            // Handle redirect/append
-            if (op == Operator.REDIRECT || op == Operator.APPEND) {
-                if (stage.redirectTarget() != null && lastOutput != null) {
-                    if (op == Operator.APPEND) {
+            // Post-execution: handle redirect/append for the last stage of the group
+            if (lastGroupOp == Operator.REDIRECT || lastGroupOp == Operator.APPEND) {
+                if (lastGroupStage.redirectTarget() != null && lastOutput != null) {
+                    if (lastGroupOp == Operator.APPEND) {
                         Files.writeString(
-                                stage.redirectTarget(),
+                                lastGroupStage.redirectTarget(),
                                 lastOutput + System.lineSeparator(),
                                 StandardOpenOption.CREATE,
                                 StandardOpenOption.APPEND);
                     } else {
-                        Files.writeString(stage.redirectTarget(), lastOutput + System.lineSeparator());
+                        Files.writeString(lastGroupStage.redirectTarget(), lastOutput + System.lineSeparator());
                     }
                     lastResult = null;
                     lastOutput = null;
                 }
-            } else if (op == Operator.STDERR_REDIRECT || op == Operator.COMBINED_REDIRECT) {
-                // Already handled above via stream redirection
+            } else if (lastGroupOp == Operator.STDERR_REDIRECT || lastGroupOp == Operator.COMBINED_REDIRECT) {
                 lastResult = null;
                 lastOutput = null;
-            } else if (op == Operator.SEQUENCE) {
-                // Sequence: always continue, reset output for next independent command
+            } else if (lastGroupOp == Operator.SEQUENCE) {
                 lastOutput = null;
             }
         }
 
         return lastResult;
+    }
+
+    /**
+     * Executes a group of stages connected by PIPE operators concurrently with streaming I/O.
+     * <p>
+     * Stages are connected via {@link PipePumpInputStream} pairs. Producer stages (all but
+     * the last) run in separate threads. The last stage runs in the current thread. When a
+     * producer finishes, closing its output stream signals EOF to the downstream consumer.
+     *
+     * @param groupStages the stages in the pipe group (size &gt; 1)
+     * @param flipArgs arguments from a preceding FLIP operator, or null
+     * @return a two-element array: {@code [result, output]} from the last stage
+     * @throws Exception if the last stage fails and the error should propagate
+     */
+    private Object[] executePipeGroup(List<Pipeline.Stage> groupStages, String flipArgs) throws Exception {
+        int n = groupStages.size();
+        Pipeline.Stage lastGroupStage = groupStages.get(n - 1);
+        Operator lastGroupOp = lastGroupStage.operator();
+
+        // Create N-1 pump connections between stages
+        PipePumpInputStream[] pumps = new PipePumpInputStream[n - 1];
+        for (int p = 0; p < n - 1; p++) {
+            pumps[p] = new PipePumpInputStream();
+        }
+
+        // Resolve commands and arguments for all stages
+        Command[] commands = new Command[n];
+        String[][] argsArrays = new String[n][];
+        for (int s = 0; s < n; s++) {
+            Pipeline.Stage stage = groupStages.get(s);
+            String cmdLine = stage.commandLine();
+            if (cmdLine == null || cmdLine.trim().isEmpty()) {
+                closePumps(pumps);
+                throw new IllegalArgumentException("Empty command in pipeline");
+            }
+
+            String[] parts = cmdLine.trim().split("\\s+", 2);
+            String cmdName = parts[0];
+            String argsStr = parts.length > 1 ? parts[1] : "";
+
+            // FLIP args apply to the first stage only
+            if (s == 0 && flipArgs != null) {
+                argsStr = argsStr.isEmpty() ? flipArgs : argsStr + " " + flipArgs;
+            }
+
+            Command cmd = findCommand(cmdName);
+            if (cmd == null) {
+                closePumps(pumps);
+                throw new IllegalArgumentException("Unknown command: " + cmdName);
+            }
+
+            String[] cmdArgs = argsStr.isEmpty() ? new String[0] : argsStr.split("\\s+");
+            if (cmdArgs.length > 0 && !cmd.subcommands().isEmpty()) {
+                Command sub = cmd.subcommands().get(cmdArgs[0]);
+                if (sub != null) {
+                    cmd = sub;
+                    cmdArgs = Arrays.copyOfRange(cmdArgs, 1, cmdArgs.length);
+                }
+            }
+
+            commands[s] = cmd;
+            argsArrays[s] = cmdArgs;
+        }
+
+        // Set up first stage input
+        InputStream firstIn = session.in();
+        Pipeline.Stage firstStage = groupStages.get(0);
+        if (firstStage.inputSource() != null) {
+            firstIn = new ByteArrayInputStream(Files.readAllBytes(firstStage.inputSource()));
+        }
+
+        // Set up last stage output and error
+        boolean captureLastOutput = (lastGroupOp == Operator.PIPE || lastGroupOp == Operator.FLIP);
+        ByteArrayOutputStream lastCapture = captureLastOutput ? new ByteArrayOutputStream() : null;
+        PrintStream lastOut = captureLastOutput ? new PrintStream(lastCapture) : session.out();
+        PrintStream lastErr = session.err();
+        boolean lastStderrRedirected = false;
+        if (lastGroupOp == Operator.STDERR_REDIRECT && lastGroupStage.redirectTarget() != null) {
+            OutputStream errFile = Files.newOutputStream(
+                    lastGroupStage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            lastErr = new PrintStream(errFile);
+            lastStderrRedirected = true;
+        } else if (lastGroupOp == Operator.COMBINED_REDIRECT && lastGroupStage.redirectTarget() != null) {
+            OutputStream combinedFile = Files.newOutputStream(
+                    lastGroupStage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            PrintStream combinedStream = new PrintStream(combinedFile);
+            lastOut = combinedStream;
+            lastErr = combinedStream;
+            lastStderrRedirected = true;
+        }
+
+        // Create per-stage sessions with wired I/O
+        CommandSession[] stageSessions = new CommandSession[n];
+        for (int s = 0; s < n; s++) {
+            InputStream stageIn;
+            PrintStream stageOut;
+            PrintStream stageErr = session.err();
+
+            if (s == 0) {
+                stageIn = firstIn;
+                stageOut = new PrintStream(pumps[0].getOutputStream(), true);
+            } else if (s == n - 1) {
+                stageIn = pumps[n - 2];
+                stageOut = lastOut;
+                stageErr = lastErr;
+            } else {
+                stageIn = pumps[s - 1];
+                stageOut = new PrintStream(pumps[s].getOutputStream(), true);
+            }
+
+            // Per-stage input redirect overrides pipe input
+            Pipeline.Stage stage = groupStages.get(s);
+            if (s > 0 && stage.inputSource() != null) {
+                stageIn = new ByteArrayInputStream(Files.readAllBytes(stage.inputSource()));
+            }
+
+            stageSessions[s] = session.fork(stageIn, stageOut, stageErr);
+        }
+
+        // Start producer threads (stages 0..n-2)
+        Thread[] threads = new Thread[n - 1];
+        for (int t = 0; t < n - 1; t++) {
+            final int idx = t;
+            threads[t] = new Thread(() -> {
+                try {
+                    commands[idx].execute(stageSessions[idx], argsArrays[idx]);
+                } catch (Exception ignored) {
+                    // Producer errors are ignored; the pipeline result
+                    // is determined by the last stage (bash semantics).
+                } finally {
+                    stageSessions[idx].out().close();
+                }
+            });
+            threads[t].setDaemon(true);
+            threads[t].start();
+        }
+
+        // Run last stage in current thread
+        Object lastResult;
+        String lastOutput;
+        try {
+            lastResult = commands[n - 1].execute(stageSessions[n - 1], argsArrays[n - 1]);
+            if (captureLastOutput) {
+                stageSessions[n - 1].out().flush();
+                String captured = lastCapture.toString().trim();
+                lastOutput = captured.isEmpty() ? (lastResult != null ? lastResult.toString() : null) : captured;
+            } else {
+                lastOutput = lastResult != null ? lastResult.toString() : null;
+            }
+            session.setLastExitCode(0);
+        } catch (Exception e) {
+            session.setLastExitCode(1);
+            if (lastGroupOp == Operator.AND || lastGroupOp == Operator.OR || lastGroupOp == Operator.SEQUENCE) {
+                lastResult = null;
+                lastOutput = null;
+            } else {
+                throw e;
+            }
+        } finally {
+            // Close all pumps to unblock any stuck producers
+            closePumps(pumps);
+            // Wait for all producer threads to complete
+            for (Thread t : threads) {
+                t.join();
+            }
+            // Flush redirected streams
+            if (lastStderrRedirected) {
+                lastOut.flush();
+                lastErr.flush();
+            }
+        }
+
+        return new Object[] {lastResult, lastOutput};
+    }
+
+    private static void closePumps(PipePumpInputStream[] pumps) {
+        for (PipePumpInputStream pump : pumps) {
+            try {
+                pump.close();
+            } catch (IOException ignored) {
+            }
+        }
     }
 
     @Override
@@ -534,6 +734,25 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             }
         }
         return true;
+    }
+
+    /**
+     * A {@link NonBlockingPumpInputStream} subclass that allows draining buffered data
+     * after the write side is closed.
+     * <p>
+     * The base class's {@code checkClosed()} throws {@link org.jline.utils.ClosedException}
+     * in strict mode (default in JLine 4.x), which prevents reading data that is still
+     * buffered when the producer closes the stream. This override lets {@code wait()} handle
+     * the closed state correctly: it returns available data first, then EOF once the buffer
+     * is empty and the stream is closed.
+     */
+    private static class PipePumpInputStream extends NonBlockingPumpInputStream {
+        @Override
+        protected void checkClosed() throws IOException {
+            // Allow reads on a closed pump so buffered data can be drained.
+            // The internal wait() method returns data when the read buffer has
+            // remaining bytes, or EOF once the buffer is empty and closed is true.
+        }
     }
 
     @Override

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -144,17 +144,6 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
     }
 
     @Override
-    public Command findCommand(String name) {
-        for (CommandGroup group : groups) {
-            Command cmd = group.command(name);
-            if (cmd != null) {
-                return cmd;
-            }
-        }
-        return null;
-    }
-
-    @Override
     public Object execute(String line) throws Exception {
         if (line == null || line.trim().isEmpty()) {
             return null;
@@ -658,16 +647,12 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
      * Waits for all producer threads to complete, handling interruption gracefully.
      */
     private static void joinProducers(Thread[] threads) {
-        boolean interrupted = false;
         for (Thread t : threads) {
             try {
                 t.join();
             } catch (InterruptedException e) {
-                interrupted = true;
+                Thread.currentThread().interrupt();
             }
-        }
-        if (interrupted) {
-            Thread.currentThread().interrupt();
         }
     }
 
@@ -678,13 +663,15 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         if (redirectStream != null) {
             try {
                 redirectStream.close();
-            } catch (IOException ignored) {
+            } catch (IOException e) {
+                // Best-effort cleanup; the command already completed
             }
         }
         for (InputStream is : inputRedirects) {
             try {
                 is.close();
-            } catch (IOException ignored) {
+            } catch (IOException e) {
+                // Best-effort cleanup; the command already completed
             }
         }
     }
@@ -693,7 +680,8 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         for (PipePumpInputStream pump : pumps) {
             try {
                 pump.close();
-            } catch (IOException ignored) {
+            } catch (IOException e) {
+                // Best-effort cleanup; unblocking stuck producers is the priority
             }
         }
     }

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -806,7 +806,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
     /**
      * No-op default implementation; does nothing.
      *
-     * Subclasses may override to release or close allocated resources. 
+     * Subclasses may override to release or close allocated resources.
      */
     @Override
     public void close() {

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -337,38 +337,48 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
 
                 // Handle input redirection
                 InputStream originalIn = session.in();
-                boolean inputRedirected = false;
+                InputStream inputRedirect = null;
                 if (stage.inputSource() != null) {
-                    byte[] inputBytes = Files.readAllBytes(stage.inputSource());
-                    session.setIn(new ByteArrayInputStream(inputBytes));
-                    inputRedirected = true;
+                    inputRedirect = Files.newInputStream(stage.inputSource());
+                    session.setIn(inputRedirect);
                 }
 
                 // If this stage pipes into the next, capture stdout instead of printing to terminal
                 Operator op = stage.operator();
                 boolean captureOutput = (op == Operator.PIPE || op == Operator.FLIP);
 
-                // For stderr/combined redirect, we redirect streams before execution
+                // Redirect streams before execution
                 PrintStream originalOut = session.out();
                 PrintStream originalErr = session.err();
                 ByteArrayOutputStream capture = null;
-                boolean stderrRedirected = false;
+                OutputStream redirectStream = null;
+                boolean outputRedirected = false;
 
                 if (captureOutput) {
                     capture = new ByteArrayOutputStream();
                     session.setOut(new PrintStream(capture));
+                } else if ((op == Operator.REDIRECT || op == Operator.APPEND) && stage.redirectTarget() != null) {
+                    redirectStream = Files.newOutputStream(
+                            stage.redirectTarget(),
+                            op == Operator.APPEND
+                                    ? new StandardOpenOption[] {StandardOpenOption.CREATE, StandardOpenOption.APPEND}
+                                    : new StandardOpenOption[] {
+                                        StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
+                                    });
+                    session.setOut(new PrintStream(redirectStream));
+                    outputRedirected = true;
                 } else if (op == Operator.STDERR_REDIRECT && stage.redirectTarget() != null) {
-                    OutputStream errFile = Files.newOutputStream(
+                    redirectStream = Files.newOutputStream(
                             stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-                    session.setErr(new PrintStream(errFile));
-                    stderrRedirected = true;
+                    session.setErr(new PrintStream(redirectStream));
+                    outputRedirected = true;
                 } else if (op == Operator.COMBINED_REDIRECT && stage.redirectTarget() != null) {
-                    OutputStream combinedFile = Files.newOutputStream(
+                    redirectStream = Files.newOutputStream(
                             stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-                    PrintStream combinedStream = new PrintStream(combinedFile);
+                    PrintStream combinedStream = new PrintStream(redirectStream);
                     session.setOut(combinedStream);
                     session.setErr(combinedStream);
-                    stderrRedirected = true;
+                    outputRedirected = true;
                 }
 
                 try {
@@ -396,34 +406,27 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                     if (captureOutput) {
                         session.setOut(originalOut);
                     }
-                    if (stderrRedirected) {
+                    if (outputRedirected) {
                         session.out().flush();
                         session.err().flush();
                         session.setOut(originalOut);
                         session.setErr(originalErr);
+                        if (redirectStream != null) {
+                            redirectStream.close();
+                        }
                     }
-                    if (inputRedirected) {
+                    if (inputRedirect != null) {
                         session.setIn(originalIn);
+                        inputRedirect.close();
                     }
                 }
             }
 
-            // Post-execution: handle redirect/append for the last stage of the group
-            if (lastGroupOp == Operator.REDIRECT || lastGroupOp == Operator.APPEND) {
-                if (lastGroupStage.redirectTarget() != null && lastOutput != null) {
-                    if (lastGroupOp == Operator.APPEND) {
-                        Files.writeString(
-                                lastGroupStage.redirectTarget(),
-                                lastOutput + System.lineSeparator(),
-                                StandardOpenOption.CREATE,
-                                StandardOpenOption.APPEND);
-                    } else {
-                        Files.writeString(lastGroupStage.redirectTarget(), lastOutput + System.lineSeparator());
-                    }
-                    lastResult = null;
-                    lastOutput = null;
-                }
-            } else if (lastGroupOp == Operator.STDERR_REDIRECT || lastGroupOp == Operator.COMBINED_REDIRECT) {
+            // Post-execution: update result tracking based on trailing operator
+            if (lastGroupOp == Operator.REDIRECT
+                    || lastGroupOp == Operator.APPEND
+                    || lastGroupOp == Operator.STDERR_REDIRECT
+                    || lastGroupOp == Operator.COMBINED_REDIRECT) {
                 lastResult = null;
                 lastOutput = null;
             } else if (lastGroupOp == Operator.SEQUENCE) {
@@ -499,8 +502,10 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         // Set up first stage input
         InputStream firstIn = session.in();
         Pipeline.Stage firstStage = groupStages.get(0);
+        InputStream inputRedirect = null;
         if (firstStage.inputSource() != null) {
-            firstIn = new ByteArrayInputStream(Files.readAllBytes(firstStage.inputSource()));
+            inputRedirect = Files.newInputStream(firstStage.inputSource());
+            firstIn = inputRedirect;
         }
 
         // Set up last stage output and error
@@ -508,19 +513,26 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         ByteArrayOutputStream lastCapture = captureLastOutput ? new ByteArrayOutputStream() : null;
         PrintStream lastOut = captureLastOutput ? new PrintStream(lastCapture) : session.out();
         PrintStream lastErr = session.err();
-        boolean lastStderrRedirected = false;
-        if (lastGroupOp == Operator.STDERR_REDIRECT && lastGroupStage.redirectTarget() != null) {
-            OutputStream errFile = Files.newOutputStream(
+        OutputStream redirectStream = null;
+        if ((lastGroupOp == Operator.REDIRECT || lastGroupOp == Operator.APPEND)
+                && lastGroupStage.redirectTarget() != null) {
+            redirectStream = Files.newOutputStream(
+                    lastGroupStage.redirectTarget(),
+                    lastGroupOp == Operator.APPEND
+                            ? new StandardOpenOption[] {StandardOpenOption.CREATE, StandardOpenOption.APPEND}
+                            : new StandardOpenOption[] {StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
+                            });
+            lastOut = new PrintStream(redirectStream);
+        } else if (lastGroupOp == Operator.STDERR_REDIRECT && lastGroupStage.redirectTarget() != null) {
+            redirectStream = Files.newOutputStream(
                     lastGroupStage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-            lastErr = new PrintStream(errFile);
-            lastStderrRedirected = true;
+            lastErr = new PrintStream(redirectStream);
         } else if (lastGroupOp == Operator.COMBINED_REDIRECT && lastGroupStage.redirectTarget() != null) {
-            OutputStream combinedFile = Files.newOutputStream(
+            redirectStream = Files.newOutputStream(
                     lastGroupStage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-            PrintStream combinedStream = new PrintStream(combinedFile);
+            PrintStream combinedStream = new PrintStream(redirectStream);
             lastOut = combinedStream;
             lastErr = combinedStream;
-            lastStderrRedirected = true;
         }
 
         // Create per-stage sessions with wired I/O
@@ -545,7 +557,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             // Per-stage input redirect overrides pipe input
             Pipeline.Stage stage = groupStages.get(s);
             if (s > 0 && stage.inputSource() != null) {
-                stageIn = new ByteArrayInputStream(Files.readAllBytes(stage.inputSource()));
+                stageIn = Files.newInputStream(stage.inputSource());
             }
 
             stageSessions[s] = session.fork(stageIn, stageOut, stageErr);
@@ -597,10 +609,15 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             for (Thread t : threads) {
                 t.join();
             }
-            // Flush redirected streams
-            if (lastStderrRedirected) {
+            // Close redirected output stream
+            if (redirectStream != null) {
                 lastOut.flush();
                 lastErr.flush();
+                redirectStream.close();
+            }
+            // Close redirected input stream
+            if (inputRedirect != null) {
+                inputRedirect.close();
             }
         }
 

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -332,37 +332,25 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 PrintStream originalErr = session.err();
                 ByteArrayOutputStream capture = null;
                 OutputStream redirectStream = null;
-                boolean outputRedirected = false;
 
                 if (captureOutput) {
                     capture = new ByteArrayOutputStream();
                     session.setOut(new PrintStream(capture));
-                } else if ((op == Operator.REDIRECT || op == Operator.APPEND) && stage.redirectTarget() != null) {
-                    redirectStream = openRedirectStream(op, stage.redirectTarget());
-                    session.setOut(new PrintStream(redirectStream));
-                    outputRedirected = true;
-                } else if (op == Operator.STDERR_REDIRECT && stage.redirectTarget() != null) {
-                    redirectStream = openRedirectStream(op, stage.redirectTarget());
-                    session.setErr(new PrintStream(redirectStream));
-                    outputRedirected = true;
-                } else if (op == Operator.COMBINED_REDIRECT && stage.redirectTarget() != null) {
-                    redirectStream = openRedirectStream(op, stage.redirectTarget());
-                    PrintStream combinedStream = new PrintStream(redirectStream);
-                    session.setOut(combinedStream);
-                    session.setErr(combinedStream);
-                    outputRedirected = true;
+                } else {
+                    PrintStream[] outErr = {originalOut, originalErr};
+                    redirectStream = setupRedirectStreams(op, stage.redirectTarget(), outErr);
+                    if (redirectStream != null) {
+                        session.setOut(outErr[0]);
+                        session.setErr(outErr[1]);
+                    }
                 }
 
                 try {
                     lastResult = cmd.execute(session, args);
                     if (captureOutput) {
                         session.out().flush();
-                        String captured = capture.toString().trim();
-                        lastOutput =
-                                captured.isEmpty() ? (lastResult != null ? lastResult.toString() : null) : captured;
-                    } else {
-                        lastOutput = lastResult != null ? lastResult.toString() : null;
                     }
+                    lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
                     session.setLastExitCode(0);
                 } catch (Exception e) {
                     session.setLastExitCode(1);
@@ -375,17 +363,10 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                     }
                     throw e;
                 } finally {
-                    if (captureOutput) {
-                        session.setOut(originalOut);
-                    }
-                    if (outputRedirected) {
-                        session.out().flush();
-                        session.err().flush();
-                        session.setOut(originalOut);
-                        session.setErr(originalErr);
-                        if (redirectStream != null) {
-                            redirectStream.close();
-                        }
+                    session.setOut(originalOut);
+                    session.setErr(originalErr);
+                    if (redirectStream != null) {
+                        redirectStream.close();
                     }
                     if (inputRedirect != null) {
                         session.setIn(originalIn);
@@ -435,14 +416,71 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         // Resolve commands and arguments for all stages
         Command[] commands = new Command[n];
         String[][] argsArrays = new String[n][];
-        for (int s = 0; s < n; s++) {
-            Pipeline.Stage stage = groupStages.get(s);
-            String cmdLine = stage.commandLine();
+        resolveAllCommands(groupStages, flipArgs, pumps, commands, argsArrays);
+
+        // Set up input redirects (tracked for cleanup)
+        List<InputStream> inputRedirects = new ArrayList<>();
+        InputStream firstIn = setupInputRedirect(groupStages.get(0), session.in(), inputRedirects);
+
+        // Set up last stage output/error redirection
+        boolean captureLastOutput = (lastGroupOp == Operator.PIPE || lastGroupOp == Operator.FLIP);
+        ByteArrayOutputStream lastCapture = captureLastOutput ? new ByteArrayOutputStream() : null;
+        PrintStream[] outErr = {captureLastOutput ? new PrintStream(lastCapture) : session.out(), session.err()};
+        OutputStream redirectStream =
+                captureLastOutput ? null : setupRedirectStreams(lastGroupOp, lastGroupStage.redirectTarget(), outErr);
+
+        // Create per-stage sessions and start producer threads
+        CommandSession[] stageSessions =
+                createStageSessions(groupStages, pumps, firstIn, outErr[0], outErr[1], inputRedirects);
+        Thread[] threads = startProducers(commands, stageSessions, argsArrays);
+
+        // Run last stage in current thread
+        Object lastResult;
+        String lastOutput;
+        try {
+            lastResult = commands[n - 1].execute(stageSessions[n - 1], argsArrays[n - 1]);
+            if (captureLastOutput) {
+                stageSessions[n - 1].out().flush();
+            }
+            lastOutput = resolveOutputString(captureLastOutput ? lastCapture : null, lastResult);
+            session.setLastExitCode(0);
+        } catch (Exception e) {
+            session.setLastExitCode(1);
+            if (lastGroupOp == Operator.AND || lastGroupOp == Operator.OR || lastGroupOp == Operator.SEQUENCE) {
+                lastResult = null;
+                lastOutput = null;
+            } else {
+                throw e;
+            }
+        } finally {
+            closePumps(pumps);
+            joinProducers(threads);
+            if (redirectStream != null) {
+                outErr[0].flush();
+                outErr[1].flush();
+            }
+            closeStreams(redirectStream, inputRedirects);
+        }
+
+        return new Object[] {lastResult, lastOutput};
+    }
+
+    /**
+     * Resolves commands and arguments for all stages in a pipe group.
+     * On failure, closes pumps before throwing.
+     */
+    private void resolveAllCommands(
+            List<Pipeline.Stage> groupStages,
+            String flipArgs,
+            PipePumpInputStream[] pumps,
+            Command[] commands,
+            String[][] argsArrays) {
+        for (int s = 0; s < groupStages.size(); s++) {
+            String cmdLine = groupStages.get(s).commandLine();
             if (cmdLine == null || cmdLine.trim().isEmpty()) {
                 closePumps(pumps);
                 throw new IllegalArgumentException("Empty command in pipeline");
             }
-
             try {
                 Object[] resolved = resolveCommand(cmdLine, s == 0 ? flipArgs : null);
                 commands[s] = (Command) resolved[0];
@@ -452,37 +490,34 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 throw e;
             }
         }
+    }
 
-        // Set up first stage input
-        InputStream firstIn = session.in();
-        Pipeline.Stage firstStage = groupStages.get(0);
-        InputStream inputRedirect = null;
-        if (firstStage.inputSource() != null) {
-            inputRedirect = Files.newInputStream(firstStage.inputSource());
-            firstIn = inputRedirect;
+    /**
+     * Sets up input redirection for a stage, tracking the opened stream for cleanup.
+     * Returns the redirect stream if the stage has an input source, or the default otherwise.
+     */
+    private static InputStream setupInputRedirect(
+            Pipeline.Stage stage, InputStream defaultIn, List<InputStream> inputRedirects) throws IOException {
+        if (stage.inputSource() != null) {
+            InputStream redirect = Files.newInputStream(stage.inputSource());
+            inputRedirects.add(redirect);
+            return redirect;
         }
+        return defaultIn;
+    }
 
-        // Set up last stage output and error
-        boolean captureLastOutput = (lastGroupOp == Operator.PIPE || lastGroupOp == Operator.FLIP);
-        ByteArrayOutputStream lastCapture = captureLastOutput ? new ByteArrayOutputStream() : null;
-        PrintStream lastOut = captureLastOutput ? new PrintStream(lastCapture) : session.out();
-        PrintStream lastErr = session.err();
-        OutputStream redirectStream = null;
-        if ((lastGroupOp == Operator.REDIRECT || lastGroupOp == Operator.APPEND)
-                && lastGroupStage.redirectTarget() != null) {
-            redirectStream = openRedirectStream(lastGroupOp, lastGroupStage.redirectTarget());
-            lastOut = new PrintStream(redirectStream);
-        } else if (lastGroupOp == Operator.STDERR_REDIRECT && lastGroupStage.redirectTarget() != null) {
-            redirectStream = openRedirectStream(lastGroupOp, lastGroupStage.redirectTarget());
-            lastErr = new PrintStream(redirectStream);
-        } else if (lastGroupOp == Operator.COMBINED_REDIRECT && lastGroupStage.redirectTarget() != null) {
-            redirectStream = openRedirectStream(lastGroupOp, lastGroupStage.redirectTarget());
-            PrintStream combinedStream = new PrintStream(redirectStream);
-            lastOut = combinedStream;
-            lastErr = combinedStream;
-        }
-
-        // Create per-stage sessions with wired I/O
+    /**
+     * Creates per-stage sessions with wired I/O for a pipe group.
+     */
+    private CommandSession[] createStageSessions(
+            List<Pipeline.Stage> groupStages,
+            PipePumpInputStream[] pumps,
+            InputStream firstIn,
+            PrintStream lastOut,
+            PrintStream lastErr,
+            List<InputStream> inputRedirects)
+            throws IOException {
+        int n = groupStages.size();
         CommandSession[] stageSessions = new CommandSession[n];
         for (int s = 0; s < n; s++) {
             InputStream stageIn;
@@ -501,18 +536,22 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 stageOut = new PrintStream(pumps[s].getOutputStream(), true);
             }
 
-            // Per-stage input redirect overrides pipe input
-            Pipeline.Stage stage = groupStages.get(s);
-            if (s > 0 && stage.inputSource() != null) {
-                stageIn = Files.newInputStream(stage.inputSource());
+            // Per-stage input redirect overrides pipe input (non-first stages)
+            if (s > 0) {
+                stageIn = setupInputRedirect(groupStages.get(s), stageIn, inputRedirects);
             }
 
             stageSessions[s] = session.fork(stageIn, stageOut, stageErr);
         }
+        return stageSessions;
+    }
 
-        // Start producer threads (stages 0..n-2)
-        Thread[] threads = new Thread[n - 1];
-        for (int t = 0; t < n - 1; t++) {
+    /**
+     * Creates and starts producer threads for all stages except the last.
+     */
+    private static Thread[] startProducers(Command[] commands, CommandSession[] stageSessions, String[][] argsArrays) {
+        Thread[] threads = new Thread[commands.length - 1];
+        for (int t = 0; t < threads.length; t++) {
             final int idx = t;
             threads[t] = new Thread(() -> {
                 try {
@@ -527,55 +566,53 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             threads[t].setDaemon(true);
             threads[t].start();
         }
-
-        // Run last stage in current thread
-        Object lastResult;
-        String lastOutput;
-        try {
-            lastResult = commands[n - 1].execute(stageSessions[n - 1], argsArrays[n - 1]);
-            if (captureLastOutput) {
-                stageSessions[n - 1].out().flush();
-                String captured = lastCapture.toString().trim();
-                lastOutput = captured.isEmpty() ? (lastResult != null ? lastResult.toString() : null) : captured;
-            } else {
-                lastOutput = lastResult != null ? lastResult.toString() : null;
-            }
-            session.setLastExitCode(0);
-        } catch (Exception e) {
-            session.setLastExitCode(1);
-            if (lastGroupOp == Operator.AND || lastGroupOp == Operator.OR || lastGroupOp == Operator.SEQUENCE) {
-                lastResult = null;
-                lastOutput = null;
-            } else {
-                throw e;
-            }
-        } finally {
-            // Close all pumps to unblock any stuck producers
-            closePumps(pumps);
-            // Wait for all producer threads to complete
-            for (Thread t : threads) {
-                t.join();
-            }
-            // Close redirected output stream
-            if (redirectStream != null) {
-                lastOut.flush();
-                lastErr.flush();
-                redirectStream.close();
-            }
-            // Close redirected input stream
-            if (inputRedirect != null) {
-                inputRedirect.close();
-            }
-        }
-
-        return new Object[] {lastResult, lastOutput};
+        return threads;
     }
 
     /**
-     * Closes the given array of PipePumpInputStream instances, suppressing any IOException thrown by individual closes.
+     * Configures output/error redirect streams based on the operator.
+     * If a redirect applies, the corresponding entry in {@code outErr} is replaced.
      *
-     * @param pumps the pumps to close
+     * @return the underlying redirect OutputStream (caller must close), or null if no redirect
      */
+    private static OutputStream setupRedirectStreams(Operator op, Path target, PrintStream[] outErr)
+            throws IOException {
+        if (target == null) {
+            return null;
+        }
+        OutputStream rs = openRedirectStream(op, target);
+        switch (op) {
+            case REDIRECT:
+            case APPEND:
+                outErr[0] = new PrintStream(rs);
+                return rs;
+            case STDERR_REDIRECT:
+                outErr[1] = new PrintStream(rs);
+                return rs;
+            case COMBINED_REDIRECT:
+                PrintStream combined = new PrintStream(rs);
+                outErr[0] = combined;
+                outErr[1] = combined;
+                return rs;
+            default:
+                rs.close();
+                return null;
+        }
+    }
+
+    /**
+     * Extracts the output string from a captured stream or command result.
+     */
+    private static String resolveOutputString(ByteArrayOutputStream capture, Object result) {
+        if (capture != null) {
+            String captured = capture.toString().trim();
+            if (!captured.isEmpty()) {
+                return captured;
+            }
+        }
+        return result != null ? result.toString() : null;
+    }
+
     /**
      * Parses a command line, resolves the command and any subcommand, and applies
      * optional flip arguments. Returns a two-element array: {@code [Command, String[]]}.
@@ -615,6 +652,41 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             return Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
         }
         return Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    /**
+     * Waits for all producer threads to complete, handling interruption gracefully.
+     */
+    private static void joinProducers(Thread[] threads) {
+        boolean interrupted = false;
+        for (Thread t : threads) {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Closes redirect and input streams, suppressing IOExceptions.
+     */
+    private static void closeStreams(OutputStream redirectStream, List<InputStream> inputRedirects) {
+        if (redirectStream != null) {
+            try {
+                redirectStream.close();
+            } catch (IOException ignored) {
+            }
+        }
+        for (InputStream is : inputRedirects) {
+            try {
+                is.close();
+            } catch (IOException ignored) {
+            }
+        }
     }
 
     private static void closePumps(PipePumpInputStream[] pumps) {

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -246,6 +246,19 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         }
     }
 
+    /**
+     * Execute the pipeline's stages, honoring pipes, conditional operators, FLIP semantics,
+     * redirections (redirect/append/stderr/combined), and sequencing.
+     *
+     * <p>Stages connected by PIPE are grouped and executed as a concurrent pipeline; single-stage
+     * stages are executed inline. The method updates the session's last exit code, applies
+     * FLIP by passing trimmed previous output as arguments to the first stage of the next group,
+     * captures or redirects stdout/stderr as required, and applies redirect/append targets
+     * after a group's execution when present.</p>
+     *
+     * @return the result object produced by the last executed stage, or `null` if no result was produced
+     * @throws Exception if execution or I/O fails and the error is not suppressed by conditional operators
+     */
     private Object doExecutePipelineStages(Pipeline pipeline) throws Exception {
         List<Pipeline.Stage> stages = pipeline.stages();
         Object lastResult = null;
@@ -594,6 +607,11 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         return new Object[] {lastResult, lastOutput};
     }
 
+    /**
+     * Closes the given array of PipePumpInputStream instances, suppressing any IOException thrown by individual closes.
+     *
+     * @param pumps the pumps to close
+     */
     private static void closePumps(PipePumpInputStream[] pumps) {
         for (PipePumpInputStream pump : pumps) {
             try {
@@ -603,6 +621,14 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         }
     }
 
+    /**
+     * Creates a completer that provides completions for every registered command name and its aliases.
+     *
+     * Builds a SystemCompleter, registers a completer for each command and each of its alias strings, and
+     * finalizes it into a candidate-producing completer.
+     *
+     * @return a Completer that offers argument and command-name completions for all registered commands and aliases
+     */
     @Override
     public Completer completer() {
         SystemCompleter completer = new SystemCompleter();
@@ -704,14 +730,13 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
     }
 
     /**
-     * Checks whether a line is a bare variable assignment ({@code NAME=VALUE}).
-     * <p>
-     * A line is a variable assignment if it contains {@code =} and the part before
-     * it is a valid identifier (letters, digits, underscores, starting with a letter
-     * or underscore). The line must not contain spaces before the {@code =}.
+     * Determines whether a trimmed line is a bare variable assignment of the form NAME=VALUE.
+     *
+     * The name portion must contain no spaces, start with a letter or underscore, and consist only of letters,
+     * digits, or underscores.
      *
      * @param line the trimmed input line
-     * @return true if the line is a variable assignment
+     * @return {@code true} if the line matches `NAME=VALUE` with a valid name, {@code false} otherwise
      */
     private static boolean isVariableAssignment(String line) {
         int eq = line.indexOf('=');
@@ -747,6 +772,12 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
      * is empty and the stream is closed.
      */
     private static class PipePumpInputStream extends NonBlockingPumpInputStream {
+        /**
+         * No-op override that permits reading any buffered bytes after the pump is closed.
+         *
+         * This prevents the stream from enforcing a strict closed state so consumers can
+         * drain remaining data instead of encountering an immediate closed error.
+         */
         @Override
         protected void checkClosed() throws IOException {
             // Allow reads on a closed pump so buffered data can be drained.
@@ -755,6 +786,11 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         }
     }
 
+    /**
+     * No-op default implementation; does nothing.
+     *
+     * Subclasses may override to release or close allocated resources. 
+     */
     @Override
     public void close() {
         // Nothing to close by default

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -10,6 +10,7 @@ package org.jline.shell.impl;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -309,31 +310,10 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                     continue;
                 }
 
-                // Parse command name and args
-                String[] parts = cmdLine.trim().split("\\s+", 2);
-                String cmdName = parts[0];
-                String argsStr = parts.length > 1 ? parts[1] : "";
-
-                // Handle FLIP args from previous group
-                if (flipArgs != null) {
-                    argsStr = argsStr.isEmpty() ? flipArgs : argsStr + " " + flipArgs;
-                }
-
-                Command cmd = findCommand(cmdName);
-                if (cmd == null) {
-                    throw new IllegalArgumentException("Unknown command: " + cmdName);
-                }
-
-                String[] args = argsStr.isEmpty() ? new String[0] : argsStr.split("\\s+");
-
-                // Subcommand routing: check if first arg matches a subcommand
-                if (args.length > 0 && !cmd.subcommands().isEmpty()) {
-                    Command sub = cmd.subcommands().get(args[0]);
-                    if (sub != null) {
-                        cmd = sub;
-                        args = Arrays.copyOfRange(args, 1, args.length);
-                    }
-                }
+                // Resolve command and arguments
+                Object[] resolved = resolveCommand(cmdLine, flipArgs);
+                Command cmd = (Command) resolved[0];
+                String[] args = (String[]) resolved[1];
 
                 // Handle input redirection
                 InputStream originalIn = session.in();
@@ -358,23 +338,15 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                     capture = new ByteArrayOutputStream();
                     session.setOut(new PrintStream(capture));
                 } else if ((op == Operator.REDIRECT || op == Operator.APPEND) && stage.redirectTarget() != null) {
-                    redirectStream = Files.newOutputStream(
-                            stage.redirectTarget(),
-                            op == Operator.APPEND
-                                    ? new StandardOpenOption[] {StandardOpenOption.CREATE, StandardOpenOption.APPEND}
-                                    : new StandardOpenOption[] {
-                                        StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
-                                    });
+                    redirectStream = openRedirectStream(op, stage.redirectTarget());
                     session.setOut(new PrintStream(redirectStream));
                     outputRedirected = true;
                 } else if (op == Operator.STDERR_REDIRECT && stage.redirectTarget() != null) {
-                    redirectStream = Files.newOutputStream(
-                            stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                    redirectStream = openRedirectStream(op, stage.redirectTarget());
                     session.setErr(new PrintStream(redirectStream));
                     outputRedirected = true;
                 } else if (op == Operator.COMBINED_REDIRECT && stage.redirectTarget() != null) {
-                    redirectStream = Files.newOutputStream(
-                            stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                    redirectStream = openRedirectStream(op, stage.redirectTarget());
                     PrintStream combinedStream = new PrintStream(redirectStream);
                     session.setOut(combinedStream);
                     session.setErr(combinedStream);
@@ -471,32 +443,14 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 throw new IllegalArgumentException("Empty command in pipeline");
             }
 
-            String[] parts = cmdLine.trim().split("\\s+", 2);
-            String cmdName = parts[0];
-            String argsStr = parts.length > 1 ? parts[1] : "";
-
-            // FLIP args apply to the first stage only
-            if (s == 0 && flipArgs != null) {
-                argsStr = argsStr.isEmpty() ? flipArgs : argsStr + " " + flipArgs;
-            }
-
-            Command cmd = findCommand(cmdName);
-            if (cmd == null) {
+            try {
+                Object[] resolved = resolveCommand(cmdLine, s == 0 ? flipArgs : null);
+                commands[s] = (Command) resolved[0];
+                argsArrays[s] = (String[]) resolved[1];
+            } catch (IllegalArgumentException e) {
                 closePumps(pumps);
-                throw new IllegalArgumentException("Unknown command: " + cmdName);
+                throw e;
             }
-
-            String[] cmdArgs = argsStr.isEmpty() ? new String[0] : argsStr.split("\\s+");
-            if (cmdArgs.length > 0 && !cmd.subcommands().isEmpty()) {
-                Command sub = cmd.subcommands().get(cmdArgs[0]);
-                if (sub != null) {
-                    cmd = sub;
-                    cmdArgs = Arrays.copyOfRange(cmdArgs, 1, cmdArgs.length);
-                }
-            }
-
-            commands[s] = cmd;
-            argsArrays[s] = cmdArgs;
         }
 
         // Set up first stage input
@@ -516,20 +470,13 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         OutputStream redirectStream = null;
         if ((lastGroupOp == Operator.REDIRECT || lastGroupOp == Operator.APPEND)
                 && lastGroupStage.redirectTarget() != null) {
-            redirectStream = Files.newOutputStream(
-                    lastGroupStage.redirectTarget(),
-                    lastGroupOp == Operator.APPEND
-                            ? new StandardOpenOption[] {StandardOpenOption.CREATE, StandardOpenOption.APPEND}
-                            : new StandardOpenOption[] {StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
-                            });
+            redirectStream = openRedirectStream(lastGroupOp, lastGroupStage.redirectTarget());
             lastOut = new PrintStream(redirectStream);
         } else if (lastGroupOp == Operator.STDERR_REDIRECT && lastGroupStage.redirectTarget() != null) {
-            redirectStream = Files.newOutputStream(
-                    lastGroupStage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            redirectStream = openRedirectStream(lastGroupOp, lastGroupStage.redirectTarget());
             lastErr = new PrintStream(redirectStream);
         } else if (lastGroupOp == Operator.COMBINED_REDIRECT && lastGroupStage.redirectTarget() != null) {
-            redirectStream = Files.newOutputStream(
-                    lastGroupStage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            redirectStream = openRedirectStream(lastGroupOp, lastGroupStage.redirectTarget());
             PrintStream combinedStream = new PrintStream(redirectStream);
             lastOut = combinedStream;
             lastErr = combinedStream;
@@ -629,6 +576,47 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
      *
      * @param pumps the pumps to close
      */
+    /**
+     * Parses a command line, resolves the command and any subcommand, and applies
+     * optional flip arguments. Returns a two-element array: {@code [Command, String[]]}.
+     */
+    private Object[] resolveCommand(String cmdLine, String flipArgs) {
+        String[] parts = cmdLine.trim().split("\\s+", 2);
+        String cmdName = parts[0];
+        String argsStr = parts.length > 1 ? parts[1] : "";
+
+        if (flipArgs != null) {
+            argsStr = argsStr.isEmpty() ? flipArgs : argsStr + " " + flipArgs;
+        }
+
+        Command cmd = findCommand(cmdName);
+        if (cmd == null) {
+            throw new IllegalArgumentException("Unknown command: " + cmdName);
+        }
+
+        String[] args = argsStr.isEmpty() ? new String[0] : argsStr.split("\\s+");
+
+        if (args.length > 0 && !cmd.subcommands().isEmpty()) {
+            Command sub = cmd.subcommands().get(args[0]);
+            if (sub != null) {
+                cmd = sub;
+                args = Arrays.copyOfRange(args, 1, args.length);
+            }
+        }
+
+        return new Object[] {cmd, args};
+    }
+
+    /**
+     * Opens an output stream for a redirect operator.
+     */
+    private static OutputStream openRedirectStream(Operator op, Path target) throws IOException {
+        if (op == Operator.APPEND) {
+            return Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        }
+        return Files.newOutputStream(target, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
     private static void closePumps(PipePumpInputStream[] pumps) {
         for (PipePumpInputStream pump : pumps) {
             try {

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -265,14 +265,8 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             i++;
 
             // Skip based on previous group's trailing operator
-            if (groupStart > 0) {
-                Operator prevOp = stages.get(groupStart - 1).operator();
-                if (prevOp == Operator.AND && session.lastExitCode() != 0) {
-                    continue;
-                }
-                if (prevOp == Operator.OR && session.lastExitCode() == 0) {
-                    continue;
-                }
+            if (shouldSkipGroup(stages, groupStart)) {
+                continue;
             }
 
             // FLIP: previous output becomes arguments for first stage
@@ -295,72 +289,10 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 Pipeline.Stage stage = stages.get(groupStart);
                 String cmdLine = stage.commandLine();
 
-                if (cmdLine == null || cmdLine.trim().isEmpty()) {
-                    continue;
-                }
-
-                // Resolve command and arguments
-                Object[] resolved = resolveCommand(cmdLine, flipArgs);
-                Command cmd = (Command) resolved[0];
-                String[] args = (String[]) resolved[1];
-
-                // Handle input redirection
-                InputStream originalIn = session.in();
-                InputStream inputRedirect = null;
-                if (stage.inputSource() != null) {
-                    inputRedirect = Files.newInputStream(stage.inputSource());
-                    session.setIn(inputRedirect);
-                }
-
-                // If this stage pipes into the next, capture stdout instead of printing to terminal
-                Operator op = stage.operator();
-                boolean captureOutput = (op == Operator.PIPE || op == Operator.FLIP);
-
-                // Redirect streams before execution
-                PrintStream originalOut = session.out();
-                PrintStream originalErr = session.err();
-                ByteArrayOutputStream capture = null;
-                OutputStream redirectStream = null;
-
-                if (captureOutput) {
-                    capture = new ByteArrayOutputStream();
-                    session.setOut(new PrintStream(capture));
-                } else {
-                    PrintStream[] outErr = {originalOut, originalErr};
-                    redirectStream = setupRedirectStreams(op, stage.redirectTarget(), outErr);
-                    if (redirectStream != null) {
-                        session.setOut(outErr[0]);
-                        session.setErr(outErr[1]);
-                    }
-                }
-
-                try {
-                    lastResult = cmd.execute(session, args);
-                    if (captureOutput) {
-                        session.out().flush();
-                    }
-                    lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
-                    session.setLastExitCode(0);
-                } catch (Exception e) {
-                    session.setLastExitCode(1);
-                    lastResult = null;
-                    lastOutput = null;
-
-                    // For conditionals and sequence, swallow the exception and continue
-                    if (op == Operator.AND || op == Operator.OR || op == Operator.SEQUENCE) {
-                        continue;
-                    }
-                    throw e;
-                } finally {
-                    session.setOut(originalOut);
-                    session.setErr(originalErr);
-                    if (redirectStream != null) {
-                        redirectStream.close();
-                    }
-                    if (inputRedirect != null) {
-                        session.setIn(originalIn);
-                        inputRedirect.close();
-                    }
+                if (cmdLine != null && !cmdLine.trim().isEmpty()) {
+                    Object[] stageResult = executeSingleStage(stage, cmdLine, flipArgs);
+                    lastResult = stageResult[0];
+                    lastOutput = (String) stageResult[1];
                 }
             }
 
@@ -377,6 +309,90 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         }
 
         return lastResult;
+    }
+
+    /**
+     * Returns true if the group at {@code groupStart} should be skipped based on the
+     * preceding stage's trailing operator and the last exit code.
+     */
+    private boolean shouldSkipGroup(List<Pipeline.Stage> stages, int groupStart) {
+        if (groupStart <= 0) {
+            return false;
+        }
+        Operator prevOp = stages.get(groupStart - 1).operator();
+        return (prevOp == Operator.AND && session.lastExitCode() != 0)
+                || (prevOp == Operator.OR && session.lastExitCode() == 0);
+    }
+
+    /**
+     * Executes a single pipeline stage, handling I/O redirection and output capture.
+     *
+     * @return a two-element array: {@code [result, output]}
+     */
+    private Object[] executeSingleStage(Pipeline.Stage stage, String cmdLine, String flipArgs) throws Exception {
+        Object[] resolved = resolveCommand(cmdLine, flipArgs);
+        Command cmd = (Command) resolved[0];
+        String[] args = (String[]) resolved[1];
+
+        // Handle input redirection
+        InputStream originalIn = session.in();
+        InputStream inputRedirect = null;
+        if (stage.inputSource() != null) {
+            inputRedirect = Files.newInputStream(stage.inputSource());
+            session.setIn(inputRedirect);
+        }
+
+        // If this stage pipes into the next, capture stdout instead of printing to terminal
+        Operator op = stage.operator();
+        boolean captureOutput = (op == Operator.PIPE || op == Operator.FLIP);
+
+        // Redirect streams before execution
+        PrintStream originalOut = session.out();
+        PrintStream originalErr = session.err();
+        ByteArrayOutputStream capture = null;
+        OutputStream redirectStream = null;
+
+        if (captureOutput) {
+            capture = new ByteArrayOutputStream();
+            session.setOut(new PrintStream(capture));
+        } else {
+            PrintStream[] outErr = {originalOut, originalErr};
+            redirectStream = setupRedirectStreams(op, stage.redirectTarget(), outErr);
+            if (redirectStream != null) {
+                session.setOut(outErr[0]);
+                session.setErr(outErr[1]);
+            }
+        }
+
+        Object lastResult;
+        String lastOutput;
+        try {
+            lastResult = cmd.execute(session, args);
+            if (captureOutput) {
+                session.out().flush();
+            }
+            lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
+            session.setLastExitCode(0);
+        } catch (Exception e) {
+            session.setLastExitCode(1);
+            lastResult = null;
+            lastOutput = null;
+            if (op != Operator.AND && op != Operator.OR && op != Operator.SEQUENCE) {
+                throw e;
+            }
+        } finally {
+            session.setOut(originalOut);
+            session.setErr(originalErr);
+            if (redirectStream != null) {
+                redirectStream.close();
+            }
+            if (inputRedirect != null) {
+                session.setIn(originalIn);
+                inputRedirect.close();
+            }
+        }
+
+        return new Object[] {lastResult, lastOutput};
     }
 
     /**

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -35,7 +35,12 @@ public class DefaultCommandDispatcherTest {
         terminal = TerminalBuilder.builder().dumb(true).build();
         dispatcher = new DefaultCommandDispatcher(terminal);
         dispatcher.addGroup(new SimpleCommandGroup(
-                "test", new EchoCommand(), new FailCommand(), new UpperCommand(), new NoopCommand()));
+                "test",
+                new EchoCommand(),
+                new FailCommand(),
+                new UpperCommand(),
+                new NoopCommand(),
+                new ReverseCommand()));
     }
 
     // --- Fixture commands ---
@@ -85,10 +90,38 @@ public class DefaultCommandDispatcherTest {
         }
 
         @Override
-        public Object execute(CommandSession session, String[] args) {
-            Object pipeInput = session.get("_pipe_input");
-            String input = pipeInput != null ? pipeInput.toString().trim() : String.join(" ", args);
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            String input;
+            if (args.length > 0) {
+                input = String.join(" ", args);
+            } else {
+                input = new String(session.in().readAllBytes()).trim();
+            }
             String result = input.toUpperCase();
+            session.out().println(result);
+            return result;
+        }
+    }
+
+    static class ReverseCommand extends AbstractCommand {
+        ReverseCommand() {
+            super("reverse");
+        }
+
+        @Override
+        public String description() {
+            return "Reverse pipe input";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            String input;
+            if (args.length > 0) {
+                input = String.join(" ", args);
+            } else {
+                input = new String(session.in().readAllBytes()).trim();
+            }
+            String result = new StringBuilder(input).reverse().toString();
             session.out().println(result);
             return result;
         }
@@ -135,6 +168,12 @@ public class DefaultCommandDispatcherTest {
     void multiStagePipe() throws Exception {
         Object result = dispatcher.execute("echo test | upper | upper");
         assertEquals("TEST", result);
+    }
+
+    @Test
+    void threeStagePipe() throws Exception {
+        Object result = dispatcher.execute("echo hello | upper | reverse");
+        assertEquals("OLLEH", result);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replace the sequential fully-buffered pipe implementation in `DefaultCommandDispatcher` with real streaming pipes using `NonBlockingPumpInputStream`
- Consecutive PIPE-connected stages now run concurrently in separate threads, with data flowing through circular buffers that provide natural backpressure
- Add `CommandSession.fork()` for creating child sessions with independent I/O streams but shared terminal/variables
- Remove the `_pipe_input` session variable hack — pipe-consuming commands now read from `session.in()` directly

Supersedes #1775 with a more complete solution: instead of just fixing the stdin wiring, this implements true concurrent streaming pipes.

## Details

The previous implementation ran each pipeline stage sequentially, capturing the full output in a `ByteArrayOutputStream` before passing it to the next stage. This meant:
- No streaming: the entire output had to fit in memory before the next stage could start
- No concurrency: stages ran one after another
- A hacky `_pipe_input` session variable to pass data between stages

The new implementation identifies groups of consecutive PIPE-connected stages and runs them concurrently:
- Producer stages (all but the last in a group) run in daemon threads
- The last stage runs in the current thread
- Stages are connected via `PipePumpInputStream` (a subclass of `NonBlockingPumpInputStream` that allows draining buffered data after close)
- Non-PIPE operators (AND, OR, SEQUENCE, FLIP) retain sequential behavior

## Test plan

- [x] All 207 existing shell tests pass (including pipe, flip, AND/OR/SEQUENCE, redirect, background, alias tests)
- [x] New `threeStagePipe` test: `echo hello | upper | reverse` → `OLLEH`
- [x] Spotless formatting verified

## Follow-up

- #1776 — Bulk `read(byte[], int, int)` in `NonBlockingPumpInputStream` for better pipe throughput

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pipeline execution now batches piped stages and runs them concurrently for more reliable multi-stage behavior and consistent IO/FLIP semantics.
  * Added session forking to run commands with isolated input/output streams.

* **Behavior Changes**
  * Built-in commands now prefer command arguments and otherwise read from standard input, standardizing piped input resolution.

* **Tests**
  * Added multi-stage pipeline coverage including an extra transformation stage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->