### PR TITLE
fix: add VT100 response feedback to SwingTerminal and WebTerminal

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
@@ -267,6 +267,16 @@ public class SwingTerminal extends LineDisciplineTerminal {
             this.component = component;
         }
 
+        private void feedbackVt100Response() throws IOException {
+            if (component == null || terminal == null) {
+                return;
+            }
+            String response = component.read();
+            if (!response.isEmpty()) {
+                terminal.processInputBytes(response.getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
         public void setTerminal(SwingTerminal terminal) {
             this.terminal = terminal;
             initializeDecoder();
@@ -337,6 +347,7 @@ public class SwingTerminal extends LineDisciplineTerminal {
             if (pendingOutput.length() > 0) {
                 component.write(pendingOutput.toString());
                 pendingOutput.setLength(0);
+                feedbackVt100Response();
             }
         }
 
@@ -374,6 +385,7 @@ public class SwingTerminal extends LineDisciplineTerminal {
             if (output.position() > 0) {
                 output.flip();
                 component.write(output.toString());
+                feedbackVt100Response();
             }
 
             // If there are remaining bytes (incomplete multi-byte sequence), save them
@@ -855,6 +867,10 @@ public class SwingTerminal extends LineDisciplineTerminal {
          */
         public boolean isDirty() {
             return screenTerminal.isDirty();
+        }
+
+        public String read() {
+            return screenTerminal.read();
         }
 
         // KeyListener implementation

--- a/builtins/src/main/java/org/jline/builtins/WebTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/WebTerminal.java
@@ -92,7 +92,9 @@ public class WebTerminal extends LineDisciplineTerminal {
         this.component.setWebTerminal(this);
 
         // Connect the output stream to the component
-        ((WebTerminalOutputStream) masterOutput).setComponent(this.component);
+        WebTerminalOutputStream outputStream = (WebTerminalOutputStream) masterOutput;
+        outputStream.setComponent(this.component);
+        outputStream.setWebTerminal(this);
     }
 
     /**
@@ -395,6 +397,7 @@ public class WebTerminal extends LineDisciplineTerminal {
     private static class WebTerminalOutputStream extends OutputStream {
 
         private WebTerminalComponent component;
+        private WebTerminal webTerminal;
         private final byte[] utf8Buf = new byte[4];
         private int utf8Pos;
         private int utf8Len;
@@ -409,6 +412,7 @@ public class WebTerminal extends LineDisciplineTerminal {
                 // Determine expected UTF-8 sequence length from the leading byte
                 if (b < 0x80) {
                     component.write(String.valueOf((char) b));
+                    feedbackVt100Response();
                     return;
                 } else if ((b & 0xE0) == 0xC0) {
                     utf8Len = 2;
@@ -419,6 +423,7 @@ public class WebTerminal extends LineDisciplineTerminal {
                 } else {
                     // Invalid leading byte or continuation byte on its own
                     component.write("\uFFFD");
+                    feedbackVt100Response();
                     return;
                 }
             }
@@ -426,6 +431,7 @@ public class WebTerminal extends LineDisciplineTerminal {
             if (utf8Pos == utf8Len) {
                 String text = new String(utf8Buf, 0, utf8Len, StandardCharsets.UTF_8);
                 component.write(text);
+                feedbackVt100Response();
                 utf8Pos = 0;
                 utf8Len = 0;
             }
@@ -464,6 +470,7 @@ public class WebTerminal extends LineDisciplineTerminal {
                     int completeLen = incompleteStart - (off + i);
                     if (completeLen > 0) {
                         component.write(new String(b, off + i, completeLen, StandardCharsets.UTF_8));
+                        feedbackVt100Response();
                     }
                     for (int j = incompleteStart; j < end; j++) {
                         utf8Buf[utf8Pos++] = b[j];
@@ -474,6 +481,7 @@ public class WebTerminal extends LineDisciplineTerminal {
             }
             // All complete - decode directly
             component.write(new String(b, off + i, len - i, StandardCharsets.UTF_8));
+            feedbackVt100Response();
         }
 
         @Override
@@ -483,6 +491,20 @@ public class WebTerminal extends LineDisciplineTerminal {
 
         public void setComponent(WebTerminalComponent component) {
             this.component = component;
+        }
+
+        public void setWebTerminal(WebTerminal webTerminal) {
+            this.webTerminal = webTerminal;
+        }
+
+        private void feedbackVt100Response() throws IOException {
+            if (component == null || webTerminal == null) {
+                return;
+            }
+            String response = component.read();
+            if (!response.isEmpty()) {
+                webTerminal.processInputBytes(response.getBytes(StandardCharsets.UTF_8));
+            }
         }
     }
 

--- a/builtins/src/test/java/org/jline/builtins/Vt100ResponseFeedbackTest.java
+++ b/builtins/src/test/java/org/jline/builtins/Vt100ResponseFeedbackTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.awt.GraphicsEnvironment;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.jline.terminal.Attributes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Vt100ResponseFeedbackTest {
+
+    static boolean isHeadless() {
+        return GraphicsEnvironment.isHeadless();
+    }
+
+    private String readAvailable(InputStream in, long timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (in.available() == 0 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        byte[] buf = new byte[256];
+        int total = 0;
+        while (in.available() > 0 && total < buf.length) {
+            int n = in.read(buf, total, buf.length - total);
+            if (n <= 0) break;
+            total += n;
+        }
+        return new String(buf, 0, total, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void webTerminalFeedsDsrResponse() throws Exception {
+        try (WebTerminal terminal = new WebTerminal("localhost", 0, 80, 24)) {
+            Attributes attrs = terminal.getAttributes();
+            attrs.setLocalFlag(Attributes.LocalFlag.ECHO, false);
+            terminal.setAttributes(attrs);
+
+            terminal.output().write("\033[6n".getBytes(StandardCharsets.UTF_8));
+            terminal.output().flush();
+
+            String response = readAvailable(terminal.input(), 2000);
+            assertEquals("\033[1;1R", response);
+        }
+    }
+
+    @Test
+    void webTerminalFeedsDeviceAttributesResponse() throws Exception {
+        try (WebTerminal terminal = new WebTerminal("localhost", 0, 80, 24)) {
+            Attributes attrs = terminal.getAttributes();
+            attrs.setLocalFlag(Attributes.LocalFlag.ECHO, false);
+            terminal.setAttributes(attrs);
+
+            terminal.output().write("\033[c".getBytes(StandardCharsets.UTF_8));
+            terminal.output().flush();
+
+            String response = readAvailable(terminal.input(), 2000);
+            assertEquals("\033[?1;2c", response);
+        }
+    }
+
+    @Test
+    void webTerminalDsrReflectsCursorPosition() throws Exception {
+        try (WebTerminal terminal = new WebTerminal("localhost", 0, 80, 24)) {
+            Attributes attrs = terminal.getAttributes();
+            attrs.setLocalFlag(Attributes.LocalFlag.ECHO, false);
+            terminal.setAttributes(attrs);
+
+            terminal.output().write("Hello".getBytes(StandardCharsets.UTF_8));
+            terminal.output().flush();
+            // drain any existing input
+            readAvailable(terminal.input(), 100);
+
+            terminal.output().write("\033[6n".getBytes(StandardCharsets.UTF_8));
+            terminal.output().flush();
+
+            String response = readAvailable(terminal.input(), 2000);
+            assertEquals("\033[1;6R", response);
+        }
+    }
+
+    @Test
+    @DisabledIf("isHeadless")
+    void swingTerminalFeedsDsrResponse() throws Exception {
+        try (SwingTerminal terminal = new SwingTerminal(80, 24)) {
+            Attributes attrs = terminal.getAttributes();
+            attrs.setLocalFlag(Attributes.LocalFlag.ECHO, false);
+            terminal.setAttributes(attrs);
+
+            terminal.output().write("\033[6n".getBytes(StandardCharsets.UTF_8));
+            terminal.output().flush();
+
+            String response = readAvailable(terminal.input(), 2000);
+            assertEquals("\033[1;1R", response);
+        }
+    }
+
+    @Test
+    @DisabledIf("isHeadless")
+    void swingTerminalFeedsDeviceAttributesResponse() throws Exception {
+        try (SwingTerminal terminal = new SwingTerminal(80, 24)) {
+            Attributes attrs = terminal.getAttributes();
+            attrs.setLocalFlag(Attributes.LocalFlag.ECHO, false);
+            terminal.setAttributes(attrs);
+
+            terminal.output().write("\033[c".getBytes(StandardCharsets.UTF_8));
+            terminal.output().flush();
+
+            String response = readAvailable(terminal.input(), 2000);
+            assertEquals("\033[?1;2c", response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1797 (partial — bug fix only, refactoring in a follow-up PR).

SwingTerminal and WebTerminal never fed VT100 responses back to the `LineDisciplineTerminal` after writing to the `ScreenTerminal`. This means terminal query-response sequences like cursor position reports (`DSR`) and device attributes (`DA`) were silently lost.

DisplayTest and Tmux already do this correctly: after `ScreenTerminal.write()`, they call `read()` to collect any VT100 output and feed it back via `processInputBytes()`.

### Changes

- **SwingTerminal**: Add `read()` to `TerminalComponent`, add `feedbackVt100Response()` to `SwingTerminalOutputStream` called after each `component.write()`
- **WebTerminal**: Add `webTerminal` reference to `WebTerminalOutputStream`, add `feedbackVt100Response()` called after each `component.write()`

### Test plan

- [x] `./mvx mvn test -pl builtins` — 1071 tests pass
- [x] `./mvx mvn test -pl terminal -Dtest=DisplayTest` — 2 tests pass
- [x] `./mvx mvn spotless:apply -pl builtins` — no formatting changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced terminal input/output feedback so graphical terminals reflect immediate echo and VT100 responses.
  * Improved web-based terminal response handling for more accurate command feedback and interaction.
  * Output operations now process and incorporate feedback data promptly for consistent terminal behavior.

* **Tests**
  * Added automated tests validating VT100 feedback and echo behavior across terminal implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->