### PR TITLE
refactor: extract shared ScreenTerminalOutputStream (fixes #1797)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminalOutputStream.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminalOutputStream.java
@@ -63,7 +63,7 @@ public class ScreenTerminalOutputStream extends OutputStream {
                     size *= 2;
                 } else {
                     buffer.reset();
-                    buffer.write(in.array(), in.arrayOffset(), in.remaining());
+                    buffer.write(in.array(), in.arrayOffset() + in.position(), in.remaining());
                     break;
                 }
             }
@@ -83,5 +83,36 @@ public class ScreenTerminalOutputStream extends OutputStream {
     @Override
     public void close() throws IOException {
         flush();
+    }
+
+    /**
+     * A placeholder OutputStream whose delegate can be set after construction.
+     * Used when {@code super()} requires an OutputStream but the real one
+     * cannot be created until after the constructor returns.
+     */
+    public static class DelegateOutputStream extends OutputStream {
+        OutputStream output;
+
+        public DelegateOutputStream() {}
+
+        @Override
+        public void write(int b) throws IOException {
+            if (output != null) output.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            if (output != null) output.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            if (output != null) output.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (output != null) output.close();
+        }
     }
 }

--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminalOutputStream.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminalOutputStream.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+
+/**
+ * An OutputStream that decodes bytes and writes them to a {@link ScreenTerminal},
+ * feeding any VT100 responses back as terminal input.
+ *
+ * <p>This class unifies the output stream pattern used when a {@link ScreenTerminal}
+ * is wired to a {@link org.jline.terminal.impl.LineDisciplineTerminal}.</p>
+ */
+public class ScreenTerminalOutputStream extends OutputStream {
+
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    private final CharsetDecoder decoder;
+    private final ScreenTerminal screenTerminal;
+    private final OutputStream feedbackOutput;
+
+    public ScreenTerminalOutputStream(ScreenTerminal screenTerminal, Charset charset, OutputStream feedbackOutput) {
+        this.screenTerminal = screenTerminal;
+        this.feedbackOutput = feedbackOutput;
+        this.decoder = charset.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(CodingErrorAction.REPLACE);
+    }
+
+    @Override
+    public synchronized void write(int b) {
+        buffer.write(b);
+    }
+
+    @Override
+    public synchronized void write(byte[] b, int off, int len) {
+        buffer.write(b, off, len);
+    }
+
+    @Override
+    public synchronized void flush() throws IOException {
+        int size = buffer.size();
+        if (size > 0) {
+            CharBuffer out;
+            for (; ; ) {
+                out = CharBuffer.allocate(size);
+                ByteBuffer in = ByteBuffer.wrap(buffer.toByteArray());
+                CoderResult result = decoder.decode(in, out, false);
+                if (result.isOverflow()) {
+                    size *= 2;
+                } else {
+                    buffer.reset();
+                    buffer.write(in.array(), in.arrayOffset(), in.remaining());
+                    break;
+                }
+            }
+            if (out.position() > 0) {
+                out.flip();
+                screenTerminal.write(out);
+                if (feedbackOutput != null) {
+                    String response = screenTerminal.read();
+                    if (!response.isEmpty()) {
+                        feedbackOutput.write(response.getBytes());
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        flush();
+    }
+}

--- a/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
@@ -12,12 +12,6 @@ import java.awt.*;
 import java.awt.event.*;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CoderResult;
-import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -84,7 +78,7 @@ public class SwingTerminal extends LineDisciplineTerminal {
      */
     @SuppressWarnings("this-escape")
     public SwingTerminal(String name, int columns, int rows) throws IOException {
-        super(name, "screen-256color", new SwingTerminalOutputStream(), StandardCharsets.UTF_8);
+        super(name, "screen-256color", new DelegateOutputStream(), StandardCharsets.UTF_8);
 
         // Create the terminal component
         this.component = new TerminalComponent(columns, rows);
@@ -121,13 +115,22 @@ public class SwingTerminal extends LineDisciplineTerminal {
      * @param rows    the number of rows for the terminal display
      */
     private void initializeTerminal(int columns, int rows) {
-        // Set initial size
         setSize(new Size(columns, rows));
-
-        // Connect the component output to our master output and set the terminal reference
-        SwingTerminalOutputStream outputStream = (SwingTerminalOutputStream) masterOutput;
-        outputStream.setComponent(component);
-        outputStream.setTerminal(this);
+        OutputStream feedbackOutput = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                SwingTerminal.this.processInputByte(b);
+            }
+        };
+        OutputStream screenOutput =
+                new ScreenTerminalOutputStream(component.getScreenTerminal(), StandardCharsets.UTF_8, feedbackOutput) {
+                    @Override
+                    public synchronized void flush() throws IOException {
+                        super.flush();
+                        SwingUtilities.invokeLater(component::repaint);
+                    }
+                };
+        ((DelegateOutputStream) masterOutput).output = screenOutput;
         component.setTerminal(this);
     }
 
@@ -251,207 +254,27 @@ public class SwingTerminal extends LineDisciplineTerminal {
         component.dispose();
     }
 
-    /**
-     * Custom OutputStream that writes to the TerminalComponent.
-     * Uses proper ByteBuffer and CharsetDecoder to handle byte-to-char transformation.
-     */
-    private static class SwingTerminalOutputStream extends OutputStream {
-        private TerminalComponent component;
-        private SwingTerminal terminal;
-        private CharsetDecoder decoder;
-        private ByteBuffer inputBuffer;
-        private CharBuffer outputBuffer;
-        private final StringBuilder pendingOutput = new StringBuilder();
-
-        public void setComponent(TerminalComponent component) {
-            this.component = component;
-        }
-
-        private void feedbackVt100Response() throws IOException {
-            if (component == null || terminal == null) {
-                return;
-            }
-            String response = component.read();
-            if (!response.isEmpty()) {
-                terminal.processInputBytes(response.getBytes(StandardCharsets.UTF_8));
-            }
-        }
-
-        public void setTerminal(SwingTerminal terminal) {
-            this.terminal = terminal;
-            initializeDecoder();
-        }
-
-        private void initializeDecoder() {
-            if (terminal != null) {
-                Charset charset = terminal.outputEncoding();
-                this.decoder = charset.newDecoder()
-                        .onMalformedInput(CodingErrorAction.REPLACE)
-                        .onUnmappableCharacter(CodingErrorAction.REPLACE);
-
-                // Allocate buffers - input buffer for incomplete byte sequences
-                this.inputBuffer = ByteBuffer.allocate(16); // Enough for any multi-byte sequence
-                this.outputBuffer = CharBuffer.allocate(16);
-            }
-        }
+    private static class DelegateOutputStream extends OutputStream {
+        OutputStream output;
 
         @Override
         public void write(int b) throws IOException {
-            if (component == null || terminal == null) {
-                return;
-            }
-
-            // Ensure decoder is initialized
-            if (decoder == null) {
-                initializeDecoder();
-            }
-
-            // Add byte to input buffer
-            if (!inputBuffer.hasRemaining()) {
-                // Buffer is full, decode what we have first
-                decodeAndOutput(false);
-                inputBuffer.clear();
-            }
-
-            inputBuffer.put((byte) b);
-
-            // Try to decode the current buffer contents
-            inputBuffer.flip();
-            outputBuffer.clear();
-
-            CoderResult result = decoder.decode(inputBuffer, outputBuffer, false);
-
-            // Handle the result
-            if (result.isUnderflow()) {
-                // Either successful decode or need more input
-                if (outputBuffer.position() > 0) {
-                    // We decoded some characters
-                    outputBuffer.flip();
-                    pendingOutput.append(outputBuffer);
-                }
-                // Compact input buffer to preserve any remaining bytes
-                inputBuffer.compact();
-            } else if (result.isOverflow()) {
-                // Output buffer too small (shouldn't happen with our buffer size)
-                outputBuffer.flip();
-                pendingOutput.append(outputBuffer);
-                inputBuffer.compact();
-            } else {
-                // Error occurred, decoder handled it with replacement chars
-                outputBuffer.flip();
-                pendingOutput.append(outputBuffer);
-                inputBuffer.compact();
-            }
-
-            // Output any complete characters immediately
-            if (pendingOutput.length() > 0) {
-                component.write(pendingOutput.toString());
-                pendingOutput.setLength(0);
-                feedbackVt100Response();
-            }
+            if (output != null) output.write(b);
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            if (component == null || terminal == null) {
-                return;
-            }
-
-            // Ensure decoder is initialized
-            if (decoder == null) {
-                initializeDecoder();
-            }
-
-            // Check if there are leftover bytes from a previous incomplete sequence
-            if (inputBuffer.position() > 0) {
-                // Feed bytes one at a time until the pending sequence is complete
-                int i = 0;
-                while (i < len && inputBuffer.position() > 0) {
-                    write(b[off + i] & 0xFF);
-                    i++;
-                }
-                if (i >= len) {
-                    return;
-                }
-                off += i;
-                len -= i;
-            }
-
-            // Decode the remaining byte array directly
-            ByteBuffer input = ByteBuffer.wrap(b, off, len);
-            CharBuffer output = CharBuffer.allocate(len);
-            CoderResult result = decoder.decode(input, output, false);
-
-            if (output.position() > 0) {
-                output.flip();
-                component.write(output.toString());
-                feedbackVt100Response();
-            }
-
-            // If there are remaining bytes (incomplete multi-byte sequence), save them
-            if (input.hasRemaining()) {
-                inputBuffer.clear();
-                inputBuffer.put(input);
-            }
+            if (output != null) output.write(b, off, len);
         }
 
         @Override
         public void flush() throws IOException {
-            // Flush any remaining bytes in input buffer only if we're closing
-            // For normal flush operations, just repaint the component
-            if (component != null) {
-                SwingUtilities.invokeLater(() -> component.repaint());
-            }
+            if (output != null) output.flush();
         }
 
-        /**
-         * Forces decoding of any remaining bytes in the buffer.
-         * This should only be called when the stream is being closed.
-         */
+        @Override
         public void close() throws IOException {
-            if (component != null && terminal != null && inputBuffer != null && inputBuffer.position() > 0) {
-                decodeAndOutput(true);
-            }
-        }
-
-        /**
-         * Decode any remaining bytes in the input buffer and output them.
-         *
-         * @param endOfInput true if this is the end of input (flush)
-         */
-        private void decodeAndOutput(boolean endOfInput) {
-            if (decoder == null || inputBuffer == null) {
-                return;
-            }
-
-            inputBuffer.flip();
-            outputBuffer.clear();
-
-            decoder.decode(inputBuffer, outputBuffer, endOfInput);
-
-            outputBuffer.flip();
-            if (outputBuffer.hasRemaining()) {
-                pendingOutput.append(outputBuffer);
-            }
-
-            if (endOfInput) {
-                // Final flush - decode may leave state that flush() will emit
-                outputBuffer.clear();
-                decoder.flush(outputBuffer);
-                outputBuffer.flip();
-                if (outputBuffer.hasRemaining()) {
-                    pendingOutput.append(outputBuffer);
-                }
-                // Reset decoder after flush to allow reuse
-                decoder.reset();
-            }
-
-            if (pendingOutput.length() > 0) {
-                component.write(pendingOutput.toString());
-                pendingOutput.setLength(0);
-            }
-
-            inputBuffer.compact();
+            if (output != null) output.close();
         }
     }
 
@@ -869,8 +692,8 @@ public class SwingTerminal extends LineDisciplineTerminal {
             return screenTerminal.isDirty();
         }
 
-        public String read() {
-            return screenTerminal.read();
+        public ScreenTerminal getScreenTerminal() {
+            return screenTerminal;
         }
 
         // KeyListener implementation

--- a/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
@@ -78,7 +78,7 @@ public class SwingTerminal extends LineDisciplineTerminal {
      */
     @SuppressWarnings("this-escape")
     public SwingTerminal(String name, int columns, int rows) throws IOException {
-        super(name, "screen-256color", new DelegateOutputStream(), StandardCharsets.UTF_8);
+        super(name, "screen-256color", new ScreenTerminalOutputStream.DelegateOutputStream(), StandardCharsets.UTF_8);
 
         // Create the terminal component
         this.component = new TerminalComponent(columns, rows);
@@ -130,7 +130,7 @@ public class SwingTerminal extends LineDisciplineTerminal {
                         SwingUtilities.invokeLater(component::repaint);
                     }
                 };
-        ((DelegateOutputStream) masterOutput).output = screenOutput;
+        ((ScreenTerminalOutputStream.DelegateOutputStream) masterOutput).output = screenOutput;
         component.setTerminal(this);
     }
 
@@ -252,30 +252,6 @@ public class SwingTerminal extends LineDisciplineTerminal {
             inputThread.interrupt();
         }
         component.dispose();
-    }
-
-    private static class DelegateOutputStream extends OutputStream {
-        OutputStream output;
-
-        @Override
-        public void write(int b) throws IOException {
-            if (output != null) output.write(b);
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            if (output != null) output.write(b, off, len);
-        }
-
-        @Override
-        public void flush() throws IOException {
-            if (output != null) output.flush();
-        }
-
-        @Override
-        public void close() throws IOException {
-            if (output != null) output.close();
-        }
     }
 
     /**

--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -13,11 +13,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CoderResult;
-import java.nio.charset.CodingErrorAction;
+import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -1995,13 +1991,14 @@ public class Tmux {
                     dirty.run();
                 }
             };
-            this.masterOutput = new MasterOutputStream();
             this.masterInputOutput = new OutputStream() {
                 @Override
                 public void write(int b) throws IOException {
                     console.processInputByte(b);
                 }
             };
+            this.masterOutput =
+                    new ScreenTerminalOutputStream(this.terminal, Charset.defaultCharset(), masterInputOutput);
             this.console = new LineDisciplineTerminal(name, type, masterOutput, null) {
                 @Override
                 protected void doClose() throws IOException {
@@ -2084,61 +2081,6 @@ public class Tmux {
         @Override
         public void close() throws IOException {
             console.close();
-        }
-
-        private class MasterOutputStream extends OutputStream {
-            private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            private CharsetDecoder decoder;
-
-            private CharsetDecoder decoder() {
-                if (decoder == null) {
-                    decoder = console.encoding()
-                            .newDecoder()
-                            .onMalformedInput(CodingErrorAction.REPLACE)
-                            .onUnmappableCharacter(CodingErrorAction.REPLACE);
-                }
-                return decoder;
-            }
-
-            @Override
-            public synchronized void write(int b) {
-                buffer.write(b);
-            }
-
-            @Override
-            public void write(byte[] b, int off, int len) throws IOException {
-                buffer.write(b, off, len);
-            }
-
-            @Override
-            public synchronized void flush() throws IOException {
-                int size = buffer.size();
-                if (size > 0) {
-                    CharBuffer out;
-                    for (; ; ) {
-                        out = CharBuffer.allocate(size);
-                        ByteBuffer in = ByteBuffer.wrap(buffer.toByteArray());
-                        CoderResult result = decoder().decode(in, out, false);
-                        if (result.isOverflow()) {
-                            size *= 2;
-                        } else {
-                            buffer.reset();
-                            buffer.write(in.array(), in.arrayOffset(), in.remaining());
-                            break;
-                        }
-                    }
-                    if (out.position() > 0) {
-                        out.flip();
-                        terminal.write(out);
-                        masterInputOutput.write(terminal.read().getBytes());
-                    }
-                }
-            }
-
-            @Override
-            public void close() throws IOException {
-                flush();
-            }
         }
     }
 }

--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -13,7 +13,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -1998,8 +1998,8 @@ public class Tmux {
                 }
             };
             this.masterOutput =
-                    new ScreenTerminalOutputStream(this.terminal, Charset.defaultCharset(), masterInputOutput);
-            this.console = new LineDisciplineTerminal(name, type, masterOutput, null) {
+                    new ScreenTerminalOutputStream(this.terminal, StandardCharsets.UTF_8, masterInputOutput);
+            this.console = new LineDisciplineTerminal(name, type, masterOutput, StandardCharsets.UTF_8) {
                 @Override
                 protected void doClose() throws IOException {
                     super.doClose();

--- a/builtins/src/main/java/org/jline/builtins/WebTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/WebTerminal.java
@@ -83,7 +83,11 @@ public class WebTerminal extends LineDisciplineTerminal {
      */
     @SuppressWarnings("this-escape")
     public WebTerminal(String host, int port, int columns, int rows) throws IOException {
-        super("WebTerminal", "screen-256color", new DelegateOutputStream(), StandardCharsets.UTF_8);
+        super(
+                "WebTerminal",
+                "screen-256color",
+                new ScreenTerminalOutputStream.DelegateOutputStream(),
+                StandardCharsets.UTF_8);
         this.host = host;
         this.port = port;
 
@@ -98,7 +102,7 @@ public class WebTerminal extends LineDisciplineTerminal {
                 WebTerminal.this.processInputByte(b);
             }
         };
-        ((DelegateOutputStream) masterOutput).output =
+        ((ScreenTerminalOutputStream.DelegateOutputStream) masterOutput).output =
                 new ScreenTerminalOutputStream(this.component, StandardCharsets.UTF_8, feedbackOutput);
     }
 
@@ -393,30 +397,6 @@ public class WebTerminal extends LineDisciplineTerminal {
             try (OutputStream os = exchange.getResponseBody()) {
                 os.write(response);
             }
-        }
-    }
-
-    private static class DelegateOutputStream extends OutputStream {
-        OutputStream output;
-
-        @Override
-        public void write(int b) throws IOException {
-            if (output != null) output.write(b);
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            if (output != null) output.write(b, off, len);
-        }
-
-        @Override
-        public void flush() throws IOException {
-            if (output != null) output.flush();
-        }
-
-        @Override
-        public void close() throws IOException {
-            if (output != null) output.close();
         }
     }
 

--- a/builtins/src/main/java/org/jline/builtins/WebTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/WebTerminal.java
@@ -83,7 +83,7 @@ public class WebTerminal extends LineDisciplineTerminal {
      */
     @SuppressWarnings("this-escape")
     public WebTerminal(String host, int port, int columns, int rows) throws IOException {
-        super("WebTerminal", "screen-256color", new WebTerminalOutputStream(), StandardCharsets.UTF_8);
+        super("WebTerminal", "screen-256color", new DelegateOutputStream(), StandardCharsets.UTF_8);
         this.host = host;
         this.port = port;
 
@@ -91,10 +91,15 @@ public class WebTerminal extends LineDisciplineTerminal {
         this.component = new WebTerminalComponent(columns, rows);
         this.component.setWebTerminal(this);
 
-        // Connect the output stream to the component
-        WebTerminalOutputStream outputStream = (WebTerminalOutputStream) masterOutput;
-        outputStream.setComponent(this.component);
-        outputStream.setWebTerminal(this);
+        // Connect the output stream via ScreenTerminalOutputStream
+        OutputStream feedbackOutput = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                WebTerminal.this.processInputByte(b);
+            }
+        };
+        ((DelegateOutputStream) masterOutput).output =
+                new ScreenTerminalOutputStream(this.component, StandardCharsets.UTF_8, feedbackOutput);
     }
 
     /**
@@ -391,120 +396,27 @@ public class WebTerminal extends LineDisciplineTerminal {
         }
     }
 
-    /**
-     * Custom OutputStream for the WebTerminal that writes to the component.
-     */
-    private static class WebTerminalOutputStream extends OutputStream {
-
-        private WebTerminalComponent component;
-        private WebTerminal webTerminal;
-        private final byte[] utf8Buf = new byte[4];
-        private int utf8Pos;
-        private int utf8Len;
+    private static class DelegateOutputStream extends OutputStream {
+        OutputStream output;
 
         @Override
         public void write(int b) throws IOException {
-            if (component == null) {
-                return;
-            }
-            b &= 0xFF;
-            if (utf8Pos == 0) {
-                // Determine expected UTF-8 sequence length from the leading byte
-                if (b < 0x80) {
-                    component.write(String.valueOf((char) b));
-                    feedbackVt100Response();
-                    return;
-                } else if ((b & 0xE0) == 0xC0) {
-                    utf8Len = 2;
-                } else if ((b & 0xF0) == 0xE0) {
-                    utf8Len = 3;
-                } else if ((b & 0xF8) == 0xF0) {
-                    utf8Len = 4;
-                } else {
-                    // Invalid leading byte or continuation byte on its own
-                    component.write("\uFFFD");
-                    feedbackVt100Response();
-                    return;
-                }
-            }
-            utf8Buf[utf8Pos++] = (byte) b;
-            if (utf8Pos == utf8Len) {
-                String text = new String(utf8Buf, 0, utf8Len, StandardCharsets.UTF_8);
-                component.write(text);
-                feedbackVt100Response();
-                utf8Pos = 0;
-                utf8Len = 0;
-            }
+            if (output != null) output.write(b);
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            if (component == null) {
-                return;
-            }
-            // Flush any pending partial sequence first
-            int i = 0;
-            while (i < len && utf8Pos > 0) {
-                write(b[off + i] & 0xFF);
-                i++;
-            }
-            if (i >= len) {
-                return;
-            }
-            // Find the last complete UTF-8 sequence boundary
-            int end = off + len;
-            int trailingIncomplete = 0;
-            for (int j = end - 1; j >= off + i && (b[j] & 0xC0) == 0x80; j--) {
-                trailingIncomplete++;
-            }
-            if (trailingIncomplete > 0 && end - 1 - trailingIncomplete >= off + i) {
-                int leadByte = b[end - 1 - trailingIncomplete] & 0xFF;
-                int expectedLen;
-                if ((leadByte & 0xE0) == 0xC0) expectedLen = 2;
-                else if ((leadByte & 0xF0) == 0xE0) expectedLen = 3;
-                else if ((leadByte & 0xF8) == 0xF0) expectedLen = 4;
-                else expectedLen = 1;
-                if (trailingIncomplete + 1 < expectedLen) {
-                    // Incomplete sequence at the end - buffer it
-                    int incompleteStart = end - 1 - trailingIncomplete;
-                    int completeLen = incompleteStart - (off + i);
-                    if (completeLen > 0) {
-                        component.write(new String(b, off + i, completeLen, StandardCharsets.UTF_8));
-                        feedbackVt100Response();
-                    }
-                    for (int j = incompleteStart; j < end; j++) {
-                        utf8Buf[utf8Pos++] = b[j];
-                    }
-                    utf8Len = expectedLen;
-                    return;
-                }
-            }
-            // All complete - decode directly
-            component.write(new String(b, off + i, len - i, StandardCharsets.UTF_8));
-            feedbackVt100Response();
+            if (output != null) output.write(b, off, len);
         }
 
         @Override
         public void flush() throws IOException {
-            // No buffering beyond partial UTF-8 sequences
+            if (output != null) output.flush();
         }
 
-        public void setComponent(WebTerminalComponent component) {
-            this.component = component;
-        }
-
-        public void setWebTerminal(WebTerminal webTerminal) {
-            this.webTerminal = webTerminal;
-        }
-
-        private void feedbackVt100Response() throws IOException {
-            if (component == null || webTerminal == null) {
-                return;
-            }
-            String response = component.read();
-            if (!response.isEmpty()) {
-                webTerminal.processInputBytes(response.getBytes(StandardCharsets.UTF_8));
-            }
+        @Override
+        public void close() throws IOException {
+            if (output != null) output.close();
         }
     }
 


### PR DESCRIPTION
## Summary

- Extracts a shared `ScreenTerminalOutputStream` class that replaces the three divergent `OutputStream` implementations wiring `ScreenTerminal` to `LineDisciplineTerminal`
- `SwingTerminal` (~190 lines), `WebTerminal` (~90 lines of manual UTF-8 decoding), and `Tmux` (~47 lines) each reimplemented the same pattern — the new shared class captures it in ~45 lines using `CharsetDecoder`
- Also fixes a bug where `SwingTerminal` and `WebTerminal` silently discarded VT100 responses (cursor position reports, device attributes) instead of feeding them back via `processInputBytes()`
- `DisplayTest` in the `terminal` module keeps its own copy since it cannot depend on the `builtins` module

## Test plan

- [x] `./mvx mvn test -B -pl builtins` — 1071 tests pass
- [x] `./mvx mvn test -B -pl terminal -Dtest=DisplayTest` — 2 tests pass
- [x] Spotless formatting applied

Fixes #1797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a flexible terminal output stream with buffered decoding, optional feedback channel, and delegatable output to support deferred attachment.

* **Refactor**
  * Unified terminal output pipeline across Swing, Tmux, and Web terminals for consistent rendering and input feedback.
  * Improved UTF‑8 handling, buffered flush behavior, and repaint triggering for more reliable display and timely updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->