### PR TITLE
fix: use console encoding instead of default charset in Tmux

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -15,7 +15,6 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
@@ -2089,10 +2088,17 @@ public class Tmux {
 
         private class MasterOutputStream extends OutputStream {
             private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            private final CharsetDecoder decoder = Charset.defaultCharset()
-                    .newDecoder()
-                    .onMalformedInput(CodingErrorAction.REPLACE)
-                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
+            private CharsetDecoder decoder;
+
+            private CharsetDecoder decoder() {
+                if (decoder == null) {
+                    decoder = console.encoding()
+                            .newDecoder()
+                            .onMalformedInput(CodingErrorAction.REPLACE)
+                            .onUnmappableCharacter(CodingErrorAction.REPLACE);
+                }
+                return decoder;
+            }
 
             @Override
             public synchronized void write(int b) {
@@ -2112,7 +2118,7 @@ public class Tmux {
                     for (; ; ) {
                         out = CharBuffer.allocate(size);
                         ByteBuffer in = ByteBuffer.wrap(buffer.toByteArray());
-                        CoderResult result = decoder.decode(in, out, false);
+                        CoderResult result = decoder().decode(in, out, false);
                         if (result.isOverflow()) {
                             size *= 2;
                         } else {

--- a/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
+++ b/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jline.terminal.Size;
+import org.jline.terminal.impl.LineDisciplineTerminal;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TmuxEncodingTest {
+
+    @Test
+    void paneDecodesMultiByteCharactersCorrectly() throws Exception {
+        ByteArrayOutputStream masterOut = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "screen-256color", masterOut, StandardCharsets.UTF_8);
+        terminal.setSize(new Size(80, 24));
+
+        CountDownLatch textWritten = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        Tmux tmux = new Tmux(terminal, new PrintStream(OutputStream.nullOutputStream()), paneTerminal -> {
+            new Thread(
+                            () -> {
+                                try {
+                                    paneTerminal.writer().print("Hello 世界 café");
+                                    paneTerminal.writer().flush();
+                                    textWritten.countDown();
+                                    Thread.sleep(2000);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                            },
+                            "test-pane")
+                    .start();
+        });
+
+        Thread tmuxThread = new Thread(
+                () -> {
+                    try {
+                        tmux.run();
+                    } catch (IOException e) {
+                        // expected when terminal closes
+                    }
+                },
+                "tmux-main");
+        tmuxThread.setDaemon(true);
+        tmuxThread.start();
+
+        assertTrue(textWritten.await(5, TimeUnit.SECONDS), "Text should be written within timeout");
+
+        // Poll for output rather than fixed sleep
+        long deadline = System.currentTimeMillis() + 3000;
+        String output = "";
+        while (System.currentTimeMillis() < deadline) {
+            output = masterOut.toString(StandardCharsets.UTF_8);
+            if (output.contains("世")) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+
+        terminal.close();
+        tmuxThread.join(5000);
+
+        assertNull(error.get(), "Runner should not throw");
+
+        // Wide CJK characters occupy 2 terminal cells each, so the Display may
+        // insert filler between them.  Check for individual characters.
+        // Strip ANSI escape sequences to get plain text.
+        String plain = output.replaceAll("\\[[^@-~]*[@-~]", "");
+        assertTrue(plain.contains("世"), "Should contain first CJK character");
+        assertTrue(plain.contains("界"), "Should contain second CJK character");
+        assertTrue(plain.contains("café"), "Should contain accented characters");
+    }
+}


### PR DESCRIPTION
## Summary

- The `CharsetDecoder` in `Tmux.VirtualConsole.MasterOutputStream` used `Charset.defaultCharset()` instead of the console's actual encoding
- This could cause incorrect character decoding when the terminal encoding differs from the JVM default charset
- Changed to lazy initialization using `console.encoding()`, since `console` is not yet assigned when `MasterOutputStream` is constructed

Related to #1797

## Test plan

- [x] `./mvx mvn test -B -pl builtins` — 1071 tests pass
- [x] Spotless formatting applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal output now uses the console's configured encoding when decoding buffered bytes, improving multi-byte character handling and reducing encoding-related display issues.
* **Tests**
  * Added an automated test that verifies multi-byte characters (e.g., CJK and accented characters) are correctly decoded and rendered in terminal output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->