### PR TITLE
fix: add missing CDTR_IFLOW readback in OsX toAttributes

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -383,6 +383,7 @@ class CLibrary {
             addFlag(c_cflag, cflag, Attributes.ControlFlag.CLOCAL, CLOCAL);
             addFlag(c_cflag, cflag, Attributes.ControlFlag.CCTS_OFLOW, CCTS_OFLOW);
             addFlag(c_cflag, cflag, Attributes.ControlFlag.CRTS_IFLOW, CRTS_IFLOW);
+            addFlag(c_cflag, cflag, Attributes.ControlFlag.CDTR_IFLOW, CDTR_IFLOW);
             addFlag(c_cflag, cflag, Attributes.ControlFlag.CDSR_OFLOW, CDSR_OFLOW);
             addFlag(c_cflag, cflag, Attributes.ControlFlag.CCAR_OFLOW, CCAR_OFLOW);
             // Local flags

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/osx/OsXNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/osx/OsXNativePty.java
@@ -328,6 +328,7 @@ public class OsXNativePty extends JniNativePty {
         addFlag(tio.c_cflag, cflag, Attributes.ControlFlag.CLOCAL, CLOCAL);
         addFlag(tio.c_cflag, cflag, Attributes.ControlFlag.CCTS_OFLOW, CCTS_OFLOW);
         addFlag(tio.c_cflag, cflag, Attributes.ControlFlag.CRTS_IFLOW, CRTS_IFLOW);
+        addFlag(tio.c_cflag, cflag, Attributes.ControlFlag.CDTR_IFLOW, CDTR_IFLOW);
         addFlag(tio.c_cflag, cflag, Attributes.ControlFlag.CDSR_OFLOW, CDSR_OFLOW);
         addFlag(tio.c_cflag, cflag, Attributes.ControlFlag.CCAR_OFLOW, CCAR_OFLOW);
         // Local flags


### PR DESCRIPTION
## Summary

- Add missing `addFlag` call for `CDTR_IFLOW` in `toAttributes()` / `asAttributes()`
- The flag was written in `toTermios()` but never read back, causing it to be silently lost on roundtrip
- Applied to both JNI (`OsXNativePty`) and FFM (`CLibrary`) terminal providers

Closes #1830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced terminal attribute detection to properly recognize and support the DTR input flow control (CDTR_IFLOW) flag, improving compatibility with hardware flow control configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->