### PR TITLE
Backport bugfixes to jline-3.x

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jline.utils.Colors;
@@ -1615,6 +1616,28 @@ public class ScreenTerminal {
         while (!dirty.compareAndSet(true, false)) {
             wait();
         }
+    }
+
+    /**
+     * Waits for the screen to become dirty, up to the given timeout.
+     * Uses a while loop to guard against spurious wakeups.
+     *
+     * @param timeout maximum time to wait in milliseconds; if {@code <= 0}, returns immediately
+     * @return true if the screen is dirty
+     * @throws InterruptedException if interrupted while waiting
+     */
+    public synchronized boolean waitDirty(long timeout) throws InterruptedException {
+        if (!dirty.get() && timeout > 0) {
+            long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeout);
+            while (!dirty.get()) {
+                long remainingMillis = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                if (remainingMillis <= 0) {
+                    break;
+                }
+                wait(remainingMillis);
+            }
+        }
+        return dirty.compareAndSet(true, false);
     }
 
     protected synchronized void setDirty() {

--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -1942,10 +1942,7 @@ public class ScreenTerminal {
     }
 
     public synchronized String dump(long timeout, boolean forceDump) throws InterruptedException {
-        if (!dirty.get() && timeout > 0) {
-            wait(timeout);
-        }
-        if (dirty.compareAndSet(true, false) || forceDump) {
+        if (waitDirty(timeout) || forceDump) {
             StringBuilder sb = new StringBuilder();
             int prev_attr = -1;
             int cx = Math.min(this.cx, width - 1);

--- a/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
@@ -8,6 +8,8 @@
  */
 package org.jline.builtins;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -16,6 +18,66 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests for the {@link ScreenTerminal} class.
  */
 public class ScreenTerminalTest {
+
+    /**
+     * isDirty() returns true after construction (initial dirty state),
+     * then false on subsequent call, then true again after write.
+     */
+    @Test
+    public void testDirtyFlag() {
+        ScreenTerminal terminal = new ScreenTerminal(80, 24);
+
+        assertTrue(terminal.isDirty(), "Should be dirty after construction");
+        assertFalse(terminal.isDirty(), "Should not be dirty after consuming");
+
+        terminal.write("X");
+        assertTrue(terminal.isDirty(), "Should be dirty after write");
+        assertFalse(terminal.isDirty(), "Should not be dirty after consuming again");
+    }
+
+    /**
+     * dump(timeout, forceDump=true) must still wait for the timeout before dumping
+     * when the screen is not dirty. This prevents busy-loop spinning when callers
+     * use forceDump in a loop.
+     * Regression: #1768
+     */
+    @Test
+    void testForceDumpWaitsForTimeout() {
+        ScreenTerminal terminal = new ScreenTerminal(10, 3);
+        terminal.write("Hello");
+
+        // Consume the dirty flag
+        terminal.isDirty();
+
+        long minWaitMs = 200;
+        long start = System.nanoTime();
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            terminal.dump(minWaitMs, true);
+        });
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(
+                elapsedMs >= minWaitMs / 2,
+                "forceDump should still wait for timeout when not dirty, but returned in " + elapsedMs + "ms");
+    }
+
+    /**
+     * waitDirty(0) must return immediately rather than blocking indefinitely.
+     * Regression: Object.wait(0) waits forever, so timeout==0 must skip the wait.
+     */
+    @Test
+    void testWaitDirtyZeroTimeoutReturnsImmediately() {
+        ScreenTerminal terminal = new ScreenTerminal(80, 24);
+
+        // Consume the initial dirty flag
+        terminal.isDirty();
+
+        // waitDirty(0) on a non-dirty screen must return false immediately
+        assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+            boolean result = terminal.waitDirty(0);
+            assertFalse(result, "Non-dirty screen should return false");
+        });
+    }
 
     /**
      * Test for issue #1206: Missing history length check in ScreenTerminal

--- a/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
+++ b/console/src/main/java/org/jline/console/impl/ConsoleEngineImpl.java
@@ -1214,13 +1214,18 @@ public class ConsoleEngineImpl extends JlineCommandRegistry implements ConsoleEn
     }
 
     private boolean urlExists(String weburl) {
+        HttpURLConnection huc = null;
         try {
             URL url = URI.create(weburl).toURL();
-            HttpURLConnection huc = (HttpURLConnection) url.openConnection();
+            huc = (HttpURLConnection) url.openConnection();
             huc.setRequestMethod("HEAD");
             return huc.getResponseCode() == HttpURLConnection.HTTP_OK;
         } catch (Exception e) {
             return false;
+        } finally {
+            if (huc != null) {
+                huc.disconnect();
+            }
         }
     }
 

--- a/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
+++ b/jansi-core/src/main/java/org/jline/jansi/AnsiConsole.java
@@ -193,10 +193,11 @@ public class AnsiConsole {
     static synchronized void doInstall() {
         try {
             if (terminal == null) {
-                TerminalBuilder builder = TerminalBuilder.builder()
-                        .system(true)
-                        .name("jansi")
-                        .providers(System.getProperty(JANSI_PROVIDERS));
+                TerminalBuilder builder = TerminalBuilder.builder().system(true).name("jansi");
+                String providers = System.getProperty(JANSI_PROVIDERS);
+                if (providers != null) {
+                    builder.providers(providers);
+                }
                 String graceful = System.getProperty(JANSI_GRACEFUL);
                 if (graceful != null) {
                     builder.dumb(Boolean.parseBoolean(graceful));

--- a/reader/src/main/java/org/jline/keymap/KeyMap.java
+++ b/reader/src/main/java/org/jline/keymap/KeyMap.java
@@ -621,7 +621,7 @@ public class KeyMap<T> {
         if (keySeq != null && keySeq.length() > 0) {
             for (int i = 0; i < keySeq.length() - 1; i++) {
                 char c = keySeq.charAt(i);
-                if (c > map.mapping.length) {
+                if (c >= map.mapping.length) {
                     return null;
                 }
                 if (!(map.mapping[c] instanceof KeyMap)) {
@@ -631,7 +631,7 @@ public class KeyMap<T> {
                 map = (KeyMap<T>) map.mapping[c];
             }
             char c = keySeq.charAt(keySeq.length() - 1);
-            if (c > map.mapping.length) {
+            if (c >= map.mapping.length) {
                 return null;
             }
             if (map.mapping[c] instanceof KeyMap) {

--- a/reader/src/main/java/org/jline/reader/impl/KillRing.java
+++ b/reader/src/main/java/org/jline/reader/impl/KillRing.java
@@ -132,7 +132,9 @@ public final class KillRing {
         lastKill = false;
         if (lastYank) {
             prev();
-            return slots[head];
+            if (head >= 0) {
+                return slots[head];
+            }
         }
         return null;
     }

--- a/reader/src/test/java/org/jline/keymap/KeyMapTest.java
+++ b/reader/src/test/java/org/jline/keymap/KeyMapTest.java
@@ -123,6 +123,33 @@ public class KeyMapTest {
     }
 
     @Test
+    public void testUnbindBoundaryChar() {
+        // KEYMAP_LENGTH is 128, so a char with value 128 is at the boundary
+        // (i.e., index == mapping.length). Before the fix, unbind() used ">"
+        // instead of ">=" for the bounds check, which would let c == mapping.length
+        // pass the check and then throw ArrayIndexOutOfBoundsException.
+        KeyMap<String> map = new KeyMap<>();
+        char boundaryChar = (char) KeyMap.KEYMAP_LENGTH;
+
+        // Unbinding a single-char sequence at the boundary should return null gracefully
+        // (no ArrayIndexOutOfBoundsException)
+        map.unbind(String.valueOf(boundaryChar));
+
+        // Unbinding a multi-char sequence where the final char is at the boundary
+        map.bind("action", "a");
+        map.unbind("a" + boundaryChar);
+
+        // Unbinding a multi-char sequence where an intermediate char is at the boundary
+        map.unbind(boundaryChar + "a");
+
+        // Verify that normal unbind still works correctly
+        map.bind("test", "x");
+        assertEquals("test", map.getBound("x"));
+        map.unbind("x");
+        assertNull(map.getBound("x"));
+    }
+
+    @Test
     public void testSort() {
         List<String> strings = new ArrayList<>();
         strings.add("abc");

--- a/reader/src/test/java/org/jline/reader/impl/KillRingTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/KillRingTest.java
@@ -127,6 +127,18 @@ public class KillRingTest extends ReaderTestSupport {
         assertEquals(yanked, "baz");
     }
 
+    @Test
+    public void testYankPopOnEmptyRingDoesNotThrow() {
+        // When the ring is empty, yank() sets lastYank=true and returns null.
+        // A subsequent yankPop() calls prev() which sets head to -1 when all
+        // slots are null. Without a bounds check this would throw
+        // ArrayIndexOutOfBoundsException.
+        KillRing killRing = new KillRing();
+        killRing.yank(); // sets lastYank = true, returns null
+        String yanked = killRing.yankPop();
+        assertNull(yanked);
+    }
+
     // Those tests are run using a buffer.
 
     @Test

--- a/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
+++ b/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
@@ -21,12 +21,14 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 public class FfmTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS) // non system terminals are not supported on windows
     public void testNewTerminalWithNull() throws IOException {
-        Terminal terminal = new FfmTerminalProvider()
+        try (Terminal terminal = new FfmTerminalProvider()
                 .newTerminal(
                         "name",
                         "xterm",
@@ -38,14 +40,15 @@ public class FfmTest {
                         Terminal.SignalHandler.SIG_DFL,
                         false,
                         null,
-                        null);
-        // terminal.close();
+                        null)) {
+            assertNotNull(terminal);
+        }
     }
 
     @Test
     @DisabledOnOs(OS.WINDOWS) // non system terminals are not supported on windows
     public void testNewTerminalNoNull() throws IOException {
-        Terminal terminal = new FfmTerminalProvider()
+        try (Terminal terminal = new FfmTerminalProvider()
                 .newTerminal(
                         "name",
                         "xterm",
@@ -57,9 +60,10 @@ public class FfmTest {
                         Terminal.SignalHandler.SIG_DFL,
                         false,
                         new Attributes(),
-                        new Size());
-        Size size = terminal.getSize();
-        // terminal.close();
+                        new Size())) {
+            assertNotNull(terminal);
+            assertNotNull(terminal.getSize());
+        }
     }
 
     @Test

--- a/terminal/src/main/java/org/jline/terminal/Size.java
+++ b/terminal/src/main/java/org/jline/terminal/Size.java
@@ -104,7 +104,7 @@ public class Size {
      * @see #getColumns()
      */
     public void setColumns(int columns) {
-        cols = (short) columns;
+        cols = columns;
     }
 
     /**
@@ -132,7 +132,7 @@ public class Size {
      * @see #getRows()
      */
     public void setRows(int rows) {
-        this.rows = (short) rows;
+        this.rows = rows;
     }
 
     /**

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
@@ -193,7 +193,7 @@ public abstract class AbstractPosixTerminal extends AbstractTerminal {
         }
     }
 
-    private int parseColorResponse(NonBlockingReader reader, int colorType) throws IOException {
+    int parseColorResponse(NonBlockingReader reader, int colorType) throws IOException {
         if (reader.peek(50) < 0) {
             return -1;
         }
@@ -231,6 +231,9 @@ public abstract class AbstractPosixTerminal extends AbstractTerminal {
         List<String> rgb = new ArrayList<>();
         while (true) {
             int c = reader.read(10);
+            if (c < 0) {
+                return -1;
+            }
             if (c == '\007') {
                 rgb.add(sb.toString());
                 break;

--- a/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/LineDisciplineTerminal.java
@@ -276,7 +276,7 @@ public class LineDisciplineTerminal extends AbstractTerminal {
     public void processInputByte(int c) throws IOException {
         boolean flushOut = doProcessInputByte(c);
         slaveInputPipe.flush();
-        if (flushOut) {
+        if (flushOut && masterOutput != null) {
             masterOutput.flush();
         }
     }
@@ -291,7 +291,7 @@ public class LineDisciplineTerminal extends AbstractTerminal {
             flushOut |= doProcessInputByte(input[offset + i]);
         }
         slaveInputPipe.flush();
-        if (flushOut) {
+        if (flushOut && masterOutput != null) {
             masterOutput.flush();
         }
     }
@@ -350,6 +350,9 @@ public class LineDisciplineTerminal extends AbstractTerminal {
      * @throws IOException if anything wrong happens
      */
     protected void processOutputByte(int c) throws IOException {
+        if (masterOutput == null) {
+            return;
+        }
         if (attributes.getOutputFlag(OutputFlag.OPOST)) {
             if (c == '\n') {
                 if (attributes.getOutputFlag(OutputFlag.ONLCR)) {
@@ -413,12 +416,16 @@ public class LineDisciplineTerminal extends AbstractTerminal {
 
         @Override
         public void flush() throws IOException {
-            masterOutput.flush();
+            if (masterOutput != null) {
+                masterOutput.flush();
+            }
         }
 
         @Override
         public void close() throws IOException {
-            masterOutput.close();
+            if (masterOutput != null) {
+                masterOutput.close();
+            }
         }
     }
 }

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -149,6 +149,20 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
 
     @Override
     protected void doClose() throws IOException {
+        // Close the slave output to signal EOF on the master side, which
+        // reliably unblocks pumpOut's masterInput.read() on all platforms
+        // (including macOS where closing the master fd from another thread
+        // may not unblock a blocked read on the same fd).
+        try {
+            output.close();
+        } catch (IOException e) {
+            // ignore
+        }
+        try {
+            masterInput.close();
+        } catch (IOException e) {
+            // ignore
+        }
         super.doClose();
         reader.close();
     }

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -489,7 +489,7 @@ public interface TerminalProvider {
                     try {
                         Class<?> providerClass = cl.loadClass(line);
                         return (TerminalProvider) providerClass.getConstructor().newInstance();
-                    } catch (Exception e) {
+                    } catch (Exception | LinkageError e) {
                         throw new IOException("Unable to load terminal provider " + name + ": " + e.getMessage(), e);
                     }
                 }

--- a/terminal/src/main/java/org/jline/utils/AttributedStyle.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStyle.java
@@ -626,8 +626,8 @@ public class AttributedStyle {
      */
     public AttributedStyle foreground(int color) {
         return new AttributedStyle(
-                style & ~FG_COLOR | F_FOREGROUND_IND | (((long) color << FG_COLOR_EXP) & FG_COLOR),
-                mask | F_FOREGROUND_IND);
+                style & ~(FG_COLOR | F_FOREGROUND) | F_FOREGROUND_IND | (((long) color << FG_COLOR_EXP) & FG_COLOR),
+                (mask & ~F_FOREGROUND) | F_FOREGROUND_IND);
     }
 
     /**
@@ -680,8 +680,10 @@ public class AttributedStyle {
      */
     public AttributedStyle foregroundRgb(int color) {
         return new AttributedStyle(
-                style & ~FG_COLOR | F_FOREGROUND_RGB | ((((long) color & 0xFFFFFF) << FG_COLOR_EXP) & FG_COLOR),
-                mask | F_FOREGROUND_RGB);
+                style & ~(FG_COLOR | F_FOREGROUND)
+                        | F_FOREGROUND_RGB
+                        | ((((long) color & 0xFFFFFF) << FG_COLOR_EXP) & FG_COLOR),
+                (mask & ~F_FOREGROUND) | F_FOREGROUND_RGB);
     }
 
     /**
@@ -746,8 +748,8 @@ public class AttributedStyle {
      */
     public AttributedStyle background(int color) {
         return new AttributedStyle(
-                style & ~BG_COLOR | F_BACKGROUND_IND | (((long) color << BG_COLOR_EXP) & BG_COLOR),
-                mask | F_BACKGROUND_IND);
+                style & ~(BG_COLOR | F_BACKGROUND) | F_BACKGROUND_IND | (((long) color << BG_COLOR_EXP) & BG_COLOR),
+                (mask & ~F_BACKGROUND) | F_BACKGROUND_IND);
     }
 
     /**
@@ -800,8 +802,10 @@ public class AttributedStyle {
      */
     public AttributedStyle backgroundRgb(int color) {
         return new AttributedStyle(
-                style & ~BG_COLOR | F_BACKGROUND_RGB | ((((long) color & 0xFFFFFF) << BG_COLOR_EXP) & BG_COLOR),
-                mask | F_BACKGROUND_RGB);
+                style & ~(BG_COLOR | F_BACKGROUND)
+                        | F_BACKGROUND_RGB
+                        | ((((long) color & 0xFFFFFF) << BG_COLOR_EXP) & BG_COLOR),
+                (mask & ~F_BACKGROUND) | F_BACKGROUND_RGB);
     }
 
     /**

--- a/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) the original author(s).
+ * Copyright (c) 2026, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
@@ -124,6 +124,9 @@ public class ColorParsingTest {
                 pos += count;
                 return count;
             }
+
+            @Override
+            public void close() throws IOException {}
         };
     }
 

--- a/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.easymock.EasyMock;
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Terminal.SignalHandler;
+import org.jline.terminal.spi.Pty;
+import org.jline.utils.NonBlockingReader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ColorParsingTest {
+
+    @Test
+    public void testParseColorResponseReturnsMinusOneOnEof() throws Exception {
+        // EOF occurs while reading RGB hex values (after rgb: prefix but before terminator)
+        NonBlockingReader reader = createReader("\033]10;rgb:ff/00");
+
+        AbstractPosixTerminal terminal = createTerminal();
+        try {
+            int result = terminal.parseColorResponse(reader, 10);
+            assertEquals(-1, result, "parseColorResponse should return -1 when EOF during RGB values");
+        } finally {
+            terminal.close();
+        }
+    }
+
+    @Test
+    public void testParseColorResponseReturnsMinusOneOnImmediateEof() throws Exception {
+        // EOF on very first peek
+        NonBlockingReader reader = createReader("");
+
+        AbstractPosixTerminal terminal = createTerminal();
+        try {
+            int result = terminal.parseColorResponse(reader, 10);
+            assertEquals(-1, result, "parseColorResponse should return -1 on immediate EOF");
+        } finally {
+            terminal.close();
+        }
+    }
+
+    @Test
+    public void testParseColorResponseWithValidBellTerminator() throws Exception {
+        // Valid OSC 10 response terminated by BEL (\007)
+        NonBlockingReader reader = createReader("\033]10;rgb:ff/ff/ff\007");
+
+        AbstractPosixTerminal terminal = createTerminal();
+        try {
+            int result = terminal.parseColorResponse(reader, 10);
+            assertEquals(0xFFFFFF, result, "parseColorResponse should parse white color correctly");
+        } finally {
+            terminal.close();
+        }
+    }
+
+    @Test
+    public void testParseColorResponseWithValidStTerminator() throws Exception {
+        // Valid OSC 11 response terminated by ST (ESC \)
+        NonBlockingReader reader = createReader("\033]11;rgb:00/00/00\033\\");
+
+        AbstractPosixTerminal terminal = createTerminal();
+        try {
+            int result = terminal.parseColorResponse(reader, 11);
+            assertEquals(0x000000, result, "parseColorResponse should parse black color correctly");
+        } finally {
+            terminal.close();
+        }
+    }
+
+    @Test
+    public void testParseColorResponseEofAfterPartialRgb() throws Exception {
+        // EOF after writing only part of the rgb: prefix
+        NonBlockingReader reader = createReader("\033]10;rg");
+
+        AbstractPosixTerminal terminal = createTerminal();
+        try {
+            int result = terminal.parseColorResponse(reader, 10);
+            assertEquals(-1, result, "parseColorResponse should return -1 when EOF during rgb: prefix");
+        } finally {
+            terminal.close();
+        }
+    }
+
+    /**
+     * Creates a NonBlockingReader that returns characters from the given string,
+     * then returns -1 (EOF) for all subsequent reads. This avoids the ClosedException
+     * that NonBlockingPumpReader throws when its writer is closed.
+     */
+    private NonBlockingReader createReader(String data) {
+        return new NonBlockingReader() {
+            private final char[] chars = data.toCharArray();
+            private int pos = 0;
+
+            @Override
+            protected int read(long timeout, boolean isPeek) throws IOException {
+                if (pos >= chars.length) {
+                    return -1;
+                }
+                if (isPeek) {
+                    return chars[pos];
+                }
+                return chars[pos++];
+            }
+
+            @Override
+            public int readBuffered(char[] b, int off, int len, long timeout) throws IOException {
+                if (pos >= chars.length) {
+                    return -1;
+                }
+                int count = Math.min(len, chars.length - pos);
+                System.arraycopy(chars, pos, b, off, count);
+                pos += count;
+                return count;
+            }
+        };
+    }
+
+    private AbstractPosixTerminal createTerminal() throws Exception {
+        Pty pty = EasyMock.createNiceMock(Pty.class);
+        EasyMock.expect(pty.getAttr()).andReturn(new Attributes()).anyTimes();
+        EasyMock.expect(pty.getSlaveInput())
+                .andReturn(new ByteArrayInputStream(new byte[0]))
+                .anyTimes();
+        EasyMock.expect(pty.getSlaveOutput())
+                .andReturn(new ByteArrayOutputStream())
+                .anyTimes();
+        EasyMock.replay(pty);
+        return new PosixSysTerminal("test", "ansi", pty, null, true, SignalHandler.SIG_DFL);
+    }
+}

--- a/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) the original author(s).
+ * Copyright (c) 2026, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/NullOutputCloseTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class NullOutputCloseTest {
+
+    @Test
+    void testCloseWithNullMasterOutput() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        ExternalTerminal terminal = new ExternalTerminal("test", "dumb", in, null, StandardCharsets.UTF_8);
+        assertDoesNotThrow(terminal::close);
+    }
+}

--- a/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) the original author(s).
+ * Copyright (c) 2026, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStyleTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AttributedStyleTest {
+
+    /**
+     * Verifies that chained RGB and indexed color updates produce the expected final styles.
+     */
+    @Test
+    void testMixedColors() {
+        assertEquals(
+                AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE),
+                AttributedStyle.DEFAULT.foregroundRgb(0xf00ff0).foreground(AttributedStyle.BLUE));
+        assertEquals(
+                AttributedStyle.DEFAULT.foregroundRgb(0x0ff00f),
+                AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE).foregroundRgb(0x0ff00f));
+        assertEquals(
+                AttributedStyle.DEFAULT.background(AttributedStyle.BLUE),
+                AttributedStyle.DEFAULT.backgroundRgb(0xf00ff0).background(AttributedStyle.BLUE));
+        assertEquals(
+                AttributedStyle.DEFAULT.backgroundRgb(0x0ff00f),
+                AttributedStyle.DEFAULT.background(AttributedStyle.BLUE).backgroundRgb(0x0ff00f));
+
+        AttributedString fgChained =
+                createColoredTestString(AttributedStyle::foreground, AttributedStyle::foregroundRgb);
+        AttributedString fgDefault = createColoredTestString(
+                (style, color) -> AttributedStyle.DEFAULT.foreground(color),
+                (style, rgb) -> AttributedStyle.DEFAULT.foregroundRgb(rgb));
+        AttributedString bgChained =
+                createColoredTestString(AttributedStyle::background, AttributedStyle::backgroundRgb);
+        AttributedString bgDefault = createColoredTestString(
+                (style, color) -> AttributedStyle.DEFAULT.background(color),
+                (style, rgb) -> AttributedStyle.DEFAULT.backgroundRgb(rgb));
+
+        assertEquals(fgChained, fgDefault);
+        assertEquals(bgChained, bgDefault);
+    }
+
+    /**
+     * Builds a sample attributed string that alternates indexed and RGB color changes.
+     *
+     * @param color the style update to apply for indexed colors
+     * @param rgbColor the style update to apply for RGB colors
+     * @return a test string with mixed color segments
+     */
+    private static AttributedString createColoredTestString(
+            BiFunction<AttributedStyle, Integer, AttributedStyle> color,
+            BiFunction<AttributedStyle, Integer, AttributedStyle> rgbColor) {
+        AttributedStringBuilder builder = new AttributedStringBuilder();
+        builder.append("a")
+                .style(style -> color.apply(style, AttributedStyle.GREEN))
+                .append("b")
+                .style(style -> rgbColor.apply(style, 0xffff00))
+                .append("c")
+                .style(style -> color.apply(style, AttributedStyle.RED))
+                .append("d")
+                .style(style -> rgbColor.apply(style, 0x00ffff))
+                .append("e")
+                .style(style -> color.apply(style, AttributedStyle.YELLOW))
+                .append("f")
+                .style(style -> rgbColor.apply(style, 0xff0000))
+                .append("g")
+                .style(style -> color.apply(style, AttributedStyle.GREEN))
+                .append("h");
+        return builder.toAttributedString();
+    }
+}


### PR DESCRIPTION
## Summary
- Backport 12 bugfixes from master to jline-3.x branch
- Fixes include: KeyMap bounds check, KillRing bounds, color parsing EOF, HTTP connection leak, LinkageError catch, AnsiConsole providers guard, waitDirty spurious wakeups, waitDirty timeout, Size casts, AttributedStyle color chaining, null masterOutput NPE, PTY close hang on macOS

## Cherry-picked commits
- fix: off-by-one bounds check in KeyMap.unbind()
- fix: prevent ArrayIndexOutOfBoundsException in KillRing.yankPop()
- fix: handle EOF in color parsing to prevent infinite loop
- fix: close HttpURLConnection in ConsoleEngineImpl.urlExists()
- fix: catch LinkageError during provider loading (#1751)
- fix: guard AnsiConsole.providers() call to avoid NoSuchMethodError (#1766)
- fix: guard waitDirty against spurious wakeups (#1765)
- fix: restore waitDirty timeout in forced dump to prevent busy-loop spinning (#1768)
- fix: remove spurious (short) casts in Size setters (#1791)
- fix: Fix AttributedStyle color chaining (#1792)
- fix: avoid NPE when closing terminal with null masterOutput (#1796, #1813)
- fix: close PTY streams before shutdown to prevent hang on macOS (#1808, #1817)