### PR TITLE
fix: avoid NPE when closing terminal with null masterOutput

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
@@ -276,7 +276,7 @@ public class LineDisciplineTerminal extends AbstractTerminal {
     public void processInputByte(int c) throws IOException {
         boolean flushOut = doProcessInputByte(c);
         slaveInputPipe.flush();
-        if (flushOut) {
+        if (flushOut && masterOutput != null) {
             masterOutput.flush();
         }
     }
@@ -291,7 +291,7 @@ public class LineDisciplineTerminal extends AbstractTerminal {
             flushOut |= doProcessInputByte(input[offset + i]);
         }
         slaveInputPipe.flush();
-        if (flushOut) {
+        if (flushOut && masterOutput != null) {
             masterOutput.flush();
         }
     }
@@ -350,6 +350,9 @@ public class LineDisciplineTerminal extends AbstractTerminal {
      * @throws IOException if anything wrong happens
      */
     protected void processOutputByte(int c) throws IOException {
+        if (masterOutput == null) {
+            return;
+        }
         if (attributes.getOutputFlag(OutputFlag.OPOST)) {
             if (c == '\n') {
                 if (attributes.getOutputFlag(OutputFlag.ONLCR)) {
@@ -413,12 +416,16 @@ public class LineDisciplineTerminal extends AbstractTerminal {
 
         @Override
         public void flush() throws IOException {
-            masterOutput.flush();
+            if (masterOutput != null) {
+                masterOutput.flush();
+            }
         }
 
         @Override
         public void close() throws IOException {
-            masterOutput.close();
+            if (masterOutput != null) {
+                masterOutput.close();
+            }
         }
     }
 }

--- a/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class NullOutputCloseTest {
+
+    @Test
+    void testCloseWithNullMasterOutput() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        ExternalTerminal terminal = new ExternalTerminal("test", "dumb", in, null, StandardCharsets.UTF_8);
+        assertDoesNotThrow(terminal::close);
+    }
+}


### PR DESCRIPTION
Fixes #1796

## Summary

- Add null guards for `masterOutput` in `LineDisciplineTerminal.FilteringOutputStream.flush()` and `close()` to prevent NPE when closing a terminal created with `system(false)` and no output stream
- Also guard `processOutputByte()`, `processInputByte()`, and `processInputBytes()` for completeness
- Add test verifying that closing an `ExternalTerminal` with null `masterOutput` does not throw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal stability by adding defensive null checks to output processing and stream closure operations, preventing potential exceptions when output streams are unavailable.

* **Tests**
  * Added new test case to verify the terminal closes gracefully in edge-case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->