### PR TITLE
fix: move Terminal parameter to first position in columnSubSequence and columnSplitLength

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -1375,14 +1375,14 @@ public class Less {
                 if (terminalLine == 0 && offsetInLine > 0) {
                     off = Math.max(offsetInLine, off);
                 }
-                toDisplay = curLine.columnSubSequence(off, off + width, terminal);
+                toDisplay = curLine.columnSubSequence(terminal, off, off + width);
                 curLine = null;
             } else {
                 if (terminalLine == 0 && offsetInLine > 0) {
-                    curLine = curLine.columnSubSequence(offsetInLine, Integer.MAX_VALUE, terminal);
+                    curLine = curLine.columnSubSequence(terminal, offsetInLine, Integer.MAX_VALUE);
                 }
-                toDisplay = curLine.columnSubSequence(0, width, terminal);
-                curLine = curLine.columnSubSequence(width, Integer.MAX_VALUE, terminal);
+                toDisplay = curLine.columnSubSequence(terminal, 0, width);
+                curLine = curLine.columnSubSequence(terminal, width, Integer.MAX_VALUE);
                 if (curLine.length() == 0) {
                     curLine = null;
                 }

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -944,56 +944,56 @@ public class Nano implements Editor {
             int[] hls = highlightStart();
             int[] hle = highlightEnd();
             if (hls[0] == -1 || hle[0] == -1) {
-                line.append(disp.columnSubSequence(curOffset, nextOffset, terminal));
+                line.append(disp.columnSubSequence(terminal, curOffset, nextOffset));
             } else if (hls[0] == hle[0]) {
                 if (curLine == hls[0]) {
                     if (hls[1] > nextOffset) {
-                        line.append(disp.columnSubSequence(curOffset, nextOffset, terminal));
+                        line.append(disp.columnSubSequence(terminal, curOffset, nextOffset));
                     } else if (hls[1] < curOffset) {
                         if (hle[1] > nextOffset) {
                             line.append(
-                                    disp.columnSubSequence(curOffset, nextOffset, terminal), AttributedStyle.INVERSE);
+                                    disp.columnSubSequence(terminal, curOffset, nextOffset), AttributedStyle.INVERSE);
                         } else if (hle[1] > curOffset) {
-                            line.append(disp.columnSubSequence(curOffset, hle[1], terminal), AttributedStyle.INVERSE);
-                            line.append(disp.columnSubSequence(hle[1], nextOffset, terminal));
+                            line.append(disp.columnSubSequence(terminal, curOffset, hle[1]), AttributedStyle.INVERSE);
+                            line.append(disp.columnSubSequence(terminal, hle[1], nextOffset));
                         } else {
-                            line.append(disp.columnSubSequence(curOffset, nextOffset, terminal));
+                            line.append(disp.columnSubSequence(terminal, curOffset, nextOffset));
                         }
                     } else {
-                        line.append(disp.columnSubSequence(curOffset, hls[1], terminal));
+                        line.append(disp.columnSubSequence(terminal, curOffset, hls[1]));
                         if (hle[1] > nextOffset) {
-                            line.append(disp.columnSubSequence(hls[1], nextOffset, terminal), AttributedStyle.INVERSE);
+                            line.append(disp.columnSubSequence(terminal, hls[1], nextOffset), AttributedStyle.INVERSE);
                         } else {
-                            line.append(disp.columnSubSequence(hls[1], hle[1], terminal), AttributedStyle.INVERSE);
-                            line.append(disp.columnSubSequence(hle[1], nextOffset, terminal));
+                            line.append(disp.columnSubSequence(terminal, hls[1], hle[1]), AttributedStyle.INVERSE);
+                            line.append(disp.columnSubSequence(terminal, hle[1], nextOffset));
                         }
                     }
                 } else {
-                    line.append(disp.columnSubSequence(curOffset, nextOffset, terminal));
+                    line.append(disp.columnSubSequence(terminal, curOffset, nextOffset));
                 }
             } else {
                 if (curLine > hls[0] && curLine < hle[0]) {
-                    line.append(disp.columnSubSequence(curOffset, nextOffset, terminal), AttributedStyle.INVERSE);
+                    line.append(disp.columnSubSequence(terminal, curOffset, nextOffset), AttributedStyle.INVERSE);
                 } else if (curLine == hls[0]) {
                     if (hls[1] > nextOffset) {
-                        line.append(disp.columnSubSequence(curOffset, nextOffset, terminal));
+                        line.append(disp.columnSubSequence(terminal, curOffset, nextOffset));
                     } else if (hls[1] < curOffset) {
-                        line.append(disp.columnSubSequence(curOffset, nextOffset, terminal), AttributedStyle.INVERSE);
+                        line.append(disp.columnSubSequence(terminal, curOffset, nextOffset), AttributedStyle.INVERSE);
                     } else {
-                        line.append(disp.columnSubSequence(curOffset, hls[1], terminal));
-                        line.append(disp.columnSubSequence(hls[1], nextOffset, terminal), AttributedStyle.INVERSE);
+                        line.append(disp.columnSubSequence(terminal, curOffset, hls[1]));
+                        line.append(disp.columnSubSequence(terminal, hls[1], nextOffset), AttributedStyle.INVERSE);
                     }
                 } else if (curLine == hle[0]) {
                     if (hle[1] < curOffset) {
-                        line.append(disp.columnSubSequence(curOffset, nextOffset, terminal));
+                        line.append(disp.columnSubSequence(terminal, curOffset, nextOffset));
                     } else if (hle[1] > nextOffset) {
-                        line.append(disp.columnSubSequence(curOffset, nextOffset, terminal), AttributedStyle.INVERSE);
+                        line.append(disp.columnSubSequence(terminal, curOffset, nextOffset), AttributedStyle.INVERSE);
                     } else {
-                        line.append(disp.columnSubSequence(curOffset, hle[1], terminal), AttributedStyle.INVERSE);
-                        line.append(disp.columnSubSequence(hle[1], nextOffset, terminal));
+                        line.append(disp.columnSubSequence(terminal, curOffset, hle[1]), AttributedStyle.INVERSE);
+                        line.append(disp.columnSubSequence(terminal, hle[1], nextOffset));
                     }
                 } else {
-                    line.append(disp.columnSubSequence(curOffset, nextOffset, terminal));
+                    line.append(disp.columnSubSequence(terminal, curOffset, nextOffset));
                 }
             }
         }

--- a/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
+++ b/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
@@ -459,7 +459,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
             out = asb.toAttributedString();
         }
         if (width != null) {
-            out = out.columnSubSequence(0, width, terminal());
+            out = out.columnSubSequence(terminal(), 0, width);
         }
         return out;
     }
@@ -704,7 +704,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
     private AttributedString truncateValue(Map<String, Object> options, AttributedString value) {
         if (value.columnLength(terminal()) > (int) options.getOrDefault(Printer.MAX_COLUMN_WIDTH, Integer.MAX_VALUE)) {
             AttributedStringBuilder asb = new AttributedStringBuilder();
-            asb.append(value.columnSubSequence(0, (int) options.get(Printer.MAX_COLUMN_WIDTH) - 3, terminal()));
+            asb.append(value.columnSubSequence(terminal(), 0, (int) options.get(Printer.MAX_COLUMN_WIDTH) - 3));
             asb.append("...");
             return asb.toAttributedString();
         }
@@ -925,7 +925,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
                                 asb.append("\t");
                                 first = false;
                             }
-                            asb.columnSubSequence(0, width, terminal()).println(terminal());
+                            asb.columnSubSequence(terminal(), 0, width).println(terminal());
                             int row = 0;
                             for (Map<String, Object> m : convertedCollection) {
                                 AttributedStringBuilder asb2 = new AttributedStringBuilder().tabs(columns);
@@ -951,7 +951,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
                                     asb2.append(v);
                                     asb2.append("\t");
                                 }
-                                asb2.columnSubSequence(0, width, terminal()).println(terminal());
+                                asb2.columnSubSequence(terminal(), 0, width).println(terminal());
                             }
                         } else if (collectionObject(elem) && !options.containsKey(Printer.TO_STRING)) {
                             List<Integer> columns = new ArrayList<>();
@@ -996,7 +996,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
                                     asb.append(v);
                                     asb.append("\t");
                                 }
-                                asb.columnSubSequence(0, width, terminal()).println(terminal());
+                                asb.columnSubSequence(terminal(), 0, width).println(terminal());
                             }
                         } else {
                             highlightList(options, collection, width);
@@ -1070,7 +1070,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
                 } else {
                     asb.append(highlightValue(options, null, o));
                 }
-                println(asb.columnSubSequence(0, width, terminal()), maxrows);
+                println(asb.columnSubSequence(terminal(), 0, width), maxrows);
             }
         } else {
             int maxWidth = 0;
@@ -1091,7 +1091,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
             AttributedStringBuilder asb = new AttributedStringBuilder().tabs(tabs);
             for (Object o : collection) {
                 if (asb.length() + maxWidth > width) {
-                    println(asb.columnSubSequence(0, width, terminal()), maxrows);
+                    println(asb.columnSubSequence(terminal(), 0, width), maxrows);
                     asb = new AttributedStringBuilder().tabs(tabs);
                 }
                 if (highlighter != null && o instanceof String) {
@@ -1101,7 +1101,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
                 }
                 asb.append("\t");
             }
-            println(asb.columnSubSequence(0, width, terminal()), maxrows);
+            println(asb.columnSubSequence(terminal(), 0, width), maxrows);
         }
     }
 
@@ -1195,14 +1195,14 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
                     Map<String, Object> childMap =
                             convert ? objectToMap(options, elem) : keysToString((Map<Object, Object>) elem);
                     if (!childMap.isEmpty()) {
-                        println(asb.columnSubSequence(0, width, terminal()), maxrows);
+                        println(asb.columnSubSequence(terminal(), 0, width), maxrows);
                         highlightMap(options, childMap, width, depth + 1);
                         highlightValue = false;
                     }
                 } else if (collectionObject(elem)) {
                     List<Object> collection = objectToList(elem);
                     if (!collection.isEmpty()) {
-                        println(asb.columnSubSequence(0, width, terminal()), maxrows);
+                        println(asb.columnSubSequence(terminal(), 0, width), maxrows);
                         Map<String, Object> listOptions = new HashMap<>(options);
                         listOptions.put(Printer.TO_STRING, true);
                         highlightList(listOptions, collection, width, depth + 1);
@@ -1217,12 +1217,12 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
                     if (val.contains('\n')) {
                         for (String v : val.toString().split("\\r?\\n")) {
                             asb.append(highlightValue(options, entry.getKey(), v));
-                            println(asb.columnSubSequence(0, width, terminal()), maxrows);
+                            println(asb.columnSubSequence(terminal(), 0, width), maxrows);
                             asb = new AttributedStringBuilder().tabs(Arrays.asList(0, max + 1));
                         }
                     } else {
                         asb.append(val);
-                        println(asb.columnSubSequence(0, width, terminal()), maxrows);
+                        println(asb.columnSubSequence(terminal(), 0, width), maxrows);
                     }
                 } else {
                     if (val.contains('\n')) {
@@ -1232,7 +1232,7 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
                     } else {
                         asb.append(val);
                     }
-                    println(asb.columnSubSequence(0, width, terminal()), maxrows);
+                    println(asb.columnSubSequence(terminal(), 0, width), maxrows);
                 }
             }
         }

--- a/console/src/main/java/org/jline/widget/TailTipWidgets.java
+++ b/console/src/main/java/org/jline/widget/TailTipWidgets.java
@@ -647,7 +647,7 @@ public class TailTipWidgets extends Widgets {
                     asb.append("\t");
                     asb.append(cmdDesc.optionDescription(key));
                     if (asb.columnLength(reader.getTerminal()) > columnWidth - 2) {
-                        AttributedString trunc = asb.columnSubSequence(0, columnWidth - 5, reader.getTerminal());
+                        AttributedString trunc = asb.columnSubSequence(reader.getTerminal(), 0, columnWidth - 5);
                         asb = new AttributedStringBuilder().tabs(tabs);
                         asb.append(trunc);
                         asb.append("...", new AttributedStyle(AttributedStyle.INVERSE));
@@ -657,7 +657,7 @@ public class TailTipWidgets extends Widgets {
                             asb.append(" ");
                         }
                     }
-                    keyList.add(asb.toAttributedString().columnSubSequence(0, columnWidth, reader.getTerminal()));
+                    keyList.add(asb.toAttributedString().columnSubSequence(reader.getTerminal(), 0, columnWidth));
                 } else {
                     asb.append(keyList.get(row - descriptionSize));
                     asb.append(HelpException.highlightSyntax(key, resolver));

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4264,13 +4264,13 @@ public class LineReaderImpl implements LineReader, Flushable {
                 if (smallTerminalOffset > 0) {
                     sb.setLength(0);
                     sb.append("…");
-                    sb.append(full.columnSubSequence(smallTerminalOffset + w, Integer.MAX_VALUE, terminal));
+                    sb.append(full.columnSubSequence(terminal, smallTerminalOffset + w, Integer.MAX_VALUE));
                     full = sb.toAttributedString();
                 }
                 int length = full.columnLength(terminal);
                 if (length >= smallTerminalOffset + width) {
                     sb.setLength(0);
-                    sb.append(full.columnSubSequence(0, width - w, terminal));
+                    sb.append(full.columnSubSequence(terminal, 0, width - w));
                     sb.append("…");
                     full = sb.toAttributedString();
                 }
@@ -4287,7 +4287,7 @@ public class LineReaderImpl implements LineReader, Flushable {
                 newLines = new ArrayList<>();
                 newLines.add(full);
             } else {
-                newLines = full.columnSplitLength(size.getColumns(), true, display.delayLineWrap(), terminal);
+                newLines = full.columnSplitLength(terminal, size.getColumns(), true, display.delayLineWrap());
             }
 
             List<AttributedString> rightPromptLines;
@@ -4316,7 +4316,7 @@ public class LineReaderImpl implements LineReader, Flushable {
                 }
                 sb.append(insertSecondaryPrompts(new AttributedString(buffer), secondaryPrompts, false));
                 List<AttributedString> promptLines =
-                        sb.columnSplitLength(size.getColumns(), false, display.delayLineWrap(), terminal);
+                        sb.columnSplitLength(terminal, size.getColumns(), false, display.delayLineWrap());
                 if (!promptLines.isEmpty()) {
                     cursorNewLinesId = promptLines.size() - 1;
                     cursorColPos = promptLines.get(promptLines.size() - 1).columnLength(terminal);
@@ -6000,7 +6000,7 @@ public class LineReaderImpl implements LineReader, Flushable {
                             rw = right.columnLength(terminal);
                             if (rw > rem) {
                                 right = AttributedStringBuilder.append(
-                                        right.columnSubSequence(0, rem - WCWidth.wcwidth('…'), terminal), "…");
+                                        right.columnSubSequence(terminal, 0, rem - WCWidth.wcwidth('…')), "…");
                                 rw = right.columnLength(terminal);
                             }
                             right = AttributedStringBuilder.append(DESC_PREFIX, right, DESC_SUFFIX);

--- a/shell/src/main/java/org/jline/shell/widget/CommandTailTipWidgets.java
+++ b/shell/src/main/java/org/jline/shell/widget/CommandTailTipWidgets.java
@@ -736,7 +736,7 @@ public class CommandTailTipWidgets {
                     asb.append("\t");
                     asb.append(cmdDesc.optionDescription(key));
                     if (asb.columnLength(reader.getTerminal()) > columnWidth - 2) {
-                        AttributedString trunc = asb.columnSubSequence(0, columnWidth - 5, reader.getTerminal());
+                        AttributedString trunc = asb.columnSubSequence(reader.getTerminal(), 0, columnWidth - 5);
                         asb = new AttributedStringBuilder().tabs(tabs);
                         asb.append(trunc);
                         asb.append("...", new AttributedStyle(AttributedStyle.INVERSE));
@@ -746,7 +746,7 @@ public class CommandTailTipWidgets {
                             asb.append(" ");
                         }
                     }
-                    keyList.add(asb.toAttributedString().columnSubSequence(0, columnWidth, reader.getTerminal()));
+                    keyList.add(asb.toAttributedString().columnSubSequence(reader.getTerminal(), 0, columnWidth));
                 } else {
                     asb.append(keyList.get(row - descriptionSize));
                     asb.append(highlightOption(key));

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -1064,12 +1064,6 @@ public abstract class AttributedCharSequence implements CharSequence {
     }
 
     /**
-     * Returns a subsequence of this attributed string based on column positions.
-     *
-     * @param start    the starting column position (inclusive)
-     * @param stop     the ending column position (exclusive)
-     * @param terminal the terminal to query for grapheme cluster mode, or {@code null}
-     * @return the subsequence spanning the specified column range
      * @deprecated Use {@link #columnSubSequence(Terminal, int, int)} instead
      */
     @Deprecated
@@ -1155,13 +1149,6 @@ public abstract class AttributedCharSequence implements CharSequence {
     }
 
     /**
-     * Splits this attributed string into multiple lines based on column width.
-     *
-     * @param columns         the maximum width of each line in columns
-     * @param includeNewlines whether to include newline characters in the resulting lines
-     * @param delayLineWrap   whether to delay line wrapping until the last possible moment
-     * @param terminal        the terminal to query for grapheme cluster mode, or {@code null}
-     * @return a list of attributed strings, each representing a line
      * @deprecated Use {@link #columnSplitLength(Terminal, int, boolean, boolean)} instead
      */
     @Deprecated

--- a/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedCharSequence.java
@@ -1024,18 +1024,18 @@ public abstract class AttributedCharSequence implements CharSequence {
      * @return the subsequence spanning the specified column range
      */
     public AttributedString columnSubSequence(int start, int stop) {
-        return columnSubSequence(start, stop, null);
+        return columnSubSequence(null, start, stop);
     }
 
     /**
      * Returns a subsequence of this attributed string based on column positions.
      *
+     * @param terminal the terminal to query for grapheme cluster mode, or {@code null}
      * @param start    the starting column position (inclusive)
      * @param stop     the ending column position (exclusive)
-     * @param terminal the terminal to query for grapheme cluster mode, or {@code null}
      * @return the subsequence spanning the specified column range
      */
-    public AttributedString columnSubSequence(int start, int stop, Terminal terminal) {
+    public AttributedString columnSubSequence(Terminal terminal, int start, int stop) {
         BreakIterator bi = WCWidth.createGraphemeBreakIterator(this);
         int begin = 0;
         int col = 0;
@@ -1061,6 +1061,20 @@ public abstract class AttributedCharSequence implements CharSequence {
             col += w;
         }
         return subSequence(begin, end);
+    }
+
+    /**
+     * Returns a subsequence of this attributed string based on column positions.
+     *
+     * @param start    the starting column position (inclusive)
+     * @param stop     the ending column position (exclusive)
+     * @param terminal the terminal to query for grapheme cluster mode, or {@code null}
+     * @return the subsequence spanning the specified column range
+     * @deprecated Use {@link #columnSubSequence(Terminal, int, int)} instead
+     */
+    @Deprecated
+    public AttributedString columnSubSequence(int start, int stop, Terminal terminal) {
+        return columnSubSequence(terminal, start, stop);
     }
 
     /**
@@ -1102,20 +1116,20 @@ public abstract class AttributedCharSequence implements CharSequence {
      * @return a list of attributed strings, each representing a line
      */
     public List<AttributedString> columnSplitLength(int columns, boolean includeNewlines, boolean delayLineWrap) {
-        return columnSplitLength(columns, includeNewlines, delayLineWrap, (Terminal) null);
+        return columnSplitLength(null, columns, includeNewlines, delayLineWrap);
     }
 
     /**
      * Splits this attributed string into multiple lines based on column width.
      *
+     * @param terminal        the terminal to query for grapheme cluster mode, or {@code null}
      * @param columns         the maximum width of each line in columns
      * @param includeNewlines whether to include newline characters in the resulting lines
      * @param delayLineWrap   whether to delay line wrapping until the last possible moment
-     * @param terminal        the terminal to query for grapheme cluster mode, or {@code null}
      * @return a list of attributed strings, each representing a line
      */
     public List<AttributedString> columnSplitLength(
-            int columns, boolean includeNewlines, boolean delayLineWrap, Terminal terminal) {
+            Terminal terminal, int columns, boolean includeNewlines, boolean delayLineWrap) {
         List<AttributedString> strings = new ArrayList<>();
         int cur = 0;
         int beg = cur;
@@ -1138,6 +1152,22 @@ public abstract class AttributedCharSequence implements CharSequence {
         }
         strings.add(subSequence(beg, cur));
         return strings;
+    }
+
+    /**
+     * Splits this attributed string into multiple lines based on column width.
+     *
+     * @param columns         the maximum width of each line in columns
+     * @param includeNewlines whether to include newline characters in the resulting lines
+     * @param delayLineWrap   whether to delay line wrapping until the last possible moment
+     * @param terminal        the terminal to query for grapheme cluster mode, or {@code null}
+     * @return a list of attributed strings, each representing a line
+     * @deprecated Use {@link #columnSplitLength(Terminal, int, boolean, boolean)} instead
+     */
+    @Deprecated
+    public List<AttributedString> columnSplitLength(
+            int columns, boolean includeNewlines, boolean delayLineWrap, Terminal terminal) {
+        return columnSplitLength(terminal, columns, includeNewlines, delayLineWrap);
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -217,7 +217,7 @@ public class Display {
             this.columns = columns;
             this.columns1 = columns + 1;
             oldLines = AttributedString.join(AttributedString.EMPTY, oldLines)
-                    .columnSplitLength(columns, true, delayLineWrap(), terminal);
+                    .columnSplitLength(terminal, columns, true, delayLineWrap());
         }
         // When the terminal buffer is wider than the visible window (e.g. Windows with
         // a wide screen buffer), auto-wrap occurs at the buffer width, not the visible
@@ -937,7 +937,7 @@ public class Display {
                 int row = targetPos / columns1;
                 AttributedString lastChar = row >= newLines.size()
                         ? AttributedString.EMPTY
-                        : newLines.get(row).columnSubSequence(columns - 1, columns, terminal);
+                        : newLines.get(row).columnSubSequence(terminal, columns - 1, columns);
                 if (lastChar.length() == 0) rawPrint((int) ' ');
                 else rawPrint(lastChar);
                 cursorPos++;

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -231,7 +231,7 @@ public class Status {
             AttributedString str = lines.get(i);
             if (str.columnLength(terminal) > columns) {
                 str = new AttributedStringBuilder(columns)
-                        .append(lines.get(i).columnSubSequence(0, columns - ellipsis.columnLength(terminal), terminal))
+                        .append(lines.get(i).columnSubSequence(terminal, 0, columns - ellipsis.columnLength(terminal)))
                         .append(ellipsis)
                         .toAttributedString();
             } else if (str.columnLength(terminal) < columns) {

--- a/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedCharSequenceTest.java
@@ -200,15 +200,15 @@ public class AttributedCharSequenceTest {
             String text = "AB" + FAMILY_EMOJI + "CD";
             AttributedString as = new AttributedString(text);
 
-            assertEquals("AB", as.columnSubSequence(0, 2, t).toString());
-            assertEquals(FAMILY_EMOJI, as.columnSubSequence(2, 4, t).toString());
-            assertEquals("CD", as.columnSubSequence(4, 6, t).toString());
+            assertEquals("AB", as.columnSubSequence(t, 0, 2).toString());
+            assertEquals(FAMILY_EMOJI, as.columnSubSequence(t, 2, 4).toString());
+            assertEquals("CD", as.columnSubSequence(t, 4, 6).toString());
 
             // Two flags: extract each one
             String twoFlags = FLAG_FR + FLAG_FR;
             AttributedString flags = new AttributedString(twoFlags);
-            assertEquals(FLAG_FR, flags.columnSubSequence(0, 2, t).toString());
-            assertEquals(FLAG_FR, flags.columnSubSequence(2, 4, t).toString());
+            assertEquals(FLAG_FR, flags.columnSubSequence(t, 0, 2).toString());
+            assertEquals(FLAG_FR, flags.columnSubSequence(t, 2, 4).toString());
         } finally {
             t.close();
         }
@@ -222,9 +222,9 @@ public class AttributedCharSequenceTest {
             String text = "AB" + RAINBOW_FLAG + "CD";
             AttributedString as = new AttributedString(text);
 
-            assertEquals("AB", as.columnSubSequence(0, 2, t).toString());
-            assertEquals(RAINBOW_FLAG, as.columnSubSequence(2, 4, t).toString());
-            assertEquals("CD", as.columnSubSequence(4, 6, t).toString());
+            assertEquals("AB", as.columnSubSequence(t, 0, 2).toString());
+            assertEquals(RAINBOW_FLAG, as.columnSubSequence(t, 2, 4).toString());
+            assertEquals("CD", as.columnSubSequence(t, 4, 6).toString());
         } finally {
             t.close();
         }
@@ -259,7 +259,7 @@ public class AttributedCharSequenceTest {
     public void testColumnSubSequenceNoArgDelegatesToNull() {
         AttributedString as = new AttributedString("Hello");
         assertEquals(
-                as.columnSubSequence(1, 3, null).toString(),
+                as.columnSubSequence(null, 1, 3).toString(),
                 as.columnSubSequence(1, 3).toString());
     }
 
@@ -270,7 +270,7 @@ public class AttributedCharSequenceTest {
             // "AB" + family + "CD" = 6 columns; split at 4
             String text = "AB" + FAMILY_EMOJI + "CD";
             AttributedString as = new AttributedString(text);
-            List<AttributedString> lines = as.columnSplitLength(4, false, true, t);
+            List<AttributedString> lines = as.columnSplitLength(t, 4, false, true);
             assertEquals(2, lines.size());
             assertEquals("AB" + FAMILY_EMOJI, lines.get(0).toString());
             assertEquals("CD", lines.get(1).toString());
@@ -278,7 +278,7 @@ public class AttributedCharSequenceTest {
             // Three families = 6 columns; split at 5 → [family+family, family]
             String three = FAMILY_EMOJI + FAMILY_EMOJI + FAMILY_EMOJI;
             AttributedString as3 = new AttributedString(three);
-            List<AttributedString> lines3 = as3.columnSplitLength(5, false, true, t);
+            List<AttributedString> lines3 = as3.columnSplitLength(t, 5, false, true);
             assertEquals(2, lines3.size());
             assertEquals(FAMILY_EMOJI + FAMILY_EMOJI, lines3.get(0).toString());
             assertEquals(FAMILY_EMOJI, lines3.get(1).toString());
@@ -294,7 +294,7 @@ public class AttributedCharSequenceTest {
             // "AB" + rainbow flag (2 cols) + "CD" = 6 columns; split at 4
             String text = "AB" + RAINBOW_FLAG + "CD";
             AttributedString as = new AttributedString(text);
-            List<AttributedString> lines = as.columnSplitLength(4, false, true, t);
+            List<AttributedString> lines = as.columnSplitLength(t, 4, false, true);
             assertEquals(2, lines.size());
             assertEquals("AB" + RAINBOW_FLAG, lines.get(0).toString());
             assertEquals("CD", lines.get(1).toString());
@@ -302,7 +302,7 @@ public class AttributedCharSequenceTest {
             // Three rainbow flags = 6 columns; split at 5 → [flag+flag, flag]
             String three = RAINBOW_FLAG + RAINBOW_FLAG + RAINBOW_FLAG;
             AttributedString as3 = new AttributedString(three);
-            List<AttributedString> lines3 = as3.columnSplitLength(5, false, true, t);
+            List<AttributedString> lines3 = as3.columnSplitLength(t, 5, false, true);
             assertEquals(2, lines3.size());
             assertEquals(RAINBOW_FLAG + RAINBOW_FLAG, lines3.get(0).toString());
             assertEquals(RAINBOW_FLAG, lines3.get(1).toString());
@@ -316,7 +316,7 @@ public class AttributedCharSequenceTest {
         Terminal t = GraphemeClusterTestTerminal.create();
         try {
             AttributedString as = new AttributedString("AB\nCD");
-            List<AttributedString> lines = as.columnSplitLength(80, false, true, t);
+            List<AttributedString> lines = as.columnSplitLength(t, 80, false, true);
             assertEquals(2, lines.size());
             assertEquals("AB", lines.get(0).toString());
             assertEquals("CD", lines.get(1).toString());
@@ -328,7 +328,7 @@ public class AttributedCharSequenceTest {
     @Test
     public void testColumnSplitLengthNoArgDelegatesToNull() {
         AttributedString as = new AttributedString("Hello World");
-        List<AttributedString> a = as.columnSplitLength(5, false, true, null);
+        List<AttributedString> a = as.columnSplitLength(null, 5, false, true);
         List<AttributedString> b = as.columnSplitLength(5, false, true);
         assertEquals(a.size(), b.size());
         for (int i = 0; i < a.size(); i++) {


### PR DESCRIPTION
## Summary

Fixes #1786.

- Move the `Terminal` parameter from the last position to the first position in `columnSubSequence` and `columnSplitLength` methods on `AttributedCharSequence`, consistent with the existing `columnLength(Terminal, int, int)` convention
- Preserve old signatures as `@Deprecated` delegating overloads for backwards compatibility
- Update all callers across the codebase (Display, Status, LineReaderImpl, Nano, Less, DefaultPrinter, TailTipWidgets, CommandTailTipWidgets) and tests to use the new parameter order

## Test plan

- [x] All existing `AttributedCharSequenceTest` and `AttributedStringTest` tests pass (28 tests)
- [x] Full build compiles successfully
- [x] Deprecated overloads delegate correctly to new methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reordered parameters for terminal-aware text slicing/splitting APIs so the terminal/context is supplied first.
  * Added deprecated overloads to preserve compatibility with existing callers.
  * Updated all usages and tests across the project to match the new API order, preserving visible truncation, wrapping and highlighting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->