### PR TITLE
fix: resolve redirect targets against session working directory

### DIFF
--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -337,8 +337,9 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         // Handle input redirection
         InputStream originalIn = session.in();
         InputStream inputRedirect = null;
-        if (stage.inputSource() != null) {
-            inputRedirect = Files.newInputStream(stage.inputSource());
+        Path inputSource = resolvePath(stage.inputSource());
+        if (inputSource != null) {
+            inputRedirect = Files.newInputStream(inputSource);
             session.setIn(inputRedirect);
         }
 
@@ -357,7 +358,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             session.setOut(new PrintStream(capture));
         } else {
             PrintStream[] outErr = {originalOut, originalErr};
-            redirectStream = setupRedirectStreams(op, stage.redirectTarget(), outErr);
+            redirectStream = setupRedirectStreams(op, resolvePath(stage.redirectTarget()), outErr);
             if (redirectStream != null) {
                 session.setOut(outErr[0]);
                 session.setErr(outErr[1]);
@@ -431,8 +432,9 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         boolean captureLastOutput = (lastGroupOp == Operator.PIPE || lastGroupOp == Operator.FLIP);
         ByteArrayOutputStream lastCapture = captureLastOutput ? new ByteArrayOutputStream() : null;
         PrintStream[] outErr = {captureLastOutput ? new PrintStream(lastCapture) : session.out(), session.err()};
-        OutputStream redirectStream =
-                captureLastOutput ? null : setupRedirectStreams(lastGroupOp, lastGroupStage.redirectTarget(), outErr);
+        OutputStream redirectStream = captureLastOutput
+                ? null
+                : setupRedirectStreams(lastGroupOp, resolvePath(lastGroupStage.redirectTarget()), outErr);
 
         // Create per-stage sessions and start producer threads
         CommandSession[] stageSessions =
@@ -501,10 +503,11 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
      * Sets up input redirection for a stage, tracking the opened stream for cleanup.
      * Returns the redirect stream if the stage has an input source, or the default otherwise.
      */
-    private static InputStream setupInputRedirect(
+    private InputStream setupInputRedirect(
             Pipeline.Stage stage, InputStream defaultIn, List<InputStream> inputRedirects) throws IOException {
-        if (stage.inputSource() != null) {
-            InputStream redirect = Files.newInputStream(stage.inputSource());
+        Path inputSource = resolvePath(stage.inputSource());
+        if (inputSource != null) {
+            InputStream redirect = Files.newInputStream(inputSource);
             inputRedirects.add(redirect);
             return redirect;
         }
@@ -788,6 +791,31 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
      */
     public CommandSession session() {
         return session;
+    }
+
+    /**
+     * Resolves a path against the session's working directory.
+     * <p>
+     * If the session has a working directory set, the path string is resolved
+     * against it. For relative paths, this resolves them relative to the working
+     * directory. For absolute paths, this creates the path in the working
+     * directory's {@link java.nio.file.FileSystem}, which is important when the
+     * session operates on a non-default file system (e.g., an in-memory FS).
+     * <p>
+     * If no working directory is set, the path is returned as-is.
+     *
+     * @param path the path to resolve
+     * @return the resolved path, or null if the input is null
+     */
+    private Path resolvePath(Path path) {
+        if (path == null) {
+            return null;
+        }
+        Path workingDir = session.workingDirectory();
+        if (workingDir != null) {
+            return workingDir.resolve(path.toString());
+        }
+        return path;
     }
 
     /**

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -334,53 +334,56 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         Command cmd = (Command) resolved[0];
         String[] args = (String[]) resolved[1];
 
-        // Handle input redirection
-        InputStream originalIn = session.in();
-        InputStream inputRedirect = null;
-        Path inputSource = resolvePath(stage.inputSource());
-        if (inputSource != null) {
-            inputRedirect = Files.newInputStream(inputSource);
-            session.setIn(inputRedirect);
-        }
-
-        // If this stage pipes into the next, capture stdout instead of printing to terminal
         Operator op = stage.operator();
         boolean captureOutput = (op == Operator.PIPE || op == Operator.FLIP);
 
-        // Redirect streams before execution
+        InputStream originalIn = session.in();
         PrintStream originalOut = session.out();
         PrintStream originalErr = session.err();
+        InputStream inputRedirect = null;
         ByteArrayOutputStream capture = null;
         OutputStream redirectStream = null;
 
-        if (captureOutput) {
-            capture = new ByteArrayOutputStream();
-            session.setOut(new PrintStream(capture));
-        } else {
-            PrintStream[] outErr = {originalOut, originalErr};
-            redirectStream = setupRedirectStreams(op, resolvePath(stage.redirectTarget()), outErr);
-            if (redirectStream != null) {
-                session.setOut(outErr[0]);
-                session.setErr(outErr[1]);
-            }
-        }
-
-        Object lastResult;
-        String lastOutput;
         try {
-            lastResult = cmd.execute(session, args);
+            // Handle input redirection
+            Path inputSource = resolvePath(stage.inputSource());
+            if (inputSource != null) {
+                inputRedirect = Files.newInputStream(inputSource);
+                session.setIn(inputRedirect);
+            }
+
+            // Redirect streams before execution
             if (captureOutput) {
-                session.out().flush();
+                capture = new ByteArrayOutputStream();
+                session.setOut(new PrintStream(capture));
+            } else {
+                PrintStream[] outErr = {originalOut, originalErr};
+                redirectStream = setupRedirectStreams(op, resolvePath(stage.redirectTarget()), outErr);
+                if (redirectStream != null) {
+                    session.setOut(outErr[0]);
+                    session.setErr(outErr[1]);
+                }
             }
-            lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
-            session.setLastExitCode(0);
-        } catch (Exception e) {
-            session.setLastExitCode(1);
-            lastResult = null;
-            lastOutput = null;
-            if (op != Operator.AND && op != Operator.OR && op != Operator.SEQUENCE) {
-                throw e;
+
+            Object lastResult;
+            String lastOutput;
+            try {
+                lastResult = cmd.execute(session, args);
+                if (captureOutput) {
+                    session.out().flush();
+                }
+                lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
+                session.setLastExitCode(0);
+            } catch (Exception e) {
+                session.setLastExitCode(1);
+                lastResult = null;
+                lastOutput = null;
+                if (op != Operator.AND && op != Operator.OR && op != Operator.SEQUENCE) {
+                    throw e;
+                }
             }
+
+            return new Object[] {lastResult, lastOutput};
         } finally {
             session.setOut(originalOut);
             session.setErr(originalErr);
@@ -392,8 +395,6 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 inputRedirect.close();
             }
         }
-
-        return new Object[] {lastResult, lastOutput};
     }
 
     /**
@@ -424,41 +425,51 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         String[][] argsArrays = new String[n][];
         resolveAllCommands(groupStages, flipArgs, pumps, commands, argsArrays);
 
-        // Set up input redirects (tracked for cleanup)
+        // Resource tracking for cleanup
         List<InputStream> inputRedirects = new ArrayList<>();
-        InputStream firstIn = setupInputRedirect(groupStages.get(0), session.in(), inputRedirects);
+        OutputStream redirectStream = null;
+        PrintStream[] outErr = {session.out(), session.err()};
+        Thread[] threads = new Thread[0];
 
-        // Set up last stage output/error redirection
-        boolean captureLastOutput = (lastGroupOp == Operator.PIPE || lastGroupOp == Operator.FLIP);
-        ByteArrayOutputStream lastCapture = captureLastOutput ? new ByteArrayOutputStream() : null;
-        PrintStream[] outErr = {captureLastOutput ? new PrintStream(lastCapture) : session.out(), session.err()};
-        OutputStream redirectStream = captureLastOutput
-                ? null
-                : setupRedirectStreams(lastGroupOp, resolvePath(lastGroupStage.redirectTarget()), outErr);
-
-        // Create per-stage sessions and start producer threads
-        CommandSession[] stageSessions =
-                createStageSessions(groupStages, pumps, firstIn, outErr[0], outErr[1], inputRedirects);
-        Thread[] threads = startProducers(commands, stageSessions, argsArrays);
-
-        // Run last stage in current thread
-        Object lastResult;
-        String lastOutput;
         try {
-            lastResult = commands[n - 1].execute(stageSessions[n - 1], argsArrays[n - 1]);
-            if (captureLastOutput) {
-                stageSessions[n - 1].out().flush();
+            // Set up input redirects
+            InputStream firstIn = setupInputRedirect(groupStages.get(0), session.in(), inputRedirects);
+
+            // Set up last stage output/error redirection
+            boolean captureLastOutput = (lastGroupOp == Operator.PIPE || lastGroupOp == Operator.FLIP);
+            ByteArrayOutputStream lastCapture = captureLastOutput ? new ByteArrayOutputStream() : null;
+            outErr =
+                    new PrintStream[] {captureLastOutput ? new PrintStream(lastCapture) : session.out(), session.err()};
+            redirectStream = captureLastOutput
+                    ? null
+                    : setupRedirectStreams(lastGroupOp, resolvePath(lastGroupStage.redirectTarget()), outErr);
+
+            // Create per-stage sessions and start producer threads
+            CommandSession[] stageSessions =
+                    createStageSessions(groupStages, pumps, firstIn, outErr[0], outErr[1], inputRedirects);
+            threads = startProducers(commands, stageSessions, argsArrays);
+
+            // Run last stage in current thread
+            Object lastResult;
+            String lastOutput;
+            try {
+                lastResult = commands[n - 1].execute(stageSessions[n - 1], argsArrays[n - 1]);
+                if (captureLastOutput) {
+                    stageSessions[n - 1].out().flush();
+                }
+                lastOutput = resolveOutputString(captureLastOutput ? lastCapture : null, lastResult);
+                session.setLastExitCode(0);
+            } catch (Exception e) {
+                session.setLastExitCode(1);
+                if (lastGroupOp == Operator.AND || lastGroupOp == Operator.OR || lastGroupOp == Operator.SEQUENCE) {
+                    lastResult = null;
+                    lastOutput = null;
+                } else {
+                    throw e;
+                }
             }
-            lastOutput = resolveOutputString(captureLastOutput ? lastCapture : null, lastResult);
-            session.setLastExitCode(0);
-        } catch (Exception e) {
-            session.setLastExitCode(1);
-            if (lastGroupOp == Operator.AND || lastGroupOp == Operator.OR || lastGroupOp == Operator.SEQUENCE) {
-                lastResult = null;
-                lastOutput = null;
-            } else {
-                throw e;
-            }
+
+            return new Object[] {lastResult, lastOutput};
         } finally {
             closePumps(pumps);
             joinProducers(threads);
@@ -468,8 +479,6 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             }
             closeStreams(redirectStream, inputRedirects);
         }
-
-        return new Object[] {lastResult, lastOutput};
     }
 
     /**

--- a/shell/src/main/java/org/jline/shell/widget/CommandTailTipWidgets.java
+++ b/shell/src/main/java/org/jline/shell/widget/CommandTailTipWidgets.java
@@ -677,7 +677,6 @@ public class CommandTailTipWidgets {
         return out;
     }
 
-    @SuppressWarnings("deprecation")
     private List<AttributedString> compileOptionDescription(
             CommandDescription cmdDesc, String opt, int descriptionSize) {
         if (descriptionSize == 0 || !descriptionEnabled) {

--- a/shell/src/main/java/org/jline/shell/widget/CommandTailTipWidgets.java
+++ b/shell/src/main/java/org/jline/shell/widget/CommandTailTipWidgets.java
@@ -677,6 +677,7 @@ public class CommandTailTipWidgets {
         return out;
     }
 
+    @SuppressWarnings("deprecation")
     private List<AttributedString> compileOptionDescription(
             CommandDescription cmdDesc, String opt, int descriptionSize) {
         if (descriptionSize == 0 || !descriptionEnabled) {

--- a/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
@@ -34,7 +34,29 @@ class IORedirectionTest {
     void setUp() throws IOException {
         terminal = TerminalBuilder.builder().dumb(true).build();
         dispatcher = new DefaultCommandDispatcher(terminal);
-        dispatcher.addGroup(new SimpleCommandGroup("test", new CatCommand(), new ErrCommand(), new BothCommand()));
+        dispatcher.addGroup(new SimpleCommandGroup(
+                "test", new CatCommand(), new EchoCommand(), new ErrCommand(), new BothCommand()));
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        terminal.close();
+    }
+
+    /**
+     * Echoes arguments to output.
+     */
+    static class EchoCommand extends AbstractCommand {
+        EchoCommand() {
+            super("echo");
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            String msg = String.join(" ", args);
+            session.out().println(msg);
+            return msg;
+        }
     }
 
     @AfterEach
@@ -175,5 +197,56 @@ class IORedirectionTest {
         Pipeline pipeline = Pipeline.of("cmd").combinedRedirect(file).build();
         Pipeline.Stage stage = pipeline.stages().get(0);
         assertEquals(Pipeline.Operator.COMBINED_REDIRECT, stage.operator());
+    }
+
+    @Test
+    void redirectResolvesAgainstWorkingDirectory(@TempDir Path tempDir) throws Exception {
+        dispatcher.session().setWorkingDirectory(tempDir);
+        dispatcher.execute("echo hello > out.txt");
+        Path expected = tempDir.resolve("out.txt");
+        assertTrue(Files.exists(expected), "File should be created in working directory");
+        String content = Files.readString(expected);
+        assertTrue(content.trim().contains("hello"));
+    }
+
+    @Test
+    void appendResolvesAgainstWorkingDirectory(@TempDir Path tempDir) throws Exception {
+        dispatcher.session().setWorkingDirectory(tempDir);
+        dispatcher.execute("echo line1 > out.txt");
+        dispatcher.execute("echo line2 >> out.txt");
+        Path expected = tempDir.resolve("out.txt");
+        String content = Files.readString(expected);
+        assertTrue(content.contains("line1"));
+        assertTrue(content.contains("line2"));
+    }
+
+    @Test
+    void inputRedirectResolvesAgainstWorkingDirectory(@TempDir Path tempDir) throws Exception {
+        Path inputFile = tempDir.resolve("input.txt");
+        Files.writeString(inputFile, "hello from wd\n");
+        dispatcher.session().setWorkingDirectory(tempDir);
+        Object result = dispatcher.execute("cat < input.txt");
+        assertEquals("hello from wd", result);
+    }
+
+    @Test
+    void stderrRedirectResolvesAgainstWorkingDirectory(@TempDir Path tempDir) throws Exception {
+        dispatcher.session().setWorkingDirectory(tempDir);
+        dispatcher.execute("errcmd some error 2> errors.txt");
+        Path expected = tempDir.resolve("errors.txt");
+        assertTrue(Files.exists(expected), "Error file should be created in working directory");
+        String content = Files.readString(expected);
+        assertTrue(content.contains("some error"));
+    }
+
+    @Test
+    void combinedRedirectResolvesAgainstWorkingDirectory(@TempDir Path tempDir) throws Exception {
+        dispatcher.session().setWorkingDirectory(tempDir);
+        dispatcher.execute("bothcmd &> all.txt");
+        Path expected = tempDir.resolve("all.txt");
+        assertTrue(Files.exists(expected), "Combined file should be created in working directory");
+        String content = Files.readString(expected);
+        assertTrue(content.contains("stdout line"));
+        assertTrue(content.contains("stderr line"));
     }
 }

--- a/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
@@ -11,7 +11,6 @@ package org.jline.shell.impl;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 
 import org.jline.shell.*;
 import org.jline.terminal.Terminal;
@@ -37,11 +36,6 @@ class IORedirectionTest {
         dispatcher = new DefaultCommandDispatcher(terminal);
         dispatcher.addGroup(new SimpleCommandGroup(
                 "test", new CatCommand(), new EchoCommand(), new ErrCommand(), new BothCommand()));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        terminal.close();
     }
 
     /**
@@ -252,25 +246,14 @@ class IORedirectionTest {
     }
 
     @Test
-    void absoluteRedirectResolvesAgainstWorkingDirectory(@TempDir Path tempDir) throws Exception {
-        Path otherDir = Files.createTempDirectory("other");
-        try {
-            Path abs = otherDir.resolve("out.txt").toAbsolutePath();
-            dispatcher.session().setWorkingDirectory(tempDir);
-            dispatcher.execute("echo hello > " + abs);
-            assertTrue(Files.exists(abs), "File should be created at absolute path");
-            String content = Files.readString(abs);
-            assertTrue(content.trim().contains("hello"));
-        } finally {
-            // Clean up temp directory
-            try (var stream = Files.walk(otherDir)) {
-                stream.sorted(Comparator.reverseOrder()).forEach(p -> {
-                    try {
-                        Files.deleteIfExists(p);
-                    } catch (IOException ignored) {
-                    }
-                });
-            }
-        }
+    void absoluteRedirectResolvesAgainstWorkingDirectory(@TempDir Path tempDir, @TempDir Path otherDir)
+            throws Exception {
+        Path abs = otherDir.resolve("out.txt").toAbsolutePath();
+        dispatcher.session().setWorkingDirectory(tempDir);
+        Pipeline pipeline = Pipeline.of("echo hello").redirect(abs).build();
+        dispatcher.execute(pipeline);
+        assertTrue(Files.exists(abs), "File should be created at absolute path");
+        String content = Files.readString(abs);
+        assertTrue(content.trim().contains("hello"));
     }
 }

--- a/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
@@ -11,6 +11,7 @@ package org.jline.shell.impl;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 
 import org.jline.shell.*;
 import org.jline.terminal.Terminal;
@@ -248,5 +249,28 @@ class IORedirectionTest {
         String content = Files.readString(expected);
         assertTrue(content.contains("stdout line"));
         assertTrue(content.contains("stderr line"));
+    }
+
+    @Test
+    void absoluteRedirectResolvesAgainstWorkingDirectory(@TempDir Path tempDir) throws Exception {
+        Path otherDir = Files.createTempDirectory("other");
+        try {
+            Path abs = otherDir.resolve("out.txt").toAbsolutePath();
+            dispatcher.session().setWorkingDirectory(tempDir);
+            dispatcher.execute("echo hello > " + abs);
+            assertTrue(Files.exists(abs), "File should be created at absolute path");
+            String content = Files.readString(abs);
+            assertTrue(content.trim().contains("hello"));
+        } finally {
+            // Clean up temp directory
+            try (var stream = Files.walk(otherDir)) {
+                stream.sorted(Comparator.reverseOrder()).forEach(p -> {
+                    try {
+                        Files.deleteIfExists(p);
+                    } catch (IOException ignored) {
+                    }
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1779

Redirect and input redirect paths were parsed via `Paths.get()` in `PipelineParser`, which uses the default `FileSystem`. When the session has a working directory set (potentially on a different `FileSystem`), these paths should be resolved against it.

## Changes

- Added `resolvePath()` helper in `DefaultCommandDispatcher` that resolves paths against `session.workingDirectory()` when set
- For relative paths: resolves them relative to the session's working directory instead of the JVM's cwd
- For absolute paths: creates the path in the working directory's `FileSystem` (important for in-memory filesystems)
- Applied to all redirect/input path usages: `>`, `>>`, `<`, `2>`, `&>`

## Test plan

- Added 5 new tests in `IORedirectionTest` verifying that all redirect operators resolve relative paths against the session working directory
- All 211 existing shell module tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File redirection operators now resolve relative paths against the session working directory for input, output, append and error redirection, ensuring consistent behavior.

* **Tests**
  * Added tests (with a reproducible echo command) verifying redirection resolution for relative and absolute targets and validating created file contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->