### PR TITLE
fix: deprecate SwingTerminal.dispose() in favor of close() (fixes #1805)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
@@ -238,7 +238,12 @@ public class SwingTerminal extends LineDisciplineTerminal {
 
     /**
      * Disposes of the terminal resources.
+     *
+     * @deprecated Use {@link #close()} instead, which properly handles all cleanup
+     *     including disposing of resources. This method will be made package-private
+     *     or removed in a future major release.
      */
+    @Deprecated
     public void dispose() {
         if (inputThread != null) {
             inputThread.interrupt();

--- a/builtins/src/test/java/org/jline/builtins/SwingTerminalEncodingTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SwingTerminalEncodingTest.java
@@ -38,7 +38,6 @@ class SwingTerminalEncodingTest {
     @AfterEach
     void tearDown() throws IOException {
         if (swingTerminal != null) {
-            swingTerminal.dispose();
             swingTerminal.close();
         }
     }

--- a/demo/src/main/java/org/jline/demo/Launcher.java
+++ b/demo/src/main/java/org/jline/demo/Launcher.java
@@ -111,7 +111,6 @@ public class Launcher {
             }
         } finally {
             terminal.close();
-            terminal.dispose();
             frame.dispose();
         }
     }

--- a/demo/src/main/java/org/jline/demo/examples/SwingTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SwingTerminalExample.java
@@ -44,7 +44,11 @@ public class SwingTerminalExample {
         frame.addWindowListener(new java.awt.event.WindowAdapter() {
             @Override
             public void windowClosing(java.awt.event.WindowEvent e) {
-                terminal.dispose();
+                try {
+                    terminal.close();
+                } catch (java.io.IOException ex) {
+                    // ignore
+                }
             }
         });
 
@@ -56,7 +60,11 @@ public class SwingTerminalExample {
                     } catch (Exception e) {
                         e.printStackTrace();
                     } finally {
-                        terminal.dispose();
+                        try {
+                            terminal.close();
+                        } catch (java.io.IOException e) {
+                            // ignore
+                        }
                         frame.dispose();
                     }
                 },
@@ -95,7 +103,11 @@ public class SwingTerminalExample {
         frame.addWindowListener(new java.awt.event.WindowAdapter() {
             @Override
             public void windowClosing(java.awt.event.WindowEvent e) {
-                terminal.dispose();
+                try {
+                    terminal.close();
+                } catch (java.io.IOException ex) {
+                    // ignore
+                }
             }
         });
 
@@ -107,7 +119,11 @@ public class SwingTerminalExample {
                     } catch (Exception e) {
                         e.printStackTrace();
                     } finally {
-                        terminal.dispose();
+                        try {
+                            terminal.close();
+                        } catch (java.io.IOException e) {
+                            // ignore
+                        }
                         frame.dispose();
                     }
                 },


### PR DESCRIPTION
## Summary

- Deprecate `SwingTerminal.dispose()` with `@Deprecated` annotation, pointing users to `close()` instead
- Remove redundant `dispose()` calls from `SwingTerminalEncodingTest` and `Launcher` where `close()` is already called
- Replace `dispose()` calls with `close()` in `SwingTerminalExample` demo code

`close()` already delegates to `dispose()` internally via `doClose()`, so all cleanup behavior is preserved.

Fixes #1805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation**
  * `SwingTerminal.dispose()` is now deprecated. Users should migrate to `close()` for proper resource cleanup.

* **Chores**
  * Updated internal cleanup sequences to use the recommended `close()` method instead of the deprecated alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->