### PR TITLE
fix: correct Linux PENDIN termios constant

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -926,7 +926,7 @@ class CLibrary {
             ECHOPRT = 0x0000400;
             ECHOKE = 0x0000800;
             FLUSHO = 0x0001000;
-            PENDIN = 0x0002000;
+            PENDIN = 0x0004000;
             IEXTEN = 0x0008000;
             EXTPROC = 0x0010000;
         } else if (osName.startsWith("Solaris") || osName.startsWith("SunOS")) {

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/linux/LinuxNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/linux/LinuxNativePty.java
@@ -193,7 +193,7 @@ public class LinuxNativePty extends JniNativePty {
     private static final int ECHOPRT = 0x0000400;
     private static final int ECHOKE = 0x0000800;
     private static final int FLUSHO = 0x0001000;
-    private static final int PENDIN = 0x0002000;
+    private static final int PENDIN = 0x0004000;
     private static final int IEXTEN = 0x0008000;
     private static final int EXTPROC = 0x0010000;
 


### PR DESCRIPTION
## Summary

- Fix `PENDIN` local flag constant: `0x0002000` (8192) → `0x0004000` (16384) per Linux `asm-generic/termbits.h` (octal `0040000`)
- Applied to both JNI (`LinuxNativePty`) and FFM (`CLibrary`) terminal providers

## Impact

Currently low — JLine uses this constant symmetrically in `toTermios()` and `toAttributes()`, so the wrong value roundtrips correctly. However, interoperability with termios structs set by other programs (e.g., reading terminal state set by the shell) would silently lose this flag.

Closes #1833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect terminal attribute flag configuration on Linux platforms, improving terminal behavior and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->