### PR TITLE
fix: close PTY streams before shutdown to prevent hang on macOS (fixes #1808)

### DIFF
--- a/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
+++ b/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
@@ -23,13 +23,12 @@ import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-// TODO: Figure out why try-with-resources in these tests hang on MAC-OS.
 class FfmTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS) // non system terminals are not supported on windows
     void testNewTerminalWithNull() throws IOException {
-        Terminal terminal = new FfmTerminalProvider()
+        try (Terminal terminal = new FfmTerminalProvider()
                 .newTerminal(
                         "name",
                         "xterm",
@@ -41,14 +40,15 @@ class FfmTest {
                         Terminal.SignalHandler.SIG_DFL,
                         false,
                         null,
-                        null);
-        assertNotNull(terminal);
+                        null)) {
+            assertNotNull(terminal);
+        }
     }
 
     @Test
     @DisabledOnOs(OS.WINDOWS) // non system terminals are not supported on windows
     void testNewTerminalNoNull() throws IOException {
-        Terminal terminal = new FfmTerminalProvider()
+        try (Terminal terminal = new FfmTerminalProvider()
                 .newTerminal(
                         "name",
                         "xterm",
@@ -60,9 +60,10 @@ class FfmTest {
                         Terminal.SignalHandler.SIG_DFL,
                         false,
                         new Attributes(),
-                        new Size());
-        assertNotNull(terminal);
-        assertNotNull(terminal.getSize());
+                        new Size())) {
+            assertNotNull(terminal);
+            assertNotNull(terminal.getSize());
+        }
     }
 
     @Test

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -149,6 +149,20 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
 
     @Override
     protected void doClose() throws IOException {
+        // Close the slave output to signal EOF on the master side, which
+        // reliably unblocks pumpOut's masterInput.read() on all platforms
+        // (including macOS where closing the master fd from another thread
+        // may not unblock a blocked read on the same fd).
+        try {
+            output.close();
+        } catch (IOException e) {
+            // ignore
+        }
+        try {
+            masterInput.close();
+        } catch (IOException e) {
+            // ignore
+        }
         super.doClose();
         reader.close();
     }


### PR DESCRIPTION
## Summary

- Fix `PosixPtyTerminal.doClose()` to close the slave output and master input streams before calling `pty.close()`, which reliably unblocks the `pumpOut` thread on all platforms including macOS
- Restore try-with-resources in `FfmTest` now that terminals close cleanly

## Root cause

On macOS, closing a file descriptor from one thread does not reliably unblock a `read()` blocked on the same fd in another thread (this is implementation-defined per POSIX). The `pumpOut` thread blocks on `masterInput.read()` (PTY master fd), and `pty.close()` closing that same fd from the main thread was not waking it up.

## Fix

Close the slave output (`output`) first, which signals EOF on the master side via the kernel's PTY layer. This is a cross-fd notification (slave→master) handled by the kernel, not a same-fd close, so it works reliably on all platforms. Also close `masterInput` directly to ensure the stream object is marked closed.

## Test plan

- [x] `FfmTest` passes with try-with-resources on macOS (was hanging before)
- [x] Full `terminal` module test suite passes (267 tests)
- [x] Full `terminal-ffm` module test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability with better resource lifecycle management.

* **Bug Fixes**
  * Enhanced terminal shutdown to properly close all output streams and ensure pending read operations complete reliably without blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->