### PR TITLE
fix: close terminals properly in tests (fixes #1806)

### DIFF
--- a/prompt/src/test/java/org/jline/prompt/IntegrationTest.java
+++ b/prompt/src/test/java/org/jline/prompt/IntegrationTest.java
@@ -19,172 +19,170 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Integration test for the JLine Prompt API.
  */
-// TODO: Fix terminals created with TerminalBuilder.builder().system(false).build() NPE'ing when closed.
 class IntegrationTest {
 
     @Test
     void testBasicPromptCreation() throws Exception {
-        // Create a terminal (in test mode)
-        Terminal terminal = TerminalBuilder.builder().system(false).build();
+        try (Terminal terminal = TerminalBuilder.builder().system(false).build()) {
+            // Create a prompter
+            Prompter prompter = PrompterFactory.create(terminal);
+            assertNotNull(prompter);
 
-        // Create a prompter
-        Prompter prompter = PrompterFactory.create(terminal);
-        assertNotNull(prompter);
+            // Get the prompt builder
+            PromptBuilder builder = prompter.newBuilder();
+            assertNotNull(builder);
 
-        // Get the prompt builder
-        PromptBuilder builder = prompter.newBuilder();
-        assertNotNull(builder);
+            // Test creating different types of builders
+            InputBuilder inputBuilder = builder.createInputPrompt();
+            assertNotNull(inputBuilder);
 
-        // Test creating different types of builders
-        InputBuilder inputBuilder = builder.createInputPrompt();
-        assertNotNull(inputBuilder);
+            ListBuilder listBuilder = builder.createListPrompt();
+            assertNotNull(listBuilder);
 
-        ListBuilder listBuilder = builder.createListPrompt();
-        assertNotNull(listBuilder);
+            CheckboxBuilder checkboxBuilder = builder.createCheckboxPrompt();
+            assertNotNull(checkboxBuilder);
 
-        CheckboxBuilder checkboxBuilder = builder.createCheckboxPrompt();
-        assertNotNull(checkboxBuilder);
+            ChoiceBuilder choiceBuilder = builder.createChoicePrompt();
+            assertNotNull(choiceBuilder);
 
-        ChoiceBuilder choiceBuilder = builder.createChoicePrompt();
-        assertNotNull(choiceBuilder);
+            ConfirmBuilder confirmBuilder = builder.createConfirmPrompt();
+            assertNotNull(confirmBuilder);
 
-        ConfirmBuilder confirmBuilder = builder.createConfirmPrompt();
-        assertNotNull(confirmBuilder);
-
-        TextBuilder textBuilder = builder.createText();
-        assertNotNull(textBuilder);
+            TextBuilder textBuilder = builder.createText();
+            assertNotNull(textBuilder);
+        }
     }
 
     @Test
     void testFluentBuilderAPI() throws Exception {
-        Terminal terminal = TerminalBuilder.builder().system(false).build();
+        try (Terminal terminal = TerminalBuilder.builder().system(false).build()) {
+            Prompter prompter = PrompterFactory.create(terminal);
+            PromptBuilder builder = prompter.newBuilder();
 
-        Prompter prompter = PrompterFactory.create(terminal);
-        PromptBuilder builder = prompter.newBuilder();
+            // Test fluent API for input prompt
+            PromptBuilder result1 = builder.createInputPrompt()
+                    .name("test_input")
+                    .message("Enter something:")
+                    .defaultValue("default")
+                    .mask('*')
+                    .addPrompt();
+            assertSame(builder, result1);
 
-        // Test fluent API for input prompt
-        PromptBuilder result1 = builder.createInputPrompt()
-                .name("test_input")
-                .message("Enter something:")
-                .defaultValue("default")
-                .mask('*')
-                .addPrompt();
-        assertSame(builder, result1);
+            // Test fluent API for list prompt
+            PromptBuilder result2 = builder.createListPrompt()
+                    .name("test_list")
+                    .message("Choose an option:")
+                    .newItem("option1")
+                    .text("Option 1")
+                    .add()
+                    .newItem("option2")
+                    .text("Option 2")
+                    .add()
+                    .addPrompt();
+            assertSame(builder, result2);
 
-        // Test fluent API for list prompt
-        PromptBuilder result2 = builder.createListPrompt()
-                .name("test_list")
-                .message("Choose an option:")
-                .newItem("option1")
-                .text("Option 1")
-                .add()
-                .newItem("option2")
-                .text("Option 2")
-                .add()
-                .addPrompt();
-        assertSame(builder, result2);
+            // Test fluent API for checkbox prompt
+            PromptBuilder result3 = builder.createCheckboxPrompt()
+                    .name("test_checkbox")
+                    .message("Select options:")
+                    .newItem("cb1")
+                    .text("Checkbox 1")
+                    .checked(true)
+                    .add()
+                    .newItem("cb2")
+                    .text("Checkbox 2")
+                    .add()
+                    .addPrompt();
+            assertSame(builder, result3);
 
-        // Test fluent API for checkbox prompt
-        PromptBuilder result3 = builder.createCheckboxPrompt()
-                .name("test_checkbox")
-                .message("Select options:")
-                .newItem("cb1")
-                .text("Checkbox 1")
-                .checked(true)
-                .add()
-                .newItem("cb2")
-                .text("Checkbox 2")
-                .add()
-                .addPrompt();
-        assertSame(builder, result3);
+            // Test fluent API for choice prompt
+            PromptBuilder result4 = builder.createChoicePrompt()
+                    .name("test_choice")
+                    .message("Pick a choice:")
+                    .newChoice("choice1")
+                    .key('a')
+                    .text("Choice A")
+                    .defaultChoice(true)
+                    .add()
+                    .addPrompt();
+            assertSame(builder, result4);
 
-        // Test fluent API for choice prompt
-        PromptBuilder result4 = builder.createChoicePrompt()
-                .name("test_choice")
-                .message("Pick a choice:")
-                .newChoice("choice1")
-                .key('a')
-                .text("Choice A")
-                .defaultChoice(true)
-                .add()
-                .addPrompt();
-        assertSame(builder, result4);
+            // Test fluent API for confirm prompt
+            PromptBuilder result5 = builder.createConfirmPrompt()
+                    .name("test_confirm")
+                    .message("Are you sure?")
+                    .defaultValue(true)
+                    .addPrompt();
+            assertSame(builder, result5);
 
-        // Test fluent API for confirm prompt
-        PromptBuilder result5 = builder.createConfirmPrompt()
-                .name("test_confirm")
-                .message("Are you sure?")
-                .defaultValue(true)
-                .addPrompt();
-        assertSame(builder, result5);
+            // Test fluent API for text display
+            PromptBuilder result6 = builder.createText()
+                    .name("test_text")
+                    .message("This is a message")
+                    .text("Additional text")
+                    .addPrompt();
+            assertSame(builder, result6);
 
-        // Test fluent API for text display
-        PromptBuilder result6 = builder.createText()
-                .name("test_text")
-                .message("This is a message")
-                .text("Additional text")
-                .addPrompt();
-        assertSame(builder, result6);
-
-        // Build the prompts
-        List<? extends Prompt> prompts = builder.build();
-        assertNotNull(prompts);
-        assertEquals(6, prompts.size());
+            // Build the prompts
+            List<? extends Prompt> prompts = builder.build();
+            assertNotNull(prompts);
+            assertEquals(6, prompts.size());
+        }
     }
 
     @Test
     void testPromptTypes() throws Exception {
-        Terminal terminal = TerminalBuilder.builder().system(false).build();
+        try (Terminal terminal = TerminalBuilder.builder().system(false).build()) {
+            Prompter prompter = PrompterFactory.create(terminal);
+            PromptBuilder builder = prompter.newBuilder();
 
-        Prompter prompter = PrompterFactory.create(terminal);
-        PromptBuilder builder = prompter.newBuilder();
+            // Build a variety of prompts
+            builder.createInputPrompt()
+                    .name("input")
+                    .message("Input:")
+                    .addPrompt()
+                    .createListPrompt()
+                    .name("list")
+                    .message("List:")
+                    .newItem("item1")
+                    .text("Item 1")
+                    .add()
+                    .addPrompt()
+                    .createCheckboxPrompt()
+                    .name("checkbox")
+                    .message("Checkbox:")
+                    .newItem("cb1")
+                    .text("CB 1")
+                    .add()
+                    .addPrompt()
+                    .createChoicePrompt()
+                    .name("choice")
+                    .message("Choice:")
+                    .newChoice("ch1")
+                    .key('a')
+                    .text("Choice 1")
+                    .add()
+                    .addPrompt()
+                    .createConfirmPrompt()
+                    .name("confirm")
+                    .message("Confirm:")
+                    .addPrompt()
+                    .createText()
+                    .name("text")
+                    .message("Text display")
+                    .addPrompt();
 
-        // Build a variety of prompts
-        builder.createInputPrompt()
-                .name("input")
-                .message("Input:")
-                .addPrompt()
-                .createListPrompt()
-                .name("list")
-                .message("List:")
-                .newItem("item1")
-                .text("Item 1")
-                .add()
-                .addPrompt()
-                .createCheckboxPrompt()
-                .name("checkbox")
-                .message("Checkbox:")
-                .newItem("cb1")
-                .text("CB 1")
-                .add()
-                .addPrompt()
-                .createChoicePrompt()
-                .name("choice")
-                .message("Choice:")
-                .newChoice("ch1")
-                .key('a')
-                .text("Choice 1")
-                .add()
-                .addPrompt()
-                .createConfirmPrompt()
-                .name("confirm")
-                .message("Confirm:")
-                .addPrompt()
-                .createText()
-                .name("text")
-                .message("Text display")
-                .addPrompt();
+            List<? extends Prompt> prompts = builder.build();
+            assertEquals(6, prompts.size());
 
-        List<? extends Prompt> prompts = builder.build();
-        assertEquals(6, prompts.size());
-
-        // Verify prompt types
-        assertInstanceOf(InputPrompt.class, prompts.get(0));
-        assertInstanceOf(ListPrompt.class, prompts.get(1));
-        assertInstanceOf(CheckboxPrompt.class, prompts.get(2));
-        assertInstanceOf(ChoicePrompt.class, prompts.get(3));
-        assertInstanceOf(ConfirmPrompt.class, prompts.get(4));
-        assertInstanceOf(TextPrompt.class, prompts.get(5));
+            // Verify prompt types
+            assertInstanceOf(InputPrompt.class, prompts.get(0));
+            assertInstanceOf(ListPrompt.class, prompts.get(1));
+            assertInstanceOf(CheckboxPrompt.class, prompts.get(2));
+            assertInstanceOf(ChoicePrompt.class, prompts.get(3));
+            assertInstanceOf(ConfirmPrompt.class, prompts.get(4));
+            assertInstanceOf(TextPrompt.class, prompts.get(5));
+        }
     }
 
     @Test

--- a/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
@@ -12,6 +12,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -22,6 +24,12 @@ class NullOutputCloseTest {
     void testCloseWithNullMasterOutput() throws IOException {
         ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
         ExternalTerminal terminal = new ExternalTerminal("test", "dumb", in, null, StandardCharsets.UTF_8);
+        assertDoesNotThrow(terminal::close);
+    }
+
+    @Test
+    void testCloseSystemFalseTerminal() throws IOException {
+        Terminal terminal = TerminalBuilder.builder().system(false).build();
         assertDoesNotThrow(terminal::close);
     }
 }


### PR DESCRIPTION
## Summary

- Update `IntegrationTest` in the `prompt` module to use try-with-resources for proper terminal cleanup, removing the TODO workaround for the NPE that was fixed in #1813
- Add a `TerminalBuilder.builder().system(false).build()` + `close()` test to `NullOutputCloseTest` to verify the fix at the builder level

## Test plan

- [x] `NullOutputCloseTest` passes (2 tests, including the new `testCloseSystemFalseTerminal`)
- [x] `IntegrationTest` passes (4 tests, all now using try-with-resources)
- [x] Full `terminal` module test suite passes (267 tests)
- [x] Full `prompt` module test suite passes (54 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test suite with improved resource cleanup procedures and automatic terminal closure
  * Expanded test coverage for terminal closure operations across different configurations to ensure reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->