### PR TITLE
feat: bulk read for NonBlockingPumpInputStream

### DIFF
--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
@@ -82,6 +82,20 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
     }
 
     @Override
+    public synchronized int read(byte[] b, int off, int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException();
+        } else if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+        checkClosed();
+        checkIoException();
+        return copyAvailable(b, off, len, 0L);
+    }
+
+    @Override
     public synchronized int read(long timeout, boolean isPeek) throws IOException {
         checkClosed();
         checkIoException();
@@ -98,23 +112,37 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
     public synchronized int readBuffered(byte[] b, int off, int len, long timeout) throws IOException {
         if (b == null) {
             throw new NullPointerException();
-        } else if (off < 0 || len < 0 || off + len < b.length) {
+        } else if (off < 0 || len < 0 || len > b.length - off) {
             throw new IllegalArgumentException();
         } else if (len == 0) {
             return 0;
-        } else {
-            checkClosed();
-            checkIoException();
-            int res = wait(readBuffer, timeout);
-            if (res >= 0) {
-                res = 0;
-                while (res < len && readBuffer.hasRemaining()) {
-                    b[off + res++] = (byte) (readBuffer.get() & 0x00FF);
-                }
-            }
-            rewind(readBuffer, writeBuffer);
-            return res;
         }
+        checkClosed();
+        checkIoException();
+        return copyAvailable(b, off, len, timeout);
+    }
+
+    /**
+     * Waits for data and copies available bytes from the circular buffer into {@code b}.
+     * Handles wrap-around by reading both segments when the read position crosses
+     * the end of the underlying array.
+     */
+    private int copyAvailable(byte[] b, int off, int len, long timeout) throws IOException {
+        int res = wait(readBuffer, timeout);
+        if (res >= 0) {
+            res = 0;
+            int count = Math.min(len, readBuffer.remaining());
+            readBuffer.get(b, off, count);
+            res += count;
+            // If we consumed the entire segment and the buffer wraps, read the second segment
+            if (rewind(readBuffer, writeBuffer) && res < len && readBuffer.hasRemaining()) {
+                count = Math.min(len - res, readBuffer.remaining());
+                readBuffer.get(b, off + res, count);
+                res += count;
+            }
+        }
+        rewind(readBuffer, writeBuffer);
+        return res;
     }
 
     public synchronized void setIoException(IOException exception) {

--- a/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
@@ -10,12 +10,16 @@ package org.jline.utils;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -176,5 +180,150 @@ class NonBlockingTest {
             assertEquals(bytes[i], b, "Mismatch at " + i);
         }
         assertEquals(NonBlockingInputStream.READ_EXPIRED, is.read(100));
+    }
+
+    @Test
+    void testPumpBulkRead() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        byte[] data = "Hello, JLine!".getBytes(StandardCharsets.UTF_8);
+        out.write(data);
+        out.flush();
+
+        byte[] buf = new byte[64];
+        int n = pump.read(buf, 0, buf.length);
+        assertEquals(data.length, n);
+        assertArrayEquals(data, Arrays.copyOf(buf, n));
+    }
+
+    @Test
+    void testPumpBulkReadPartial() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        byte[] data = "Hello, JLine!".getBytes(StandardCharsets.UTF_8);
+        out.write(data);
+        out.flush();
+
+        // Read fewer bytes than available
+        byte[] buf = new byte[5];
+        int n = pump.read(buf, 0, buf.length);
+        assertEquals(5, n);
+        assertArrayEquals("Hello".getBytes(StandardCharsets.UTF_8), buf);
+    }
+
+    @Test
+    void testPumpBulkReadWrapAround() throws IOException {
+        // Small buffer to force wrap-around
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream(16);
+        OutputStream out = pump.getOutputStream();
+
+        // Fill most of the buffer and consume it to advance the read position
+        byte[] filler = new byte[12];
+        Arrays.fill(filler, (byte) 'x');
+        out.write(filler);
+        out.flush();
+        byte[] discard = new byte[12];
+        assertEquals(12, pump.read(discard, 0, 12));
+
+        // Now write data that wraps around the circular buffer boundary
+        byte[] data = "ABCDEFGHIJ".getBytes(StandardCharsets.UTF_8); // 10 bytes, wraps at position 16
+        out.write(data);
+        out.flush();
+
+        // Bulk read should get all 10 bytes across the wrap
+        byte[] buf = new byte[16];
+        int n = pump.read(buf, 0, buf.length);
+        assertEquals(10, n);
+        assertArrayEquals(data, Arrays.copyOf(buf, n));
+    }
+
+    @Test
+    void testPumpBulkReadClosed() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        pump.close();
+
+        byte[] buf = new byte[16];
+        assertThrows(ClosedException.class, () -> pump.read(buf, 0, buf.length));
+    }
+
+    @Test
+    void testPumpReadBufferedBulk() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        byte[] data = "Hello, JLine!".getBytes(StandardCharsets.UTF_8);
+        out.write(data);
+        out.flush();
+
+        byte[] buf = new byte[64];
+        int n = pump.readBuffered(buf, 0, buf.length, 100);
+        assertEquals(data.length, n);
+        assertArrayEquals(data, Arrays.copyOf(buf, n));
+    }
+
+    @Test
+    void testPumpReadBufferedWrapAround() throws IOException {
+        // Small buffer to force wrap-around
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream(16);
+        OutputStream out = pump.getOutputStream();
+
+        // Advance positions past the middle of the buffer
+        byte[] filler = new byte[12];
+        Arrays.fill(filler, (byte) 'x');
+        out.write(filler);
+        out.flush();
+        byte[] discard = new byte[12];
+        pump.readBuffered(discard, 0, 12, 100);
+
+        // Write data that wraps around
+        byte[] data = "ABCDEFGHIJ".getBytes(StandardCharsets.UTF_8);
+        out.write(data);
+        out.flush();
+
+        byte[] buf = new byte[16];
+        int n = pump.readBuffered(buf, 0, buf.length, 100);
+        assertEquals(10, n);
+        assertArrayEquals(data, Arrays.copyOf(buf, n));
+    }
+
+    @Test
+    void testPumpBulkReadLargePayload() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream(4096);
+        OutputStream out = pump.getOutputStream();
+
+        // Simulate a large payload written in chunks from another thread
+        byte[] payload = new byte[10000];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) (i & 0xFF);
+        }
+
+        Thread writer = new Thread(() -> {
+            try {
+                out.write(payload);
+                out.flush();
+                out.close();
+            } catch (IOException e) {
+                fail(e);
+            }
+        });
+        writer.start();
+
+        // Read it all back using bulk reads
+        byte[] result = new byte[payload.length];
+        int total = 0;
+        boolean sawBulk = false;
+        while (total < payload.length) {
+            int n = pump.read(result, total, result.length - total);
+            if (n == -1) break;
+            if (n == NonBlockingInputStream.READ_EXPIRED) continue;
+            assertTrue(n > 0, "read should return at least 1 byte, got " + n);
+            if (n > 1) sawBulk = true;
+            total += n;
+        }
+        assertEquals(payload.length, total);
+        assertArrayEquals(payload, result);
+        assertTrue(sawBulk, "At least one bulk read (n > 1) should have occurred");
     }
 }


### PR DESCRIPTION
## Summary

- Override `read(byte[], int, int)` in `NonBlockingPumpInputStream` to do bulk `ByteBuffer.get()` from the circular buffer instead of inheriting the parent's 1-byte-at-a-time implementation
- Optimize `readBuffered(byte[], int, int, long)` with the same bulk copy + wrap-around handling
- Both methods handle circular buffer wrap-around, reading across the boundary in a single call
- Parent `NonBlockingInputStream` is untouched — its conservative single-byte behavior is intentional for interactive terminal input

Fixes #1776

## Test plan

- [x] Basic bulk read returns all available bytes
- [x] Partial read (request fewer bytes than available)
- [x] Wrap-around read spans both segments of the circular buffer
- [x] Closed stream throws `ClosedException`
- [x] `readBuffered` bulk and wrap-around paths
- [x] Large payload (10KB) with concurrent writer confirms `n > 1` per call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk multi-byte read support for input streams.

* **Performance Improvements**
  * More efficient bulk copying and proper handling of circular-buffer wrap-around to reduce per-byte overhead.

* **Bug Fixes**
  * Stronger argument validation and closed/I/O state checks for bulk reads.
  * Adjusted input redirection timing for single-stage commands to better couple resource lifecycle with execution.

* **Tests**
  * New tests covering bulk reads, partial reads, wrap-around, closed-stream behavior, and large concurrent transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->