### PR TITLE
feat: Added UnknownCommandException for Shell module

### DIFF
--- a/shell/src/main/java/org/jline/shell/CommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/CommandDispatcher.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 import org.jline.reader.Completer;
 import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
 
 /**
  * Central dispatcher that aggregates {@link CommandGroup}s and handles
@@ -125,12 +127,25 @@ public interface CommandDispatcher extends AutoCloseable {
     default void cleanUp() {}
 
     /**
+     * @return A {@link AttributedStyle} to be used when printing exception messages.
+     */
+    default AttributedStyle errorStyle() {
+        return AttributedStyle.DEFAULT.foreground(AttributedStyle.RED);
+    }
+
+    /**
      * Traces an exception (e.g., prints it to the terminal).
      *
      * @param exception the exception to trace
      */
     default void trace(Throwable exception) {
-        exception.printStackTrace();
+        if (exception instanceof UnknownCommandException) {
+            AttributedStringBuilder asb = new AttributedStringBuilder();
+            asb.styled(errorStyle(), exception.getMessage());
+            asb.toAttributedString().println(terminal());
+            return;
+        }
+        exception.printStackTrace(terminal().writer());
     }
 
     /**

--- a/shell/src/main/java/org/jline/shell/UnknownCommandException.java
+++ b/shell/src/main/java/org/jline/shell/UnknownCommandException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell;
+
+/**
+ * This exception is thrown by an {@link org.jline.shell.CommandDispatcher}
+ * when it failed to find a requested command.
+ */
+public class UnknownCommandException extends RuntimeException {
+
+    private static final long serialVersionUID = 3184448976067428498L;
+
+    public UnknownCommandException(String message) {
+        super(message);
+    }
+}

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -501,7 +501,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 Object[] resolved = resolveCommand(cmdLine, s == 0 ? flipArgs : null);
                 commands[s] = (Command) resolved[0];
                 argsArrays[s] = (String[]) resolved[1];
-            } catch (IllegalArgumentException e) {
+            } catch (UnknownCommandException e) {
                 closePumps(pumps);
                 throw e;
             }
@@ -645,7 +645,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
 
         Command cmd = findCommand(cmdName);
         if (cmd == null) {
-            throw new IllegalArgumentException("Unknown command: " + cmdName);
+            throw new UnknownCommandException("Unknown command: " + cmdName);
         }
 
         String[] args = argsStr.isEmpty() ? new String[0] : argsStr.split("\\s+");

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -23,6 +23,8 @@ import org.jline.reader.impl.completer.SystemCompleter;
 import org.jline.shell.*;
 import org.jline.shell.Pipeline.Operator;
 import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
 
 /**
  * Default implementation of {@link CommandDispatcher} that supports pipeline execution.
@@ -290,7 +292,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
 
             Command cmd = findCommand(cmdName);
             if (cmd == null) {
-                throw new IllegalArgumentException("Unknown command: " + cmdName);
+                throw new UnknownCommandException("Unknown command: " + cmdName);
             }
 
             String[] args = argsStr.isEmpty() ? new String[0] : argsStr.split("\\s+");
@@ -534,6 +536,17 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             }
         }
         return true;
+    }
+
+    @Override
+    public void trace(Throwable exception) {
+        if (exception instanceof UnknownCommandException) {
+            AttributedStringBuilder asb = new AttributedStringBuilder();
+            asb.styled(AttributedStyle.DEFAULT.foreground(AttributedStyle.RED), exception.getMessage());
+            asb.toAttributedString().println(terminal());
+            return;
+        }
+        CommandDispatcher.super.trace(exception);
     }
 
     @Override

--- a/shell/src/main/java/org/jline/shell/impl/UnknownCommandException.java
+++ b/shell/src/main/java/org/jline/shell/impl/UnknownCommandException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+public class UnknownCommandException extends RuntimeException {
+
+    private static final long serialVersionUID = 3184448976067428498L;
+
+    public UnknownCommandException(String message) {
+        super(message);
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -162,7 +162,7 @@ class DefaultCommandDispatcherTest {
 
     @Test
     void unknownCommand() {
-        assertThrows(IllegalArgumentException.class, () -> dispatcher.execute("nonexistent"));
+        assertThrows(UnknownCommandException.class, () -> dispatcher.execute("nonexistent"));
     }
 
     @Test

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -115,7 +115,7 @@ public class DefaultCommandDispatcherTest {
 
     @Test
     void unknownCommand() {
-        assertThrows(IllegalArgumentException.class, () -> dispatcher.execute("nonexistent"));
+        assertThrows(UnknownCommandException.class, () -> dispatcher.execute("nonexistent"));
     }
 
     @Test


### PR DESCRIPTION
The old (semi-) deprecated comsole module commands had a UnknownCommandException. This would be thrown when attemting to call a command that does not exist.
There was also special handling for this command (which this pull also adds to the shell module) to print a small red "Unknown command" message, which makes more sense than printing an entire stacktrace when attemting to use the default builders in the shell module.

The new exception extends RuntimeException as opposed to Exception in the comsole module. This is to align with the same logic as using an unchecked exception for this error (like IllegalArgumentException).

I intentionally did _not_ extend IllegalArgumentException, this is because this exception indicates that there was an issue with the (command) arguments, so it would make sense to reserve throwing this exception type for the implementation of the actual commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a command can't be resolved: users now see a concise, styled error message instead of a full stack trace; other errors still print details via the terminal output.
* **Tests**
  * Unit tests updated to expect the new unresolved-command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->