### PR TITLE
fix: Fix AttributedStyle color chaining

### DIFF
--- a/terminal/src/main/java/org/jline/utils/AttributedStyle.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStyle.java
@@ -628,8 +628,8 @@ public class AttributedStyle {
      */
     public AttributedStyle foreground(int color) {
         return new AttributedStyle(
-                style & ~FG_COLOR | F_FOREGROUND_IND | (((long) color << FG_COLOR_EXP) & FG_COLOR),
-                mask | F_FOREGROUND_IND);
+                style & ~(FG_COLOR | F_FOREGROUND) | F_FOREGROUND_IND | (((long) color << FG_COLOR_EXP) & FG_COLOR),
+                (mask & ~F_FOREGROUND) | F_FOREGROUND_IND);
     }
 
     /**
@@ -682,8 +682,10 @@ public class AttributedStyle {
      */
     public AttributedStyle foregroundRgb(int color) {
         return new AttributedStyle(
-                style & ~FG_COLOR | F_FOREGROUND_RGB | ((((long) color & 0xFFFFFF) << FG_COLOR_EXP) & FG_COLOR),
-                mask | F_FOREGROUND_RGB);
+                style & ~(FG_COLOR | F_FOREGROUND)
+                        | F_FOREGROUND_RGB
+                        | ((((long) color & 0xFFFFFF) << FG_COLOR_EXP) & FG_COLOR),
+                (mask & ~F_FOREGROUND) | F_FOREGROUND_RGB);
     }
 
     /**
@@ -748,8 +750,8 @@ public class AttributedStyle {
      */
     public AttributedStyle background(int color) {
         return new AttributedStyle(
-                style & ~BG_COLOR | F_BACKGROUND_IND | (((long) color << BG_COLOR_EXP) & BG_COLOR),
-                mask | F_BACKGROUND_IND);
+                style & ~(BG_COLOR | F_BACKGROUND) | F_BACKGROUND_IND | (((long) color << BG_COLOR_EXP) & BG_COLOR),
+                (mask & ~F_BACKGROUND) | F_BACKGROUND_IND);
     }
 
     /**
@@ -802,8 +804,10 @@ public class AttributedStyle {
      */
     public AttributedStyle backgroundRgb(int color) {
         return new AttributedStyle(
-                style & ~BG_COLOR | F_BACKGROUND_RGB | ((((long) color & 0xFFFFFF) << BG_COLOR_EXP) & BG_COLOR),
-                mask | F_BACKGROUND_RGB);
+                style & ~(BG_COLOR | F_BACKGROUND)
+                        | F_BACKGROUND_RGB
+                        | ((((long) color & 0xFFFFFF) << BG_COLOR_EXP) & BG_COLOR),
+                (mask & ~F_BACKGROUND) | F_BACKGROUND_RGB);
     }
 
     /**

--- a/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AttributedStyleTest {
+class AttributedStyleTest {
 
     /**
      * Verifies that chained RGB and indexed color updates produce the expected final styles.

--- a/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AttributedStyleTest {
+
+    /**
+     * Verifies that chained RGB and indexed color updates produce the expected final styles.
+     */
+    @Test
+    public void testMixedColors() {
+        assertEquals(
+                AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE),
+                AttributedStyle.DEFAULT.foregroundRgb(0xf00ff0).foreground(AttributedStyle.BLUE));
+        assertEquals(
+                AttributedStyle.DEFAULT.foregroundRgb(0x0ff00f),
+                AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE).foregroundRgb(0x0ff00f));
+        assertEquals(
+                AttributedStyle.DEFAULT.background(AttributedStyle.BLUE),
+                AttributedStyle.DEFAULT.backgroundRgb(0xf00ff0).background(AttributedStyle.BLUE));
+        assertEquals(
+                AttributedStyle.DEFAULT.backgroundRgb(0x0ff00f),
+                AttributedStyle.DEFAULT.background(AttributedStyle.BLUE).backgroundRgb(0x0ff00f));
+
+        AttributedString fgChained =
+                createColoredTestString(AttributedStyle::foreground, AttributedStyle::foregroundRgb);
+        AttributedString fgDefault = createColoredTestString(
+                (style, color) -> AttributedStyle.DEFAULT.foreground(color),
+                (style, rgb) -> AttributedStyle.DEFAULT.foregroundRgb(rgb));
+        AttributedString bgChained =
+                createColoredTestString(AttributedStyle::background, AttributedStyle::backgroundRgb);
+        AttributedString bgDefault = createColoredTestString(
+                (style, color) -> AttributedStyle.DEFAULT.background(color),
+                (style, rgb) -> AttributedStyle.DEFAULT.backgroundRgb(rgb));
+
+        assertEquals(fgChained, fgDefault);
+        assertEquals(bgChained, bgDefault);
+    }
+
+    /**
+     * Builds a sample attributed string that alternates indexed and RGB color changes.
+     *
+     * @param color the style update to apply for indexed colors
+     * @param rgbColor the style update to apply for RGB colors
+     * @return a test string with mixed color segments
+     */
+    private static AttributedString createColoredTestString(
+            BiFunction<AttributedStyle, Integer, AttributedStyle> color,
+            BiFunction<AttributedStyle, Integer, AttributedStyle> rgbColor) {
+        AttributedStringBuilder builder = new AttributedStringBuilder();
+        builder.append("a")
+                .style(style -> color.apply(style, AttributedStyle.GREEN))
+                .append("b")
+                .style(style -> rgbColor.apply(style, 0xffff00))
+                .append("c")
+                .style(style -> color.apply(style, AttributedStyle.RED))
+                .append("d")
+                .style(style -> rgbColor.apply(style, 0x00ffff))
+                .append("e")
+                .style(style -> color.apply(style, AttributedStyle.YELLOW))
+                .append("f")
+                .style(style -> rgbColor.apply(style, 0xff0000))
+                .append("g")
+                .style(style -> color.apply(style, AttributedStyle.GREEN))
+                .append("h");
+        return builder.toAttributedString();
+    }
+}

--- a/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
@@ -20,7 +20,7 @@ class AttributedStyleTest {
      * Verifies that chained RGB and indexed color updates produce the expected final styles.
      */
     @Test
-    public void testMixedColors() {
+    void testMixedColors() {
         assertEquals(
                 AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE),
                 AttributedStyle.DEFAULT.foregroundRgb(0xf00ff0).foreground(AttributedStyle.BLUE));


### PR DESCRIPTION
When creating and manipulating an AttributedStyle, one would expect the following 2 statements to give the same results.
`AttributedStyle.DEFAULT.underline().foreground(AttributedStyle.GREEN).foregroundRgb(0xff0000)`
`AttributedStyle.DEFAULT.underline().foregroundRgb(0xff0000)`

This scenario is a bit strange, but it is what happens under the hood when calling:
```
new AttributedStringBuilder()
                .style(AttributedStyle.DEFAULT.underline())
                .append("a")
                .style(style -> style.foreground(AttributedStyle.GREEN))
                .append("b")
                .style(style -> style.foregroundRgb(0xff0000))
                .append("c")
```

Because the functions applying the color style only applied their own feaature bit (IND or RGB), the old flag was never cleared, leading to both the RGB and INDEX flags being set. This pull resolves that by not only clearing the color bits, bit also the color feature bits before applying the net color.

Pull also includes new tests to ensure proper behaviour (for FG and BG).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected color-state handling so switching between indexed and RGB colors yields consistent styled text and prevents mode-mixing visual issues.

* **Tests**
  * Added unit tests covering mixed indexed/RGB color sequences to verify consistent results and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->