### PR TITLE
fix: remove spurious (short) casts in Size setters

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/Size.java
+++ b/terminal/src/main/java/org/jline/terminal/Size.java
@@ -65,8 +65,6 @@ public class Size {
     /**
      * Constructs a Size with the specified number of columns and rows.
      *
-     * <p>Input values are truncated to a 16-bit signed range when stored.</p>
-     *
      * @param columns the number of columns (width)
      * @param rows the number of rows (height)
      */
@@ -111,7 +109,7 @@ public class Size {
      * @see #getColumns()
      */
     public void setColumns(int columns) {
-        cols = (short) columns;
+        cols = columns;
     }
 
     /**
@@ -139,7 +137,7 @@ public class Size {
      * @see #getRows()
      */
     public void setRows(int rows) {
-        this.rows = (short) rows;
+        this.rows = rows;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Remove `(short)` casts in `Size.setColumns()` and `Size.setRows()` that silently truncated values while storing into `int` fields
- Remove now-stale javadoc mentioning "truncated to a 16-bit signed range"

The fields have been `int` since the class was created in 2016, but the setters cast to `short` before assignment. This gave no memory saving (the truncated value was widened back to `int`) — only silent data loss for values above 32767. No real terminal hits this limit, but the casts are wrong regardless.

## Test plan

- [x] Terminal module compiles cleanly
- [x] Existing tests pass (no test exercises values > 32767)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal size handling improved: The terminal size configuration now properly accommodates larger column and row dimensions. Previously, values were being truncated to a 16-bit signed integer range, limiting maximum terminal sizes. This restriction has been removed, enabling support for terminals with significantly larger dimensions while maintaining full precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->