### PR TITLE
perf: optimize Display.update for minimal allocation and output bytes

### DIFF
--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -245,52 +245,70 @@ public abstract class AttributedCharSequence implements CharSequence {
      */
     public String toAnsi(int colors, ForceMode force, ColorPalette palette, String altIn, String altOut) {
         ByteArrayBuilder buf = new ByteArrayBuilder();
-        toAnsiBytes(buf, colors, force, palette, altIn, altOut);
+        long[] state = {0, 0};
+        toAnsiBytes(buf, 0, length(), colors, force, palette, altIn, altOut, state);
+        if (state[1] != 0) {
+            buf.appendAscii(altOut);
+        }
+        if (state[0] != 0) {
+            buf.csi().appendAscii("0m");
+        }
         return buf.toStringUtf8();
     }
 
     /**
-     * Write the ANSI-encoded UTF-8 bytes for this attributed string into the provided buffer.
+     * Write ANSI-encoded UTF-8 bytes for a range, carrying style state across calls.
      *
-     * <p>The method encodes styles, colors, decoration attributes, and alternate-charset
-     * box-drawing sequences as ANSI control sequences and appends their UTF-8 bytes to
-     * {@code buf}. If {@code palette} is null, the default palette is used. The method
-     * ensures any active alternate-charset is exited and final style state is reset
-     * before returning.</p>
+     * <p>This method does not reset style state on entry and does not emit a final
+     * {@code \e[0m} reset on exit. The caller manages the terminal style state via
+     * the {@code state} array:</p>
+     * <ul>
+     *   <li>{@code state[0]} — current style code (long)</li>
+     *   <li>{@code state[1]} — alt charset active (0 or 1)</li>
+     * </ul>
      *
-     * @param buf     the byte buffer to write UTF-8 bytes and ANSI control sequences to
-     * @param colors  the number of displayable colors to target when emitting color sequences
-     * @param force   the force mode that influences whether truecolor/256-color forms are used
-     * @param palette the color palette to use for rounding/indexing, or null to use the default
-     * @param altIn   the sequence to enter the terminal's alternate character set, or null
-     * @param altOut  the sequence to exit the terminal's alternate character set, or null
+     * <p>For self-contained rendering, initialize {@code state} to {@code {0, 0}}
+     * and emit a final reset after the call if {@code state[0] != 0}.</p>
+     *
+     * @param buf        the byte buffer to write UTF-8 bytes and ANSI control sequences to
+     * @param rangeStart start index in this sequence (inclusive)
+     * @param rangeEnd   end index in this sequence (exclusive)
+     * @param colors     the number of displayable colors to target
+     * @param force      the force mode for color rendering
+     * @param palette    the color palette, or null to use the default
+     * @param altIn      the sequence to enter alternate character set, or null
+     * @param altOut     the sequence to exit alternate character set, or null
+     * @param state      a reusable two-element array tracking style [0] and alt charset [1] state
      */
+    @SuppressWarnings("java:S107") // parameter count justified: avoids allocation of a parameter object in hot path
     void toAnsiBytes(
-            ByteArrayBuilder buf, int colors, ForceMode force, ColorPalette palette, String altIn, String altOut) {
-        long style = 0;
-        long[] colorState = {0, 0}; // [foreground, background]
-        boolean alt = false;
+            ByteArrayBuilder buf,
+            int rangeStart,
+            int rangeEnd,
+            int colors,
+            ForceMode force,
+            ColorPalette palette,
+            String altIn,
+            String altOut,
+            long[] state) {
+        long style = state[0];
+        boolean alt = state[1] != 0;
         if (palette == null) {
             palette = ColorPalette.DEFAULT;
         }
-        int i = 0;
-        int len = length();
-        while (i < len) {
+        int i = rangeStart;
+        while (i < rangeEnd) {
             char c = substituteChar(charAt(i), altIn, altOut);
             alt = emitAltCharset(buf, charAt(i), alt, altIn, altOut);
             long s = styleCodeAt(i) & ~F_HIDDEN;
             if (style != s) {
-                emitStyleChange(buf, style, s, colorState, colors, force, palette);
+                emitStyleChange(buf, style, s, colors, force, palette);
                 style = s;
             }
-            i += emitUtf8Char(buf, c, i, len);
+            i += emitUtf8Char(buf, c, i, rangeEnd);
         }
-        if (alt) {
-            buf.appendAscii(altOut);
-        }
-        if (style != 0) {
-            buf.csi().appendAscii("0m");
-        }
+        state[0] = style;
+        state[1] = alt ? 1 : 0;
     }
 
     /**
@@ -350,42 +368,42 @@ public abstract class AttributedCharSequence implements CharSequence {
      * @param buf        the byte-oriented builder to which CSI parameters and the final 'm' are appended
      * @param prevStyle  previously applied style code
      * @param newStyle   target style code to apply
-     * @param colorState two-element array tracking currently applied foreground (0) and background (1);
-     *                   this method mutates its entries to the values actually emitted
      * @param colors     terminal maximum color capability (affects truecolor/256-color selection)
      * @param force      force mode controlling preference for 256/true color output
      * @param palette    color palette used to round/lookup colors when not emitting direct RGB
      */
+    private static final long COLOR_BITS = F_FOREGROUND | F_BACKGROUND | FG_COLOR | BG_COLOR;
+
     private static void emitStyleChange(
-            ByteArrayBuilder buf,
-            long prevStyle,
-            long newStyle,
-            long[] colorState,
-            int colors,
-            ForceMode force,
-            ColorPalette palette) {
-        long fg = (newStyle & F_FOREGROUND) != 0 ? newStyle & (FG_COLOR | F_FOREGROUND) : 0;
-        long bg = (newStyle & F_BACKGROUND) != 0 ? newStyle & (BG_COLOR | F_BACKGROUND) : 0;
+            ByteArrayBuilder buf, long prevStyle, long newStyle, int colors, ForceMode force, ColorPalette palette) {
         if (newStyle == 0) {
             buf.csi().appendAscii("0m");
-            colorState[0] = 0;
-            colorState[1] = 0;
             return;
         }
         long d = (prevStyle ^ newStyle) & MASK;
+        // Fast path: if only text attributes changed (no color change), skip color extraction
+        if (((prevStyle ^ newStyle) & COLOR_BITS) == 0) {
+            buf.csi();
+            boolean first = appendDecorationAttrsB(buf, d, newStyle, true);
+            first = appendBoldFaintB(buf, d, newStyle, first);
+            buf.appendAscii('m');
+            return;
+        }
+        long fg = (newStyle & F_FOREGROUND) != 0 ? newStyle & (FG_COLOR | F_FOREGROUND) : 0;
+        long bg = (newStyle & F_BACKGROUND) != 0 ? newStyle & (BG_COLOR | F_BACKGROUND) : 0;
+        long prevFg = (prevStyle & F_FOREGROUND) != 0 ? prevStyle & (FG_COLOR | F_FOREGROUND) : 0;
+        long prevBg = (prevStyle & F_BACKGROUND) != 0 ? prevStyle & (BG_COLOR | F_BACKGROUND) : 0;
         buf.csi();
         boolean first = true;
         first = appendDecorationAttrsB(buf, d, newStyle, first);
-        if (colorState[0] != fg) {
+        if (prevFg != fg) {
             first = appendColorB(buf, fg, true, colors, force, palette, first);
             if (fg > 0 && usedBasicFgColor(fg, colors, force, palette)) {
                 d |= (newStyle & F_BOLD);
             }
-            colorState[0] = fg;
         }
-        if (colorState[1] != bg) {
+        if (prevBg != bg) {
             first = appendColorB(buf, bg, false, colors, force, palette, first);
-            colorState[1] = bg;
         }
         first = appendBoldFaintB(buf, d, newStyle, first);
         buf.appendAscii('m');
@@ -812,6 +830,8 @@ public abstract class AttributedCharSequence implements CharSequence {
 
     protected abstract char[] buffer();
 
+    abstract long[] styleBuffer();
+
     protected abstract int offset();
 
     @Override
@@ -927,10 +947,54 @@ public abstract class AttributedCharSequence implements CharSequence {
      * @return the display width in columns
      */
     public int columnLength(Terminal terminal) {
+        return columnLength(terminal, 0, length());
+    }
+
+    /**
+     * Returns the display width in columns for a range of this attributed string.
+     *
+     * <p>This is an allocation-free alternative to creating a subSequence and calling
+     * {@link #columnLength(Terminal)} on it.</p>
+     *
+     * @param terminal   the terminal to query for grapheme cluster mode, or {@code null}
+     * @param rangeStart start index in this sequence (inclusive)
+     * @param rangeEnd   end index in this sequence (exclusive)
+     * @return the display width in columns for the specified range
+     * @since 4.1.0
+     */
+    public int columnLength(Terminal terminal, int rangeStart, int rangeEnd) {
+        BreakIterator bi = WCWidth.HAS_JDK_GRAPHEME_SUPPORT ? BreakIterator.getCharacterInstance() : null;
+        return columnLength(terminal, bi, new WCWidth.CharSequenceCharacterIterator(), rangeStart, rangeEnd);
+    }
+
+    /**
+     * Returns the display width in columns for a range of this attributed string,
+     * using a pre-allocated {@link BreakIterator} and {@link WCWidth.CharSequenceCharacterIterator}
+     * to avoid per-call allocation.
+     *
+     * @param terminal   the terminal to query for grapheme cluster mode, or {@code null}
+     * @param rangeStart start index in this sequence (inclusive)
+     * @param rangeEnd   end index in this sequence (exclusive)
+     * @param bi         a pre-allocated BreakIterator, or {@code null}
+     * @param iter       a reusable CharSequenceCharacterIterator
+     * @return the display width in columns for the specified range
+     */
+    int columnLength(
+            Terminal terminal,
+            BreakIterator bi,
+            WCWidth.CharSequenceCharacterIterator iter,
+            int rangeStart,
+            int rangeEnd) {
         int cols = 0;
-        int len = length();
-        BreakIterator bi = WCWidth.createGraphemeBreakIterator(this);
-        for (int cur = 0; cur < len; ) {
+        if (bi != null
+                && ((terminal != null && terminal.getGraphemeClusterMode())
+                        || (terminal == null && WCWidth.HAS_JDK_GRAPHEME_SUPPORT))) {
+            WCWidth.resetGraphemeBreakIterator(bi, this, iter);
+        } else {
+            bi = null;
+        }
+        int cur = rangeStart;
+        while (cur < rangeEnd) {
             int charCount = WCWidth.charCountForDisplay(this, cur, terminal, bi);
             int w = isHidden(cur) ? 0 : WCWidth.wcwidthForDisplay(this, cur, terminal, charCount);
             cur += charCount;

--- a/terminal/src/main/java/org/jline/utils/AttributedString.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedString.java
@@ -189,7 +189,7 @@ public class AttributedString extends AttributedCharSequence {
      * @param start the start index in the buffers
      * @param end the end index in the buffers
      */
-    AttributedString(char[] buffer, long[] style, int start, int end) {
+    protected AttributedString(char[] buffer, long[] style, int start, int end) {
         this.buffer = buffer;
         this.style = style;
         this.start = start;
@@ -333,6 +333,11 @@ public class AttributedString extends AttributedCharSequence {
     @Override
     protected char[] buffer() {
         return buffer;
+    }
+
+    @Override
+    long[] styleBuffer() {
+        return style;
     }
 
     /**

--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -193,6 +193,11 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
         return buffer;
     }
 
+    @Override
+    long[] styleBuffer() {
+        return style;
+    }
+
     /**
      * Returns the offset in the buffer where this attributed string builder starts.
      *

--- a/terminal/src/main/java/org/jline/utils/DiffHelper.java
+++ b/terminal/src/main/java/org/jline/utils/DiffHelper.java
@@ -96,49 +96,101 @@ public class DiffHelper {
     }
 
     /**
-     * Compute a list of difference between two lines.
-     * The result will contain at most 4 Diff objects, as the method
-     * aims to return the common prefix, inserted text, deleted text and
-     * common suffix.
-     * The computation is done on characters and their attributes expressed
-     * as ansi sequences.
+     * Compute the common prefix and suffix lengths between two attributed strings
+     * without any object allocation.
      *
-     * @param text1 the old line
-     * @param text2 the new line
-     * @return a list of Diff
+     * <p>This is an allocation-free alternative to {@link #diff(AttributedString, AttributedString)}
+     * that stores the common prefix length in {@code result[0]} and the common suffix length
+     * in {@code result[1]}. The caller can derive the diff segments from these two values:
+     * <ul>
+     *   <li>EQUAL prefix: {@code [s1, s1 + result[0])}</li>
+     *   <li>INSERT: {@code [s2 + result[0], e2 - result[1])}</li>
+     *   <li>DELETE: {@code [s1 + result[0], e1 - result[1])}</li>
+     *   <li>EQUAL suffix: {@code [e1 - result[1], e1)}</li>
+     * </ul>
+     *
+     * @param text1  the old line
+     * @param s1     start index in text1 (inclusive)
+     * @param e1     end index in text1 (exclusive)
+     * @param text2  the new line
+     * @param s2     start index in text2 (inclusive)
+     * @param e2     end index in text2 (exclusive)
+     * @param result a reusable two-element array; on return result[0] = commonStart, result[1] = commonEnd
+     */
+    static void diff(AttributedString text1, int s1, int e1, AttributedString text2, int s2, int e2, int[] result) {
+        int n = Math.min(e1 - s1, e2 - s2);
+        int commonStart = commonPrefixLength(text1, s1, e1, text2, s2, e2, n);
+        result[0] = commonStart;
+        result[1] = commonSuffixLength(text1, e1, text2, e2, n - commonStart);
+    }
+
+    /**
+     * Scan forward for the common prefix length, respecting hidden-range boundaries.
+     */
+    private static int commonPrefixLength(
+            AttributedString text1, int s1, int e1, AttributedString text2, int s2, int e2, int n) {
+        int commonStart = 0;
+        int startHiddenRange = -1;
+        while (commonStart < n
+                && text1.charAt(s1 + commonStart) == text2.charAt(s2 + commonStart)
+                && text1.styleCodeAt(s1 + commonStart) == text2.styleCodeAt(s2 + commonStart)) {
+            if (text1.isHidden(s1 + commonStart)) {
+                if (startHiddenRange < 0) startHiddenRange = commonStart;
+            } else {
+                startHiddenRange = -1;
+            }
+            commonStart++;
+        }
+        if (startHiddenRange >= 0
+                && (((e1 - s1) > commonStart && text1.isHidden(s1 + commonStart))
+                        || ((e2 - s2) > commonStart && text2.isHidden(s2 + commonStart)))) {
+            commonStart = startHiddenRange;
+        }
+        return commonStart;
+    }
+
+    /**
+     * Scan backward for the common suffix length, respecting hidden-range boundaries.
+     */
+    private static int commonSuffixLength(AttributedString text1, int e1, AttributedString text2, int e2, int n) {
+        int commonEnd = 0;
+        int startHiddenRange = -1;
+        while (commonEnd < n
+                && text1.charAt(e1 - commonEnd - 1) == text2.charAt(e2 - commonEnd - 1)
+                && text1.styleCodeAt(e1 - commonEnd - 1) == text2.styleCodeAt(e2 - commonEnd - 1)) {
+            if (text1.isHidden(e1 - commonEnd - 1)) {
+                if (startHiddenRange < 0) startHiddenRange = commonEnd;
+            } else {
+                startHiddenRange = -1;
+            }
+            commonEnd++;
+        }
+        if (startHiddenRange >= 0
+                && commonEnd < n
+                && (text1.isHidden(e1 - commonEnd - 1) || text2.isHidden(e2 - commonEnd - 1))) {
+            commonEnd = startHiddenRange;
+        }
+        return commonEnd;
+    }
+
+    /**
+     * Compute the differences between two attributed strings.
+     *
+     * <p>Returns a list of {@link Diff} operations (EQUAL, INSERT, DELETE) that
+     * transform {@code text1} into {@code text2}. Hidden character ranges are
+     * kept intact — they are never split across diff segments.</p>
+     *
+     * @param text1 the original text
+     * @param text2 the modified text
+     * @return a list of diff operations
      */
     public static List<Diff> diff(AttributedString text1, AttributedString text2) {
         int l1 = text1.length();
         int l2 = text2.length();
-        int n = Math.min(l1, l2);
-        int commonStart = 0;
-        // Given a run of contiguous "hidden" characters (which are
-        // sequences of uninterrupted escape sequences) we always want to
-        // print either the entire run or none of it - never a part of it.
-        int startHiddenRange = -1;
-        while (commonStart < n
-                && text1.charAt(commonStart) == text2.charAt(commonStart)
-                && text1.styleAt(commonStart).equals(text2.styleAt(commonStart))) {
-            if (text1.isHidden(commonStart)) {
-                if (startHiddenRange < 0) startHiddenRange = commonStart;
-            } else startHiddenRange = -1;
-            commonStart++;
-        }
-        if (startHiddenRange >= 0
-                && ((l1 > commonStart && text1.isHidden(commonStart))
-                        || (l2 > commonStart && text2.isHidden(commonStart)))) commonStart = startHiddenRange;
-
-        startHiddenRange = -1;
-        int commonEnd = 0;
-        while (commonEnd < n - commonStart
-                && text1.charAt(l1 - commonEnd - 1) == text2.charAt(l2 - commonEnd - 1)
-                && text1.styleAt(l1 - commonEnd - 1).equals(text2.styleAt(l2 - commonEnd - 1))) {
-            if (text1.isHidden(l1 - commonEnd - 1)) {
-                if (startHiddenRange < 0) startHiddenRange = commonEnd;
-            } else startHiddenRange = -1;
-            commonEnd++;
-        }
-        if (startHiddenRange >= 0) commonEnd = startHiddenRange;
+        int[] result = new int[2];
+        diff(text1, 0, l1, text2, 0, l2, result);
+        int commonStart = result[0];
+        int commonEnd = result[1];
         LinkedList<Diff> diffs = new LinkedList<>();
         if (commonStart > 0) {
             diffs.add(new Diff(DiffHelper.Operation.EQUAL, text1.subSequence(0, commonStart)));

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -11,12 +11,14 @@ package org.jline.utils;
 import java.io.IOError;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.text.BreakIterator;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
@@ -109,6 +111,23 @@ public class Display {
     private String ansiAltIn;
     private String ansiAltOut;
 
+    // Pre-allocated reusable arrays for zero-allocation update path
+    private final int[] diffResult = new int[2];
+    private final int[] lcsResult = new int[3];
+    // Style state: [0]=current style, [1]=alt charset (0/1)
+    private final long[] ansiColorState = new long[2];
+    private final BreakIterator graphemeBreakIterator;
+    private final WCWidth.CharSequenceCharacterIterator graphemeCharIterator;
+    private final boolean hasCursorAddress;
+    private final boolean canSkipIntraLine;
+
+    /*
+     * Minimum number of unchanged characters within a changed region that justifies
+     * a cursor-movement skip instead of re-emitting them.  A CUF escape (\e[nC)
+     * costs 4-6 bytes, so gaps shorter than this are cheaper to re-emit inline.
+     */
+    private static final int INTRA_LINE_SKIP_THRESHOLD = 8;
+
     /**
      * Create a Display bound to the given Terminal and configured for either full-screen
      * or inline (partial-screen) usage.
@@ -132,6 +151,19 @@ public class Display {
         this.wrapAtEol = this.terminalWrapAtEol;
         this.delayedWrapAtEol = this.terminalDelayedWrapAtEol;
         this.cursorDownIsNewLine = "\n".equals(Curses.tputs(terminal.getStringCapability(Capability.cursor_down)));
+        if (!AttributedCharSequence.DISABLE_ALTERNATE_CHARSET) {
+            this.ansiAltIn = Curses.tputs(terminal.getStringCapability(Capability.enter_alt_charset_mode));
+            this.ansiAltOut = Curses.tputs(terminal.getStringCapability(Capability.exit_alt_charset_mode));
+        }
+        if (WCWidth.HAS_JDK_GRAPHEME_SUPPORT) {
+            this.graphemeBreakIterator = BreakIterator.getCharacterInstance();
+            this.graphemeCharIterator = new WCWidth.CharSequenceCharacterIterator();
+        } else {
+            this.graphemeBreakIterator = null;
+            this.graphemeCharIterator = null;
+        }
+        this.hasCursorAddress = fullScreen && terminal.getStringCapability(Capability.cursor_address) != null;
+        this.canSkipIntraLine = terminal.getStringCapability(Capability.parm_right_cursor) != null;
     }
 
     /**
@@ -240,12 +272,28 @@ public class Display {
         }
     }
 
+    /**
+     * Update the display with lines containing ANSI escape sequences and flush the output.
+     *
+     * <p>Each string in the list is parsed via {@link AttributedString#fromAnsi(String)}
+     * to convert ANSI escape codes into styled {@link AttributedString}s, then delegated
+     * to {@link #update(List, int)}.</p>
+     *
+     * @param newLines         the new lines to display, with embedded ANSI escape sequences
+     * @param targetCursorPos  the desired cursor position after the update (0-based character offset
+     *                         from the start of the first line, or -1 to leave the cursor at the end)
+     */
     public void updateAnsi(List<String> newLines, int targetCursorPos) {
-        update(newLines.stream().map(AttributedString::fromAnsi).collect(Collectors.toList()), targetCursorPos);
+        List<AttributedString> attrLines = new ArrayList<>(newLines.size());
+        for (int i = 0; i < newLines.size(); i++) {
+            attrLines.add(AttributedString.fromAnsi(newLines.get(i)));
+        }
+        update(attrLines, targetCursorPos);
     }
 
     /**
      * Update the display according to the new lines and flushes the output.
+     *
      * @param newLines the lines to display
      * @param targetCursorPos desired cursor position - see Size.cursorPos.
      */
@@ -255,6 +303,98 @@ public class Display {
 
     /**
      * Update the display according to the new lines.
+     *
+     * <p>Accepts any {@link AttributedCharSequence} implementation (including
+     * {@link AttributedStringBuilder}). When mutable sequences are passed,
+     * only lines that have changed since the last frame are snapshotted via
+     * {@link AttributedCharSequence#toAttributedString()}; unchanged lines
+     * reuse the existing {@link AttributedString} from the previous frame.</p>
+     *
+     * @param newLines the lines to display
+     * @param targetCursorPos desired cursor position - see Size.cursorPos.
+     * @since 4.1.0
+     */
+    public void updateSequences(List<? extends AttributedCharSequence> newLines, int targetCursorPos) {
+        updateSequences(newLines, targetCursorPos, true);
+    }
+
+    /**
+     * Update the display according to the new lines.
+     *
+     * <p>Accepts any {@link AttributedCharSequence} implementation (including
+     * {@link AttributedStringBuilder}). When mutable sequences are passed,
+     * only lines that have changed since the last frame are snapshotted via
+     * {@link AttributedCharSequence#toAttributedString()}; unchanged lines
+     * reuse the existing {@link AttributedString} from the previous frame.</p>
+     *
+     * @param newLines the lines to display
+     * @param targetCursorPos desired cursor position - see Size.cursorPos.
+     * @param flush whether the output should be flushed or not
+     * @since 4.1.0
+     */
+    public void updateSequences(List<? extends AttributedCharSequence> newLines, int targetCursorPos, boolean flush) {
+        update(snapshotLines(newLines), targetCursorPos, flush);
+    }
+
+    /**
+     * Update the display from flat character and style arrays representing a cell grid.
+     *
+     * <p>The arrays are row-major: position {@code y * width + x} holds the data for
+     * column x, row y. The caller fills both arrays for every cell in the grid;
+     * Display compares against its internal {@code oldLines} state and only
+     * creates new {@link AttributedString} instances for rows that have changed.</p>
+     *
+     * <p>Unchanged rows reuse the existing {@code oldLines} entry by identity,
+     * so scroll detection via {@link #update(List, int, boolean)} works without
+     * additional cost.</p>
+     *
+     * @param chars  character data, length &gt;= width * height
+     * @param styles style codes (from {@link AttributedStyle#getStyle()}), same layout
+     * @param widths number of actual characters per row, length &gt;= height.
+     *               Use {@code null} if every row is exactly {@code width} chars.
+     * @param width  the column count (grid width)
+     * @param height the row count (grid height)
+     * @param targetCursorPos desired cursor position — see Size.cursorPos
+     * @param flush  whether the output should be flushed
+     * @since 4.1.0
+     */
+    public void update(
+            char[] chars, long[] styles, int[] widths, int width, int height, int targetCursorPos, boolean flush) {
+        List<AttributedString> newLines = new ArrayList<>(height);
+        for (int y = 0; y < height; y++) {
+            int offset = y * width;
+            int len = widths != null ? widths[y] : width;
+            // Compare against oldLines — skip unchanged rows
+            if (y < oldLines.size()) {
+                AttributedString old = oldLines.get(y);
+                if (old.length() == len && rowEquals(chars, styles, offset, len, old)) {
+                    newLines.add(old);
+                    continue;
+                }
+            }
+            // Changed row: snapshot into a new AttributedString
+            char[] rowChars = Arrays.copyOfRange(chars, offset, offset + len);
+            long[] rowStyles = Arrays.copyOfRange(styles, offset, offset + len);
+            newLines.add(new AttributedString(rowChars, rowStyles, 0, len));
+        }
+        update(newLines, targetCursorPos, flush);
+    }
+
+    private static boolean rowEquals(char[] chars, long[] styles, int offset, int len, AttributedString old) {
+        char[] oldBuf = old.buffer();
+        long[] oldStyle = old.styleBuffer();
+        int oldOff = old.offset();
+        for (int i = 0; i < len; i++) {
+            if (chars[offset + i] != oldBuf[oldOff + i] || styles[offset + i] != oldStyle[oldOff + i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Update the display according to the new lines.
+     *
      * @param newLines the lines to display
      * @param targetCursorPos desired cursor position - see Size.cursorPos.
      * @param flush whether the output should be flushed or not
@@ -274,13 +414,10 @@ public class Display {
             ansiColors = cols;
             ansiForceMode = AttributedCharSequence.ForceMode.None;
             ansiPalette = terminal.getPalette();
-            if (!AttributedCharSequence.DISABLE_ALTERNATE_CHARSET) {
-                ansiAltIn = Curses.tputs(terminal.getStringCapability(Capability.enter_alt_charset_mode));
-                ansiAltOut = Curses.tputs(terminal.getStringCapability(Capability.exit_alt_charset_mode));
-            } else {
-                ansiAltIn = null;
-                ansiAltOut = null;
-            }
+            // ansiAltIn / ansiAltOut are cached from the constructor
+            // Reset style state for this update cycle
+            ansiColorState[0] = 0;
+            ansiColorState[1] = 0;
         }
 
         if (reset) {
@@ -292,9 +429,11 @@ public class Display {
 
         // If dumb display, get rid of ansi sequences now
         if (cols == null || cols < 8) {
-            newLines = newLines.stream()
-                    .map(s -> new AttributedString(s.toString()))
-                    .collect(Collectors.toList());
+            List<AttributedString> stripped = new ArrayList<>(newLines.size());
+            for (int idx = 0; idx < newLines.size(); idx++) {
+                stripped.add(new AttributedString(newLines.get(idx).toString()));
+            }
+            newLines = stripped;
         }
 
         // Detect scrolling
@@ -312,13 +451,13 @@ public class Display {
                             oldLines.get(oldLines.size() - nbFooters - 1))) {
                 nbFooters++;
             }
-            List<AttributedString> o1 = newLines.subList(nbHeaders, newLines.size() - nbFooters);
-            List<AttributedString> o2 = oldLines.subList(nbHeaders, oldLines.size() - nbFooters);
-            int[] common = longestCommon(o1, o2);
-            if (common != null) {
-                int s1 = common[0];
-                int s2 = common[1];
-                int sl = common[2];
+            int fromIndex = nbHeaders;
+            int toIndex = newLines.size() - nbFooters;
+            longestCommon(newLines, fromIndex, toIndex, oldLines, fromIndex, toIndex);
+            if (lcsResult[2] > 0) {
+                int s1 = lcsResult[0];
+                int s2 = lcsResult[1];
+                int sl = lcsResult[2];
                 if (sl > 1 && s1 < s2) {
                     moveVisualCursorTo((nbHeaders + s1) * columns1);
                     int nb = s2 - s1;
@@ -330,7 +469,7 @@ public class Display {
                         moveVisualCursorTo((nbHeaders + s1 + sl) * columns1);
                         insertLines(nb);
                         for (int i = 0; i < nb; i++) {
-                            oldLines.add(nbHeaders + s1 + sl, new AttributedString(""));
+                            oldLines.add(nbHeaders + s1 + sl, AttributedString.EMPTY);
                         }
                     }
                 } else if (sl > 1 && s1 > s2) {
@@ -345,7 +484,7 @@ public class Display {
                     moveVisualCursorTo((nbHeaders + s2) * columns1);
                     insertLines(nb);
                     for (int i = 0; i < nb; i++) {
-                        oldLines.add(nbHeaders + s2, new AttributedString(""));
+                        oldLines.add(nbHeaders + s2, AttributedString.EMPTY);
                     }
                 }
             }
@@ -360,55 +499,59 @@ public class Display {
             AttributedString newLine = lineIndex < newLines.size() ? newLines.get(lineIndex) : AttributedString.EMPTY;
             currentPos = lineIndex * columns1;
             int curCol = currentPos;
-            int oldLength = oldLine.length();
-            int newLength = newLine.length();
-            boolean oldNL = oldLength > 0 && oldLine.charAt(oldLength - 1) == '\n';
-            boolean newNL = newLength > 0 && newLine.charAt(newLength - 1) == '\n';
+            // Track effective ranges instead of creating substrings
+            int oStart = 0;
+            int oEnd = oldLine.length();
+            int nStart = 0;
+            int nEnd = newLine.length();
+            boolean oldNL = oEnd > 0 && oldLine.charAt(oEnd - 1) == '\n';
+            boolean newNL = nEnd > 0 && newLine.charAt(nEnd - 1) == '\n';
             if (oldNL) {
-                oldLength--;
-                oldLine = oldLine.substring(0, oldLength);
+                oEnd--;
             }
             if (newNL) {
-                newLength--;
-                newLine = newLine.substring(0, newLength);
+                nEnd--;
             }
             if (wrapNeeded && lineIndex == (cursorPos + 1) / columns1 && lineIndex < newLines.size()) {
                 // move from right margin to next line's left margin
                 cursorPos++;
-                if (newLength == 0 || newLine.isHidden(0)) {
+                if (nEnd - nStart == 0 || newLine.isHidden(nStart)) {
                     // go to next line column zero
+                    ensureDefaultAnsiStyle();
                     rawPrint(' ');
                     puts(Capability.cursor_left);
                 } else {
-                    AttributedString firstChar = newLine.substring(0, 1);
                     // go to next line column one
-                    rawPrint(firstChar);
-                    cursorPos += firstChar.columnLength(terminal); // normally 1
-                    newLine = newLine.substring(1, newLength);
-                    newLength--;
-                    if (oldLength > 0) {
-                        oldLine = oldLine.substring(1, oldLength);
-                        oldLength--;
+                    rawPrint(newLine, nStart, nStart + 1);
+                    cursorPos += newLine.columnLength(
+                            terminal, graphemeBreakIterator, graphemeCharIterator, nStart, nStart + 1); // normally 1
+                    nStart++;
+                    if (oEnd - oStart > 0) {
+                        oStart++;
                     }
                     currentPos = cursorPos;
                 }
             }
+            int oLen = oEnd - oStart;
+            int nLen = nEnd - nStart;
             // When grapheme cluster mode is active, the terminal may retroactively
             // combine or uncombine characters as ZWJ and other combining code points
             // are added incrementally. This invalidates cursor position tracking
             // based on char-level diffs. Force a full line repaint in this case.
-            if (terminal.getGraphemeClusterMode() && !oldLine.equals(newLine)) {
+            if (terminal.getGraphemeClusterMode() && !equalsRange(oldLine, oStart, oEnd, newLine, nStart, nEnd)) {
                 cursorPos = moveVisualCursorTo(currentPos);
+                ensureDefaultAnsiStyle();
                 if (!puts(Capability.clr_eol)) {
-                    int oldLen = oldLine.columnLength(terminal);
+                    int oldLen =
+                            oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, oStart, oEnd);
                     if (oldLen > 0) {
                         rawPrint(' ', oldLen);
                         cursorPos += oldLen;
                         cursorPos = moveVisualCursorTo(currentPos);
                     }
                 }
-                rawPrint(newLine);
-                cursorPos += newLine.columnLength(terminal);
+                rawPrint(newLine, nStart, nEnd);
+                cursorPos += newLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, nStart, nEnd);
                 currentPos = cursorPos;
                 lineIndex++;
                 boolean newWrap2 = !newNL && lineIndex < newLines.size();
@@ -416,74 +559,112 @@ public class Display {
                 wrapNeeded = newWrap2;
                 continue;
             }
-            List<DiffHelper.Diff> diffs = DiffHelper.diff(oldLine, newLine);
+            // Inline diff: compute common prefix/suffix lengths without allocation
+            DiffHelper.diff(oldLine, oStart, oEnd, newLine, nStart, nEnd, diffResult);
+            int cs = diffResult[0]; // common prefix length
+            int ce = diffResult[1]; // common suffix length
+            boolean hasInsert = nLen > cs + ce;
+            boolean hasDelete = oLen > cs + ce;
+            boolean hasEqSuffix = ce > 0;
             boolean ident = true;
             boolean cleared = false;
-            for (int i = 0; i < diffs.size(); i++) {
-                DiffHelper.Diff diff = diffs.get(i);
-                int width = diff.text.columnLength(terminal);
-                switch (diff.operation) {
-                    case EQUAL:
-                        if (!ident) {
-                            cursorPos = moveVisualCursorTo(currentPos);
-                            rawPrint(diff.text);
-                            cursorPos += width;
-                            currentPos = cursorPos;
-                        } else {
-                            currentPos += width;
-                        }
-                        break;
-                    case INSERT:
-                        if (i <= diffs.size() - 2 && diffs.get(i + 1).operation == DiffHelper.Operation.EQUAL) {
-                            cursorPos = moveVisualCursorTo(currentPos);
-                            if (insertChars(width)) {
-                                rawPrint(diff.text);
-                                cursorPos += width;
-                                currentPos = cursorPos;
-                                break;
-                            }
-                        } else if (i <= diffs.size() - 2
-                                && diffs.get(i + 1).operation == DiffHelper.Operation.DELETE
-                                && width == diffs.get(i + 1).text.columnLength(terminal)) {
-                            moveVisualCursorTo(currentPos);
-                            rawPrint(diff.text);
-                            cursorPos += width;
-                            currentPos = cursorPos;
-                            i++; // skip delete
-                            break;
-                        }
-                        moveVisualCursorTo(currentPos);
-                        rawPrint(diff.text);
-                        cursorPos += width;
+            // EQUAL prefix
+            if (cs > 0) {
+                currentPos += oldLine.columnLength(
+                        terminal, graphemeBreakIterator, graphemeCharIterator, oStart, oStart + cs);
+            }
+            // INSERT
+            if (hasInsert) {
+                int iStart = nStart + cs;
+                int iEnd = nEnd - ce;
+                int insertWidth =
+                        newLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, iStart, iEnd);
+                boolean insertHandled = false;
+                // Optimization: if followed by EQUAL suffix (no DELETE), try insertChars
+                if (hasEqSuffix && !hasDelete) {
+                    cursorPos = moveVisualCursorTo(currentPos);
+                    ensureDefaultAnsiStyle();
+                    if (insertChars(insertWidth)) {
+                        rawPrint(newLine, iStart, iEnd);
+                        cursorPos += insertWidth;
                         currentPos = cursorPos;
-                        ident = false;
-                        break;
-                    case DELETE:
-                        if (cleared) {
-                            continue;
-                        }
-                        if (currentPos - curCol >= columns) {
-                            continue;
-                        }
-                        if (i <= diffs.size() - 2 && diffs.get(i + 1).operation == DiffHelper.Operation.EQUAL) {
-                            if (currentPos + diffs.get(i + 1).text.columnLength(terminal) < columns) {
-                                moveVisualCursorTo(currentPos);
-                                if (deleteChars(width)) {
-                                    break;
-                                }
-                            }
-                        }
-                        int oldLen = oldLine.columnLength(terminal);
-                        int newLen = newLine.columnLength(terminal);
-                        int nb = Math.max(oldLen, newLen) - (currentPos - curCol);
+                        insertHandled = true;
+                    }
+                }
+                // Optimization: if followed by DELETE with same width, overwrite
+                if (!insertHandled && hasDelete) {
+                    int dStart = oStart + cs;
+                    int dEnd = oEnd - ce;
+                    int deleteWidth =
+                            oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, dStart, dEnd);
+                    if (insertWidth == deleteWidth) {
                         moveVisualCursorTo(currentPos);
-                        if (!puts(Capability.clr_eol)) {
-                            rawPrint(' ', nb);
-                            cursorPos += nb;
+                        if (canSkipIntraLine && (iEnd - iStart) == (dEnd - dStart)) {
+                            emitOverwriteWithSkips(newLine, iStart, iEnd, oldLine, dStart);
+                        } else {
+                            rawPrint(newLine, iStart, iEnd);
+                            cursorPos += insertWidth;
                         }
-                        cleared = true;
-                        ident = false;
-                        break;
+                        currentPos = cursorPos;
+                        hasDelete = false; // skip DELETE processing
+                        insertHandled = true;
+                    }
+                }
+                // Default: just print
+                if (!insertHandled) {
+                    moveVisualCursorTo(currentPos);
+                    rawPrint(newLine, iStart, iEnd);
+                    cursorPos += insertWidth;
+                    currentPos = cursorPos;
+                    ident = false;
+                }
+            }
+            // DELETE
+            if (hasDelete && !cleared && currentPos - curCol < columns) {
+                int dStart = oStart + cs;
+                int dEnd = oEnd - ce;
+                int deleteWidth =
+                        oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, dStart, dEnd);
+                boolean deleteHandled = false;
+                // Optimization: if followed by EQUAL suffix, try deleteChars
+                if (hasEqSuffix) {
+                    int suffixWidth = oldLine.columnLength(
+                            terminal, graphemeBreakIterator, graphemeCharIterator, oEnd - ce, oEnd);
+                    if ((currentPos - curCol) + suffixWidth < columns) {
+                        moveVisualCursorTo(currentPos);
+                        ensureDefaultAnsiStyle();
+                        if (deleteChars(deleteWidth)) {
+                            deleteHandled = true;
+                        }
+                    }
+                }
+                if (!deleteHandled) {
+                    int oldColLen =
+                            oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, oStart, oEnd);
+                    int newColLen =
+                            newLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, nStart, nEnd);
+                    int nb = Math.max(oldColLen, newColLen) - (currentPos - curCol);
+                    moveVisualCursorTo(currentPos);
+                    ensureDefaultAnsiStyle();
+                    if (!puts(Capability.clr_eol)) {
+                        rawPrint(' ', nb);
+                        cursorPos += nb;
+                    }
+                    cleared = true;
+                    ident = false;
+                }
+            }
+            // EQUAL suffix
+            if (hasEqSuffix) {
+                int suffixWidth =
+                        oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, oEnd - ce, oEnd);
+                if (!ident) {
+                    cursorPos = moveVisualCursorTo(currentPos);
+                    rawPrint(newLine, nEnd - ce, nEnd);
+                    cursorPos += suffixWidth;
+                    currentPos = cursorPos;
+                } else {
+                    currentPos += suffixWidth;
                 }
             }
             lineIndex++;
@@ -496,11 +677,15 @@ public class Display {
                 if (newWrap != oldWrap && !(oldWrap && cleared)) {
                     moveVisualCursorTo(lineIndex * columns1 - 1, newLines);
                     if (newWrap) wrapNeeded = true;
-                    else puts(Capability.clr_eol);
+                    else {
+                        ensureDefaultAnsiStyle();
+                        puts(Capability.clr_eol);
+                    }
                 }
             } else if (atRight) {
                 if (this.wrapAtEol) {
                     if (!fullScreen || (fullScreen && lineIndex < numLines)) {
+                        ensureDefaultAnsiStyle();
                         rawPrint(' ');
                         puts(Capability.cursor_left);
                         cursorPos++;
@@ -516,6 +701,7 @@ public class Display {
             moveVisualCursorTo(targetCursorPos < 0 ? currentPos : targetCursorPos, newLines);
         }
         oldLines = newLines;
+        ensureDefaultAnsiStyle();
 
         if (useByteMode && byteBuilder.length() > 0) {
             // Flush any pending writer data, then write accumulated bytes
@@ -599,25 +785,141 @@ public class Display {
         return s != null ? s.length() : Integer.MAX_VALUE;
     }
 
-    private static int[] longestCommon(List<AttributedString> l1, List<AttributedString> l2) {
+    /*
+     * Snapshot a list of AttributedCharSequence into immutable AttributedString
+     * objects, reusing unchanged lines from oldLines to avoid unnecessary array copies.
+     */
+    private List<AttributedString> snapshotLines(List<? extends AttributedCharSequence> lines) {
+        List<AttributedString> result = new ArrayList<>(lines.size());
+        for (int i = 0; i < lines.size(); i++) {
+            AttributedCharSequence line = lines.get(i);
+            if (line instanceof AttributedString) {
+                result.add((AttributedString) line);
+            } else if (i < oldLines.size() && contentEquals(line, oldLines.get(i))) {
+                result.add(oldLines.get(i));
+            } else {
+                result.add(line.toAttributedString());
+            }
+        }
+        return result;
+    }
+
+    /*
+     * Compare two attributed char sequences for content equality using direct
+     * array access to avoid per-character virtual dispatch.
+     */
+    private static boolean contentEquals(AttributedCharSequence a, AttributedCharSequence b) {
+        int len = a.length();
+        if (len != b.length()) return false;
+        int offA = a.offset();
+        int offB = b.offset();
+        return Arrays.equals(a.buffer(), offA, offA + len, b.buffer(), offB, offB + len)
+                && Arrays.equals(a.styleBuffer(), offA, offA + len, b.styleBuffer(), offB, offB + len);
+    }
+
+    /*
+     * Compare ranges of two attributed strings for equality without allocation.
+     */
+    private static boolean equalsRange(
+            AttributedCharSequence a, int aStart, int aEnd, AttributedCharSequence b, int bStart, int bEnd) {
+        if (aEnd - aStart != bEnd - bStart) return false;
+        int offA = a.offset() + aStart;
+        int offB = b.offset() + bStart;
+        int endA = a.offset() + aEnd;
+        return Arrays.equals(a.buffer(), offA, endA, b.buffer(), offB, offB + (aEnd - aStart))
+                && Arrays.equals(a.styleBuffer(), offA, endA, b.styleBuffer(), offB, offB + (aEnd - aStart));
+    }
+
+    /*
+     * Emit the changed region of a same-width overwrite, using cursor movement
+     * to skip runs of unchanged characters that are at least
+     * INTRA_LINE_SKIP_THRESHOLD characters long.
+     *
+     * Both regions must have the same character count (not just the same
+     * display width).  When they differ, the caller should fall back to
+     * rawPrint(newLine, iStart, iEnd).
+     */
+    private void emitOverwriteWithSkips(
+            AttributedString newLine, int iStart, int iEnd, AttributedString oldLine, int dStart) {
+        int len = iEnd - iStart;
+        int pendingStart = -1; // start offset of segment to emit (-1 = none)
+        int pos = 0;
+
+        while (pos < len) {
+            // Detect run of unchanged characters
+            int runStart = pos;
+            while (pos < len
+                    && newLine.charAt(iStart + pos) == oldLine.charAt(dStart + pos)
+                    && newLine.styleCodeAt(iStart + pos) == oldLine.styleCodeAt(dStart + pos)) {
+                pos++;
+            }
+            int unchangedLen = pos - runStart;
+
+            if (unchangedLen >= INTRA_LINE_SKIP_THRESHOLD) {
+                // Gap is long enough to skip — first emit any pending content
+                pendingStart = flushPending(newLine, iStart, pendingStart, runStart);
+                // Skip the gap with cursor movement
+                int gapWidth = newLine.columnLength(
+                        terminal, graphemeBreakIterator, graphemeCharIterator, iStart + runStart, iStart + pos);
+                moveVisualCursorTo(cursorPos + gapWidth);
+            } else if (unchangedLen > 0 && pendingStart < 0) {
+                // Gap too short or at end — include in pending segment
+                pendingStart = runStart;
+            }
+
+            // Advance past the next changed character (if any)
+            if (pos < len) {
+                if (pendingStart < 0) pendingStart = pos;
+                pos++;
+            }
+        }
+
+        // Emit any remaining content
+        if (pendingStart >= 0) {
+            rawPrint(newLine, iStart + pendingStart, iEnd);
+            cursorPos += newLine.columnLength(
+                    terminal, graphemeBreakIterator, graphemeCharIterator, iStart + pendingStart, iEnd);
+        }
+    }
+
+    /*
+     * Emit the pending segment [pendingStart, segEnd) if any, and return -1.
+     */
+    private int flushPending(AttributedString line, int lineStart, int pendingStart, int segEnd) {
+        if (pendingStart >= 0) {
+            rawPrint(line, lineStart + pendingStart, lineStart + segEnd);
+            cursorPos += line.columnLength(
+                    terminal,
+                    graphemeBreakIterator,
+                    graphemeCharIterator,
+                    lineStart + pendingStart,
+                    lineStart + segEnd);
+        }
+        return -1;
+    }
+
+    private void longestCommon(
+            List<AttributedString> l1, int from1, int to1, List<AttributedString> l2, int from2, int to2) {
         int start1 = 0;
         int start2 = 0;
         int max = 0;
-        for (int i = 0; i < l1.size(); i++) {
-            for (int j = 0; j < l2.size(); j++) {
+        for (int i = from1; i < to1; i++) {
+            for (int j = from2; j < to2; j++) {
                 int x = 0;
                 while (Objects.equals(l1.get(i + x), l2.get(j + x))) {
                     x++;
-                    if (((i + x) >= l1.size()) || ((j + x) >= l2.size())) break;
+                    if (((i + x) >= to1) || ((j + x) >= to2)) break;
                 }
                 if (x > max) {
                     max = x;
-                    start1 = i;
-                    start2 = j;
+                    start1 = i - from1;
+                    start2 = j - from2;
                 }
             }
         }
-        return max != 0 ? new int[] {start1, start2, max} : null;
+        lcsResult[0] = start1;
+        lcsResult[1] = start2;
+        lcsResult[2] = max;
     }
 
     /*
@@ -662,6 +964,14 @@ public class Display {
         int c0 = i0 % width;
         int l1 = i1 / width;
         int c1 = i1 % width;
+        // Use absolute CUP for diagonal moves (both row and column change).
+        // CUP (\e[r;cH) is typically 6-10 bytes, which is almost always cheaper
+        // than the combined vertical + horizontal relative sequences.
+        if (hasCursorAddress && l0 != l1 && c0 != c1) {
+            puts(Capability.cursor_address, l1, c1);
+            cursorPos = i1;
+            return i1;
+        }
         if (c0 == columns) { // at right margin
             puts(Capability.carriage_return);
             c0 = 0;
@@ -732,10 +1042,73 @@ public class Display {
      * @param str the attributed string to write (may contain styling/ANSI sequences)
      */
     void rawPrint(AttributedString str) {
+        rawPrint(str, 0, str.length());
+    }
+
+    /**
+     * Writes a range of the given attributed string to the display output without
+     * creating a substring. In byte mode, style state is tracked across calls via
+     * {@code ansiColorState} to avoid redundant style resets and re-emissions.
+     *
+     * @param str   the attributed string to write
+     * @param start start index (inclusive)
+     * @param end   end index (exclusive)
+     */
+    void rawPrint(AttributedString str, int start, int end) {
+        if (start >= end) return;
         if (useByteMode) {
-            str.toAnsiBytes(byteBuilder, ansiColors, ansiForceMode, ansiPalette, ansiAltIn, ansiAltOut);
+            str.toAnsiBytes(
+                    byteBuilder,
+                    start,
+                    end,
+                    ansiColors,
+                    ansiForceMode,
+                    ansiPalette,
+                    ansiAltIn,
+                    ansiAltOut,
+                    ansiColorState);
         } else {
-            str.print(terminal);
+            // Non-byte-mode path: fall back to subSequence (rare path for non-UTF-8 terminals)
+            str.subSequence(start, end).print(terminal);
+        }
+    }
+
+    /*
+     * Ensure the terminal is in default ANSI style before emitting content that
+     * must appear unstyled (blanking spaces, clr_eol, insert/delete chars).
+     * Emits reset only when a non-default style is currently active.
+     */
+    private void ensureDefaultAnsiStyle() {
+        if (!useByteMode) return;
+        if (ansiColorState[1] != 0 && ansiAltOut != null) {
+            byteBuilder.appendAscii(ansiAltOut);
+            ansiColorState[1] = 0;
+        }
+        if (ansiColorState[0] != 0) {
+            byteBuilder.csi().appendAscii("0m");
+            ansiColorState[0] = 0;
+        }
+    }
+
+    private static final Object[] EMPTY_PARAMS = new Object[0];
+
+    /**
+     * Emit the terminal control sequence for a parameter-less capability without
+     * varargs allocation.
+     *
+     * @param capability the terminal capability to emit
+     * @return `true` if the capability sequence was emitted; `false` if unavailable
+     */
+    private boolean puts(Capability capability) {
+        if (useByteMode) {
+            String str = terminal.getStringCapability(capability);
+            if (str == null) {
+                return false;
+            }
+            Curses.tputs(byteAppendable, str, EMPTY_PARAMS);
+            return true;
+        } else {
+            return terminal.puts(capability, EMPTY_PARAMS);
         }
     }
 

--- a/terminal/src/main/java/org/jline/utils/WCWidth.java
+++ b/terminal/src/main/java/org/jline/utils/WCWidth.java
@@ -9,6 +9,7 @@
 package org.jline.utils;
 
 import java.text.BreakIterator;
+import java.text.CharacterIterator;
 
 import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.AbstractTerminal;
@@ -433,6 +434,112 @@ public final class WCWidth {
         BreakIterator bi = BreakIterator.getCharacterInstance();
         bi.setText(cs.toString());
         return bi;
+    }
+
+    /**
+     * Resets a pre-allocated {@link BreakIterator} to iterate over the given
+     * character sequence, using the supplied {@link CharSequenceCharacterIterator}
+     * to avoid the {@code toString()} allocation.
+     *
+     * @param bi   a pre-allocated BreakIterator (from {@link BreakIterator#getCharacterInstance()})
+     * @param cs   the character sequence to iterate over
+     * @param iter a reusable CharSequenceCharacterIterator
+     */
+    static void resetGraphemeBreakIterator(BreakIterator bi, CharSequence cs, CharSequenceCharacterIterator iter) {
+        if (bi == null) return;
+        if (iter.cs == cs) return; // already bound to this sequence
+        iter.reset(cs);
+        bi.setText(iter);
+    }
+
+    /**
+     * A reusable {@link CharacterIterator} that wraps a {@link CharSequence}
+     * without copying it to a {@code String}.
+     */
+    static final class CharSequenceCharacterIterator implements CharacterIterator, Cloneable {
+        private CharSequence cs;
+        private int begin;
+        private int end;
+        private int pos;
+
+        CharSequenceCharacterIterator() {
+            this.cs = "";
+        }
+
+        void reset(CharSequence cs) {
+            this.cs = cs;
+            this.begin = 0;
+            this.end = cs.length();
+            this.pos = 0;
+        }
+
+        @Override
+        public char first() {
+            pos = begin;
+            return current();
+        }
+
+        @Override
+        public char last() {
+            pos = (end > begin) ? end - 1 : end;
+            return current();
+        }
+
+        @Override
+        public char current() {
+            return (pos >= begin && pos < end) ? cs.charAt(pos) : DONE;
+        }
+
+        @Override
+        public char next() {
+            if (pos < end - 1) {
+                return cs.charAt(++pos);
+            }
+            pos = end;
+            return DONE;
+        }
+
+        @Override
+        public char previous() {
+            if (pos > begin) {
+                return cs.charAt(--pos);
+            }
+            return DONE;
+        }
+
+        @Override
+        public char setIndex(int position) {
+            if (position < begin || position > end) {
+                throw new IllegalArgumentException("Invalid index");
+            }
+            pos = position;
+            return current();
+        }
+
+        @Override
+        public int getBeginIndex() {
+            return begin;
+        }
+
+        @Override
+        public int getEndIndex() {
+            return end;
+        }
+
+        @Override
+        public int getIndex() {
+            return pos;
+        }
+
+        @Override
+        @SuppressWarnings("java:S2975") // clone() required: BreakIterator.setText() calls it internally
+        public Object clone() {
+            try {
+                return super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new AssertionError(e);
+            }
+        }
     }
 
     /**

--- a/terminal/src/test/java/org/jline/utils/ByteArrayBuilderTest.java
+++ b/terminal/src/test/java/org/jline/utils/ByteArrayBuilderTest.java
@@ -194,8 +194,18 @@ class ByteArrayBuilderTest {
         String ansiString = str.toAnsi(AttributedCharSequence.TRUE_COLORS, AttributedCharSequence.ForceMode.None);
 
         ByteArrayBuilder buf = new ByteArrayBuilder();
+        long[] state = {0, 0};
         str.toAnsiBytes(
-                buf, AttributedCharSequence.TRUE_COLORS, AttributedCharSequence.ForceMode.None, null, null, null);
+                buf,
+                0,
+                str.length(),
+                AttributedCharSequence.TRUE_COLORS,
+                AttributedCharSequence.ForceMode.None,
+                null,
+                null,
+                null,
+                state);
+        if (state[0] != 0) buf.csi().appendAscii("0m");
         String bytesAsString = buf.toStringUtf8();
 
         assertEquals(ansiString, bytesAsString);
@@ -216,7 +226,9 @@ class ByteArrayBuilderTest {
         String ansiString = str.toAnsi(256, AttributedCharSequence.ForceMode.None);
 
         ByteArrayBuilder buf = new ByteArrayBuilder();
-        str.toAnsiBytes(buf, 256, AttributedCharSequence.ForceMode.None, null, null, null);
+        long[] state = {0, 0};
+        str.toAnsiBytes(buf, 0, str.length(), 256, AttributedCharSequence.ForceMode.None, null, null, null, state);
+        if (state[0] != 0) buf.csi().appendAscii("0m");
 
         assertEquals(ansiString, buf.toStringUtf8());
     }
@@ -232,7 +244,9 @@ class ByteArrayBuilderTest {
         String ansiString = str.toAnsi(256, AttributedCharSequence.ForceMode.None);
 
         ByteArrayBuilder buf = new ByteArrayBuilder();
-        str.toAnsiBytes(buf, 256, AttributedCharSequence.ForceMode.None, null, null, null);
+        long[] state = {0, 0};
+        str.toAnsiBytes(buf, 0, str.length(), 256, AttributedCharSequence.ForceMode.None, null, null, null, state);
+        if (state[0] != 0) buf.csi().appendAscii("0m");
 
         assertEquals(ansiString, buf.toStringUtf8());
     }

--- a/terminal/src/test/java/org/jline/utils/DisplayBenchmarkTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayBenchmarkTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jline.terminal.Size;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Micro-benchmark for Display.update to measure throughput.
+ * Run with: ./mvx mvn test -B -pl terminal -Dtest=DisplayBenchmarkTest
+ */
+class DisplayBenchmarkTest {
+
+    private static final int WARMUP_ITERATIONS = 2_000;
+    private static final int MEASURED_ITERATIONS = 10_000;
+    private static final int ROWS = 40;
+    private static final int COLS = 120;
+
+    @Test
+    void benchmarkDisplayUpdate() throws IOException {
+        try (DisplayTest.VirtualTerminal terminal =
+                new DisplayTest.VirtualTerminal("bench", "xterm", StandardCharsets.UTF_8, COLS, ROWS)) {
+            terminal.enterRawMode();
+            Display display = new Display(terminal, true);
+            display.resize(new Size(COLS, ROWS));
+
+            // Build alternating screen content
+            List<AttributedString> screenA = buildScreen("A", ROWS, COLS);
+            List<AttributedString> screenB = buildScreen("B", ROWS, COLS);
+            // Screen with partial changes (more realistic)
+            List<AttributedString> screenC = buildPartialChangeScreen(screenA, ROWS, COLS);
+
+            // === Warmup ===
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                display.update(screenA, 0);
+                display.update(screenB, 0);
+            }
+
+            // === Measure full-repaint scenario ===
+            // Note: System.gc() is a hint, not a guarantee. Heap growth numbers
+            // are approximate and should not be used for precise allocation claims.
+            // Use JMH with -prof gc for accurate allocation measurement.
+            System.gc();
+            long memBefore =
+                    Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+            long start = System.nanoTime();
+
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                display.update(screenA, 0);
+                display.update(screenB, 0);
+            }
+
+            long elapsed = System.nanoTime() - start;
+            long memAfter =
+                    Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+
+            double msPerUpdate = (elapsed / 1_000_000.0) / (MEASURED_ITERATIONS * 2);
+
+            System.out.printf("=== Full repaint (A↔B) ===%n");
+            System.out.printf("  Iterations:    %,d update calls%n", MEASURED_ITERATIONS * 2);
+            System.out.printf("  Total time:    %.1f ms%n", elapsed / 1_000_000.0);
+            System.out.printf("  Per update:    %.3f ms%n", msPerUpdate);
+            System.out.printf("  Updates/sec:   %,.0f%n", 1000.0 / msPerUpdate);
+            System.out.printf("  Heap growth:   %,d bytes%n", memAfter - memBefore);
+
+            // === Warmup partial changes ===
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                display.update(screenA, 0);
+                display.update(screenC, 0);
+            }
+
+            // === Measure partial-change scenario ===
+            System.gc();
+            memBefore =
+                    Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+            start = System.nanoTime();
+
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                display.update(screenA, 0);
+                display.update(screenC, 0);
+            }
+
+            elapsed = System.nanoTime() - start;
+            memAfter = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+
+            msPerUpdate = (elapsed / 1_000_000.0) / (MEASURED_ITERATIONS * 2);
+
+            System.out.printf("%n=== Partial change (A↔C, ~25%% lines differ) ===%n");
+            System.out.printf("  Iterations:    %,d update calls%n", MEASURED_ITERATIONS * 2);
+            System.out.printf("  Total time:    %.1f ms%n", elapsed / 1_000_000.0);
+            System.out.printf("  Per update:    %.3f ms%n", msPerUpdate);
+            System.out.printf("  Updates/sec:   %,.0f%n", 1000.0 / msPerUpdate);
+            System.out.printf("  Heap growth:   %,d bytes%n", memAfter - memBefore);
+
+            // === Measure no-change scenario ===
+            display.update(screenA, 0);
+
+            System.gc();
+            memBefore =
+                    Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+            start = System.nanoTime();
+
+            for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+                display.update(screenA, 0);
+            }
+
+            elapsed = System.nanoTime() - start;
+            memAfter = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+
+            msPerUpdate = (elapsed / 1_000_000.0) / MEASURED_ITERATIONS;
+
+            System.out.printf("%n=== No change (A→A) ===%n");
+            System.out.printf("  Iterations:    %,d update calls%n", MEASURED_ITERATIONS);
+            System.out.printf("  Total time:    %.1f ms%n", elapsed / 1_000_000.0);
+            System.out.printf("  Per update:    %.3f ms%n", msPerUpdate);
+            System.out.printf("  Updates/sec:   %,.0f%n", 1000.0 / msPerUpdate);
+            System.out.printf("  Heap growth:   %,d bytes%n", memAfter - memBefore);
+
+            // Verify display is still in a valid state after benchmark
+            org.junit.jupiter.api.Assertions.assertTrue(msPerUpdate < 10.0, "Update should complete in under 10ms");
+        }
+    }
+
+    private List<AttributedString> buildScreen(String label, int rows, int cols) {
+        List<AttributedString> lines = new ArrayList<>(rows);
+        for (int i = 0; i < rows; i++) {
+            AttributedStringBuilder sb = new AttributedStringBuilder();
+            sb.style(AttributedStyle.DEFAULT.foreground(i % 8));
+            String text = String.format("%s-%03d: ", label, i);
+            sb.append(text);
+            sb.style(AttributedStyle.DEFAULT);
+            // Fill rest of line with content
+            StringBuilder filler = new StringBuilder();
+            while (filler.length() + text.length() < cols) {
+                filler.append("The quick brown fox jumps over the lazy dog. ");
+            }
+            sb.append(filler.substring(0, Math.max(0, cols - text.length())));
+            sb.append('\n');
+            lines.add(sb.toAttributedString());
+        }
+        return lines;
+    }
+
+    private List<AttributedString> buildPartialChangeScreen(List<AttributedString> base, int rows, int cols) {
+        List<AttributedString> lines = new ArrayList<>(base);
+        // Change ~25% of lines
+        for (int i = 0; i < rows; i += 4) {
+            AttributedStringBuilder sb = new AttributedStringBuilder();
+            sb.style(AttributedStyle.DEFAULT.foreground(2));
+            String text = String.format("MOD-%03d: ", i);
+            sb.append(text);
+            sb.style(AttributedStyle.DEFAULT.bold());
+            StringBuilder filler = new StringBuilder();
+            while (filler.length() + text.length() < cols) {
+                filler.append("Modified content here! ");
+            }
+            sb.append(filler.substring(0, Math.max(0, cols - text.length())));
+            sb.append('\n');
+            lines.set(i, sb.toAttributedString());
+        }
+        return lines;
+    }
+}

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import static org.jline.utils.InfoCmp.Capability.enter_ca_mode;
 import static org.jline.utils.InfoCmp.Capability.exit_ca_mode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DisplayTest {
 
@@ -105,21 +106,36 @@ public class DisplayTest {
             setSize(new Size(cols, rows));
         }
 
+        void startCapture() {
+            ((DelegateOutputStream) masterOutput).spy = new ByteArrayOutputStream();
+        }
+
+        byte[] stopCapture() {
+            DelegateOutputStream dos = (DelegateOutputStream) masterOutput;
+            byte[] data = dos.spy != null ? dos.spy.toByteArray() : new byte[0];
+            dos.spy = null;
+            return data;
+        }
+
         private static class DelegateOutputStream extends OutputStream {
             OutputStream output;
+            ByteArrayOutputStream spy;
 
             @Override
             public void write(int b) throws IOException {
+                if (spy != null) spy.write(b);
                 output.write(b);
             }
 
             @Override
             public void write(byte[] b) throws IOException {
+                if (spy != null) spy.write(b);
                 output.write(b);
             }
 
             @Override
             public void write(byte[] b, int off, int len) throws IOException {
+                if (spy != null) spy.write(b, off, len);
                 output.write(b, off, len);
             }
 
@@ -179,6 +195,263 @@ public class DisplayTest {
             @Override
             public void close() throws IOException {
                 flush();
+            }
+        }
+    }
+
+    @Test
+    void testIntraLineSkipOptimization() throws IOException {
+        int rows = 3;
+        int cols = 40;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            Display display = new Display(terminal, true);
+            display.resize(new Size(cols, rows));
+
+            // Frame 1: all rows filled with 'a' in default style
+            List<AttributedString> frame1 = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                AttributedStringBuilder sb = new AttributedStringBuilder();
+                for (int c = 0; c < cols; c++) sb.append('a');
+                sb.append('\n');
+                frame1.add(sb.toAttributedString());
+            }
+            display.update(frame1, 0);
+            terminal.flush();
+
+            // Start capturing output for the second update
+            terminal.startCapture();
+
+            // Frame 2: row 1 has red 'X' at col 5 and col 33
+            // (27 unchanged 'a' chars between them — well above the skip threshold)
+            List<AttributedString> frame2 = new ArrayList<>(frame1);
+            AttributedStringBuilder sb = new AttributedStringBuilder();
+            for (int c = 0; c < cols; c++) {
+                if (c == 5 || c == 33) {
+                    sb.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
+                    sb.append('X');
+                    sb.style(AttributedStyle.DEFAULT);
+                } else {
+                    sb.append('a');
+                }
+            }
+            sb.append('\n');
+            frame2.set(1, sb.toAttributedString());
+            display.update(frame2, 0);
+            terminal.flush();
+
+            byte[] captured = terminal.stopCapture();
+            String output = new String(captured, StandardCharsets.UTF_8);
+
+            // Verify optimization: no long run of 'a' chars in the output
+            // (the 27 unchanged chars should be skipped with cursor movement)
+            int maxConsecutiveA = 0;
+            int run = 0;
+            for (int i = 0; i < output.length(); i++) {
+                if (output.charAt(i) == 'a') {
+                    run++;
+                    if (run > maxConsecutiveA) maxConsecutiveA = run;
+                } else {
+                    run = 0;
+                }
+            }
+            assertTrue(
+                    maxConsecutiveA < 10,
+                    "Expected cursor movement to skip unchanged gap, but found "
+                            + maxConsecutiveA + " consecutive 'a' chars in output: "
+                            + output.replace("\u001b", "\\e"));
+
+            // Verify screen correctness
+            long[] screen = terminal.dump();
+            assertEquals('X', (char) screen[5 + cols * 1], "col 5 row 1 should be X");
+            assertEquals('X', (char) screen[33 + cols * 1], "col 33 row 1 should be X");
+            assertEquals('a', (char) screen[10 + cols * 1], "col 10 row 1 should be unchanged");
+            assertEquals('a', (char) screen[0 + cols * 1], "col 0 row 1 should be unchanged");
+            assertEquals('a', (char) screen[39 + cols * 1], "col 39 row 1 should be unchanged");
+        }
+    }
+
+    @Test
+    void testUpdateWithAttributedCharSequence() throws IOException {
+        int rows = 4;
+        int cols = 20;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            Display display = new Display(terminal, true);
+            display.resize(new Size(cols, rows));
+
+            // Use reusable AttributedStringBuilder list (simulates a TUI backend)
+            List<AttributedStringBuilder> builders = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                builders.add(new AttributedStringBuilder());
+            }
+
+            // Frame 1: fill with line numbers
+            for (int r = 0; r < rows; r++) {
+                AttributedStringBuilder sb = builders.get(r);
+                sb.setLength(0);
+                sb.append(String.format("line %d: hello", r));
+                sb.append('\n');
+            }
+            display.updateSequences(builders, 0);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            assertEquals('l', (char) screen[0], "row 0 col 0");
+            assertEquals('0', (char) screen[5], "row 0 col 5 should be '0'");
+            assertEquals('1', (char) screen[5 + cols], "row 1 col 5 should be '1'");
+
+            // Frame 2: only modify row 2
+            builders.get(2).setLength(0);
+            builders.get(2).append("line 2: CHANGED");
+            builders.get(2).append('\n');
+            display.updateSequences(builders, 0);
+            terminal.flush();
+
+            screen = terminal.dump();
+            // Unchanged rows should still be correct
+            assertEquals('h', (char) screen[8], "row 0 col 8 should still be 'h'");
+            assertEquals('h', (char) screen[8 + cols], "row 1 col 8 should still be 'h'");
+            // Changed row should reflect the update
+            assertEquals('C', (char) screen[8 + cols * 2], "row 2 col 8 should be 'C'");
+            assertEquals('h', (char) screen[8 + cols * 3], "row 3 col 8 should still be 'h'");
+        }
+    }
+
+    @Test
+    void testCellGridUpdate() throws IOException {
+        int rows = 4;
+        int cols = 20;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            Display display = new Display(terminal, true);
+            display.resize(new Size(cols, rows));
+
+            // Build a cell grid: 4 rows x 20 cols
+            char[] chars = new char[rows * cols];
+            long[] styles = new long[rows * cols];
+            for (int y = 0; y < rows; y++) {
+                String text = String.format("line %d: hello", y);
+                for (int x = 0; x < cols; x++) {
+                    chars[y * cols + x] = x < text.length() ? text.charAt(x) : ' ';
+                    styles[y * cols + x] = 0;
+                }
+            }
+
+            // Frame 1
+            display.update(chars, styles, null, cols, rows, 0, true);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            assertEquals('l', (char) screen[0], "row 0 col 0");
+            assertEquals('0', (char) screen[5], "row 0 col 5 should be '0'");
+            assertEquals('1', (char) screen[5 + cols], "row 1 col 5 should be '1'");
+
+            // Frame 2: only change row 2
+            String changed = "line 2: CHANGED!";
+            for (int x = 0; x < cols; x++) {
+                chars[2 * cols + x] = x < changed.length() ? changed.charAt(x) : ' ';
+            }
+            display.update(chars, styles, null, cols, rows, 0, true);
+            terminal.flush();
+
+            screen = terminal.dump();
+            // Unchanged rows
+            assertEquals('h', (char) screen[8], "row 0 col 8 should still be 'h'");
+            assertEquals('h', (char) screen[8 + cols], "row 1 col 8 should still be 'h'");
+            assertEquals('h', (char) screen[8 + cols * 3], "row 3 col 8 should still be 'h'");
+            // Changed row
+            assertEquals('C', (char) screen[8 + cols * 2], "row 2 col 8 should be 'C'");
+        }
+    }
+
+    @Test
+    void testCellGridWithWidths() throws IOException {
+        int rows = 3;
+        int cols = 20;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            Display display = new Display(terminal, true);
+            display.resize(new Size(cols, rows));
+
+            // Rows with varying lengths
+            char[] chars = new char[rows * cols];
+            long[] styles = new long[rows * cols];
+            int[] widths = new int[rows];
+
+            String[] texts = {"short", "a longer line here", "mid"};
+            for (int y = 0; y < rows; y++) {
+                String text = texts[y];
+                widths[y] = text.length();
+                for (int x = 0; x < text.length(); x++) {
+                    chars[y * cols + x] = text.charAt(x);
+                    styles[y * cols + x] = 0;
+                }
+            }
+
+            display.update(chars, styles, widths, cols, rows, 0, true);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            assertEquals('s', (char) screen[0], "row 0 col 0");
+            assertEquals('a', (char) screen[cols], "row 1 col 0");
+            assertEquals('m', (char) screen[cols * 2], "row 2 col 0");
+        }
+    }
+
+    @Test
+    void testCellGridParityWithListUpdate() throws IOException {
+        int rows = 3;
+        int cols = 30;
+        try (VirtualTerminal terminal1 = new VirtualTerminal("t1", "xterm", StandardCharsets.UTF_8, cols, rows);
+                VirtualTerminal terminal2 = new VirtualTerminal("t2", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal1.enterRawMode();
+            terminal2.enterRawMode();
+            Display display1 = new Display(terminal1, true);
+            display1.resize(new Size(cols, rows));
+            Display display2 = new Display(terminal2, true);
+            display2.resize(new Size(cols, rows));
+
+            // Build identical content via both APIs
+            List<AttributedString> lines = new ArrayList<>();
+            char[] chars = new char[rows * cols];
+            long[] styles = new long[rows * cols];
+
+            for (int y = 0; y < rows; y++) {
+                AttributedStringBuilder sb = new AttributedStringBuilder();
+                sb.style(AttributedStyle.DEFAULT.foreground(y % 8));
+                String text = String.format("Row %d content here", y);
+                sb.append(text);
+                sb.style(AttributedStyle.DEFAULT);
+                sb.append('\n');
+                lines.add(sb.toAttributedString());
+
+                AttributedString as = sb.toAttributedString();
+                // Fill cell arrays (without the trailing newline)
+                int len = as.length() - 1; // strip '\n'
+                for (int x = 0; x < len; x++) {
+                    chars[y * cols + x] = as.charAt(x);
+                    styles[y * cols + x] = as.styleCodeAt(x);
+                }
+                for (int x = len; x < cols; x++) {
+                    chars[y * cols + x] = ' ';
+                    styles[y * cols + x] = 0;
+                }
+            }
+
+            display1.update(lines, 0);
+            terminal1.flush();
+            display2.update(chars, styles, null, cols, rows, 0, true);
+            terminal2.flush();
+
+            long[] screen1 = terminal1.dump();
+            long[] screen2 = terminal2.dump();
+
+            for (int i = 0; i < screen1.length; i++) {
+                assertEquals(
+                        (char) screen1[i],
+                        (char) screen2[i],
+                        "Screen mismatch at position " + i + " (row " + (i / cols) + ", col " + (i % cols) + ")");
             }
         }
     }


### PR DESCRIPTION
## Summary

Optimizes `Display.update()` to minimize both heap allocation and terminal output bytes.

### Display.update() optimizations
- **Intra-line skip**: when a row has a long unchanged gap between two changed regions, emit a cursor-movement sequence (`CUF` / `CHA`) instead of re-sending the unchanged characters
- **AttributedCharSequence input**: accept `AttributedCharSequence` (not just `AttributedString`) to avoid per-frame snapshot copies
- **Fast-path for List\<AttributedString\>**: skip `snapshotLines` overhead when input is already a list of `AttributedString`
- **Cell-grid update API**: new `update(char[], long[], int[], ...)` overload with flat row-major arrays; reuses `oldLines` entries for unchanged rows via `rowEquals` check

### AttributedCharSequence allocation reduction
- **State consolidation**: `toAnsiBytes` uses `long[2]` (style + altCharset) instead of `long[4]`
- **Color fast-path**: `emitStyleChange()` skips color extraction when `(diff & COLOR_BITS) == 0` (only text decoration changed)
- **columnLength delegation**: overloads delegate to a single 5-parameter method using bare `BreakIterator` + `CharSequenceCharacterIterator`, avoiding `toString()` allocation

### DiffHelper
- **Deduplication**: public `diff(text1, text2)` delegates to the allocation-free `diff(text1, s1, e1, text2, s2, e2, result)` variant
- **Suffix rollback fix**: `commonSuffixLength` hidden-range rollback was unconditional; now conditional on whether the next character is actually hidden, matching the prefix logic

### Other
- `CharSequenceCharacterIterator` and `resetGraphemeBreakIterator` in `WCWidth` for allocation-free `BreakIterator` usage
- `@since 4.1.0` tags on new public API methods
- `DisplayBenchmarkTest` for update throughput measurement
- Tests for intra-line skip optimization, cell-grid API, and `AttributedCharSequence` input

## Test plan
- [x] `mvn test -pl terminal` — all 267 tests pass
- [x] `testIntraLineSkipOptimization` — verifies cursor movement skips unchanged gaps
- [x] `testCellGridUpdate` / `testCellGridWithWidths` / `testCellGridParityWithListUpdate` — cell-grid API correctness
- [x] `testUpdateWithAttributedCharSequence` — AttributedCharSequence input path
- [x] Existing `i737` test — regression check for full-screen update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for flexible sequence types in display updates
  * Optimized cursor movement for diagonal repositioning

* **Improvements & Optimizations**
  * Enhanced terminal display rendering performance through capability caching
  * Reduced memory allocations in diff computation and ANSI sequence generation
  * Improved grapheme cluster handling for accurate column width calculations
  * Streamlined style state tracking to minimize redundant resets

* **Tests**
  * Added performance benchmarking for display updates
  * Expanded display update validation test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->