### PR TITLE
refactor: modernize codebase with Java 9-11 idioms

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ClasspathResourceUtil.java
+++ b/builtins/src/main/java/org/jline/builtins/ClasspathResourceUtil.java
@@ -16,7 +16,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 
 /**
@@ -105,7 +104,7 @@ public class ClasspathResourceUtil {
         String scheme = uri.getScheme();
 
         if (scheme.equals("file")) {
-            return Paths.get(uri);
+            return Path.of(uri);
         }
 
         if (!scheme.equals("jar")) {

--- a/builtins/src/main/java/org/jline/builtins/Commands.java
+++ b/builtins/src/main/java/org/jline/builtins/Commands.java
@@ -14,7 +14,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -267,7 +266,7 @@ public class Commands {
     protected static List<Path> findFiles(Path root, String files) throws IOException {
         files = files.startsWith("~") ? files.replace("~", System.getProperty("user.home")) : files;
         String regex = files;
-        Path searchRoot = Paths.get("/");
+        Path searchRoot = Path.of("/");
         if (new File(files).isAbsolute()) {
             regex = regex.replaceAll("\\\\", "/").replaceAll("//", "/");
             if (regex.contains("/")) {
@@ -275,7 +274,7 @@ public class Commands {
                 while (sr.contains("*") || sr.contains("?")) {
                     sr = sr.substring(0, sr.lastIndexOf("/"));
                 }
-                searchRoot = Paths.get(sr + "/");
+                searchRoot = Path.of(sr + "/");
             }
         } else {
             regex = (root.toString().length() == 0 ? "" : root + "/") + files;
@@ -1922,13 +1921,13 @@ public class Commands {
                         String parameter = replaceFileName(currentTheme, "*" + TYPE_NANORCTHEME);
                         out.println(currentTheme.getParent() + ":");
                         PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + parameter);
-                        try (Stream<Path> pathStream = Files.walk(Paths.get(new File(parameter).getParent()))) {
+                        try (Stream<Path> pathStream = Files.walk(Path.of(new File(parameter).getParent()))) {
                             pathStream.filter(pathMatcher::matches).forEach(p -> out.println(p.getFileName()));
                         }
                     } else {
                         Path themeFile;
                         if (opt.isSet("view")) {
-                            themeFile = Paths.get(replaceFileName(currentTheme, opt.get("view")));
+                            themeFile = Path.of(replaceFileName(currentTheme, opt.get("view")));
                         } else {
                             themeFile = currentTheme;
                         }

--- a/builtins/src/main/java/org/jline/builtins/Completers.java
+++ b/builtins/src/main/java/org/jline/builtins/Completers.java
@@ -14,7 +14,6 @@ import java.lang.reflect.Array;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -655,11 +654,11 @@ public class Completers {
         }
 
         protected Path getUserDir() {
-            return Paths.get(System.getProperty("user.dir"));
+            return Path.of(System.getProperty("user.dir"));
         }
 
         protected Path getUserHome() {
-            return Paths.get(System.getProperty("user.home"));
+            return Path.of(System.getProperty("user.home"));
         }
 
         protected String getSeparator(boolean useForwardSlash) {
@@ -1203,7 +1202,7 @@ public class Completers {
                     if (valueCompleter instanceof FileNameCompleter) {
                         FileNameCompleter cc = (FileNameCompleter) valueCompleter;
                         String sep = cc.getSeparator(reader.isSet(LineReader.Option.USE_FORWARD_SLASH));
-                        val = cc.getDisplay(reader.getTerminal(), Paths.get(c.value()), Styles.lsStyle(), sep);
+                        val = cc.getDisplay(reader.getTerminal(), Path.of(c.value()), Styles.lsStyle(), sep);
                     }
                     candidates.add(new Candidate(curBuf + v, val, null, null, null, null, c.complete()));
                 }

--- a/builtins/src/main/java/org/jline/builtins/InputRC.java
+++ b/builtins/src/main/java/org/jline/builtins/InputRC.java
@@ -14,7 +14,6 @@ import java.io.Reader;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jline.reader.LineReader;
 
@@ -90,8 +89,8 @@ public final class InputRC {
     public static void configure(LineReader lineReader) throws IOException {
         String userHome = System.getProperty("user.home");
         if (userHome != null) {
-            configure(lineReader, Paths.get(userHome, ".inputrc"));
+            configure(lineReader, Path.of(userHome, ".inputrc"));
         }
-        configure(lineReader, Paths.get("/etc/inputrc"));
+        configure(lineReader, Path.of("/etc/inputrc"));
     }
 }

--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -20,7 +20,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -173,7 +172,7 @@ public class Less {
             }
         } else if (new File("/usr/share/nano").exists() && !ignorercfiles) {
             PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:/usr/share/nano/*.nanorc");
-            try (Stream<Path> pathStream = Files.walk(Paths.get("/usr/share/nano"))) {
+            try (Stream<Path> pathStream = Files.walk(Path.of("/usr/share/nano"))) {
                 pathStream.filter(pathMatcher::matches).forEach(syntaxFiles::add);
                 nanorcIgnoreErrors = true;
             } catch (IOException e) {

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -24,7 +24,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
@@ -1788,7 +1787,7 @@ public class Nano implements Editor {
             }
         } else if (new File("/usr/share/nano").exists() && !ignorercfiles) {
             PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:/usr/share/nano/*.nanorc");
-            try (Stream<Path> pathStream = Files.walk(Paths.get("/usr/share/nano"))) {
+            try (Stream<Path> pathStream = Files.walk(Path.of("/usr/share/nano"))) {
                 pathStream.filter(pathMatcher::matches).forEach(syntaxFiles::add);
                 nanorcIgnoreErrors = true;
             } catch (IOException e) {
@@ -2384,7 +2383,7 @@ public class Nano implements Editor {
         Path newPath = root.resolve(name);
         boolean isSame =
                 orgPath != null && Files.exists(orgPath) && Files.exists(newPath) && Files.isSameFile(orgPath, newPath);
-        if (!isSame && Files.exists(Paths.get(name)) && writeMode == WriteMode.WRITE) {
+        if (!isSame && Files.exists(Path.of(name)) && writeMode == WriteMode.WRITE) {
             Operation op = getYNC("File exists, OVERWRITE ? ");
             if (op != Operation.YES) {
                 return false;

--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -198,7 +198,7 @@ public class PosixCommands {
             // No argument - go to home directory
             String home = System.getProperty("user.home");
             if (home != null) {
-                newDir = Paths.get(home);
+                newDir = Path.of(home);
             } else {
                 newDir = cwd; // Stay in current directory if no home
             }
@@ -1742,7 +1742,7 @@ public class PosixCommands {
                 this.abs = abs;
                 try {
                     this.path = Files.isSameFile(abs, root)
-                            ? Paths.get(".")
+                            ? Path.of(".")
                             : abs.startsWith(root) ? root.relativize(abs) : abs;
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/builtins/src/main/java/org/jline/builtins/PosixCommandsRegistry.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommandsRegistry.java
@@ -28,7 +28,7 @@ import org.jline.terminal.Terminal;
  * <h3>Usage Example:</h3>
  * <pre>{@code
  * Terminal terminal = TerminalBuilder.builder().build();
- * Path currentDir = Paths.get(".");
+ * Path currentDir = Path.of(".");
  *
  * PosixCommandsRegistry registry = new PosixCommandsRegistry(
  *     terminal.input(),

--- a/builtins/src/test/java/org/jline/builtins/CommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CommandsTest.java
@@ -11,7 +11,7 @@ package org.jline.builtins;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.reader.History;
 import org.jline.reader.LineReader;
@@ -58,7 +58,7 @@ class CommandsTest {
                 lineReader.setVariable(LineReader.HISTORY_FILE_SIZE, maxLines);
                 lineReader.getHistory().save();
                 PrintStream out = new PrintStream(os, false);
-                Commands.history(lineReader, out, out, Paths.get(""), new String[] {"-d"});
+                Commands.history(lineReader, out, out, Path.of(""), new String[] {"-d"});
                 assertEquals(
                         maxLines + 1, os.toString(StandardCharsets.UTF_8).split("\\s+\\d{2}:\\d{2}:\\d{2}\\s+").length);
             }

--- a/builtins/src/test/java/org/jline/builtins/NanoClasspathConfigTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NanoClasspathConfigTest.java
@@ -12,7 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.Path;
 import java.util.function.Supplier;
 
 import org.jline.keymap.KeyMap;
@@ -34,7 +34,7 @@ class NanoClasspathConfigTest {
      */
     static class NanoCommand {
         Integer doCall() throws Exception {
-            Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
+            Supplier<Path> workDir = () -> Path.of(System.getProperty("user.dir"));
             try (Terminal terminal = createTestTerminal()) {
                 String[] argv = new String[] {"--ignorercfiles"}; // Ignore default config files
                 Options opt = Options.compile(Nano.usage()).parse(argv);

--- a/builtins/src/test/java/org/jline/builtins/NanoSuggestionBoxTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NanoSuggestionBoxTest.java
@@ -12,7 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +34,7 @@ class NanoSuggestionBoxTest {
      */
     static class TestableNano extends Nano {
         TestableNano(Terminal terminal) {
-            super(terminal, Paths.get("."));
+            super(terminal, Path.of("."));
         }
 
         /**

--- a/builtins/src/test/java/org/jline/builtins/NanoTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NanoTest.java
@@ -10,7 +10,7 @@ package org.jline.builtins;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.keymap.KeyMap;
 import org.jline.terminal.Size;
@@ -37,7 +37,7 @@ class NanoTest {
             String[] argv = {"--ignorercfiles"};
             Nano nano = new Nano(
                     terminal,
-                    Paths.get("target/test.txt"),
+                    Path.of("target/test.txt"),
                     Options.compile(Nano.usage()).parse(argv));
             assertNotNull(nano);
             nano.run();

--- a/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterTest.java
@@ -11,7 +11,6 @@ package org.jline.builtins;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -162,7 +161,7 @@ class SyntaxHighlighterTest {
         URL resourceUrl = SyntaxHighlighterTest.class.getClassLoader().getResource("nano");
         Assertions.assertNotNull(resourceUrl, "nano test resources directory not found");
 
-        Path nanoResourcesPath = Paths.get(resourceUrl.toURI());
+        Path nanoResourcesPath = Path.of(resourceUrl.toURI());
         try (Stream<Path> list = Files.list(nanoResourcesPath)
                 .filter(Files::isRegularFile)
                 .filter(p -> p.toString().endsWith(".nanorc"))

--- a/builtins/src/test/java/org/jline/example/Example.java
+++ b/builtins/src/test/java/org/jline/example/Example.java
@@ -9,7 +9,7 @@
 package org.jline.example;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -546,11 +546,11 @@ class Example {
                     } else if ("sleep".equals(pl.word())) {
                         Thread.sleep(3000);
                     } else if ("nano".equals(pl.word())) {
-                        Commands.nano(terminal, System.out, System.err, Paths.get(""), argv);
+                        Commands.nano(terminal, System.out, System.err, Path.of(""), argv);
                     } else if ("less".equals(pl.word())) {
-                        Commands.less(terminal, System.in, System.out, System.err, Paths.get(""), argv);
+                        Commands.less(terminal, System.in, System.out, System.err, Path.of(""), argv);
                     } else if ("history".equals(pl.word())) {
-                        Commands.history(reader, System.out, System.err, Paths.get(""), argv);
+                        Commands.history(reader, System.out, System.err, Path.of(""), argv);
                     } else if ("setopt".equals(pl.word())) {
                         Commands.setopt(reader, System.out, System.err, argv);
                     } else if ("unsetopt".equals(pl.word())) {

--- a/console-ui/src/test/java/org/jline/consoleui/Issue1025.java
+++ b/console-ui/src/test/java/org/jline/consoleui/Issue1025.java
@@ -98,7 +98,7 @@ class Issue1025 {
                 .defaultValue("John Doe")
                 // .mask('*')
                 .addCompleter(
-                        // new Completers.FilesCompleter(() -> Paths.get(System.getProperty("user.dir"))))
+                        // new Completers.FilesCompleter(() -> Path.of(System.getProperty("user.dir"))))
                         new StringsCompleter("Jim", "Jack", "John", "Donald", "Dock"))
                 .addPrompt();
 

--- a/console-ui/src/test/java/org/jline/consoleui/examples/Basic.java
+++ b/console-ui/src/test/java/org/jline/consoleui/examples/Basic.java
@@ -77,7 +77,7 @@ class Basic {
                     .defaultValue("John Doe")
                     // .mask('*')
                     .addCompleter(
-                            // new Completers.FilesCompleter(() -> Paths.get(System.getProperty("user.dir"))))
+                            // new Completers.FilesCompleter(() -> Path.of(System.getProperty("user.dir"))))
                             new StringsCompleter("Jim", "Jack", "John", "Donald", "Dock"))
                     .addPrompt();
 

--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -124,7 +124,7 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
             aliasFile = configPath.getUserConfig("aliases.json", true);
             if (aliasFile == null) {
                 Log.warn("Failed to write in user config path!");
-                aliasFile = OSUtils.IS_WINDOWS ? Paths.get("NUL") : Paths.get("/dev/null");
+                aliasFile = OSUtils.IS_WINDOWS ? Path.of("NUL") : Path.of("/dev/null");
             }
             persist(aliasFile, aliases);
         } else {
@@ -394,13 +394,13 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
                     this.extension = fileExtension(command);
                     if (isScript()) {
                         this.extension = "";
-                        this.script = Paths.get(command);
+                        this.script = Path.of(command);
                         if (Files.exists(script)) {
                             scriptExtension(command);
                         }
                     }
                 } else {
-                    this.script = Paths.get(command);
+                    this.script = Path.of(command);
                     if (Files.exists(script)) {
                         scriptExtension(command);
                     } else if (engine.hasVariable(VAR_PATH)) {
@@ -408,7 +408,7 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
                         for (String p : (List<String>) engine.get(VAR_PATH)) {
                             for (String e : scriptExtensions()) {
                                 String file = command + "." + e;
-                                Path path = Paths.get(p, file);
+                                Path path = Path.of(p, file);
                                 if (Files.exists(path)) {
                                     script = path;
                                     this.extension = e;
@@ -968,12 +968,12 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
                         ? opt.get("format")
                         : engine.getSerializationFormats().get(0);
                 try {
-                    Path path = Paths.get(arg);
+                    Path path = Path.of(arg);
                     if (Files.exists(path)) {
                         if (!format.equals(SLURP_FORMAT_TEXT)) {
                             out = slurp(path, encoding, format);
                         } else {
-                            out = Files.readAllLines(Paths.get(arg), encoding);
+                            out = Files.readAllLines(Path.of(arg), encoding);
                         }
                     } else {
                         if (!format.equals(SLURP_FORMAT_TEXT)) {

--- a/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
+++ b/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
@@ -11,7 +11,6 @@ package org.jline.console.impl;
 import java.io.File;
 import java.math.BigDecimal;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -425,10 +424,10 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
         } else {
             Path nanorc = configPath != null ? configPath.getConfig(DEFAULT_NANORC_FILE) : null;
             if (engine != null && engine.hasVariable(VAR_NANORC)) {
-                nanorc = Paths.get((String) engine.get(VAR_NANORC));
+                nanorc = Path.of((String) engine.get(VAR_NANORC));
             }
             if (nanorc == null) {
-                nanorc = Paths.get("/etc/nanorc");
+                nanorc = Path.of("/etc/nanorc");
             }
             out = SyntaxHighlighter.build(nanorc, style);
             highlighters.put(style, out);

--- a/console/src/main/java/org/jline/console/impl/SystemHighlighter.java
+++ b/console/src/main/java/org/jline/console/impl/SystemHighlighter.java
@@ -13,7 +13,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -291,7 +290,7 @@ public class SystemHighlighter extends DefaultHighlighter {
         } else {
             String separator = reader.isSet(LineReader.Option.USE_FORWARD_SLASH)
                     ? "/"
-                    : Paths.get(System.getProperty("user.dir")).getFileSystem().getSeparator();
+                    : Path.of(System.getProperty("user.dir")).getFileSystem().getSeparator();
             StringBuilder sb = new StringBuilder();
             try {
                 Path path = new File(arg).toPath();

--- a/console/src/test/java/org/jline/console/impl/SystemRegistryImplTest.java
+++ b/console/src/test/java/org/jline/console/impl/SystemRegistryImplTest.java
@@ -10,7 +10,6 @@ package org.jline.console.impl;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,8 +47,8 @@ class SystemRegistryImplTest {
     void setUp() throws IOException {
         terminal = TerminalBuilder.builder().dumb(true).build();
         Parser parser = new DefaultParser();
-        Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
-        Path cfgPath = Paths.get(".");
+        Supplier<Path> workDir = () -> Path.of(System.getProperty("user.dir"));
+        Path cfgPath = Path.of(".");
         ConfigurationPath configPath = new ConfigurationPath(cfgPath, cfgPath);
         output = new StringBuilder();
 

--- a/console/src/test/java/org/jline/example/Console.java
+++ b/console/src/test/java/org/jline/example/Console.java
@@ -9,7 +9,6 @@
 package org.jline.example;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -377,8 +376,8 @@ class Console {
             //
             // Command registers
             //
-            Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
-            ConfigurationPath configPath = new ConfigurationPath(Paths.get("."), Paths.get("."));
+            Supplier<Path> workDir = () -> Path.of(System.getProperty("user.dir"));
+            ConfigurationPath configPath = new ConfigurationPath(Path.of("."), Path.of("."));
             Builtins builtins = new Builtins(workDir, configPath, null);
             builtins.rename(Builtins.Command.TTOP, "top");
             builtins.alias("zle", "widget");

--- a/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
+++ b/demo/src/main/java/org/apache/felix/gogo/jline/Shell.java
@@ -58,7 +58,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.CharBuffer;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -329,7 +329,7 @@ public class Shell {
         session.put("#LINES", (Function) (s, arguments) -> terminal.getRows());
         session.put("#PWD", (Function) (s, arguments) -> s.currentDir().toString());
         if (!opt.isSet("nohistory")) {
-            session.put(LineReader.HISTORY_FILE, Paths.get(System.getProperty("user.home"), ".gogo.history"));
+            session.put(LineReader.HISTORY_FILE, Path.of(System.getProperty("user.home"), ".gogo.history"));
         }
 
         if (tio != null) {

--- a/demo/src/main/java/org/jline/demo/Launcher.java
+++ b/demo/src/main/java/org/jline/demo/Launcher.java
@@ -83,7 +83,7 @@ public class Launcher {
         System.out.println("WebTerminal started at " + terminal.getUrl());
         System.out.println("Open the URL in your browser to interact with the terminal.");
 
-        try {
+        try (terminal) {
             TerminalBuilder.setTerminalOverride(terminal);
             try {
                 runDemo(demoClass, args);
@@ -92,7 +92,6 @@ public class Launcher {
             }
         } finally {
             terminal.stop();
-            terminal.close();
         }
     }
 
@@ -102,7 +101,7 @@ public class Launcher {
         SwingTerminal terminal = new SwingTerminal(title, 80, 24);
         JFrame frame = terminal.createFrame(title);
 
-        try {
+        try (terminal) {
             TerminalBuilder.setTerminalOverride(terminal);
             try {
                 runDemo(demoClass, args);
@@ -110,7 +109,6 @@ public class Launcher {
                 TerminalBuilder.setTerminalOverride(null);
             }
         } finally {
-            terminal.close();
             frame.dispose();
         }
     }

--- a/demo/src/main/java/org/jline/demo/Repl.java
+++ b/demo/src/main/java/org/jline/demo/Repl.java
@@ -11,7 +11,6 @@ package org.jline.demo;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -282,7 +281,7 @@ public class Repl {
      */
     public static void main(String[] args) {
         try {
-            Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
+            Supplier<Path> workDir = () -> Path.of(System.getProperty("user.dir"));
             //
             // Parser & Terminal
             //
@@ -310,7 +309,7 @@ public class Repl {
             String root = file.getCanonicalPath()
                     .replace("classes", "")
                     .replaceAll("\\\\", "/"); // forward slashes works better also in windows!
-            File jnanorcFile = Paths.get(root, DEFAULT_NANORC_FILE).toFile();
+            File jnanorcFile = Path.of(root, DEFAULT_NANORC_FILE).toFile();
             if (!jnanorcFile.exists()) {
                 try (FileWriter fw = new FileWriter(jnanorcFile)) {
                     fw.write("theme " + root + "nanorc/dark.nanorctheme\n");
@@ -322,7 +321,7 @@ public class Repl {
             //
             GroovyEngine scriptEngine = new GroovyEngine();
             scriptEngine.put("ROOT", root);
-            ConfigurationPath configPath = new ConfigurationPath(Paths.get(root), Paths.get(root));
+            ConfigurationPath configPath = new ConfigurationPath(Path.of(root), Path.of(root));
             Printer printer = new DefaultPrinter(scriptEngine, configPath);
             ConsoleEngineImpl consoleEngine = new ConsoleEngineImpl(scriptEngine, printer, workDir, configPath);
             Builtins builtins = new Builtins(
@@ -361,7 +360,7 @@ public class Repl {
                     .variable(LineReader.SECONDARY_PROMPT_PATTERN, "%M%P > ")
                     .variable(LineReader.INDENTATION, 2)
                     .variable(LineReader.LIST_MAX, 100)
-                    .variable(LineReader.HISTORY_FILE, Paths.get(root, "history"))
+                    .variable(LineReader.HISTORY_FILE, Path.of(root, "history"))
                     .option(Option.INSERT_BRACKET, true)
                     .option(Option.EMPTY_WORD_OPTIONS, false)
                     .option(Option.GROUP_PERSIST, true)
@@ -384,7 +383,7 @@ public class Repl {
             new TailTipWidgets(reader, systemRegistry::commandDescription, 5, TipType.COMPLETER);
             KeyMap<Binding> keyMap = reader.getKeyMaps().get("main");
             keyMap.bind(new Reference(Widgets.TAILTIP_TOGGLE), KeyMap.alt("s"));
-            systemRegistry.initialize(Paths.get(root, "init.jline").toFile());
+            systemRegistry.initialize(Path.of(root, "init.jline").toFile());
             //
             // REPL-loop
             //

--- a/demo/src/main/java/org/jline/demo/examples/AggregateCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AggregateCompleterExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.builtins.Completers;
 import org.jline.reader.Completer;
@@ -30,7 +30,7 @@ public class AggregateCompleterExample {
     public static void main(String[] args) throws IOException {
         Completer aggregateCompleter = new AggregateCompleter(
                 new StringsCompleter("help", "exit"),
-                new ArgumentCompleter(new StringsCompleter("open"), new Completers.FilesCompleter(Paths.get(""))));
+                new ArgumentCompleter(new StringsCompleter("open"), new Completers.FilesCompleter(Path.of(""))));
 
         Terminal terminal = TerminalBuilder.builder().build();
         LineReader reader = LineReaderBuilder.builder()

--- a/demo/src/main/java/org/jline/demo/examples/ArchitectureExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ArchitectureExample.java
@@ -9,7 +9,6 @@
 package org.jline.demo.examples;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
@@ -51,7 +50,7 @@ public class ArchitectureExample {
 
         // SNIPPET_START: UsingHistory
         // Create a history file
-        Path historyFile = Paths.get(System.getProperty("user.home"), ".myapp_history");
+        Path historyFile = Path.of(System.getProperty("user.home"), ".myapp_history");
 
         // Create a line reader with history
         LineReader readerWithHistory = LineReaderBuilder.builder()

--- a/demo/src/main/java/org/jline/demo/examples/ArgumentCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ArgumentCompleterExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.builtins.Completers.FilesCompleter;
 import org.jline.reader.Completer;
@@ -28,7 +28,7 @@ public class ArgumentCompleterExample {
     public static void main(String[] args) throws IOException {
         // First argument is a command, second is a file
         Completer commandCompleter = new StringsCompleter("open", "save", "delete");
-        Completer fileCompleter = new FilesCompleter(Paths.get(System.getProperty("user.dir")));
+        Completer fileCompleter = new FilesCompleter(Path.of(System.getProperty("user.dir")));
 
         // HIGHLIGHT_START: Create an ArgumentCompleter
         Completer argCompleter = new ArgumentCompleter(commandCompleter, fileCompleter);

--- a/demo/src/main/java/org/jline/demo/examples/AsyncInputExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/AsyncInputExample.java
@@ -25,66 +25,64 @@ public class AsyncInputExample {
 
     // SNIPPET_START: AsyncInputExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
-        NonBlockingReader reader = terminal.reader();
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
+            NonBlockingReader reader = terminal.reader();
 
-        // Flag to control input handling
-        AtomicBoolean running = new AtomicBoolean(true);
+            // Flag to control input handling
+            AtomicBoolean running = new AtomicBoolean(true);
 
-        // Start input handling thread
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        executor.submit(() -> {
-            try {
-                // Continuously read input
-                while (running.get()) {
-                    int c = reader.read(100);
-                    if (c != -1) {
-                        // Process the input
-                        terminal.writer().println("\nReceived input: " + (char) c);
+            // Start input handling thread
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            executor.submit(() -> {
+                try {
+                    // Continuously read input
+                    while (running.get()) {
+                        int c = reader.read(100);
+                        if (c != -1) {
+                            // Process the input
+                            terminal.writer().println("\nReceived input: " + (char) c);
 
-                        if (c == 'q' || c == 'Q') {
-                            running.set(false);
+                            if (c == 'q' || c == 'Q') {
+                                running.set(false);
+                            }
+
+                            terminal.writer().flush();
                         }
-
+                    }
+                } catch (IOException | IllegalStateException e) {
+                    if (running.get()) {
+                        terminal.writer().println("Error reading input: " + e.getMessage());
                         terminal.writer().flush();
                     }
                 }
-            } catch (IOException e) {
-                if (running.get()) {
-                    terminal.writer().println("Error reading input: " + e.getMessage());
-                    terminal.writer().flush();
-                }
-            }
-        });
+            });
 
-        // Main application loop
-        try {
-            terminal.writer().println("Press keys (q to quit):");
-            terminal.writer().flush();
-
-            int count = 0;
-            while (running.get() && count < 30) {
-                // Simulate application work
-                terminal.writer().print(".");
+            // Main application loop
+            try {
+                terminal.writer().println("Press keys (q to quit):");
                 terminal.writer().flush();
 
-                TimeUnit.MILLISECONDS.sleep(500);
-                count++;
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            // Shutdown input handling
-            running.set(false);
-            executor.shutdownNow();
-            try {
-                executor.awaitTermination(1, TimeUnit.SECONDS);
+                int count = 0;
+                while (running.get() && count < 30) {
+                    // Simulate application work
+                    terminal.writer().print(".");
+                    terminal.writer().flush();
+
+                    TimeUnit.MILLISECONDS.sleep(500);
+                    count++;
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+            } finally {
+                // Shutdown executor while terminal is still open
+                running.set(false);
+                executor.shutdownNow();
+                try {
+                    executor.awaitTermination(1, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
-
-            terminal.writer().println("\nExiting...");
-            terminal.close();
         }
     }
     // SNIPPET_END: AsyncInputExample

--- a/demo/src/main/java/org/jline/demo/examples/ConsoleScriptExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ConsoleScriptExample.java
@@ -11,7 +11,6 @@ package org.jline.demo.examples;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Example demonstrating a console script in JLine.
@@ -58,7 +57,7 @@ public class ConsoleScriptExample {
                 + "exit \"Script completed successfully!\"\n";
 
         // Write the example script to a file for demonstration purposes
-        Path scriptPath = Paths.get("hello.jline");
+        Path scriptPath = Path.of("hello.jline");
         Files.write(scriptPath, consoleScript.getBytes());
 
         System.out.println("Created example console script: " + scriptPath.toAbsolutePath());

--- a/demo/src/main/java/org/jline/demo/examples/ConsoleUIExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ConsoleUIExample.java
@@ -27,29 +27,25 @@ public class ConsoleUIExample {
     // SNIPPET_START: ConsoleUIBasicExample
     public static void main(String[] args) throws IOException {
         // Create a terminal
-        Terminal terminal = TerminalBuilder.builder().build();
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
+            // Create a ConsolePrompt with the terminal
+            ConsolePrompt prompt = new ConsolePrompt(terminal);
 
-        // Create a ConsolePrompt with the terminal
-        ConsolePrompt prompt = new ConsolePrompt(terminal);
+            // Get a PromptBuilder to create UI elements
+            PromptBuilder builder = prompt.getPromptBuilder();
 
-        // Get a PromptBuilder to create UI elements
-        PromptBuilder builder = prompt.getPromptBuilder();
+            // Create a simple yes/no prompt
+            builder.createConfirmPromp()
+                    .name("continue")
+                    .message("Do you want to continue?")
+                    .defaultValue(ConfirmChoice.ConfirmationValue.YES)
+                    .addPrompt();
 
-        // Create a simple yes/no prompt
-        builder.createConfirmPromp()
-                .name("continue")
-                .message("Do you want to continue?")
-                .defaultValue(ConfirmChoice.ConfirmationValue.YES)
-                .addPrompt();
-
-        try {
             // Display the prompt and get the result
             Map<String, PromptResultItemIF> result = prompt.prompt(builder.build());
             System.out.println("You chose: " + result.get("continue"));
         } catch (Exception e) {
             e.printStackTrace();
-        } finally {
-            terminal.close();
         }
     }
     // SNIPPET_END: ConsoleUIBasicExample

--- a/demo/src/main/java/org/jline/demo/examples/ContextAwareCompleter.java
+++ b/demo/src/main/java/org/jline/demo/examples/ContextAwareCompleter.java
@@ -8,7 +8,7 @@
  */
 package org.jline.demo.examples;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +29,7 @@ public class ContextAwareCompleter implements Completer {
 
     public ContextAwareCompleter() {
         contextCompleters.put("default", new StringsCompleter("help", "context", "exit"));
-        contextCompleters.put("file", new Completers.FilesCompleter(Paths.get("")));
+        contextCompleters.put("file", new Completers.FilesCompleter(Path.of("")));
         contextCompleters.put("user", new StringsCompleter("admin", "guest", "user1", "user2"));
     }
 

--- a/demo/src/main/java/org/jline/demo/examples/ControlCharsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ControlCharsExample.java
@@ -22,9 +22,7 @@ public class ControlCharsExample {
 
     // SNIPPET_START: ControlCharsExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
-
-        try {
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
             // Get current attributes
             Attributes attributes = terminal.getAttributes();
 
@@ -55,8 +53,6 @@ public class ControlCharsExample {
             }
 
             terminal.writer().flush();
-        } finally {
-            terminal.close();
         }
     }
     // SNIPPET_END: ControlCharsExample

--- a/demo/src/main/java/org/jline/demo/examples/CustomTerminalBehaviorExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/CustomTerminalBehaviorExample.java
@@ -26,9 +26,7 @@ public class CustomTerminalBehaviorExample {
 
     // SNIPPET_START: CustomTerminalBehaviorExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
-
-        try {
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
             // Save original attributes
             Attributes originalAttributes = terminal.getAttributes();
 
@@ -48,23 +46,24 @@ public class CustomTerminalBehaviorExample {
             // Apply custom attributes
             terminal.setAttributes(customAttributes);
 
-            terminal.writer().println("Terminal configured with custom attributes");
-            terminal.writer().println("Type some text and press Enter (Ctrl+D to exit):");
-            terminal.writer().flush();
-
-            // Read lines until EOF
-            String line;
-            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
-            while ((line = reader.readLine(">")) != null) {
-                terminal.writer().println("You typed: " + line);
-                terminal.writer().println("Type another line (Ctrl+D to exit):");
+            try {
+                terminal.writer().println("Terminal configured with custom attributes");
+                terminal.writer().println("Type some text and press Enter (Ctrl+D to exit):");
                 terminal.writer().flush();
-            }
 
-            // Restore original attributes
-            terminal.setAttributes(originalAttributes);
-        } finally {
-            terminal.close();
+                // Read lines until EOF
+                String line;
+                LineReader reader =
+                        LineReaderBuilder.builder().terminal(terminal).build();
+                while ((line = reader.readLine(">")) != null) {
+                    terminal.writer().println("You typed: " + line);
+                    terminal.writer().println("Type another line (Ctrl+D to exit):");
+                    terminal.writer().flush();
+                }
+            } finally {
+                // Restore original attributes
+                terminal.setAttributes(originalAttributes);
+            }
         }
     }
     // SNIPPET_END: CustomTerminalBehaviorExample

--- a/demo/src/main/java/org/jline/demo/examples/DirectoriesCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/DirectoriesCompleterExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.builtins.Completers.DirectoriesCompleter;
 import org.jline.reader.Completer;
@@ -26,7 +26,7 @@ public class DirectoriesCompleterExample {
     // SNIPPET_START: DirectoriesCompleterExample
     public static void main(String[] args) throws IOException {
         // Create a completer that only completes directory names
-        Completer dirCompleter = new DirectoriesCompleter(Paths.get("."));
+        Completer dirCompleter = new DirectoriesCompleter(Path.of("."));
 
         Terminal terminal = TerminalBuilder.builder().build();
         LineReader reader = LineReaderBuilder.builder()

--- a/demo/src/main/java/org/jline/demo/examples/FilesCompleterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/FilesCompleterExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.builtins.Completers.FilesCompleter;
 import org.jline.reader.Completer;
@@ -26,7 +26,7 @@ public class FilesCompleterExample {
     // SNIPPET_START: FilesCompleterExample
     public static void main(String[] args) throws IOException {
         // Create a completer that only completes .txt files
-        Completer filesCompleter = new FilesCompleter(Paths.get("."), "*.txt");
+        Completer filesCompleter = new FilesCompleter(Path.of("."), "*.txt");
 
         Terminal terminal = TerminalBuilder.builder().build();
         LineReader reader = LineReaderBuilder.builder()

--- a/demo/src/main/java/org/jline/demo/examples/GroovyScriptExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/GroovyScriptExample.java
@@ -11,7 +11,6 @@ package org.jline.demo.examples;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Example demonstrating a Groovy script in JLine.
@@ -59,7 +58,7 @@ public class GroovyScriptExample {
                 + "return \"Script completed successfully!\"\n";
 
         // Write the example script to a file for demonstration purposes
-        Path scriptPath = Paths.get("hello.groovy");
+        Path scriptPath = Path.of("hello.groovy");
         Files.write(scriptPath, groovyScript.getBytes());
 
         System.out.println("Created example Groovy script: " + scriptPath.toAbsolutePath());

--- a/demo/src/main/java/org/jline/demo/examples/HistorySetupExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HistorySetupExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.reader.History;
 import org.jline.reader.LineReader;
@@ -35,7 +35,7 @@ public class HistorySetupExample {
         LineReader reader = LineReaderBuilder.builder()
                 .terminal(terminal)
                 .history(history)
-                .variable(LineReader.HISTORY_FILE, Paths.get("history.txt"))
+                .variable(LineReader.HISTORY_FILE, Path.of("history.txt"))
                 .build();
 
         System.out.println("Type commands and use up/down arrows to navigate history");

--- a/demo/src/main/java/org/jline/demo/examples/HistorySizeExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HistorySizeExample.java
@@ -28,7 +28,7 @@ public class HistorySizeExample {
         // Configure history with size limits
         LineReader reader = LineReaderBuilder.builder()
                 .terminal(terminal)
-                .variable(LineReader.HISTORY_FILE, Path.of("~/.myapp_history"))
+                .variable(LineReader.HISTORY_FILE, Path.of(System.getProperty("user.home"), ".myapp_history"))
                 .variable(LineReader.HISTORY_SIZE, 1000) // Maximum entries in memory
                 .variable(LineReader.HISTORY_FILE_SIZE, 2000) // Maximum entries in file
                 .build();

--- a/demo/src/main/java/org/jline/demo/examples/HistorySizeExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/HistorySizeExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -28,7 +28,7 @@ public class HistorySizeExample {
         // Configure history with size limits
         LineReader reader = LineReaderBuilder.builder()
                 .terminal(terminal)
-                .variable(LineReader.HISTORY_FILE, Paths.get("~/.myapp_history"))
+                .variable(LineReader.HISTORY_FILE, Path.of("~/.myapp_history"))
                 .variable(LineReader.HISTORY_SIZE, 1000) // Maximum entries in memory
                 .variable(LineReader.HISTORY_FILE_SIZE, 2000) // Maximum entries in file
                 .build();

--- a/demo/src/main/java/org/jline/demo/examples/InputFlagsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/InputFlagsExample.java
@@ -23,9 +23,7 @@ public class InputFlagsExample {
 
     // SNIPPET_START: InputFlagsExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
-
-        try {
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
             // Get current attributes
             Attributes attributes = terminal.getAttributes();
 
@@ -52,8 +50,6 @@ public class InputFlagsExample {
             }
 
             terminal.writer().flush();
-        } finally {
-            terminal.close();
         }
     }
     // SNIPPET_END: InputFlagsExample

--- a/demo/src/main/java/org/jline/demo/examples/LineReaderCreationExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/LineReaderCreationExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -34,7 +34,7 @@ public class LineReaderCreationExample {
         LineReader customReader = LineReaderBuilder.builder()
                 .terminal(terminal)
                 .appName("MyApp")
-                .variable(LineReader.HISTORY_FILE, Paths.get("history.txt"))
+                .variable(LineReader.HISTORY_FILE, Path.of("history.txt"))
                 .option(LineReader.Option.AUTO_FRESH_LINE, true)
                 .option(LineReader.Option.HISTORY_BEEP, false)
                 .build();

--- a/demo/src/main/java/org/jline/demo/examples/LineReaderExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/LineReaderExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -34,7 +34,7 @@ public class LineReaderExample {
         LineReader customReader = LineReaderBuilder.builder()
                 .terminal(terminal)
                 .appName("MyApp")
-                .variable(LineReader.HISTORY_FILE, Paths.get("history.txt"))
+                .variable(LineReader.HISTORY_FILE, Path.of("history.txt"))
                 .option(LineReader.Option.AUTO_FRESH_LINE, true)
                 .option(LineReader.Option.HISTORY_BEEP, false)
                 .build();

--- a/demo/src/main/java/org/jline/demo/examples/LineReaderMouseExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/LineReaderMouseExample.java
@@ -22,32 +22,30 @@ public class LineReaderMouseExample {
 
     // SNIPPET_START: LineReaderMouseExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
+            try {
+                // Enable mouse support
+                terminal.trackMouse(Terminal.MouseTracking.Normal);
 
-        try {
-            // Enable mouse support
-            terminal.trackMouse(Terminal.MouseTracking.Normal);
+                // Create a LineReader with mouse support
+                LineReader reader = LineReaderBuilder.builder()
+                        .terminal(terminal)
+                        .variable(LineReader.MOUSE, true) // Enable mouse support
+                        .build();
 
-            // Create a LineReader with mouse support
-            LineReader reader = LineReaderBuilder.builder()
-                    .terminal(terminal)
-                    .variable(LineReader.MOUSE, true) // Enable mouse support
-                    .build();
+                System.out.println("Mouse support enabled in LineReader.");
+                System.out.println("Try clicking in the input line or using the mouse wheel.");
+                System.out.println("Type 'exit' to quit.");
 
-            System.out.println("Mouse support enabled in LineReader.");
-            System.out.println("Try clicking in the input line or using the mouse wheel.");
-            System.out.println("Type 'exit' to quit.");
-
-            // Read lines with mouse support
-            String line;
-            while (!(line = reader.readLine("prompt> ")).equalsIgnoreCase("exit")) {
-                System.out.println("You entered: " + line);
+                // Read lines with mouse support
+                String line;
+                while (!(line = reader.readLine("prompt> ")).equalsIgnoreCase("exit")) {
+                    System.out.println("You entered: " + line);
+                }
+            } finally {
+                // Disable mouse tracking before exiting
+                terminal.trackMouse(Terminal.MouseTracking.Off);
             }
-        } finally {
-            // Disable mouse tracking before exiting
-            terminal.trackMouse(Terminal.MouseTracking.Off);
-
-            terminal.close();
         }
     }
     // SNIPPET_END: LineReaderMouseExample

--- a/demo/src/main/java/org/jline/demo/examples/MouseEventHandlingExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MouseEventHandlingExample.java
@@ -23,93 +23,91 @@ public class MouseEventHandlingExample {
 
     // SNIPPET_START: MouseEventHandlingExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
+            try {
+                // Set up signal handler for CTRL+C
+                terminal.handle(Signal.INT, SignalHandler.SIG_IGN);
 
-        try {
-            // Set up signal handler for CTRL+C
-            terminal.handle(Signal.INT, SignalHandler.SIG_IGN);
+                // Enable mouse tracking
+                terminal.trackMouse(Terminal.MouseTracking.Normal);
 
-            // Enable mouse tracking
-            terminal.trackMouse(Terminal.MouseTracking.Normal);
+                System.out.println("Mouse tracking enabled. Click or move the mouse in the terminal...");
+                System.out.println("Press 'q' to exit.");
 
-            System.out.println("Mouse tracking enabled. Click or move the mouse in the terminal...");
-            System.out.println("Press 'q' to exit.");
+                NonBlockingReader reader = terminal.reader();
+                StringBuilder buffer = new StringBuilder();
+                boolean esc = false;
+                boolean bracket = false;
+                boolean mouse = false;
 
-            NonBlockingReader reader = terminal.reader();
-            StringBuilder buffer = new StringBuilder();
-            boolean esc = false;
-            boolean bracket = false;
-            boolean mouse = false;
+                // Event loop
+                while (true) {
+                    int c = reader.read();
 
-            // Event loop
-            while (true) {
-                int c = reader.read();
+                    // Check for 'q' to exit
+                    if (c == 'q') {
+                        break;
+                    }
 
-                // Check for 'q' to exit
-                if (c == 'q') {
-                    break;
-                }
+                    // Parse escape sequences for mouse events
+                    if (c == '\033') {
+                        // ESC character - start of escape sequence
+                        esc = true;
+                        buffer.setLength(0);
+                    } else if (esc && c == '[') {
+                        // [ character after ESC - potential mouse event
+                        bracket = true;
+                    } else if (esc && bracket && c == 'M') {
+                        // M character after ESC[ - confirmed mouse event
+                        mouse = true;
+                        buffer.setLength(0);
+                    } else if (mouse && buffer.length() < 3) {
+                        // Collect the 3 bytes that define the mouse event
+                        buffer.append((char) c);
 
-                // Parse escape sequences for mouse events
-                if (c == '\033') {
-                    // ESC character - start of escape sequence
-                    esc = true;
-                    buffer.setLength(0);
-                } else if (esc && c == '[') {
-                    // [ character after ESC - potential mouse event
-                    bracket = true;
-                } else if (esc && bracket && c == 'M') {
-                    // M character after ESC[ - confirmed mouse event
-                    mouse = true;
-                    buffer.setLength(0);
-                } else if (mouse && buffer.length() < 3) {
-                    // Collect the 3 bytes that define the mouse event
-                    buffer.append((char) c);
+                        if (buffer.length() == 3) {
+                            // We have a complete mouse event
+                            int b = buffer.charAt(0) - 32;
+                            int x = buffer.charAt(1) - 32;
+                            int y = buffer.charAt(2) - 32;
 
-                    if (buffer.length() == 3) {
-                        // We have a complete mouse event
-                        int b = buffer.charAt(0) - 32;
-                        int x = buffer.charAt(1) - 32;
-                        int y = buffer.charAt(2) - 32;
+                            // Decode the event type
+                            boolean press = (b & 3) != 3;
+                            boolean release = (b & 3) == 3;
+                            boolean wheel = (b & 64) != 0;
 
-                        // Decode the event type
-                        boolean press = (b & 3) != 3;
-                        boolean release = (b & 3) == 3;
-                        boolean wheel = (b & 64) != 0;
+                            // Determine which button was used
+                            String button = "unknown";
+                            if ((b & 3) == 0) button = "left";
+                            if ((b & 3) == 1) button = "middle";
+                            if ((b & 3) == 2) button = "right";
 
-                        // Determine which button was used
-                        String button = "unknown";
-                        if ((b & 3) == 0) button = "left";
-                        if ((b & 3) == 1) button = "middle";
-                        if ((b & 3) == 2) button = "right";
+                            // Print the event details
+                            terminal.writer()
+                                    .println(String.format(
+                                            "Mouse event: %s button %s at position (%d,%d)",
+                                            press ? "pressed" : (release ? "released" : (wheel ? "wheel" : "moved")),
+                                            button,
+                                            x,
+                                            y));
+                            terminal.flush();
 
-                        // Print the event details
-                        terminal.writer()
-                                .println(String.format(
-                                        "Mouse event: %s button %s at position (%d,%d)",
-                                        press ? "pressed" : (release ? "released" : (wheel ? "wheel" : "moved")),
-                                        button,
-                                        x,
-                                        y));
-                        terminal.flush();
-
-                        // Reset state
+                            // Reset state
+                            esc = false;
+                            bracket = false;
+                            mouse = false;
+                        }
+                    } else {
+                        // Not a mouse event or incomplete sequence
                         esc = false;
                         bracket = false;
                         mouse = false;
                     }
-                } else {
-                    // Not a mouse event or incomplete sequence
-                    esc = false;
-                    bracket = false;
-                    mouse = false;
                 }
+            } finally {
+                // Disable mouse tracking before exiting
+                terminal.trackMouse(Terminal.MouseTracking.Off);
             }
-        } finally {
-            // Disable mouse tracking before exiting
-            terminal.trackMouse(Terminal.MouseTracking.Off);
-
-            terminal.close();
         }
     }
     // SNIPPET_END: MouseEventHandlingExample

--- a/demo/src/main/java/org/jline/demo/examples/MouseInteractiveUIExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MouseInteractiveUIExample.java
@@ -25,102 +25,100 @@ public class MouseInteractiveUIExample {
 
     // SNIPPET_START: MouseInteractiveUIExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
+            try {
+                // Enable mouse tracking
+                terminal.trackMouse(Terminal.MouseTracking.Normal);
 
-        try {
-            // Enable mouse tracking
-            terminal.trackMouse(Terminal.MouseTracking.Normal);
+                // Create a display for managing the screen
+                Display display = new Display(terminal, true);
 
-            // Create a display for managing the screen
-            Display display = new Display(terminal, true);
+                // Define some buttons
+                List<Button> buttons = new ArrayList<>();
+                buttons.add(new Button(5, 3, "Button 1", () -> {
+                    terminal.writer().println("Button 1 clicked!");
+                    terminal.flush();
+                }));
+                buttons.add(new Button(5, 5, "Button 2", () -> {
+                    terminal.writer().println("Button 2 clicked!");
+                    terminal.flush();
+                }));
+                buttons.add(new Button(5, 7, "Exit", () -> {
+                    // This will be used to exit the application
+                }));
 
-            // Define some buttons
-            List<Button> buttons = new ArrayList<>();
-            buttons.add(new Button(5, 3, "Button 1", () -> {
-                terminal.writer().println("Button 1 clicked!");
+                // Initial render
+                display.clear();
+                terminal.writer().println("Interactive UI Example");
+                terminal.writer().println("Click on the buttons below:");
+                terminal.writer().println();
+
+                for (Button button : buttons) {
+                    button.render(terminal);
+                }
+
                 terminal.flush();
-            }));
-            buttons.add(new Button(5, 5, "Button 2", () -> {
-                terminal.writer().println("Button 2 clicked!");
-                terminal.flush();
-            }));
-            buttons.add(new Button(5, 7, "Exit", () -> {
-                // This will be used to exit the application
-            }));
 
-            // Initial render
-            display.clear();
-            terminal.writer().println("Interactive UI Example");
-            terminal.writer().println("Click on the buttons below:");
-            terminal.writer().println();
+                // Event loop
+                boolean running = true;
+                StringBuilder buffer = new StringBuilder();
+                boolean esc = false;
+                boolean bracket = false;
+                boolean mouse = false;
 
-            for (Button button : buttons) {
-                button.render(terminal);
-            }
+                while (running) {
+                    int c = terminal.reader().read();
 
-            terminal.flush();
+                    // Parse escape sequences for mouse events
+                    if (c == '\033') {
+                        esc = true;
+                        buffer.setLength(0);
+                    } else if (esc && c == '[') {
+                        bracket = true;
+                    } else if (esc && bracket && c == 'M') {
+                        mouse = true;
+                        buffer.setLength(0);
+                    } else if (mouse && buffer.length() < 3) {
+                        buffer.append((char) c);
 
-            // Event loop
-            boolean running = true;
-            StringBuilder buffer = new StringBuilder();
-            boolean esc = false;
-            boolean bracket = false;
-            boolean mouse = false;
+                        if (buffer.length() == 3) {
+                            int b = buffer.charAt(0) - 32;
+                            int x = buffer.charAt(1) - 32;
+                            int y = buffer.charAt(2) - 32;
 
-            while (running) {
-                int c = terminal.reader().read();
+                            // Check if this is a mouse press event
+                            if ((b & 3) != 3 && (b & 64) == 0) {
+                                // Check if any button was clicked
+                                for (Button button : buttons) {
+                                    if (button.isInside(x, y)) {
+                                        button.click();
 
-                // Parse escape sequences for mouse events
-                if (c == '\033') {
-                    esc = true;
-                    buffer.setLength(0);
-                } else if (esc && c == '[') {
-                    bracket = true;
-                } else if (esc && bracket && c == 'M') {
-                    mouse = true;
-                    buffer.setLength(0);
-                } else if (mouse && buffer.length() < 3) {
-                    buffer.append((char) c);
+                                        // Check if Exit button was clicked
+                                        if (button.getText().equals("Exit")) {
+                                            running = false;
+                                        }
 
-                    if (buffer.length() == 3) {
-                        int b = buffer.charAt(0) - 32;
-                        int x = buffer.charAt(1) - 32;
-                        int y = buffer.charAt(2) - 32;
-
-                        // Check if this is a mouse press event
-                        if ((b & 3) != 3 && (b & 64) == 0) {
-                            // Check if any button was clicked
-                            for (Button button : buttons) {
-                                if (button.isInside(x, y)) {
-                                    button.click();
-
-                                    // Check if Exit button was clicked
-                                    if (button.getText().equals("Exit")) {
-                                        running = false;
+                                        break;
                                     }
-
-                                    break;
                                 }
                             }
-                        }
 
-                        // Reset state
+                            // Reset state
+                            esc = false;
+                            bracket = false;
+                            mouse = false;
+                        }
+                    } else {
+                        // Not a mouse event or incomplete sequence
                         esc = false;
                         bracket = false;
                         mouse = false;
                     }
-                } else {
-                    // Not a mouse event or incomplete sequence
-                    esc = false;
-                    bracket = false;
-                    mouse = false;
                 }
+            } finally {
+                // Disable mouse tracking before exiting
+                terminal.trackMouse(Terminal.MouseTracking.Off);
             }
-        } finally {
-            // Disable mouse tracking before exiting
-            terminal.trackMouse(Terminal.MouseTracking.Off);
-
-            terminal.close();
         }
     }
 

--- a/demo/src/main/java/org/jline/demo/examples/MouseSupportBasicsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MouseSupportBasicsExample.java
@@ -20,33 +20,31 @@ public class MouseSupportBasicsExample {
 
     // SNIPPET_START: MouseSupportBasicsExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
+            try {
+                // Enable mouse tracking
+                terminal.trackMouse(Terminal.MouseTracking.Normal);
+                terminal.flush();
 
-        try {
-            // Enable mouse tracking
-            terminal.trackMouse(Terminal.MouseTracking.Normal);
-            terminal.flush();
+                System.out.println("Mouse tracking enabled. Click anywhere in the terminal...");
+                System.out.println("Press Enter to exit.");
 
-            System.out.println("Mouse tracking enabled. Click anywhere in the terminal...");
-            System.out.println("Press Enter to exit.");
+                // Simple event loop
+                while (true) {
+                    int c = terminal.reader().read();
+                    if (c == '\r' || c == '\n') {
+                        break;
+                    }
 
-            // Simple event loop
-            while (true) {
-                int c = terminal.reader().read();
-                if (c == '\r' || c == '\n') {
-                    break;
+                    // Process input (including mouse events)
+                    // Mouse events come as escape sequences
+                    // We'll see how to properly handle these in the next examples
                 }
-
-                // Process input (including mouse events)
-                // Mouse events come as escape sequences
-                // We'll see how to properly handle these in the next examples
+            } finally {
+                // Disable mouse tracking before exiting
+                terminal.trackMouse(Terminal.MouseTracking.Off);
+                terminal.flush();
             }
-        } finally {
-            // Disable mouse tracking before exiting
-            terminal.trackMouse(Terminal.MouseTracking.Off);
-            terminal.flush();
-
-            terminal.close();
         }
     }
     // SNIPPET_END: MouseSupportBasicsExample

--- a/demo/src/main/java/org/jline/demo/examples/MouseTrackingModesExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/MouseTrackingModesExample.java
@@ -20,39 +20,37 @@ public class MouseTrackingModesExample {
 
     // SNIPPET_START: MouseTrackingModesExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
+            try {
+                // Different mouse tracking modes
 
-        try {
-            // Different mouse tracking modes
+                // 1. Basic mouse tracking (clicks only)
+                terminal.trackMouse(Terminal.MouseTracking.Button);
 
-            // 1. Basic mouse tracking (clicks only)
-            terminal.trackMouse(Terminal.MouseTracking.Button);
+                // 2. Extended mouse tracking (clicks and movement)
+                // This is terminal-dependent and may require specific escape sequences
+                terminal.writer().write("\033[?1000;1002;1006;1015h");
 
-            // 2. Extended mouse tracking (clicks and movement)
-            // This is terminal-dependent and may require specific escape sequences
-            terminal.writer().write("\033[?1000;1002;1006;1015h");
+                // 3. Any event tracking (clicks, movement, and position reports)
+                // This is terminal-dependent and may require specific escape sequences
+                terminal.writer().write("\033[?1000;1003;1006;1015h");
 
-            // 3. Any event tracking (clicks, movement, and position reports)
-            // This is terminal-dependent and may require specific escape sequences
-            terminal.writer().write("\033[?1000;1003;1006;1015h");
+                terminal.flush();
 
-            terminal.flush();
+                System.out.println("Enhanced mouse tracking enabled.");
+                System.out.println("Try clicking, moving, and scrolling the mouse.");
+                System.out.println("Press Enter to exit.");
 
-            System.out.println("Enhanced mouse tracking enabled.");
-            System.out.println("Try clicking, moving, and scrolling the mouse.");
-            System.out.println("Press Enter to exit.");
-
-            // Wait for Enter key
-            while (terminal.reader().read() != '\n') {
-                // Process events
+                // Wait for Enter key
+                while (terminal.reader().read() != '\n') {
+                    // Process events
+                }
+            } finally {
+                // Disable all mouse tracking modes
+                terminal.trackMouse(Terminal.MouseTracking.Off);
+                terminal.writer().write("\033[?1000;1002;1003;1006;1015l");
+                terminal.flush();
             }
-        } finally {
-            // Disable all mouse tracking modes
-            terminal.trackMouse(Terminal.MouseTracking.Off);
-            terminal.writer().write("\033[?1000;1002;1003;1006;1015l");
-            terminal.flush();
-
-            terminal.close();
         }
     }
     // SNIPPET_END: MouseTrackingModesExample

--- a/demo/src/main/java/org/jline/demo/examples/NanoEditorExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/NanoEditorExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.builtins.Nano;
 import org.jline.builtins.Options;
@@ -29,7 +29,7 @@ public class NanoEditorExample {
         Options options = Options.compile(Nano.usage()).parse(new String[] {"--tabsize=4", "--tabstospaces"});
 
         // Launch Nano editor
-        Nano nano = new Nano(terminal, Paths.get(""), options);
+        Nano nano = new Nano(terminal, Path.of(""), options);
         nano.open("example.txt");
     }
     // SNIPPET_END: NanoEditorExample

--- a/demo/src/main/java/org/jline/demo/examples/NanoLessCustomizationExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/NanoLessCustomizationExample.java
@@ -11,7 +11,6 @@ package org.jline.demo.examples;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -84,7 +83,7 @@ public class NanoLessCustomizationExample {
                 + "# Use theme system\n"
                 + "theme example-theme.nanorctheme\n";
 
-        Path nanorcFile = Paths.get("jnanorc");
+        Path nanorcFile = Path.of("jnanorc");
         Files.write(nanorcFile, nanorcContent.getBytes());
         return nanorcFile;
     }
@@ -100,7 +99,7 @@ public class NanoLessCustomizationExample {
                 + "# Use theme system\n"
                 + "theme example-theme.nanorctheme\n";
 
-        Path lessrcFile = Paths.get("jlessrc");
+        Path lessrcFile = Path.of("jlessrc");
         Files.write(lessrcFile, lessrcContent.getBytes());
         return lessrcFile;
     }
@@ -144,7 +143,7 @@ public class NanoLessCustomizationExample {
                 + "    }\n"
                 + "}\n";
 
-        Path sampleFile = Paths.get("SampleClass.java");
+        Path sampleFile = Path.of("SampleClass.java");
         Files.write(sampleFile, sampleContent.getBytes());
         return sampleFile;
     }

--- a/demo/src/main/java/org/jline/demo/examples/NonBlockingLineReaderExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/NonBlockingLineReaderExample.java
@@ -27,59 +27,63 @@ public class NonBlockingLineReaderExample {
 
     // SNIPPET_START: NonBlockingLineReaderExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
-        LineReader lineReader = LineReaderBuilder.builder().terminal(terminal).build();
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
+            LineReader lineReader =
+                    LineReaderBuilder.builder().terminal(terminal).build();
 
-        // Flag to control background task
-        AtomicBoolean running = new AtomicBoolean(true);
+            // Flag to control background task
+            AtomicBoolean running = new AtomicBoolean(true);
 
-        // Start background task
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        executor.submit(() -> {
-            try {
-                while (running.get()) {
-                    // Simulate background work
-                    terminal.writer().print(".");
-                    terminal.writer().flush();
-                    TimeUnit.SECONDS.sleep(1);
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (Exception e) {
-                terminal.writer().println("Error in background task: " + e.getMessage());
-                terminal.writer().flush();
-            }
-        });
-
-        try {
-            // Main input loop
-            while (running.get()) {
+            // Start background task
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            executor.submit(() -> {
                 try {
-                    // Read a line (this will block)
-                    String line = lineReader.readLine("\nprompt> ");
-
-                    if ("exit".equalsIgnoreCase(line)) {
-                        running.set(false);
-                    } else {
-                        terminal.writer().println("You entered: " + line);
+                    while (running.get()) {
+                        // Simulate background work
+                        terminal.writer().print(".");
+                        terminal.writer().flush();
+                        TimeUnit.SECONDS.sleep(1);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (Exception e) {
+                    if (running.get()) {
+                        terminal.writer().println("Error in background task: " + e.getMessage());
                         terminal.writer().flush();
                     }
-                } catch (UserInterruptException e) {
-                    // Ctrl+C pressed
-                    running.set(false);
+                }
+            });
+
+            try {
+                // Main input loop
+                while (running.get()) {
+                    try {
+                        // Read a line (this will block)
+                        String line = lineReader.readLine("\nprompt> ");
+
+                        if ("exit".equalsIgnoreCase(line)) {
+                            running.set(false);
+                        } else {
+                            terminal.writer().println("You entered: " + line);
+                            terminal.writer().flush();
+                        }
+                    } catch (UserInterruptException e) {
+                        // Ctrl+C pressed
+                        running.set(false);
+                    }
+                }
+
+                terminal.writer().println("\nExiting...");
+            } finally {
+                // Shutdown background task while terminal is still open
+                running.set(false);
+                executor.shutdownNow();
+                try {
+                    executor.awaitTermination(1, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                 }
             }
-        } finally {
-            // Shutdown background task
-            executor.shutdownNow();
-            try {
-                executor.awaitTermination(1, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-
-            terminal.writer().println("\nExiting...");
-            terminal.close();
         }
     }
     // SNIPPET_END: NonBlockingLineReaderExample

--- a/demo/src/main/java/org/jline/demo/examples/OutputFlagsExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/OutputFlagsExample.java
@@ -22,9 +22,7 @@ public class OutputFlagsExample {
 
     // SNIPPET_START: OutputFlagsExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
-
-        try {
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
             // Get current attributes
             Attributes attributes = terminal.getAttributes();
 
@@ -56,8 +54,6 @@ public class OutputFlagsExample {
             }
 
             terminal.writer().flush();
-        } finally {
-            terminal.close();
         }
     }
     // SNIPPET_END: OutputFlagsExample

--- a/demo/src/main/java/org/jline/demo/examples/PersistentHistoryExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PersistentHistoryExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -29,7 +29,7 @@ public class PersistentHistoryExample {
         LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
 
         // Set the history file
-        reader.setVariable(LineReader.HISTORY_FILE, Paths.get("~/.myapp_history"));
+        reader.setVariable(LineReader.HISTORY_FILE, Path.of("~/.myapp_history"));
 
         // Use the reader...
         String line = reader.readLine("prompt> ");

--- a/demo/src/main/java/org/jline/demo/examples/PersistentHistoryExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PersistentHistoryExample.java
@@ -29,7 +29,7 @@ public class PersistentHistoryExample {
         LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
 
         // Set the history file
-        reader.setVariable(LineReader.HISTORY_FILE, Path.of("~/.myapp_history"));
+        reader.setVariable(LineReader.HISTORY_FILE, Path.of(System.getProperty("user.home"), ".myapp_history"));
 
         // Use the reader...
         String line = reader.readLine("prompt> ");

--- a/demo/src/main/java/org/jline/demo/examples/RawModeExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/RawModeExample.java
@@ -22,9 +22,7 @@ public class RawModeExample {
 
     // SNIPPET_START: RawModeExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
-
-        try {
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
             // Save original terminal attributes
             Attributes originalAttributes = terminal.getAttributes();
 
@@ -51,8 +49,6 @@ public class RawModeExample {
 
             // Restore original terminal attributes
             terminal.setAttributes(originalAttributes);
-        } finally {
-            terminal.close();
         }
     }
     // SNIPPET_END: RawModeExample

--- a/demo/src/main/java/org/jline/demo/examples/ShellBuilderExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ShellBuilderExample.java
@@ -9,7 +9,6 @@
 package org.jline.demo.examples;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 import org.jline.builtins.PosixCommandGroup;
@@ -138,7 +137,7 @@ public class ShellBuilderExample {
                 .helpCommands(true)
                 .optionCommands(true)
                 .commandHighlighter(true)
-                .variable(LineReader.HISTORY_FILE, Paths.get(System.getProperty("user.home"), ".demo_history"))
+                .variable(LineReader.HISTORY_FILE, Path.of(System.getProperty("user.home"), ".demo_history"))
                 .option(Option.INSERT_BRACKET, true)
                 .option(Option.DISABLE_EVENT_EXPANSION, true)
                 .build()) {

--- a/demo/src/main/java/org/jline/demo/examples/SystemRegistryExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SystemRegistryExample.java
@@ -9,7 +9,6 @@
 package org.jline.demo.examples;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -32,7 +31,7 @@ public class SystemRegistryExample {
         Terminal terminal = TerminalBuilder.builder().system(true).build();
 
         // Set up working directory
-        Path workDir = Paths.get(System.getProperty("user.dir"));
+        Path workDir = Path.of(System.getProperty("user.dir"));
 
         // Create a line reader
         LineReader reader = LineReaderBuilder.builder()

--- a/demo/src/main/java/org/jline/demo/examples/TabCompletionExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TabCompletionExample.java
@@ -9,7 +9,7 @@
 package org.jline.demo.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.builtins.Completers.FilesCompleter;
 import org.jline.reader.Completer;
@@ -48,7 +48,7 @@ public class TabCompletionExample {
         // Create a more complex completer for command arguments
         Completer argCompleter = new ArgumentCompleter(
                 new StringsCompleter("open", "close", "save"),
-                new FilesCompleter(Paths.get(System.getProperty("user.dir"))));
+                new FilesCompleter(Path.of(System.getProperty("user.dir"))));
 
         // Create a line reader with the argument completer
         LineReader argReader = LineReaderBuilder.builder()

--- a/demo/src/main/java/org/jline/demo/examples/TerminalModesExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/TerminalModesExample.java
@@ -23,9 +23,7 @@ public class TerminalModesExample {
 
     // SNIPPET_START: TerminalModesExample
     public static void main(String[] args) throws IOException {
-        Terminal terminal = TerminalBuilder.builder().build();
-
-        try {
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
             // Save original attributes
             Attributes originalAttributes = terminal.getAttributes();
 
@@ -67,8 +65,6 @@ public class TerminalModesExample {
             terminal.writer().println("\nPress Enter to exit...");
             terminal.writer().flush();
             terminal.reader().read();
-        } finally {
-            terminal.close();
         }
     }
     // SNIPPET_END: TerminalModesExample

--- a/demo/src/main/java/org/jline/demo/examples/ThemeSystemExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/ThemeSystemExample.java
@@ -11,7 +11,6 @@ package org.jline.demo.examples;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -146,7 +145,7 @@ public class ThemeSystemExample {
                 + "$LINE_COMMENT   COMMENT \\n TODO: \"(FIXME|TODO|XXX)\"\n"
                 + "$BLOCK_COMMENT  COMMENT \\n DOC_COMMENT: startWith=/** \\n TODO: \"(FIXME|TODO|XXX)\"\n";
 
-        Path themeFile = Paths.get("example-theme.nanorctheme");
+        Path themeFile = Path.of("example-theme.nanorctheme");
         Files.write(themeFile, themeContent.getBytes());
         return themeFile;
     }
@@ -179,7 +178,7 @@ public class ThemeSystemExample {
                 + "# Include the LINT mixin\n"
                 + "+LINT\n";
 
-        Path syntaxFile = Paths.get("java.nanorc");
+        Path syntaxFile = Path.of("java.nanorc");
         Files.write(syntaxFile, syntaxContent.getBytes());
         return syntaxFile;
     }

--- a/graal/src/main/java/org/jline/demo/graal/Graal.java
+++ b/graal/src/main/java/org/jline/demo/graal/Graal.java
@@ -10,7 +10,7 @@ package org.jline.demo.graal;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.reader.LineReader;
 import org.jline.shell.Shell;
@@ -42,7 +42,7 @@ public class Graal {
                     .optionCommands(true)
                     .variableCommands(true)
                     .commandHighlighter(true)
-                    .historyFile(Paths.get(System.getProperty("user.home"), ".jline-graal-history"))
+                    .historyFile(Path.of(System.getProperty("user.home"), ".jline-graal-history"))
                     .option(LineReader.Option.INSERT_BRACKET, true)
                     .option(LineReader.Option.EMPTY_WORD_OPTIONS, false)
                     .option(LineReader.Option.USE_FORWARD_SLASH, true)

--- a/groovy/src/main/java/org/jline/script/GroovyCommand.java
+++ b/groovy/src/main/java/org/jline/script/GroovyCommand.java
@@ -9,7 +9,10 @@
 package org.jline.script;
 
 import java.io.File;
-import java.nio.file.*;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -290,7 +293,7 @@ public class GroovyCommand extends AbstractCommandRegistry implements CommandReg
                                 .getPathMatcher("regex:"
                                         + arg.replace("\\", "\\\\").replace(".", "\\.")
                                         + separator.replace("\\", "\\\\") + ".*\\.jar");
-                        try (Stream<Path> pathStream = Files.walk(Paths.get(arg))) {
+                        try (Stream<Path> pathStream = Files.walk(Path.of(arg))) {
                             pathStream
                                     .filter(matcher::matches)
                                     .map(Path::toString)

--- a/groovy/src/main/java/org/jline/script/GroovyEngine.java
+++ b/groovy/src/main/java/org/jline/script/GroovyEngine.java
@@ -13,7 +13,10 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.nio.file.*;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -558,7 +561,7 @@ public class GroovyEngine implements ScriptEngine {
         String syntax = groovyOption(NANORC_SYNTAX, DEFAULT_NANORC_SYNTAX);
         if (syntaxHighlighter == null || syntax == null || !syntax.equals(syntaxHighlighterStyle)) {
             String nanorcString = (String) get(VAR_NANORC);
-            Path nanorc = nanorcString != null ? Paths.get(nanorcString) : null;
+            Path nanorc = nanorcString != null ? Path.of(nanorcString) : null;
             if (syntax == null) {
                 syntaxHighlighter = SyntaxHighlighter.build("");
             } else if (syntax.contains(":") || nanorc == null) {
@@ -826,7 +829,7 @@ public class GroovyEngine implements ScriptEngine {
             dom = "regex:\\." + dom + "[A-Z]+[a-zA-Z]*\\.groovy";
             PathMatcher matcher = FileSystems.getDefault().getPathMatcher(dom);
             Set<String> out = new HashSet<>();
-            try (Stream<Path> pathStream = Files.walk(Paths.get("."))) {
+            try (Stream<Path> pathStream = Files.walk(Path.of("."))) {
                 Stream<String> classes = pathStream
                         .filter(matcher::matches)
                         .filter(p -> p.getFileName().toString().matches("[A-Z]+[a-zA-Z]*\\.groovy"))

--- a/jansi-core/src/test/java/org/jline/jansi/AnsiTest.java
+++ b/jansi-core/src/test/java/org/jline/jansi/AnsiTest.java
@@ -11,7 +11,6 @@ package org.jline.jansi;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jline.jansi.Ansi.Color;
 import org.junit.jupiter.api.Disabled;
@@ -176,7 +175,7 @@ class AnsiTest {
     @EnabledOnOs(OS.WINDOWS)
     @Disabled("Does not really fail: launch `javaw -jar jansi-xxx.jar` directly instead")
     void testAnsiMainWithNoConsole() throws Exception {
-        Path javaHome = Paths.get(System.getProperty("java.home"));
+        Path javaHome = Path.of(System.getProperty("java.home"));
         Path java = javaHome.resolve("bin\\javaw.exe");
         String cp = System.getProperty("java.class.path");
 

--- a/prompt/src/main/java/org/jline/prompt/examples/PromptCommandExample.java
+++ b/prompt/src/main/java/org/jline/prompt/examples/PromptCommandExample.java
@@ -9,7 +9,7 @@
 package org.jline.prompt.examples;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.jline.prompt.*;
@@ -39,7 +39,7 @@ public class PromptCommandExample {
                     System.in,
                     System.out,
                     System.err,
-                    Paths.get(System.getProperty("user.dir")),
+                    Path.of(System.getProperty("user.dir")),
                     terminal,
                     name -> System.getProperty(name));
 

--- a/prompt/src/test/java/org/jline/prompt/PromptCommandsTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PromptCommandsTest.java
@@ -12,7 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
@@ -55,7 +55,7 @@ class PromptCommandsTest {
                 new ByteArrayInputStream(new byte[0]),
                 new PrintStream(outStream),
                 new PrintStream(errStream),
-                Paths.get(System.getProperty("user.dir")),
+                Path.of(System.getProperty("user.dir")),
                 terminal,
                 System::getProperty);
     }

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -19,7 +19,6 @@ import java.io.InterruptedIOException;
 import java.lang.reflect.Constructor;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -360,7 +359,7 @@ public class LineReaderImpl implements LineReader, Flushable {
 
         String inputRc = getString(INPUT_RC_FILE_NAME, null);
         if (inputRc != null) {
-            Path inputRcPath = Paths.get(inputRc);
+            Path inputRcPath = Path.of(inputRc);
             if (Files.exists(inputRcPath)) {
                 try (InputStream is = Files.newInputStream(inputRcPath)) {
                     InputRC.configure(this, is);

--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -9,7 +9,10 @@
 package org.jline.reader.impl.history;
 
 import java.io.*;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.*;
@@ -45,7 +48,7 @@ import static org.jline.reader.impl.ReaderUtils.*;
  * Example usage:
  * <pre>
  * LineReader reader = LineReaderBuilder.builder()
- *     .variable(LineReader.HISTORY_FILE, Paths.get(System.getProperty("user.home"), ".myapp_history"))
+ *     .variable(LineReader.HISTORY_FILE, Path.of(System.getProperty("user.home"), ".myapp_history"))
  *     .build();
  * // History is automatically attached to the reader
  *
@@ -106,7 +109,7 @@ public class DefaultHistory implements History {
         } else if (obj instanceof File) {
             return ((File) obj).toPath();
         } else if (obj != null) {
-            return Paths.get(obj.toString());
+            return Path.of(obj.toString());
         } else {
             return null;
         }

--- a/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
@@ -11,7 +11,6 @@ package org.jline.reader.impl.history;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
@@ -41,13 +40,13 @@ class HistoryPersistenceTest extends ReaderTestSupport {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        Files.deleteIfExists(Paths.get("test"));
+        Files.deleteIfExists(Path.of("test"));
     }
 
     @Override
     @AfterEach
     public void tearDown() throws IOException {
-        Files.deleteIfExists(Paths.get("test"));
+        Files.deleteIfExists(Path.of("test"));
         super.tearDown();
     }
 
@@ -78,7 +77,7 @@ class HistoryPersistenceTest extends ReaderTestSupport {
 
     @Test
     void testFileHistory() throws Exception {
-        Path testPath = Paths.get("test");
+        Path testPath = Path.of("test");
         reader.setVariable(LineReader.HISTORY_FILE, testPath);
         reader.unsetOpt(LineReader.Option.HISTORY_INCREMENTAL);
 
@@ -109,7 +108,7 @@ class HistoryPersistenceTest extends ReaderTestSupport {
         reader.unsetOpt(LineReader.Option.HISTORY_INCREMENTAL);
         reader.option(LineReader.Option.HISTORY_TIMESTAMPED, timestamped);
         reader.setVariable(LineReader.HISTORY_FILE_SIZE, 5);
-        reader.setVariable(LineReader.HISTORY_FILE, Paths.get("test"));
+        reader.setVariable(LineReader.HISTORY_FILE, Path.of("test"));
 
         DefaultHistory history = new DefaultHistory(reader);
         for (int i = 0; i < 50; i++) {

--- a/remote-ssh/src/test/java/org/jline/builtins/ssh/SshdTest.java
+++ b/remote-ssh/src/test/java/org/jline/builtins/ssh/SshdTest.java
@@ -8,7 +8,7 @@
  */
 package org.jline.builtins.ssh;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ChannelShell;
@@ -27,7 +27,7 @@ class SshdTest {
     void test() throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(Paths.get("target/hostkey.ser")));
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(Path.of("target/hostkey.ser")));
         sshd.setPasswordAuthenticator((username, password, session) -> true);
         sshd.setShellFactory(new ShellFactoryImpl(shellParams -> {
             LineReader reader = LineReaderBuilder.builder()

--- a/shell/src/main/java/org/jline/shell/Pipeline.java
+++ b/shell/src/main/java/org/jline/shell/Pipeline.java
@@ -19,7 +19,7 @@ import java.util.List;
  * <pre>
  * Pipeline pipeline = Pipeline.of("ls")
  *     .pipe("grep pattern")       // |
- *     .redirect(Paths.get("out")) // &gt; out
+ *     .redirect(Path.of("out")) // &gt; out
  *     .build();
  * </pre>
  * <p>

--- a/shell/src/main/java/org/jline/shell/PipelineBuilder.java
+++ b/shell/src/main/java/org/jline/shell/PipelineBuilder.java
@@ -22,7 +22,7 @@ import org.jline.shell.impl.DefaultPipeline;
  * <pre>
  * Pipeline pipeline = Pipeline.of("ls -la")
  *     .pipe("grep pattern")
- *     .redirect(Paths.get("output.txt"))
+ *     .redirect(Path.of("output.txt"))
  *     .build();
  * </pre>
  *

--- a/shell/src/main/java/org/jline/shell/impl/PipelineParser.java
+++ b/shell/src/main/java/org/jline/shell/impl/PipelineParser.java
@@ -9,7 +9,6 @@
 package org.jline.shell.impl;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 
 import org.jline.shell.Pipeline;
@@ -140,7 +139,7 @@ public class PipelineParser {
                     Path target = null;
                     if (i + 1 < tokens.size()) {
                         i++;
-                        target = Paths.get(tokens.get(i).value.trim());
+                        target = Path.of(tokens.get(i).value.trim());
                     }
                     stages.add(new DefaultPipeline.DefaultStage(cmd, op, target, op == Operator.APPEND));
                 } else if (op == Operator.INPUT_REDIRECT) {
@@ -148,7 +147,7 @@ public class PipelineParser {
                     Path inputFile = null;
                     if (i + 1 < tokens.size()) {
                         i++;
-                        inputFile = Paths.get(tokens.get(i).value.trim());
+                        inputFile = Path.of(tokens.get(i).value.trim());
                     }
                     stages.add(new DefaultPipeline.DefaultStage(cmd, null, null, false, inputFile));
                 } else if (op == Operator.HEREDOC) {

--- a/shell/src/main/java/org/jline/shell/impl/ScriptCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/ScriptCommands.java
@@ -9,7 +9,6 @@
 package org.jline.shell.impl;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 
@@ -69,7 +68,7 @@ public class ScriptCommands implements CommandGroup {
             if (args.length < 1) {
                 throw new IllegalArgumentException("Usage: source <file>");
             }
-            Path scriptPath = Paths.get(args[0]);
+            Path scriptPath = Path.of(args[0]);
             if (!scriptPath.isAbsolute() && session.workingDirectory() != null) {
                 scriptPath = session.workingDirectory().resolve(scriptPath);
             }

--- a/shell/src/test/java/org/jline/shell/ShellBuilderTest.java
+++ b/shell/src/test/java/org/jline/shell/ShellBuilderTest.java
@@ -9,7 +9,6 @@
 package org.jline.shell;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jline.reader.LineReader;
 import org.jline.shell.impl.AbstractCommand;
@@ -73,7 +72,7 @@ class ShellBuilderTest {
 
     @Test
     void builderAcceptsHistoryFile() throws Exception {
-        Path historyFile = Paths.get(System.getProperty("java.io.tmpdir"), "test-history");
+        Path historyFile = Path.of(System.getProperty("java.io.tmpdir"), "test-history");
         try (Terminal terminal = TerminalBuilder.builder().dumb(true).build();
                 Shell shell = Shell.builder()
                         .terminal(terminal)

--- a/shell/src/test/java/org/jline/shell/impl/PipelineParserTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/PipelineParserTest.java
@@ -8,7 +8,7 @@
  */
 package org.jline.shell.impl;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.jline.shell.Pipeline;
@@ -91,7 +91,7 @@ class PipelineParserTest {
         assertEquals(1, pipeline.stages().size());
         assertEquals("ls", pipeline.stages().get(0).commandLine());
         assertEquals(Operator.REDIRECT, pipeline.stages().get(0).operator());
-        assertEquals(Paths.get("output.txt"), pipeline.stages().get(0).redirectTarget());
+        assertEquals(Path.of("output.txt"), pipeline.stages().get(0).redirectTarget());
         assertFalse(pipeline.stages().get(0).isAppend());
     }
 
@@ -101,7 +101,7 @@ class PipelineParserTest {
         assertEquals(1, pipeline.stages().size());
         assertEquals("echo hello", pipeline.stages().get(0).commandLine());
         assertEquals(Operator.APPEND, pipeline.stages().get(0).operator());
-        assertEquals(Paths.get("log.txt"), pipeline.stages().get(0).redirectTarget());
+        assertEquals(Path.of("log.txt"), pipeline.stages().get(0).redirectTarget());
         assertTrue(pipeline.stages().get(0).isAppend());
     }
 
@@ -121,7 +121,7 @@ class PipelineParserTest {
         assertEquals(Operator.PIPE, pipeline.stages().get(0).operator());
         assertEquals("grep foo", pipeline.stages().get(1).commandLine());
         assertEquals(Operator.REDIRECT, pipeline.stages().get(1).operator());
-        assertEquals(Paths.get("results.txt"), pipeline.stages().get(1).redirectTarget());
+        assertEquals(Path.of("results.txt"), pipeline.stages().get(1).redirectTarget());
     }
 
     @Test
@@ -175,14 +175,14 @@ class PipelineParserTest {
     void builderCreatesPipeline() {
         Pipeline pipeline = Pipeline.of("ls -la")
                 .pipe("grep pattern")
-                .redirect(Paths.get("output.txt"))
+                .redirect(Path.of("output.txt"))
                 .build();
         assertEquals(2, pipeline.stages().size());
         assertEquals("ls -la", pipeline.stages().get(0).commandLine());
         assertEquals(Operator.PIPE, pipeline.stages().get(0).operator());
         assertEquals("grep pattern", pipeline.stages().get(1).commandLine());
         assertEquals(Operator.REDIRECT, pipeline.stages().get(1).operator());
-        assertEquals(Paths.get("output.txt"), pipeline.stages().get(1).redirectTarget());
+        assertEquals(Path.of("output.txt"), pipeline.stages().get(1).redirectTarget());
     }
 
     @Test
@@ -271,7 +271,7 @@ class PipelineParserTest {
         assertEquals(1, pipeline.stages().size());
         assertEquals("ls", pipeline.stages().get(0).commandLine());
         assertEquals(Operator.REDIRECT, pipeline.stages().get(0).operator());
-        assertEquals(Paths.get("output.txt"), pipeline.stages().get(0).redirectTarget());
+        assertEquals(Path.of("output.txt"), pipeline.stages().get(0).redirectTarget());
 
         // |>> works as append
         pipeline = custom.parse("echo hello |>> log.txt");

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -19,7 +19,6 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -520,7 +519,7 @@ class CLibrary {
                     p.waitFor();
                     try (InputStream in = p.getInputStream()) {
                         hwName = readFully(in).trim();
-                        Path libDir = Paths.get("/usr/lib", hwName + "-linux-gnu");
+                        Path libDir = Path.of("/usr/lib", hwName + "-linux-gnu");
                         try (Stream<Path> stream = Files.list(libDir)) {
                             List<Path> libs = stream.filter(
                                             l -> l.getFileName().toString().startsWith("libutil.so."))

--- a/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
+++ b/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
@@ -15,7 +15,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -90,7 +89,7 @@ class InfoCmpTest {
         List<String> allCaps = packageLocations.stream()
                 .flatMap(url -> {
                     try {
-                        Path capsLocation = Paths.get(url.toURI());
+                        Path capsLocation = Path.of(url.toURI());
                         PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:**.caps");
                         try (Stream<Path> paths = Files.walk(capsLocation)) {
                             return paths


### PR DESCRIPTION
## Summary
- Replace deprecated `Paths.get()` with `Path.of()` (Java 11)
- Convert manual `try/finally/close()` patterns to proper try-with-resources, including Java 9 effectively-final variable syntax
- Expand wildcard imports to explicit imports

71 files changed, net -75 lines of boilerplate removed.

## Test plan
- [x] Full compilation passes (`mvn install -DskipTests`)
- [x] All tests pass (`mvn test`)
- [x] Spotless formatting verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized internal filesystem/path handling across the project and improved reliability by adopting automatic resource management.
  * No changes to public APIs or user-facing behavior.
* **Tests**
  * Updated tests to match the internal path/resource management updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->