### PR TITLE
feat: add filterable(boolean) option to list and checkbox prompts

### DIFF
--- a/prompt/src/main/java/org/jline/prompt/CheckboxBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/CheckboxBuilder.java
@@ -97,6 +97,16 @@ public interface CheckboxBuilder extends BaseBuilder<CheckboxBuilder> {
     }
 
     /**
+     * Set whether the checkbox list supports inline text filtering.
+     * When enabled (the default), the user can type characters to filter the displayed items.
+     * When disabled, typed characters are ignored.
+     *
+     * @param filterable true to enable filtering, false to disable
+     * @return this builder
+     */
+    CheckboxBuilder filterable(boolean filterable);
+
+    /**
      * Set the page size for pagination.
      *
      * @param pageSize the page size, or 0 for no pagination

--- a/prompt/src/main/java/org/jline/prompt/CheckboxPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/CheckboxPrompt.java
@@ -60,4 +60,15 @@ public interface CheckboxPrompt extends Prompt {
     default int getMaxSelections() {
         return 0;
     }
+
+    /**
+     * Whether the checkbox list supports inline text filtering.
+     * When enabled, the user can type characters to filter the displayed items.
+     * When disabled, typed characters are ignored.
+     *
+     * @return true if filtering is enabled, false otherwise
+     */
+    default boolean isFilterable() {
+        return true;
+    }
 }

--- a/prompt/src/main/java/org/jline/prompt/ListBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/ListBuilder.java
@@ -93,6 +93,16 @@ public interface ListBuilder extends BaseBuilder<ListBuilder> {
     }
 
     /**
+     * Set whether the list supports inline text filtering.
+     * When enabled (the default), the user can type characters to filter the displayed items.
+     * When disabled, typed characters are ignored.
+     *
+     * @param filterable true to enable filtering, false to disable
+     * @return this builder
+     */
+    ListBuilder filterable(boolean filterable);
+
+    /**
      * Set the page size for pagination.
      *
      * @param pageSize the page size, or 0 for no pagination

--- a/prompt/src/main/java/org/jline/prompt/ListPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/ListPrompt.java
@@ -42,4 +42,15 @@ public interface ListPrompt extends Prompt {
     default boolean showPageIndicator() {
         return true;
     }
+
+    /**
+     * Whether the list supports inline text filtering.
+     * When enabled, the user can type characters to filter the displayed items.
+     * When disabled, typed characters are ignored.
+     *
+     * @return true if filtering is enabled, false otherwise
+     */
+    default boolean isFilterable() {
+        return true;
+    }
 }

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxBuilder.java
@@ -37,6 +37,7 @@ public class DefaultCheckboxBuilder implements CheckboxBuilder {
     private boolean showPageIndicator = true;
     private int minSelections = 0;
     private int maxSelections = 0;
+    private boolean filterable = true;
     private Function<String, String> transformer;
     private Function<String, String> filter;
 
@@ -153,6 +154,12 @@ public class DefaultCheckboxBuilder implements CheckboxBuilder {
     }
 
     @Override
+    public CheckboxBuilder filterable(boolean filterable) {
+        this.filterable = filterable;
+        return this;
+    }
+
+    @Override
     public CheckboxBuilder pageSize(int pageSize) {
         this.pageSize = pageSize;
         return this;
@@ -217,7 +224,7 @@ public class DefaultCheckboxBuilder implements CheckboxBuilder {
                     + ") cannot be greater than maxSelections (" + maxSelections + ")");
         }
         DefaultCheckboxPrompt prompt = new DefaultCheckboxPrompt(
-                name, message, items, pageSize, showPageIndicator, minSelections, maxSelections);
+                name, message, items, pageSize, showPageIndicator, minSelections, maxSelections, filterable);
         prompt.setTransformer(transformer);
         prompt.setFilter(filter);
         parent.addPrompt(prompt);

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxPrompt.java
@@ -25,18 +25,19 @@ public class DefaultCheckboxPrompt extends DefaultPrompt implements CheckboxProm
     private final boolean showPageIndicator;
     private final int minSelections;
     private final int maxSelections;
+    private final boolean filterable;
 
     public DefaultCheckboxPrompt(String name, String message, List<CheckboxItem> items) {
-        this(name, message, items, 0, true, 0, 0);
+        this(name, message, items, 0, true, 0, 0, true);
     }
 
     public DefaultCheckboxPrompt(String name, String message, List<CheckboxItem> items, int pageSize) {
-        this(name, message, items, pageSize, true, 0, 0);
+        this(name, message, items, pageSize, true, 0, 0, true);
     }
 
     public DefaultCheckboxPrompt(
             String name, String message, List<CheckboxItem> items, int pageSize, boolean showPageIndicator) {
-        this(name, message, items, pageSize, showPageIndicator, 0, 0);
+        this(name, message, items, pageSize, showPageIndicator, 0, 0, true);
     }
 
     public DefaultCheckboxPrompt(
@@ -47,12 +48,25 @@ public class DefaultCheckboxPrompt extends DefaultPrompt implements CheckboxProm
             boolean showPageIndicator,
             int minSelections,
             int maxSelections) {
+        this(name, message, items, pageSize, showPageIndicator, minSelections, maxSelections, true);
+    }
+
+    public DefaultCheckboxPrompt(
+            String name,
+            String message,
+            List<CheckboxItem> items,
+            int pageSize,
+            boolean showPageIndicator,
+            int minSelections,
+            int maxSelections,
+            boolean filterable) {
         super(name, message);
         this.items = new ArrayList<>(items);
         this.pageSize = pageSize;
         this.showPageIndicator = showPageIndicator;
         this.minSelections = minSelections;
         this.maxSelections = maxSelections;
+        this.filterable = filterable;
     }
 
     @Override
@@ -78,5 +92,10 @@ public class DefaultCheckboxPrompt extends DefaultPrompt implements CheckboxProm
     @Override
     public int getMaxSelections() {
         return maxSelections;
+    }
+
+    @Override
+    public boolean isFilterable() {
+        return filterable;
     }
 }

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultListBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultListBuilder.java
@@ -34,6 +34,7 @@ public class DefaultListBuilder implements ListBuilder {
     private String currentItemDisabledText;
     private int pageSize = 0;
     private boolean showPageIndicator = true;
+    private boolean filterable = true;
     private Function<String, String> transformer;
     private Function<String, String> filter;
 
@@ -136,6 +137,12 @@ public class DefaultListBuilder implements ListBuilder {
     }
 
     @Override
+    public ListBuilder filterable(boolean filterable) {
+        this.filterable = filterable;
+        return this;
+    }
+
+    @Override
     public ListBuilder pageSize(int pageSize) {
         this.pageSize = pageSize;
         return this;
@@ -185,7 +192,7 @@ public class DefaultListBuilder implements ListBuilder {
      */
     @Override
     public PromptBuilder addPrompt() {
-        DefaultListPrompt prompt = new DefaultListPrompt(name, message, items, pageSize, showPageIndicator);
+        DefaultListPrompt prompt = new DefaultListPrompt(name, message, items, pageSize, showPageIndicator, filterable);
         prompt.setTransformer(transformer);
         prompt.setFilter(filter);
         parent.addPrompt(prompt);

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultListPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultListPrompt.java
@@ -23,21 +23,33 @@ public class DefaultListPrompt extends DefaultPrompt implements ListPrompt {
     private final List<ListItem> items;
     private final int pageSize;
     private final boolean showPageIndicator;
+    private final boolean filterable;
 
     public DefaultListPrompt(String name, String message, List<ListItem> items) {
-        this(name, message, items, 0, true);
+        this(name, message, items, 0, true, true);
     }
 
     public DefaultListPrompt(String name, String message, List<ListItem> items, int pageSize) {
-        this(name, message, items, pageSize, true);
+        this(name, message, items, pageSize, true, true);
     }
 
     public DefaultListPrompt(
             String name, String message, List<ListItem> items, int pageSize, boolean showPageIndicator) {
+        this(name, message, items, pageSize, showPageIndicator, true);
+    }
+
+    public DefaultListPrompt(
+            String name,
+            String message,
+            List<ListItem> items,
+            int pageSize,
+            boolean showPageIndicator,
+            boolean filterable) {
         super(name, message);
         this.items = new ArrayList<>(items);
         this.pageSize = pageSize;
         this.showPageIndicator = showPageIndicator;
+        this.filterable = filterable;
     }
 
     @Override
@@ -53,5 +65,10 @@ public class DefaultListPrompt extends DefaultPrompt implements ListPrompt {
     @Override
     public boolean showPageIndicator() {
         return showPageIndicator;
+    }
+
+    @Override
+    public boolean isFilterable() {
+        return filterable;
     }
 }

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
@@ -1063,7 +1063,7 @@ public class DefaultPrompter implements Prompter {
         while (true) {
             // Build message with filter text
             String message = prompt.getMessage();
-            if (filterText.length() > 0) {
+            if (prompt.isFilterable() && filterText.length() > 0) {
                 message = prompt.getMessage() + " [" + filterText + "]";
             }
 
@@ -1081,17 +1081,19 @@ public class DefaultPrompter implements Prompter {
                     break;
 
                 case INSERT:
-                    String ch = bindingReader.getLastBinding();
-                    filterText.append(ch);
-                    filteredItems = filterItems(allItems, filterText.toString());
-                    range = null;
-                    if (!filteredItems.isEmpty()) {
-                        selectRow = nextRow(firstItemRow - 1, firstItemRow, filteredItems);
+                    if (prompt.isFilterable()) {
+                        String ch = bindingReader.getLastBinding();
+                        filterText.append(ch);
+                        filteredItems = filterItems(allItems, filterText.toString());
+                        range = null;
+                        if (!filteredItems.isEmpty()) {
+                            selectRow = nextRow(firstItemRow - 1, firstItemRow, filteredItems);
+                        }
                     }
                     break;
 
                 case BACKSPACE:
-                    if (filterText.length() > 0) {
+                    if (prompt.isFilterable() && filterText.length() > 0) {
                         filterText.deleteCharAt(filterText.length() - 1);
                         filteredItems = filterItems(allItems, filterText.toString());
                         range = null;
@@ -1109,7 +1111,7 @@ public class DefaultPrompter implements Prompter {
                     }
                     break;
                 case ESCAPE:
-                    if (filterText.length() > 0) {
+                    if (prompt.isFilterable() && filterText.length() > 0) {
                         // First escape clears filter
                         filterText.setLength(0);
                         filteredItems = allItems;
@@ -1185,7 +1187,7 @@ public class DefaultPrompter implements Prompter {
         while (true) {
             // Build message with filter text
             String message = prompt.getMessage();
-            if (filterText.length() > 0) {
+            if (prompt.isFilterable() && filterText.length() > 0) {
                 message = prompt.getMessage() + " [" + filterText + "]";
             }
 
@@ -1203,17 +1205,19 @@ public class DefaultPrompter implements Prompter {
                     break;
 
                 case INSERT:
-                    String ch = bindingReader.getLastBinding();
-                    filterText.append(ch);
-                    filteredItems = filterItems(allItems, filterText.toString());
-                    range = null;
-                    if (!filteredItems.isEmpty()) {
-                        selectRow = nextRow(firstItemRow - 1, firstItemRow, filteredItems);
+                    if (prompt.isFilterable()) {
+                        String ch = bindingReader.getLastBinding();
+                        filterText.append(ch);
+                        filteredItems = filterItems(allItems, filterText.toString());
+                        range = null;
+                        if (!filteredItems.isEmpty()) {
+                            selectRow = nextRow(firstItemRow - 1, firstItemRow, filteredItems);
+                        }
                     }
                     break;
 
                 case BACKSPACE:
-                    if (filterText.length() > 0) {
+                    if (prompt.isFilterable() && filterText.length() > 0) {
                         filterText.deleteCharAt(filterText.length() - 1);
                         filteredItems = filterItems(allItems, filterText.toString());
                         range = null;
@@ -1243,7 +1247,7 @@ public class DefaultPrompter implements Prompter {
                     }
                     return new DefaultCheckboxResult(selectedIds, prompt);
                 case ESCAPE:
-                    if (filterText.length() > 0) {
+                    if (prompt.isFilterable() && filterText.length() > 0) {
                         filterText.setLength(0);
                         filteredItems = allItems;
                         range = null;

--- a/prompt/src/test/java/org/jline/prompt/PrompterListExecutionTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PrompterListExecutionTest.java
@@ -166,6 +166,70 @@ public class PrompterListExecutionTest {
         assertTrue(selected.contains("pepperoni"));
     }
 
+    private Prompter createPrompter(String input) throws Exception {
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write(input.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Terminal terminal =
+                TerminalBuilder.builder().type("ansi").streams(in, out).build();
+        terminal.setSize(new Size(160, 80));
+        return PrompterFactory.create(terminal);
+    }
+
+    private ListBuilder buildFruitListPrompt(Prompter prompter) {
+        return prompter.newBuilder()
+                .createListPrompt()
+                .name("fruit")
+                .message("Choose a fruit:")
+                .add("apple", "Apple")
+                .add("banana", "Banana")
+                .add("cherry", "Cherry");
+    }
+
+    @Test
+    void testListPromptFilterableSelectsFilteredItem() throws Exception {
+        // Type "ch" to filter, then Enter to select the filtered result ("Cherry")
+        Prompter prompter = createPrompter("ch\n");
+        PromptBuilder builder = buildFruitListPrompt(prompter).addPrompt();
+
+        ListResult result = (ListResult)
+                prompter.prompt(Collections.emptyList(), builder.build()).get("fruit");
+        assertEquals("cherry", result.getSelectedId());
+    }
+
+    @Test
+    void testListPromptNotFilterableIgnoresTypedCharacters() throws Exception {
+        // Type "ch" (should be ignored), then Enter to select first item
+        Prompter prompter = createPrompter("ch\n");
+        PromptBuilder builder = buildFruitListPrompt(prompter).filterable(false).addPrompt();
+
+        ListResult result = (ListResult)
+                prompter.prompt(Collections.emptyList(), builder.build()).get("fruit");
+        assertEquals("apple", result.getSelectedId());
+    }
+
+    @Test
+    void testCheckboxPromptNotFilterableIgnoresTypedCharacters() throws Exception {
+        // Type "abc" (should be ignored since filterable=false), Space to toggle first item, Enter
+        Prompter prompter = createPrompter("abc \n");
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createCheckboxPrompt()
+                .name("toppings")
+                .message("Select toppings:")
+                .filterable(false)
+                .add("cheese", "Cheese")
+                .add("pepperoni", "Pepperoni")
+                .add("mushrooms", "Mushrooms")
+                .addPrompt();
+
+        CheckboxResult result = (CheckboxResult)
+                prompter.prompt(Collections.emptyList(), builder.build()).get("toppings");
+        Set<String> selected = result.getSelectedIds();
+        assertEquals(1, selected.size());
+        assertTrue(selected.contains("cheese"));
+    }
+
     @Test
     void testChoicePromptSelectByKey() throws Exception {
         // Setup input/output streams

--- a/prompt/src/test/java/org/jline/prompt/PrompterListExecutionTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PrompterListExecutionTest.java
@@ -209,19 +209,35 @@ public class PrompterListExecutionTest {
         assertEquals("apple", result.getSelectedId());
     }
 
+    private CheckboxBuilder buildToppingsCheckboxPrompt(Prompter prompter) {
+        return prompter.newBuilder()
+                .createCheckboxPrompt()
+                .name("toppings")
+                .message("Select toppings:")
+                .add("cheese", "Cheese")
+                .add("pepperoni", "Pepperoni")
+                .add("mushrooms", "Mushrooms");
+    }
+
+    @Test
+    void testCheckboxPromptFilterableSelectsFilteredItem() throws Exception {
+        // Type "ch" to filter to items matching "ch", Space to toggle, Enter to confirm
+        Prompter prompter = createPrompter("ch \n");
+        PromptBuilder builder = buildToppingsCheckboxPrompt(prompter).addPrompt();
+
+        CheckboxResult result = (CheckboxResult)
+                prompter.prompt(Collections.emptyList(), builder.build()).get("toppings");
+        Set<String> selected = result.getSelectedIds();
+        assertEquals(1, selected.size());
+        assertTrue(selected.contains("cheese"));
+    }
+
     @Test
     void testCheckboxPromptNotFilterableIgnoresTypedCharacters() throws Exception {
         // Type "abc" (should be ignored since filterable=false), Space to toggle first item, Enter
         Prompter prompter = createPrompter("abc \n");
-        PromptBuilder builder = prompter.newBuilder();
-        builder.createCheckboxPrompt()
-                .name("toppings")
-                .message("Select toppings:")
-                .filterable(false)
-                .add("cheese", "Cheese")
-                .add("pepperoni", "Pepperoni")
-                .add("mushrooms", "Mushrooms")
-                .addPrompt();
+        PromptBuilder builder =
+                buildToppingsCheckboxPrompt(prompter).filterable(false).addPrompt();
 
         CheckboxResult result = (CheckboxResult)
                 prompter.prompt(Collections.emptyList(), builder.build()).get("toppings");


### PR DESCRIPTION
List and checkbox prompts support inline text filtering by default, where typed characters filter the displayed items. This can confuse users who may accidentally paste text or type into the prompt without realizing it activates filtering, leaving them in a state they don't know how to exit.

Add a filterable(boolean) option to ListBuilder and CheckboxBuilder (default true) that allows disabling this behavior. When set to false, typed characters, backspace, and filter-clear on escape are ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable inline text filtering for list and checkbox prompts—enabled by default; can be turned off per prompt so typed characters are ignored.

* **Tests**
  * Added integration tests validating filtering on and off for list and checkbox prompts, including selection behavior when filtering is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->