### PR TITLE
fix: erase probe emoji after grapheme cluster detection (fixes #1801)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -612,6 +612,7 @@ public abstract class AbstractTerminal implements TerminalExt {
         } catch (IOError | IOException e) {
             try {
                 puts(Capability.restore_cursor);
+                puts(Capability.clr_eol);
                 writer().flush();
             } catch (Exception ignored) {
                 // Best-effort cleanup; probing failure should not propagate
@@ -635,6 +636,7 @@ public abstract class AbstractTerminal implements TerminalExt {
         int col = readCprColumn(200);
 
         puts(Capability.restore_cursor);
+        puts(Capability.clr_eol);
         writer().flush();
         return col;
     }

--- a/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterModeTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterModeTest.java
@@ -440,6 +440,11 @@ class GraphemeClusterModeTest {
         assertTrue(terminal.getGraphemeClusterMode());
 
         responder.joinAndAssert();
+
+        // Verify probe emoji was erased (clr_eol = \033[K after each restore_cursor)
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[K"), "Probe should erase emoji via clr_eol");
+
         terminal.close();
     }
 


### PR DESCRIPTION
## Summary

- The cursor-position probe in `AbstractTerminal.probeEmojiWidth()` wrote test emoji (🇫🇷 and 👩‍🔬) to measure column displacement, then restored the cursor position — but never erased the emoji glyphs from the screen
- Added `clr_eol` after each `restore_cursor` to clear the probe output, preventing the unexpected emoji from appearing during terminal initialization
- Added test assertion to verify the cleanup sequence is emitted

Fixes #1801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced terminal cleanup behavior during cursor position detection to ensure line contents are properly cleared, resulting in improved display quality and preventing potential text artifacts from remaining on the terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->