### PR TITLE
refactor: Deduplicate AttributedCharSequence#emitStyleChange.

### DIFF
--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -10,6 +10,7 @@ package org.jline.utils;
 
 import java.text.BreakIterator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.jline.terminal.Terminal;
@@ -35,7 +36,6 @@ import static org.jline.utils.AttributedStyle.F_HIDDEN;
 import static org.jline.utils.AttributedStyle.F_INVERSE;
 import static org.jline.utils.AttributedStyle.F_ITALIC;
 import static org.jline.utils.AttributedStyle.F_UNDERLINE;
-import static org.jline.utils.AttributedStyle.MASK;
 
 /**
  * A character sequence with ANSI style attributes.
@@ -358,9 +358,18 @@ public abstract class AttributedCharSequence implements CharSequence {
         return 1;
     }
 
+    private static final long[] DECORATION_FLAGS = {F_ITALIC, F_UNDERLINE, F_BLINK, F_INVERSE, F_CONCEAL, F_CROSSED_OUT
+    };
+    private static final String[] DECORATION_ON = {"3", "4", "5", "7", "8", "9"};
+    private static final String[] DECORATION_OFF = {"23", "24", "25", "27", "28", "29"};
+
+    private static final long COLOR_BITS = F_FOREGROUND | F_BACKGROUND | FG_COLOR | BG_COLOR;
+    private static final long BOLD_FAINT_BITS = F_BOLD | F_FAINT;
+    private static final long DECORATION_BITS = Arrays.stream(DECORATION_FLAGS).reduce(0L, (a, b) -> a | b);
+
     /**
      * Emit a single CSI SGR sequence that transitions terminal attributes from prevStyle to newStyle.
-     *
+     * <p>
      * Writes ANSI SGR parameters into the provided ByteArrayBuilder and updates colorState to reflect the
      * currently applied foreground (index 0) and background (index 1) encodings. If newStyle is zero, a
      * reset sequence is emitted and colorState entries are cleared.
@@ -372,47 +381,40 @@ public abstract class AttributedCharSequence implements CharSequence {
      * @param force      force mode controlling preference for 256/true color output
      * @param palette    color palette used to round/lookup colors when not emitting direct RGB
      */
-    private static final long COLOR_BITS = F_FOREGROUND | F_BACKGROUND | FG_COLOR | BG_COLOR;
-
     private static void emitStyleChange(
             ByteArrayBuilder buf, long prevStyle, long newStyle, int colors, ForceMode force, ColorPalette palette) {
-        if (newStyle == 0) {
-            buf.csi().appendAscii("0m");
-            return;
-        }
-        long d = (prevStyle ^ newStyle) & MASK;
-        // Fast path: if only text attributes changed (no color change), skip color extraction
-        if (((prevStyle ^ newStyle) & COLOR_BITS) == 0) {
-            buf.csi();
-            boolean first = appendDecorationAttrsB(buf, d, newStyle, true);
-            first = appendBoldFaintB(buf, d, newStyle, first);
-            buf.appendAscii('m');
-            return;
-        }
-        long fg = (newStyle & F_FOREGROUND) != 0 ? newStyle & (FG_COLOR | F_FOREGROUND) : 0;
-        long bg = (newStyle & F_BACKGROUND) != 0 ? newStyle & (BG_COLOR | F_BACKGROUND) : 0;
-        long prevFg = (prevStyle & F_FOREGROUND) != 0 ? prevStyle & (FG_COLOR | F_FOREGROUND) : 0;
-        long prevBg = (prevStyle & F_BACKGROUND) != 0 ? prevStyle & (BG_COLOR | F_BACKGROUND) : 0;
         buf.csi();
+        if (newStyle == 0) {
+            buf.appendAscii("0m");
+            return;
+        }
         boolean first = true;
-        first = appendDecorationAttrsB(buf, d, newStyle, first);
-        if (prevFg != fg) {
-            first = appendColorB(buf, fg, true, colors, force, palette, first);
-            if (fg > 0 && usedBasicFgColor(fg, colors, force, palette)) {
-                d |= (newStyle & F_BOLD);
+        long diff = prevStyle ^ newStyle;
+        if ((diff & DECORATION_BITS) != 0) {
+            first = appendDecorationAttrsB(buf, diff, newStyle, first);
+        }
+        if ((diff & COLOR_BITS) != 0) {
+            long fg = (newStyle & F_FOREGROUND) != 0 ? newStyle & (FG_COLOR | F_FOREGROUND) : 0;
+            long bg = (newStyle & F_BACKGROUND) != 0 ? newStyle & (BG_COLOR | F_BACKGROUND) : 0;
+            long prevFg = (prevStyle & F_FOREGROUND) != 0 ? prevStyle & (FG_COLOR | F_FOREGROUND) : 0;
+            long prevBg = (prevStyle & F_BACKGROUND) != 0 ? prevStyle & (BG_COLOR | F_BACKGROUND) : 0;
+
+            first = appendDecorationAttrsB(buf, diff, newStyle, first);
+            if (prevFg != fg) {
+                first = appendColorB(buf, fg, true, colors, force, palette, first);
+                if (fg > 0 && usedBasicFgColor(fg, colors, force, palette)) {
+                    diff |= (newStyle & F_BOLD);
+                }
+            }
+            if (prevBg != bg) {
+                first = appendColorB(buf, bg, false, colors, force, palette, first);
             }
         }
-        if (prevBg != bg) {
-            first = appendColorB(buf, bg, false, colors, force, palette, first);
+        if ((diff & BOLD_FAINT_BITS) != 0) {
+            appendBoldFaintB(buf, diff, newStyle, first);
         }
-        first = appendBoldFaintB(buf, d, newStyle, first);
         buf.appendAscii('m');
     }
-
-    private static final long[] DECORATION_FLAGS = {F_ITALIC, F_UNDERLINE, F_BLINK, F_INVERSE, F_CONCEAL, F_CROSSED_OUT
-    };
-    private static final String[] DECORATION_ON = {"3", "4", "5", "7", "8", "9"};
-    private static final String[] DECORATION_OFF = {"23", "24", "25", "27", "28", "29"};
 
     /**
      * Appends CSI decoration parameters for each decoration flag present in `d` to `buf`, using the

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -370,8 +370,7 @@ public abstract class AttributedCharSequence implements CharSequence {
     /**
      * Emit a single CSI SGR sequence that transitions terminal attributes from prevStyle to newStyle.
      * <p>
-     * Writes ANSI SGR parameters into the provided ByteArrayBuilder. If newStyle is zero, a
-     * reset sequence is emitted and colorState entries are cleared.
+     * Writes ANSI SGR parameters into the provided ByteArrayBuilder. If newStyle is zero, a reset sequence is emitted.
      *
      * @param buf        the byte-oriented builder to which CSI parameters and the final 'm' are appended
      * @param prevStyle  previously applied style code

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -347,6 +347,7 @@ public abstract class AttributedCharSequence implements CharSequence {
 
     private static final long COLOR_BITS = F_FOREGROUND | F_BACKGROUND | FG_COLOR | BG_COLOR;
     private static final long BOLD_FAINT_BITS = F_BOLD | F_FAINT;
+    // Where the above value OR's the bold & faint flags, this reduction below OR's all flags in DECORATION_FLAGS.
     private static final long DECORATION_BITS = Arrays.stream(DECORATION_FLAGS).reduce(0L, (a, b) -> a | b);
     // MASK includes all flag bits. Since a color index and color rgb flag can never be set at the same time, this value
     // is never a valid style.

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -349,8 +349,8 @@ public abstract class AttributedCharSequence implements CharSequence {
     private static final long BOLD_FAINT_BITS = F_BOLD | F_FAINT;
     // Where the above value OR's the bold & faint flags, this reduction below OR's all flags in DECORATION_FLAGS.
     private static final long DECORATION_BITS = Arrays.stream(DECORATION_FLAGS).reduce(0L, (a, b) -> a | b);
-    // MASK includes all flag bits. Since a color index and color rgb flag can never be set at the same time, this value
-    // is never a valid style.
+    // NO_COLOR_CHANGE has all style bits enabled. Since a color index and color rgb flag bit can never be set at the
+    // same time, this value is never a valid style.
     private static final long NO_COLOR_CHANGE = 0xffffffffffffffffL;
 
     /**

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -17,25 +17,7 @@ import org.jline.terminal.Terminal;
 import org.jline.utils.InfoCmp.Capability;
 
 import static org.jline.terminal.TerminalBuilder.PROP_DISABLE_ALTERNATE_CHARSET;
-import static org.jline.utils.AttributedStyle.BG_COLOR;
-import static org.jline.utils.AttributedStyle.BG_COLOR_EXP;
-import static org.jline.utils.AttributedStyle.FG_COLOR;
-import static org.jline.utils.AttributedStyle.FG_COLOR_EXP;
-import static org.jline.utils.AttributedStyle.F_BACKGROUND;
-import static org.jline.utils.AttributedStyle.F_BACKGROUND_IND;
-import static org.jline.utils.AttributedStyle.F_BACKGROUND_RGB;
-import static org.jline.utils.AttributedStyle.F_BLINK;
-import static org.jline.utils.AttributedStyle.F_BOLD;
-import static org.jline.utils.AttributedStyle.F_CONCEAL;
-import static org.jline.utils.AttributedStyle.F_CROSSED_OUT;
-import static org.jline.utils.AttributedStyle.F_FAINT;
-import static org.jline.utils.AttributedStyle.F_FOREGROUND;
-import static org.jline.utils.AttributedStyle.F_FOREGROUND_IND;
-import static org.jline.utils.AttributedStyle.F_FOREGROUND_RGB;
-import static org.jline.utils.AttributedStyle.F_HIDDEN;
-import static org.jline.utils.AttributedStyle.F_INVERSE;
-import static org.jline.utils.AttributedStyle.F_ITALIC;
-import static org.jline.utils.AttributedStyle.F_UNDERLINE;
+import static org.jline.utils.AttributedStyle.*;
 
 /**
  * A character sequence with ANSI style attributes.
@@ -392,18 +374,16 @@ public abstract class AttributedCharSequence implements CharSequence {
             first = appendDecorationAttrsB(buf, diff, newStyle, first);
         }
         if ((diff & COLOR_BITS) != 0) {
-            long fg = (newStyle & F_FOREGROUND) != 0 ? newStyle & (FG_COLOR | F_FOREGROUND) : 0;
-            long bg = (newStyle & F_BACKGROUND) != 0 ? newStyle & (BG_COLOR | F_BACKGROUND) : 0;
-            long prevFg = (prevStyle & F_FOREGROUND) != 0 ? prevStyle & (FG_COLOR | F_FOREGROUND) : 0;
-            long prevBg = (prevStyle & F_BACKGROUND) != 0 ? prevStyle & (BG_COLOR | F_BACKGROUND) : 0;
+            long fg = getNewColor(prevStyle, newStyle, F_FOREGROUND, FG_COLOR | F_FOREGROUND);
+            long bg = getNewColor(prevStyle, newStyle, F_BACKGROUND, BG_COLOR | F_BACKGROUND);
 
-            if (prevFg != fg) {
+            if (fg != MASK) {
                 first = appendColorB(buf, fg, true, colors, force, palette, first);
                 if (fg > 0 && usedBasicFgColor(fg, colors, force, palette)) {
                     diff |= (newStyle & F_BOLD);
                 }
             }
-            if (prevBg != bg) {
+            if (bg != MASK) {
                 first = appendColorB(buf, bg, false, colors, force, palette, first);
             }
         }
@@ -411,6 +391,24 @@ public abstract class AttributedCharSequence implements CharSequence {
             appendBoldFaintB(buf, diff, newStyle, first);
         }
         buf.appendAscii('m');
+    }
+
+    /**
+     * Computes the color bits that should be carried into a style transition.
+     *
+     * @param prevStyle the previously active style bits
+     * @param newStyle the target style bits
+     * @param flagMask the style family mask to compare, such as foreground or background flags
+     * @param fullColorMask the full mask used to extract the color payload for that family
+     * @return the color payload to emit for the transition, or {@link AttributedStyle#MASK} if no color change is needed
+     */
+    private static long getNewColor(long prevStyle, long newStyle, long flagMask, long fullColorMask) {
+        long cur = (newStyle & flagMask) != 0 ? newStyle & fullColorMask : 0;
+        long prev = (prevStyle & flagMask) != 0 ? prevStyle & fullColorMask : 0;
+        if (cur != prev) {
+            return cur;
+        }
+        return MASK;
     }
 
     /**

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -370,8 +370,7 @@ public abstract class AttributedCharSequence implements CharSequence {
     /**
      * Emit a single CSI SGR sequence that transitions terminal attributes from prevStyle to newStyle.
      * <p>
-     * Writes ANSI SGR parameters into the provided ByteArrayBuilder and updates colorState to reflect the
-     * currently applied foreground (index 0) and background (index 1) encodings. If newStyle is zero, a
+     * Writes ANSI SGR parameters into the provided ByteArrayBuilder. If newStyle is zero, a
      * reset sequence is emitted and colorState entries are cleared.
      *
      * @param buf        the byte-oriented builder to which CSI parameters and the final 'm' are appended
@@ -399,7 +398,6 @@ public abstract class AttributedCharSequence implements CharSequence {
             long prevFg = (prevStyle & F_FOREGROUND) != 0 ? prevStyle & (FG_COLOR | F_FOREGROUND) : 0;
             long prevBg = (prevStyle & F_BACKGROUND) != 0 ? prevStyle & (BG_COLOR | F_BACKGROUND) : 0;
 
-            first = appendDecorationAttrsB(buf, diff, newStyle, first);
             if (prevFg != fg) {
                 first = appendColorB(buf, fg, true, colors, force, palette, first);
                 if (fg > 0 && usedBasicFgColor(fg, colors, force, palette)) {

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -348,6 +348,9 @@ public abstract class AttributedCharSequence implements CharSequence {
     private static final long COLOR_BITS = F_FOREGROUND | F_BACKGROUND | FG_COLOR | BG_COLOR;
     private static final long BOLD_FAINT_BITS = F_BOLD | F_FAINT;
     private static final long DECORATION_BITS = Arrays.stream(DECORATION_FLAGS).reduce(0L, (a, b) -> a | b);
+    // MASK includes all flag bits. Since a color index and color rgb flag can never be set at the same time, this value
+    // is never a valid style.
+    private static final long NO_COLOR_CHANGE = 0xffffffffffffffffL;
 
     /**
      * Emit a single CSI SGR sequence that transitions terminal attributes from prevStyle to newStyle.
@@ -377,13 +380,13 @@ public abstract class AttributedCharSequence implements CharSequence {
             long fg = getNewColor(prevStyle, newStyle, F_FOREGROUND, FG_COLOR | F_FOREGROUND);
             long bg = getNewColor(prevStyle, newStyle, F_BACKGROUND, BG_COLOR | F_BACKGROUND);
 
-            if (fg != MASK) {
+            if (fg != NO_COLOR_CHANGE) {
                 first = appendColorB(buf, fg, true, colors, force, palette, first);
                 if (fg > 0 && usedBasicFgColor(fg, colors, force, palette)) {
                     diff |= (newStyle & F_BOLD);
                 }
             }
-            if (bg != MASK) {
+            if (bg != NO_COLOR_CHANGE) {
                 first = appendColorB(buf, bg, false, colors, force, palette, first);
             }
         }
@@ -400,7 +403,7 @@ public abstract class AttributedCharSequence implements CharSequence {
      * @param newStyle the target style bits
      * @param flagMask the style family mask to compare, such as foreground or background flags
      * @param fullColorMask the full mask used to extract the color payload for that family
-     * @return the color payload to emit for the transition, or {@link AttributedStyle#MASK} if no color change is needed
+     * @return the color payload to emit for the transition, or {@link AttributedCharSequence#NO_COLOR_CHANGE} if no color change is needed
      */
     private static long getNewColor(long prevStyle, long newStyle, long flagMask, long fullColorMask) {
         long cur = (newStyle & flagMask) != 0 ? newStyle & fullColorMask : 0;
@@ -408,7 +411,7 @@ public abstract class AttributedCharSequence implements CharSequence {
         if (cur != prev) {
             return cur;
         }
-        return MASK;
+        return NO_COLOR_CHANGE;
     }
 
     /**

--- a/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
@@ -127,6 +127,66 @@ public class AttributedCharSequenceTest {
         assertEquals(org, rndTrip);
     }
 
+    @Test
+    public void testMixedStyleAnsiOrderingWithStyleChanges() {
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        sb.append("start");
+        sb.style(AttributedStyle.DEFAULT.underline().italic().foreground(AttributedStyle.BLUE));
+        sb.append("one");
+        sb.style(AttributedStyle.DEFAULT.underline().italic().crossedOut().foreground(AttributedStyle.BLUE));
+        sb.append("two");
+        sb.style(AttributedStyle.DEFAULT
+                .underline()
+                .foreground(AttributedStyle.BLUE)
+                .bold());
+        sb.append("three");
+        sb.style(AttributedStyle.DEFAULT);
+        sb.append("end");
+        assertEquals("start\u001b[3;4;34mone\u001b[9mtwo\u001b[23;29;1mthree\u001b[0mend", sb.toAnsi());
+
+        sb = new AttributedStringBuilder();
+        sb.append("start");
+        sb.style(AttributedStyle.DEFAULT
+                .underline()
+                .italic()
+                .foreground(AttributedStyle.YELLOW)
+                .bold());
+        sb.append("one");
+        sb.style(AttributedStyle.DEFAULT.crossedOut().italic().foreground(AttributedStyle.CYAN));
+        sb.append("two");
+        sb.style(AttributedStyle.DEFAULT.bold().foreground(AttributedStyle.RED));
+        sb.append("three");
+        sb.style(AttributedStyle.DEFAULT);
+        sb.append("end");
+        assertEquals("start\u001b[3;4;33;1mone\u001b[24;9;36;22mtwo\u001b[23;29;31;1mthree\u001b[0mend", sb.toAnsi());
+
+        sb = new AttributedStringBuilder();
+        sb.append("start");
+        sb.style(AttributedStyle.DEFAULT.underline().italic().foreground(123).bold());
+        sb.append("one");
+        sb.style(AttributedStyle.DEFAULT.underline().crossedOut().foreground(196));
+        sb.append("two");
+        sb.style(AttributedStyle.DEFAULT);
+        sb.append("end");
+        assertEquals(
+                "start\u001b[3;4;38;5;123;1mone\u001b[23;9;38;5;196;22mtwo\u001b[0mend",
+                sb.toAnsi(256, AttributedCharSequence.ForceMode.Force256Colors));
+
+        sb = new AttributedStringBuilder();
+        sb.style(AttributedStyle.DEFAULT
+                .underline()
+                .italic()
+                .crossedOut()
+                .foreground(AttributedStyle.RED)
+                .bold());
+        sb.append("one");
+        sb.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN));
+        sb.append("two");
+        sb.style(AttributedStyle.DEFAULT);
+        sb.append("end");
+        assertEquals("\u001b[3;4;9;31;1mone\u001b[23;24;29;32;22mtwo\u001b[0mend", sb.toAnsi());
+    }
+
     // --- grapheme cluster mode tests (columnLength, columnSubSequence, columnSplitLength) ---
 
     @Test


### PR DESCRIPTION
Refactor layout of AttributedCharSequence#emitStyleChange.

Core functionality remains unchanged, but duplicate code (like https://github.com/jline/jline3/blob/master/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java#L386-L389) has been streamlined, and bypasses for bold/faint and other decoration attributes have been added as well.

Pull includes new tests for AttributedCharSequence.

Also moved the javadoc of AttributedCharSequence#emitStyleChange to the actual function instead of the field above it & removed references to the old color state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Terminal style emission rewritten to produce decorations, colors, and bold/faint attributes in a stable, deterministic order while reducing redundant parameters for more consistent and efficient rendering.
* **Tests**
  * Added a test validating stable ANSI escape ordering across mixed style transitions, including 256-color output and interleaved attribute changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->