### PR TITLE
fix: correct FreeBSD PENDIN and NOFLSH termios constants

### DIFF
--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/freebsd/FreeBsdNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/freebsd/FreeBsdNativePty.java
@@ -153,8 +153,8 @@ public class FreeBsdNativePty extends JniNativePty {
     private static final int EXTPROC = 0x0000800;
     private static final int TOSTOP = 0x0400000;
     private static final int FLUSHO = 0x0800000;
-    private static final int PENDIN = 0x2000000;
-    private static final int NOFLSH = 0x8000000;
+    private static final int PENDIN = 0x20000000;
+    private static final int NOFLSH = 0x80000000;
 
     protected CLibrary.Termios toTermios(Attributes t) {
         return termios(t);


### PR DESCRIPTION
## Summary

- Fix `PENDIN` constant: `0x2000000` → `0x20000000` (missing trailing zero)
- Fix `NOFLSH` constant: `0x8000000` → `0x80000000` (missing trailing zero)

Both values were missing a trailing hex digit, making them 16x smaller than the correct FreeBSD kernel values from `sys/termios.h`.

Fixes #1831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal attribute flag handling on FreeBSD systems to properly interpret and apply terminal configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->