### PR TITLE
fix: tail -n counts lines correctly when input lacks trailing newline (fixes #1787)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -1267,6 +1267,9 @@ public class PosixCommands {
                                 while ((i = buffer.indexOf("\n", i + 1)) >= 0) {
                                     l++;
                                 }
+                                if (buffer.length() > 0 && buffer.charAt(buffer.length() - 1) != '\n') {
+                                    l++;
+                                }
                                 if (l > lines) {
                                     i = -1;
                                     l = l - lines;

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
@@ -291,6 +291,28 @@ class PosixCommandsTest {
     }
 
     @Test
+    void testTailNoTrailingNewline() throws Exception {
+        Path file = tempDir.resolve("test.txt");
+        Files.write(file, "a\nb\nc\nd\ne".getBytes());
+
+        PosixCommands.tail(context, new String[] {"tail", "-n", "2", "test.txt"});
+
+        String output = normalizeLineEndings(out.toString());
+        assertEquals("d\ne", output);
+    }
+
+    @Test
+    void testTailWithTrailingNewline() throws Exception {
+        Path file = tempDir.resolve("test.txt");
+        Files.write(file, "a\nb\nc\nd\ne\n".getBytes());
+
+        PosixCommands.tail(context, new String[] {"tail", "-n", "2", "test.txt"});
+
+        String output = normalizeLineEndings(out.toString());
+        assertEquals("d\ne\n", output);
+    }
+
+    @Test
     void testWcCommand() throws Exception {
         Path file = tempDir.resolve("test.txt");
         Files.write(file, "Line 1\nLine 2\nLine 3\n".getBytes());


### PR DESCRIPTION
## Summary

- Fix off-by-one error in `PosixCommands.tail` where `-n N` returned one extra line when input doesn't end with a newline character
- The implementation counted newline characters (`\n`) rather than lines, so the final unterminated line wasn't counted, causing the window to include one extra line
- Add tests for both trailing-newline and no-trailing-newline cases

Fixes #1787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `tail` command to properly handle files without trailing newlines. Previously, when displaying the last N lines of a file that doesn't end with a newline, the final line could be incorrectly excluded from the output. The command now correctly counts and displays all lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->