### PR TITLE
fix: register Kernel32 FFM downcall signatures for GraalVM native-image

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -78,3 +78,51 @@ jobs:
           MVX_HTTP_TIMEOUT: 300
         shell: cmd
         if: matrix.os == 'windows-latest'
+
+  native-image:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        profile: [ native-image-jni, native-image-ffm ]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          distribution: 'graalvm-community'
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-graalvm-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-graalvm-
+            ${{ runner.os }}-maven-
+
+      - name: Cache mvx tools
+        uses: actions/cache@v5
+        with:
+          path: ~/.mvx/tools
+          key: ${{ runner.os }}-mvx-tools-${{ hashFiles('.mvx/config.json5', '.mvx/mvx.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mvx-tools-
+
+      - name: Build project
+        run: ./mvx mvn -B --no-transfer-progress install -DskipTests
+        env:
+          MVX_USE_SYSTEM_JAVA: true
+          MVX_PARALLEL_DOWNLOADS: 1
+          MVX_DOWNLOAD_TIMEOUT: 300
+          MVX_HTTP_TIMEOUT: 300
+
+      - name: Build and verify native image
+        run: ./mvx mvn -B --no-transfer-progress verify -pl graal -P${{ matrix.profile }}
+        env:
+          MVX_USE_SYSTEM_JAVA: true
+          MVX_PARALLEL_DOWNLOADS: 1
+          MVX_DOWNLOAD_TIMEOUT: 300
+          MVX_HTTP_TIMEOUT: 300

--- a/graal/src/main/java/org/jline/demo/graal/Graal.java
+++ b/graal/src/main/java/org/jline/demo/graal/Graal.java
@@ -67,7 +67,7 @@ public class Graal {
     private static void check() {
         try {
             TerminalProvider provider = null;
-            for (String name : new String[] {"ffm", "jni"}) {
+            for (String name : new String[] {"ffm", "jni", "exec"}) {
                 try {
                     provider = TerminalProvider.load(name);
                     break;

--- a/graal/src/main/java/org/jline/demo/graal/Graal.java
+++ b/graal/src/main/java/org/jline/demo/graal/Graal.java
@@ -67,6 +67,7 @@ public class Graal {
      * Verify that a terminal provider can be loaded and used.
      * This is used as a smoke test for native image builds.
      */
+    @SuppressWarnings("java:S106")
     private static void check() {
         try {
             TerminalProvider provider = null;

--- a/graal/src/main/java/org/jline/demo/graal/Graal.java
+++ b/graal/src/main/java/org/jline/demo/graal/Graal.java
@@ -8,6 +8,8 @@
  */
 package org.jline.demo.graal;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
 
 import org.jline.reader.LineReader;
@@ -15,6 +17,7 @@ import org.jline.shell.Shell;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.spi.TerminalExt;
+import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.OSUtils;
 
@@ -78,6 +81,19 @@ public class Graal {
                 throw new IllegalStateException("No terminal provider found");
             }
             System.out.println("Provider loaded: " + provider.name());
+
+            for (SystemStream stream : SystemStream.values()) {
+                System.out.println("  " + stream + " is system stream: " + provider.isSystemStream(stream));
+            }
+
+            Terminal terminal = TerminalBuilder.builder()
+                    .name("check")
+                    .system(false)
+                    .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream())
+                    .build();
+            System.out.println("Terminal created: " + terminal.getName() + " (" + terminal.getType() + ")");
+            terminal.close();
+
             System.out.println("CHECK PASSED");
         } catch (Throwable t) {
             System.err.println("CHECK FAILED: " + t.getMessage());

--- a/graal/src/main/java/org/jline/demo/graal/Graal.java
+++ b/graal/src/main/java/org/jline/demo/graal/Graal.java
@@ -16,8 +16,8 @@ import org.jline.reader.LineReader;
 import org.jline.shell.Shell;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
-import org.jline.terminal.spi.TerminalExt;
 import org.jline.terminal.spi.SystemStream;
+import org.jline.terminal.spi.TerminalExt;
 import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.OSUtils;
 

--- a/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
+++ b/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
@@ -38,6 +38,42 @@
       {
         "returnType": "int",
         "parameterTypes": ["void*", "void*", "void*", "void*", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "int"]
+      },
+      {
+        "returnType": "void*",
+        "parameterTypes": ["int"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["int", "void*", "int", "int", "void*", "int", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "short"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": []
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "void*", "int", "void*", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "void*", "int", "void*"]
       }
     ]
   }


### PR DESCRIPTION
## Summary

- Backport of #1802 to 4.0.x branch
- Register all FFM foreign function signatures (downcalls) in `reachability-metadata.json` for GraalVM native-image support
- Add CI native-image build job (GraalVM CE 25) testing both `native-image-ffm` and `native-image-jni` profiles on Linux and macOS
- Enhanced `--check` smoke test that exercises `provider.isSystemStream()` (triggers FFM downcalls) and creates/closes a terminal via `TerminalBuilder`
- Add `exec` provider fallback to `--check` mode

Relates to https://github.com/tamboui/tamboui/issues/276

## Test plan

- [ ] CI native-image job passes on Linux and macOS
- [ ] `graal --check` outputs provider name, system stream status, and terminal creation confirmation
- [ ] FFM downcall signatures are correctly registered (no VMError at runtime)