### PR TITLE
fix: wire up unmapped termios constants in JNI and FFM providers

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -179,10 +179,12 @@ class CLibrary {
             c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IXANY), IXANY, c_iflag);
             c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IMAXBEL), IMAXBEL, c_iflag);
             c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IUTF8), IUTF8, c_iflag);
+            c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IUCLC), IUCLC, c_iflag);
             c_iflag(c_iflag);
             // Output flags
             long c_oflag = 0;
             c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.OPOST), OPOST, c_oflag);
+            c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.OLCUC), OLCUC, c_oflag);
             c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.ONLCR), ONLCR, c_oflag);
             c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.OXTABS), OXTABS, c_oflag);
             c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.ONOEOT), ONOEOT, c_oflag);
@@ -228,6 +230,7 @@ class CLibrary {
             c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ECHOCTL), ECHOCTL, c_lflag);
             c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ISIG), ISIG, c_lflag);
             c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ICANON), ICANON, c_lflag);
+            c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.XCASE), XCASE, c_lflag);
             c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ALTWERASE), ALTWERASE, c_lflag);
             c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.IEXTEN), IEXTEN, c_lflag);
             c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.EXTPROC), EXTPROC, c_lflag);
@@ -260,6 +263,12 @@ class CLibrary {
             c_cc[VTIME] = (byte) t.getControlChar(Attributes.ControlChar.VTIME);
             if (VSTATUS != (-1)) {
                 c_cc[VSTATUS] = (byte) t.getControlChar(Attributes.ControlChar.VSTATUS);
+            }
+            if (VSWTC != (-1)) {
+                c_cc[VSWTC] = (byte) t.getControlChar(Attributes.ControlChar.VSWTC);
+            }
+            if (VERASE2 != (-1)) {
+                c_cc[VERASE2] = (byte) t.getControlChar(Attributes.ControlChar.VERASE2);
             }
             c_cc().copyFrom(MemorySegment.ofArray(c_cc));
         }
@@ -349,10 +358,12 @@ class CLibrary {
             addFlag(c_iflag, iflag, Attributes.InputFlag.IXANY, IXANY);
             addFlag(c_iflag, iflag, Attributes.InputFlag.IMAXBEL, IMAXBEL);
             addFlag(c_iflag, iflag, Attributes.InputFlag.IUTF8, IUTF8);
+            addFlag(c_iflag, iflag, Attributes.InputFlag.IUCLC, IUCLC);
             // Output flags
             long c_oflag = c_oflag();
             EnumSet<Attributes.OutputFlag> oflag = attr.getOutputFlags();
             addFlag(c_oflag, oflag, Attributes.OutputFlag.OPOST, OPOST);
+            addFlag(c_oflag, oflag, Attributes.OutputFlag.OLCUC, OLCUC);
             addFlag(c_oflag, oflag, Attributes.OutputFlag.ONLCR, ONLCR);
             addFlag(c_oflag, oflag, Attributes.OutputFlag.OXTABS, OXTABS);
             addFlag(c_oflag, oflag, Attributes.OutputFlag.ONOEOT, ONOEOT);
@@ -397,6 +408,7 @@ class CLibrary {
             addFlag(c_lflag, lflag, Attributes.LocalFlag.ECHOCTL, ECHOCTL);
             addFlag(c_lflag, lflag, Attributes.LocalFlag.ISIG, ISIG);
             addFlag(c_lflag, lflag, Attributes.LocalFlag.ICANON, ICANON);
+            addFlag(c_lflag, lflag, Attributes.LocalFlag.XCASE, XCASE);
             addFlag(c_lflag, lflag, Attributes.LocalFlag.ALTWERASE, ALTWERASE);
             addFlag(c_lflag, lflag, Attributes.LocalFlag.IEXTEN, IEXTEN);
             addFlag(c_lflag, lflag, Attributes.LocalFlag.EXTPROC, EXTPROC);
@@ -429,6 +441,12 @@ class CLibrary {
             cc.put(Attributes.ControlChar.VTIME, (int) c_cc[VTIME]);
             if (VSTATUS != (-1)) {
                 cc.put(Attributes.ControlChar.VSTATUS, (int) c_cc[VSTATUS]);
+            }
+            if (VSWTC != (-1)) {
+                cc.put(Attributes.ControlChar.VSWTC, (int) c_cc[VSWTC]);
+            }
+            if (VERASE2 != (-1)) {
+                cc.put(Attributes.ControlChar.VERASE2, (int) c_cc[VERASE2]);
             }
             // Return
             return attr;

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/freebsd/FreeBsdNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/freebsd/FreeBsdNativePty.java
@@ -246,6 +246,7 @@ public class FreeBsdNativePty extends JniNativePty {
         tio.c_cc[VMIN] = (byte) t.getControlChar(Attributes.ControlChar.VMIN);
         tio.c_cc[VTIME] = (byte) t.getControlChar(Attributes.ControlChar.VTIME);
         //        tio.c_cc[VSTATUS] = (byte) t.getControlChar(Attributes.ControlChar.VSTATUS);
+        tio.c_cc[VERASE2] = (byte) t.getControlChar(Attributes.ControlChar.VERASE2);
         return tio;
     }
 
@@ -341,6 +342,7 @@ public class FreeBsdNativePty extends JniNativePty {
         cc.put(Attributes.ControlChar.VMIN, (int) tio.c_cc[VMIN]);
         cc.put(Attributes.ControlChar.VTIME, (int) tio.c_cc[VTIME]);
         //        cc.put(Attributes.ControlChar.VSTATUS, (int) tio.c_cc[VSTATUS]);
+        cc.put(Attributes.ControlChar.VERASE2, (int) tio.c_cc[VERASE2]);
         // Return
         return attr;
     }

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/linux/LinuxNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/linux/LinuxNativePty.java
@@ -217,8 +217,10 @@ public class LinuxNativePty extends JniNativePty {
         tio.c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IXANY), IXANY, tio.c_iflag);
         tio.c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IMAXBEL), IMAXBEL, tio.c_iflag);
         tio.c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IUTF8), IUTF8, tio.c_iflag);
+        tio.c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IUCLC), IUCLC, tio.c_iflag);
         // Output flags
         tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.OPOST), OPOST, tio.c_oflag);
+        tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.OLCUC), OLCUC, tio.c_oflag);
         tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.ONLCR), ONLCR, tio.c_oflag);
         //        tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.OXTABS), OXTABS, tio.c_oflag);
         //        tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.ONOEOT), ONOEOT, tio.c_oflag);
@@ -260,6 +262,7 @@ public class LinuxNativePty extends JniNativePty {
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ECHOCTL), ECHOCTL, tio.c_lflag);
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ISIG), ISIG, tio.c_lflag);
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ICANON), ICANON, tio.c_lflag);
+        tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.XCASE), XCASE, tio.c_lflag);
         //        tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ALTWERASE), ALTWERASE, tio.c_lflag);
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.IEXTEN), IEXTEN, tio.c_lflag);
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.EXTPROC), EXTPROC, tio.c_lflag);
@@ -286,6 +289,7 @@ public class LinuxNativePty extends JniNativePty {
         tio.c_cc[VMIN] = (byte) t.getControlChar(Attributes.ControlChar.VMIN);
         tio.c_cc[VTIME] = (byte) t.getControlChar(Attributes.ControlChar.VTIME);
         //        tio.c_cc[VSTATUS] = (byte) t.getControlChar(Attributes.ControlChar.VSTATUS);
+        tio.c_cc[VSWTC] = (byte) t.getControlChar(Attributes.ControlChar.VSWTC);
         return tio;
     }
 
@@ -307,9 +311,11 @@ public class LinuxNativePty extends JniNativePty {
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IXANY, IXANY);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IMAXBEL, IMAXBEL);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IUTF8, IUTF8);
+        addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IUCLC, IUCLC);
         // Output flags
         EnumSet<Attributes.OutputFlag> oflag = attr.getOutputFlags();
         addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.OPOST, OPOST);
+        addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.OLCUC, OLCUC);
         addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.ONLCR, ONLCR);
         //        addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.OXTABS, OXTABS);
         //        addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.ONOEOT, ONOEOT);
@@ -352,6 +358,7 @@ public class LinuxNativePty extends JniNativePty {
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.ECHOCTL, ECHOCTL);
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.ISIG, ISIG);
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.ICANON, ICANON);
+        addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.XCASE, XCASE);
         //        addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.ALTWERASE, ALTWERASE);
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.IEXTEN, IEXTEN);
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.EXTPROC, EXTPROC);
@@ -379,6 +386,7 @@ public class LinuxNativePty extends JniNativePty {
         cc.put(Attributes.ControlChar.VMIN, (int) tio.c_cc[VMIN]);
         cc.put(Attributes.ControlChar.VTIME, (int) tio.c_cc[VTIME]);
         //        cc.put(Attributes.ControlChar.VSTATUS, (int) tio.c_cc[VSTATUS]);
+        cc.put(Attributes.ControlChar.VSWTC, (int) tio.c_cc[VSWTC]);
         // Return
         return attr;
     }

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/solaris/SolarisNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/solaris/SolarisNativePty.java
@@ -217,8 +217,10 @@ public class SolarisNativePty extends JniNativePty {
         tio.c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IXANY), IXANY, tio.c_iflag);
         tio.c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IMAXBEL), IMAXBEL, tio.c_iflag);
         tio.c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IUTF8), IUTF8, tio.c_iflag);
+        tio.c_iflag = setFlag(t.getInputFlag(Attributes.InputFlag.IUCLC), IUCLC, tio.c_iflag);
         // Output flags
         tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.OPOST), OPOST, tio.c_oflag);
+        tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.OLCUC), OLCUC, tio.c_oflag);
         tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.ONLCR), ONLCR, tio.c_oflag);
         //        tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.OXTABS), OXTABS, tio.c_oflag);
         //        tio.c_oflag = setFlag(t.getOutputFlag(Attributes.OutputFlag.ONOEOT), ONOEOT, tio.c_oflag);
@@ -260,6 +262,7 @@ public class SolarisNativePty extends JniNativePty {
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ECHOCTL), ECHOCTL, tio.c_lflag);
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ISIG), ISIG, tio.c_lflag);
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ICANON), ICANON, tio.c_lflag);
+        tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.XCASE), XCASE, tio.c_lflag);
         //        tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.ALTWERASE), ALTWERASE, tio.c_lflag);
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.IEXTEN), IEXTEN, tio.c_lflag);
         tio.c_lflag = setFlag(t.getLocalFlag(Attributes.LocalFlag.EXTPROC), EXTPROC, tio.c_lflag);
@@ -287,6 +290,7 @@ public class SolarisNativePty extends JniNativePty {
         tio.c_cc[VMIN] = (byte) t.getControlChar(Attributes.ControlChar.VMIN);
         tio.c_cc[VTIME] = (byte) t.getControlChar(Attributes.ControlChar.VTIME);
         //        tio.c_cc[VSTATUS] = (byte) t.getControlChar(Attributes.ControlChar.VSTATUS);
+        tio.c_cc[VSWTC] = (byte) t.getControlChar(Attributes.ControlChar.VSWTC);
         return tio;
     }
 
@@ -309,9 +313,11 @@ public class SolarisNativePty extends JniNativePty {
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IXANY, IXANY);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IMAXBEL, IMAXBEL);
         addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IUTF8, IUTF8);
+        addFlag(tio.c_iflag, iflag, Attributes.InputFlag.IUCLC, IUCLC);
         // Output flags
         EnumSet<Attributes.OutputFlag> oflag = attr.getOutputFlags();
         addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.OPOST, OPOST);
+        addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.OLCUC, OLCUC);
         addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.ONLCR, ONLCR);
         //        addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.OXTABS, OXTABS);
         //        addFlag(tio.c_oflag, oflag, Attributes.OutputFlag.ONOEOT, ONOEOT);
@@ -354,6 +360,7 @@ public class SolarisNativePty extends JniNativePty {
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.ECHOCTL, ECHOCTL);
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.ISIG, ISIG);
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.ICANON, ICANON);
+        addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.XCASE, XCASE);
         //        addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.ALTWERASE, ALTWERASE);
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.IEXTEN, IEXTEN);
         addFlag(tio.c_lflag, lflag, Attributes.LocalFlag.EXTPROC, EXTPROC);
@@ -382,6 +389,7 @@ public class SolarisNativePty extends JniNativePty {
         cc.put(Attributes.ControlChar.VMIN, (int) tio.c_cc[VMIN]);
         cc.put(Attributes.ControlChar.VTIME, (int) tio.c_cc[VTIME]);
         //        cc.put(Attributes.ControlChar.VSTATUS, (int) tio.c_cc[VSTATUS]);
+        cc.put(Attributes.ControlChar.VSWTC, (int) tio.c_cc[VSWTC]);
         // Return
         return attr;
     }

--- a/terminal/src/main/java/org/jline/terminal/Attributes.java
+++ b/terminal/src/main/java/org/jline/terminal/Attributes.java
@@ -127,7 +127,11 @@ public class Attributes {
         /** Timeout in deciseconds for non-canonical read */
         VTIME,
         /** Status request character (typically Ctrl+T) */
-        VSTATUS
+        VSTATUS,
+        /** Switch character (Linux/Solaris) */
+        VSWTC,
+        /** Alternate erase character (FreeBSD) */
+        VERASE2
     }
 
     /**
@@ -175,6 +179,7 @@ public class Attributes {
         IXANY, /* any char will restart after stop */
         IMAXBEL, /* ring bell on input queue full */
         IUTF8, /* maintain state for UTF-8 VERASE */
+        IUCLC, /* map upper case to lower case on input (Linux/Solaris) */
 
         INORMEOL /* normalize end-of-line */
     }
@@ -210,6 +215,7 @@ public class Attributes {
      */
     public enum OutputFlag {
         OPOST, /* enable following output processing */
+        OLCUC, /* map lower case to upper case on output (Linux/Solaris) */
         ONLCR, /* map NL to CR-NL (ala CRMOD) */
         OXTABS, /* expand tabs to spaces */
         ONOEOT, /* discard EOT's (^D) on output) */
@@ -319,6 +325,7 @@ public class Attributes {
         ECHOCTL, /* echo control chars as ^(Char) */
         ISIG, /* enable signals INTR, QUIT, [D]SUSP */
         ICANON, /* canonicalize input lines */
+        XCASE, /* canonical upper/lower presentation (Linux/Solaris) */
         ALTWERASE, /* use alternate WERASE algorithm */
         IEXTEN, /* enable DISCARD and LNEXT */
         EXTPROC, /* external processing */


### PR DESCRIPTION
## Summary

Fixes #1829

Several platform-specific termios constants were defined in the JNI NativePty classes and FFM CLibrary but never wired into the `toTermios`/`toAttributes` (JNI) and `ofTermios`/`asAttributes` (FFM) mapping methods, making them silently lost during roundtrip.

This PR:
- Adds missing `Attributes` enum values: `VSWTC`, `VERASE2` (ControlChar), `IUCLC` (InputFlag), `OLCUC` (OutputFlag), `XCASE` (LocalFlag)
- Wires them in Linux and Solaris JNI providers (setFlag/addFlag + c_cc mapping for VSWTC)
- Wires VERASE2 in FreeBSD JNI provider
- Wires all in FFM CLibrary with proper `-1` guards for platform-absent constants

## Files changed

| File | Change |
|---|---|
| `Attributes.java` | Add 5 new enum values |
| `LinuxNativePty.java` | Wire IUCLC, OLCUC, XCASE, VSWTC |
| `SolarisNativePty.java` | Wire IUCLC, OLCUC, XCASE, VSWTC |
| `FreeBsdNativePty.java` | Wire VERASE2 |
| `CLibrary.java` (FFM) | Wire all 5, with guards |

## Test plan

- [x] `./mvx mvn spotless:apply` passes
- [x] `./mvx mvn test -pl terminal,terminal-jni,terminal-ffm` passes
- [x] `./mvx rebuild` passes (all 21 modules)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded terminal attribute handling with support for additional input and output character case mapping flags.
  * Added support for extra control character configurations for improved terminal setting customization across multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->