### PR TITLE
fix: backport bugfixes from master to 4.0.x

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/SwingTerminal.java
@@ -234,7 +234,12 @@ public class SwingTerminal extends LineDisciplineTerminal {
 
     /**
      * Disposes of the terminal resources.
+     *
+     * @deprecated Use {@link #close()} instead, which properly handles all cleanup
+     *     including disposing of resources. This method will be made package-private
+     *     or removed in a future major release.
      */
+    @Deprecated
     public void dispose() {
         if (inputThread != null) {
             inputThread.interrupt();

--- a/builtins/src/test/java/org/jline/builtins/SwingTerminalEncodingTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SwingTerminalEncodingTest.java
@@ -43,9 +43,9 @@ public class SwingTerminalEncodingTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws IOException {
         if (swingTerminal != null) {
-            swingTerminal.dispose();
+            swingTerminal.close();
         }
     }
 

--- a/demo/src/main/java/org/jline/demo/Launcher.java
+++ b/demo/src/main/java/org/jline/demo/Launcher.java
@@ -111,7 +111,6 @@ public class Launcher {
             }
         } finally {
             terminal.close();
-            terminal.dispose();
             frame.dispose();
         }
     }

--- a/demo/src/main/java/org/jline/demo/examples/SwingTerminalExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/SwingTerminalExample.java
@@ -44,7 +44,11 @@ public class SwingTerminalExample {
         frame.addWindowListener(new java.awt.event.WindowAdapter() {
             @Override
             public void windowClosing(java.awt.event.WindowEvent e) {
-                terminal.dispose();
+                try {
+                    terminal.close();
+                } catch (java.io.IOException ex) {
+                    // ignore
+                }
             }
         });
 
@@ -56,7 +60,11 @@ public class SwingTerminalExample {
                     } catch (Exception e) {
                         e.printStackTrace();
                     } finally {
-                        terminal.dispose();
+                        try {
+                            terminal.close();
+                        } catch (java.io.IOException e) {
+                            // ignore
+                        }
                         frame.dispose();
                     }
                 },
@@ -95,7 +103,11 @@ public class SwingTerminalExample {
         frame.addWindowListener(new java.awt.event.WindowAdapter() {
             @Override
             public void windowClosing(java.awt.event.WindowEvent e) {
-                terminal.dispose();
+                try {
+                    terminal.close();
+                } catch (java.io.IOException ex) {
+                    // ignore
+                }
             }
         });
 
@@ -107,7 +119,11 @@ public class SwingTerminalExample {
                     } catch (Exception e) {
                         e.printStackTrace();
                     } finally {
-                        terminal.dispose();
+                        try {
+                            terminal.close();
+                        } catch (java.io.IOException e) {
+                            // ignore
+                        }
                         frame.dispose();
                     }
                 },

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -10,6 +10,7 @@ package org.jline.shell.impl;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -307,8 +308,9 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             // Handle input redirection
             InputStream originalIn = session.in();
             boolean inputRedirected = false;
-            if (stage.inputSource() != null) {
-                byte[] inputBytes = Files.readAllBytes(stage.inputSource());
+            Path inputSource = resolvePath(stage.inputSource());
+            if (inputSource != null) {
+                byte[] inputBytes = Files.readAllBytes(inputSource);
                 session.setIn(new ByteArrayInputStream(inputBytes));
                 inputRedirected = true;
             }
@@ -328,12 +330,16 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 session.setOut(new PrintStream(capture));
             } else if (op == Operator.STDERR_REDIRECT && stage.redirectTarget() != null) {
                 OutputStream errFile = Files.newOutputStream(
-                        stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                        resolvePath(stage.redirectTarget()),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.TRUNCATE_EXISTING);
                 session.setErr(new PrintStream(errFile));
                 stderrRedirected = true;
             } else if (op == Operator.COMBINED_REDIRECT && stage.redirectTarget() != null) {
                 OutputStream combinedFile = Files.newOutputStream(
-                        stage.redirectTarget(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                        resolvePath(stage.redirectTarget()),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.TRUNCATE_EXISTING);
                 PrintStream combinedStream = new PrintStream(combinedFile);
                 session.setOut(combinedStream);
                 session.setErr(combinedStream);
@@ -378,14 +384,15 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             // Handle redirect/append
             if (op == Operator.REDIRECT || op == Operator.APPEND) {
                 if (stage.redirectTarget() != null && lastOutput != null) {
+                    Path redirectTarget = resolvePath(stage.redirectTarget());
                     if (op == Operator.APPEND) {
                         Files.writeString(
-                                stage.redirectTarget(),
+                                redirectTarget,
                                 lastOutput + System.lineSeparator(),
                                 StandardOpenOption.CREATE,
                                 StandardOpenOption.APPEND);
                     } else {
-                        Files.writeString(stage.redirectTarget(), lastOutput + System.lineSeparator());
+                        Files.writeString(redirectTarget, lastOutput + System.lineSeparator());
                     }
                     lastResult = null;
                     lastOutput = null;
@@ -401,6 +408,17 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         }
 
         return lastResult;
+    }
+
+    private Path resolvePath(Path path) {
+        if (path == null) {
+            return null;
+        }
+        Path workingDir = session.workingDirectory();
+        if (workingDir != null) {
+            return workingDir.resolve(path.toString());
+        }
+        return path;
     }
 
     @Override

--- a/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
+++ b/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
@@ -41,6 +41,10 @@
       },
       {
         "returnType": "int",
+        "parameterTypes": ["int", "void*", "void*"]
+      },
+      {
+        "returnType": "int",
         "parameterTypes": ["void*", "int"]
       },
       {
@@ -74,6 +78,12 @@
       {
         "returnType": "int",
         "parameterTypes": ["void*", "void*", "int", "void*"]
+      }
+    ],
+    "upcalls": [
+      {
+        "returnType": "void",
+        "parameterTypes": ["int"]
       }
     ]
   }

--- a/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
+++ b/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
@@ -28,7 +28,7 @@ public class FfmTest {
     @Test
     @DisabledOnOs(OS.WINDOWS) // non system terminals are not supported on windows
     public void testNewTerminalWithNull() throws IOException {
-        Terminal terminal = new FfmTerminalProvider()
+        try (Terminal terminal = new FfmTerminalProvider()
                 .newTerminal(
                         "name",
                         "xterm",
@@ -40,14 +40,15 @@ public class FfmTest {
                         Terminal.SignalHandler.SIG_DFL,
                         false,
                         null,
-                        null);
-        assertNotNull(terminal);
+                        null)) {
+            assertNotNull(terminal);
+        }
     }
 
     @Test
     @DisabledOnOs(OS.WINDOWS) // non system terminals are not supported on windows
     public void testNewTerminalNoNull() throws IOException {
-        Terminal terminal = new FfmTerminalProvider()
+        try (Terminal terminal = new FfmTerminalProvider()
                 .newTerminal(
                         "name",
                         "xterm",
@@ -59,9 +60,10 @@ public class FfmTest {
                         Terminal.SignalHandler.SIG_DFL,
                         false,
                         new Attributes(),
-                        new Size());
-        assertNotNull(terminal);
-        assertNotNull(terminal.getSize());
+                        new Size())) {
+            assertNotNull(terminal);
+            assertNotNull(terminal.getSize());
+        }
     }
 
     @Test

--- a/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
@@ -276,7 +276,7 @@ public class LineDisciplineTerminal extends AbstractTerminal {
     public void processInputByte(int c) throws IOException {
         boolean flushOut = doProcessInputByte(c);
         slaveInputPipe.flush();
-        if (flushOut) {
+        if (flushOut && masterOutput != null) {
             masterOutput.flush();
         }
     }
@@ -291,7 +291,7 @@ public class LineDisciplineTerminal extends AbstractTerminal {
             flushOut |= doProcessInputByte(input[offset + i]);
         }
         slaveInputPipe.flush();
-        if (flushOut) {
+        if (flushOut && masterOutput != null) {
             masterOutput.flush();
         }
     }
@@ -350,6 +350,9 @@ public class LineDisciplineTerminal extends AbstractTerminal {
      * @throws IOException if anything wrong happens
      */
     protected void processOutputByte(int c) throws IOException {
+        if (masterOutput == null) {
+            return;
+        }
         if (attributes.getOutputFlag(OutputFlag.OPOST)) {
             if (c == '\n') {
                 if (attributes.getOutputFlag(OutputFlag.ONLCR)) {
@@ -413,12 +416,16 @@ public class LineDisciplineTerminal extends AbstractTerminal {
 
         @Override
         public void flush() throws IOException {
-            masterOutput.flush();
+            if (masterOutput != null) {
+                masterOutput.flush();
+            }
         }
 
         @Override
         public void close() throws IOException {
-            masterOutput.close();
+            if (masterOutput != null) {
+                masterOutput.close();
+            }
         }
     }
 }

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -149,6 +149,20 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
 
     @Override
     protected void doClose() throws IOException {
+        // Close the slave output to signal EOF on the master side, which
+        // reliably unblocks pumpOut's masterInput.read() on all platforms
+        // (including macOS where closing the master fd from another thread
+        // may not unblock a blocked read on the same fd).
+        try {
+            output.close();
+        } catch (IOException e) {
+            // ignore
+        }
+        try {
+            masterInput.close();
+        } catch (IOException e) {
+            // ignore
+        }
         super.doClose();
         reader.close();
     }

--- a/terminal/src/main/java/org/jline/utils/AttributedStyle.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStyle.java
@@ -628,8 +628,8 @@ public class AttributedStyle {
      */
     public AttributedStyle foreground(int color) {
         return new AttributedStyle(
-                style & ~FG_COLOR | F_FOREGROUND_IND | (((long) color << FG_COLOR_EXP) & FG_COLOR),
-                mask | F_FOREGROUND_IND);
+                style & ~(FG_COLOR | F_FOREGROUND) | F_FOREGROUND_IND | (((long) color << FG_COLOR_EXP) & FG_COLOR),
+                (mask & ~F_FOREGROUND) | F_FOREGROUND_IND);
     }
 
     /**
@@ -682,8 +682,10 @@ public class AttributedStyle {
      */
     public AttributedStyle foregroundRgb(int color) {
         return new AttributedStyle(
-                style & ~FG_COLOR | F_FOREGROUND_RGB | ((((long) color & 0xFFFFFF) << FG_COLOR_EXP) & FG_COLOR),
-                mask | F_FOREGROUND_RGB);
+                style & ~(FG_COLOR | F_FOREGROUND)
+                        | F_FOREGROUND_RGB
+                        | ((((long) color & 0xFFFFFF) << FG_COLOR_EXP) & FG_COLOR),
+                (mask & ~F_FOREGROUND) | F_FOREGROUND_RGB);
     }
 
     /**
@@ -748,8 +750,8 @@ public class AttributedStyle {
      */
     public AttributedStyle background(int color) {
         return new AttributedStyle(
-                style & ~BG_COLOR | F_BACKGROUND_IND | (((long) color << BG_COLOR_EXP) & BG_COLOR),
-                mask | F_BACKGROUND_IND);
+                style & ~(BG_COLOR | F_BACKGROUND) | F_BACKGROUND_IND | (((long) color << BG_COLOR_EXP) & BG_COLOR),
+                (mask & ~F_BACKGROUND) | F_BACKGROUND_IND);
     }
 
     /**
@@ -802,8 +804,10 @@ public class AttributedStyle {
      */
     public AttributedStyle backgroundRgb(int color) {
         return new AttributedStyle(
-                style & ~BG_COLOR | F_BACKGROUND_RGB | ((((long) color & 0xFFFFFF) << BG_COLOR_EXP) & BG_COLOR),
-                mask | F_BACKGROUND_RGB);
+                style & ~(BG_COLOR | F_BACKGROUND)
+                        | F_BACKGROUND_RGB
+                        | ((((long) color & 0xFFFFFF) << BG_COLOR_EXP) & BG_COLOR),
+                (mask & ~F_BACKGROUND) | F_BACKGROUND_RGB);
     }
 
     /**

--- a/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class NullOutputCloseTest {
+
+    @Test
+    void testCloseWithNullMasterOutput() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        ExternalTerminal terminal = new ExternalTerminal("test", "dumb", in, null, StandardCharsets.UTF_8);
+        assertDoesNotThrow(terminal::close);
+    }
+}

--- a/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AttributedStyleTest {
+
+    /**
+     * Verifies that chained RGB and indexed color updates produce the expected final styles.
+     */
+    @Test
+    void testMixedColors() {
+        assertEquals(
+                AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE),
+                AttributedStyle.DEFAULT.foregroundRgb(0xf00ff0).foreground(AttributedStyle.BLUE));
+        assertEquals(
+                AttributedStyle.DEFAULT.foregroundRgb(0x0ff00f),
+                AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE).foregroundRgb(0x0ff00f));
+        assertEquals(
+                AttributedStyle.DEFAULT.background(AttributedStyle.BLUE),
+                AttributedStyle.DEFAULT.backgroundRgb(0xf00ff0).background(AttributedStyle.BLUE));
+        assertEquals(
+                AttributedStyle.DEFAULT.backgroundRgb(0x0ff00f),
+                AttributedStyle.DEFAULT.background(AttributedStyle.BLUE).backgroundRgb(0x0ff00f));
+
+        AttributedString fgChained =
+                createColoredTestString(AttributedStyle::foreground, AttributedStyle::foregroundRgb);
+        AttributedString fgDefault = createColoredTestString(
+                (style, color) -> AttributedStyle.DEFAULT.foreground(color),
+                (style, rgb) -> AttributedStyle.DEFAULT.foregroundRgb(rgb));
+        AttributedString bgChained =
+                createColoredTestString(AttributedStyle::background, AttributedStyle::backgroundRgb);
+        AttributedString bgDefault = createColoredTestString(
+                (style, color) -> AttributedStyle.DEFAULT.background(color),
+                (style, rgb) -> AttributedStyle.DEFAULT.backgroundRgb(rgb));
+
+        assertEquals(fgChained, fgDefault);
+        assertEquals(bgChained, bgDefault);
+    }
+
+    /**
+     * Builds a sample attributed string that alternates indexed and RGB color changes.
+     *
+     * @param color the style update to apply for indexed colors
+     * @param rgbColor the style update to apply for RGB colors
+     * @return a test string with mixed color segments
+     */
+    private static AttributedString createColoredTestString(
+            BiFunction<AttributedStyle, Integer, AttributedStyle> color,
+            BiFunction<AttributedStyle, Integer, AttributedStyle> rgbColor) {
+        AttributedStringBuilder builder = new AttributedStringBuilder();
+        builder.append("a")
+                .style(style -> color.apply(style, AttributedStyle.GREEN))
+                .append("b")
+                .style(style -> rgbColor.apply(style, 0xffff00))
+                .append("c")
+                .style(style -> color.apply(style, AttributedStyle.RED))
+                .append("d")
+                .style(style -> rgbColor.apply(style, 0x00ffff))
+                .append("e")
+                .style(style -> color.apply(style, AttributedStyle.YELLOW))
+                .append("f")
+                .style(style -> rgbColor.apply(style, 0xff0000))
+                .append("g")
+                .style(style -> color.apply(style, AttributedStyle.GREEN))
+                .append("h");
+        return builder.toAttributedString();
+    }
+}

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -136,7 +136,7 @@ public class DisplayTest {
 
         private class MasterOutputStream extends OutputStream {
             private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            private final CharsetDecoder decoder = Charset.defaultCharset()
+            private final CharsetDecoder decoder = encoding()
                     .newDecoder()
                     .onMalformedInput(CodingErrorAction.REPLACE)
                     .onUnmappableCharacter(CodingErrorAction.REPLACE);


### PR DESCRIPTION
## Summary

Backport of bugfixes from master to the 4.0.x release branch:

- fix: Fix AttributedStyle color chaining (#1792)
- fix: avoid NPE when closing terminal with null masterOutput (#1796) (#1813)
- fix: deprecate SwingTerminal.dispose() in favor of close() (fixes #1805) (#1811)
- fix: close PTY streams before shutdown to prevent hang on macOS (fixes #1808) (#1817)
- fix: register all FFM foreign function signatures for GraalVM native-image (#1802)
- fix: resolve redirect targets against session working directory (#1781)
- fix: use terminal encoding instead of default charset in VirtualTerminal (fixes #1821) (#1822)

## Test plan

- [x] Full build passes (`./mvx mvn install -DskipTests`)
- [x] All tests pass for affected modules
- [x] Spotless formatting applied