### PR TITLE
fix: use terminal encoding instead of default charset in VirtualTerminal (fixes #1821)

### DIFF
--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -152,7 +152,7 @@ class DisplayTest {
 
         private class MasterOutputStream extends OutputStream {
             private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            private final CharsetDecoder decoder = Charset.defaultCharset()
+            private final CharsetDecoder decoder = encoding()
                     .newDecoder()
                     .onMalformedInput(CodingErrorAction.REPLACE)
                     .onUnmappableCharacter(CodingErrorAction.REPLACE);


### PR DESCRIPTION
The `MasterOutputStream` in `VirtualTerminal` used `Charset.defaultCharset()` to decode terminal output bytes. On Windows, the default charset is typically Windows-1252, not UTF-8. This caused multi-byte UTF-8 characters like the ellipsis (`…`, U+2026) used by `Status` for line truncation to be decoded incorrectly, producing garbled output and failing the `testStatusLineTruncation` assertion.

The fix uses `encoding()` (inherited from `AbstractTerminal`) which returns the charset explicitly passed to the terminal constructor — `StandardCharsets.UTF_8` in the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected character encoding handling to use terminal's configured encoding rather than system defaults, improving compatibility with custom terminal configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->