### PR TITLE
fix: close terminal in PromptBuilderTest to prevent resource leak (fixes #1810)

### DIFF
--- a/console-ui/src/test/java/org/jline/consoleui/prompt/PromptBuilderTest.java
+++ b/console-ui/src/test/java/org/jline/consoleui/prompt/PromptBuilderTest.java
@@ -24,108 +24,105 @@ class PromptBuilderTest {
 
     @Test
     void testBuilder() throws IOException {
-        ConsolePrompt prompt = new ConsolePrompt(TerminalBuilder.builder().build());
-        PromptBuilder promptBuilder = prompt.getPromptBuilder();
+        try (var terminal = TerminalBuilder.builder().system(false).build()) {
+            ConsolePrompt prompt = new ConsolePrompt(terminal);
+            PromptBuilder promptBuilder = prompt.getPromptBuilder();
 
-        promptBuilder
-                .createConfirmPromp()
-                .name("wantapizza")
-                .message("Do you want to order a pizza?")
-                .defaultValue(ConfirmChoice.ConfirmationValue.YES)
-                .addPrompt();
+            promptBuilder
+                    .createConfirmPromp()
+                    .name("wantapizza")
+                    .message("Do you want to order a pizza?")
+                    .defaultValue(ConfirmChoice.ConfirmationValue.YES)
+                    .addPrompt();
 
-        promptBuilder
-                .createInputPrompt()
-                .name("name")
-                .message("Please enter your name")
-                .defaultValue("John Doe")
-                .addPrompt();
+            promptBuilder
+                    .createInputPrompt()
+                    .name("name")
+                    .message("Please enter your name")
+                    .defaultValue("John Doe")
+                    .addPrompt();
 
-        promptBuilder
-                .createListPrompt()
-                .name("pizzatype")
-                .message("Which pizza do you want?")
-                .newItem()
-                .text("Margherita")
-                .add() // without name (name defaults to text)
-                .newItem("veneziana")
-                .text("Veneziana")
-                .add()
-                .newItem("hawai")
-                .text("Hawai")
-                .add()
-                .newItem("quattro")
-                .text("Quattro Stagioni")
-                .add()
-                .addPrompt();
+            promptBuilder
+                    .createListPrompt()
+                    .name("pizzatype")
+                    .message("Which pizza do you want?")
+                    .newItem()
+                    .text("Margherita")
+                    .add() // without name (name defaults to text)
+                    .newItem("veneziana")
+                    .text("Veneziana")
+                    .add()
+                    .newItem("hawai")
+                    .text("Hawai")
+                    .add()
+                    .newItem("quattro")
+                    .text("Quattro Stagioni")
+                    .add()
+                    .addPrompt();
 
-        promptBuilder
-                .createCheckboxPrompt()
-                .name("topping")
-                .message("Please select additional toppings:")
-                .newSeparator("standard toppings")
-                .add()
-                .newItem()
-                .name("cheese")
-                .text("Cheese")
-                .add()
-                .newItem("bacon")
-                .text("Bacon")
-                .add()
-                .newItem("onions")
-                .text("Onions")
-                .disabledText("Sorry. Out of stock.")
-                .add()
-                .newSeparator()
-                .text("special toppings")
-                .add()
-                .newItem("salami")
-                .text("Very hot salami")
-                .check()
-                .add()
-                .newItem("salmon")
-                .text("Smoked Salmon")
-                .add()
-                .newSeparator("and our speciality...")
-                .add()
-                .newItem("special")
-                .text("Anchovies, and olives")
-                .checked(true)
-                .add()
-                .addPrompt();
+            promptBuilder
+                    .createCheckboxPrompt()
+                    .name("topping")
+                    .message("Please select additional toppings:")
+                    .newSeparator("standard toppings")
+                    .add()
+                    .newItem()
+                    .name("cheese")
+                    .text("Cheese")
+                    .add()
+                    .newItem("bacon")
+                    .text("Bacon")
+                    .add()
+                    .newItem("onions")
+                    .text("Onions")
+                    .disabledText("Sorry. Out of stock.")
+                    .add()
+                    .newSeparator()
+                    .text("special toppings")
+                    .add()
+                    .newItem("salami")
+                    .text("Very hot salami")
+                    .check()
+                    .add()
+                    .newItem("salmon")
+                    .text("Smoked Salmon")
+                    .add()
+                    .newSeparator("and our speciality...")
+                    .add()
+                    .newItem("special")
+                    .text("Anchovies, and olives")
+                    .checked(true)
+                    .add()
+                    .addPrompt();
 
-        assertNotNull(promptBuilder);
-        promptBuilder
-                .createChoicePrompt()
-                .name("payment")
-                .message("How do you want to pay?")
-                .newItem()
-                .name("cash")
-                .message("Cash")
-                .key('c')
-                .asDefault()
-                .add()
-                .newItem("visa")
-                .message("Visa Card")
-                .key('v')
-                .add()
-                .newItem("master")
-                .message("Master Card")
-                .key('m')
-                .add()
-                .newSeparator("online payment")
-                .add()
-                .newItem("paypal")
-                .message("Paypal")
-                .key('p')
-                .add()
-                .addPrompt();
+            assertNotNull(promptBuilder);
+            promptBuilder
+                    .createChoicePrompt()
+                    .name("payment")
+                    .message("How do you want to pay?")
+                    .newItem()
+                    .name("cash")
+                    .message("Cash")
+                    .key('c')
+                    .asDefault()
+                    .add()
+                    .newItem("visa")
+                    .message("Visa Card")
+                    .key('v')
+                    .add()
+                    .newItem("master")
+                    .message("Master Card")
+                    .key('m')
+                    .add()
+                    .newSeparator("online payment")
+                    .add()
+                    .newItem("paypal")
+                    .message("Paypal")
+                    .key('p')
+                    .add()
+                    .addPrompt();
 
-        List<PromptableElementIF> promptableElementList = promptBuilder.build();
-
-        // only for test. reset the default reader to a test reader to automate the input
-        // promptableElementList.get(0)
-
-        // HashMap<String, Object> result = prompt.prompt(promptableElementList);
+            List<PromptableElementIF> promptableElementList = promptBuilder.build();
+        }
     }
 }

--- a/console-ui/src/test/java/org/jline/consoleui/prompt/PromptBuilderTest.java
+++ b/console-ui/src/test/java/org/jline/consoleui/prompt/PromptBuilderTest.java
@@ -17,7 +17,7 @@ import org.jline.consoleui.prompt.builder.PromptBuilder;
 import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("removal")
 class PromptBuilderTest {
@@ -95,7 +95,6 @@ class PromptBuilderTest {
                     .add()
                     .addPrompt();
 
-            assertNotNull(promptBuilder);
             promptBuilder
                     .createChoicePrompt()
                     .name("payment")
@@ -123,6 +122,7 @@ class PromptBuilderTest {
                     .addPrompt();
 
             List<PromptableElementIF> promptableElementList = promptBuilder.build();
+            assertEquals(5, promptableElementList.size());
         }
     }
 }


### PR DESCRIPTION
## Summary

- Wrap terminal creation in `PromptBuilderTest` with try-with-resources to prevent resource leak
- Also use `system(false)` to avoid interaction with system terminal during tests
- The `IntegrationTest` leak was already fixed in #1814

Fixes #1810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved resource management in prompt builder tests by scoping terminal creation to a safe lifecycle.
  * Strengthened assertions to verify the exact number of prompt elements produced.
  * Removed obsolete test-only reset/automation code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->