### PR TITLE
fix: add GraalVM native-image support for FFM terminal provider

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -58,3 +58,23 @@ jobs:
           mvnw.cmd --no-transfer-progress verify
         shell: cmd
         if: matrix.os == 'windows-latest'
+
+  native-image:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '23'
+          distribution: 'graalvm-community'
+          cache: maven
+
+      - name: Build and verify native image
+        run: |
+          ./mvnw -B --no-transfer-progress package -Pnative-image -DskipTests
+          ./graal/target/graal --check

--- a/graal/src/main/java/org/jline/demo/graal/Graal.java
+++ b/graal/src/main/java/org/jline/demo/graal/Graal.java
@@ -8,6 +8,8 @@
  */
 package org.jline.demo.graal;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -26,7 +28,9 @@ import org.jline.reader.impl.DefaultParser;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.Terminal.Signal;
 import org.jline.terminal.TerminalBuilder;
+import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalExt;
+import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.OSUtils;
 import org.jline.widget.TailTipWidgets;
 import org.jline.widget.TailTipWidgets.TipType;
@@ -35,6 +39,10 @@ import org.jline.widget.Widgets;
 public class Graal {
 
     public static void main(String[] args) {
+        if (args.length > 0 && "--check".equals(args[0])) {
+            check();
+            return;
+        }
         try {
             // Init log
             String fname = System.getProperty("java.util.logging.config.file");
@@ -123,6 +131,42 @@ public class Graal {
             systemRegistry.close();
         } catch (Throwable t) {
             t.printStackTrace();
+        }
+    }
+
+    @SuppressWarnings("java:S106")
+    private static void check() {
+        try {
+            TerminalProvider provider = null;
+            for (String name : new String[] {"ffm", "jni", "jansi", "jna", "exec"}) {
+                try {
+                    provider = TerminalProvider.load(name);
+                    break;
+                } catch (Throwable ignored) {
+                }
+            }
+            if (provider == null) {
+                throw new IllegalStateException("No terminal provider found");
+            }
+            System.out.println("Provider loaded: " + provider.name());
+
+            for (SystemStream stream : SystemStream.values()) {
+                System.out.println("  " + stream + " is system stream: " + provider.isSystemStream(stream));
+            }
+
+            Terminal terminal = TerminalBuilder.builder()
+                    .name("check")
+                    .system(false)
+                    .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream())
+                    .build();
+            System.out.println("Terminal created: " + terminal.getName() + " (" + terminal.getType() + ")");
+            terminal.close();
+
+            System.out.println("CHECK PASSED");
+        } catch (Throwable t) {
+            System.err.println("CHECK FAILED: " + t.getMessage());
+            t.printStackTrace(System.err);
+            System.exit(1);
         }
     }
 }

--- a/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
+++ b/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
@@ -1,0 +1,79 @@
+{
+  "reflection": [
+    {
+      "type": "org.jline.terminal.impl.ffm.FfmTerminalProvider",
+      "allDeclaredConstructors": true,
+      "allPublicConstructors": true
+    }
+  ],
+  "resources": [
+    {"glob": "META-INF/services/org/jline/terminal/provider/ffm"}
+  ],
+  "foreign": {
+    "downcalls": [
+      {
+        "returnType": "int",
+        "parameterTypes": ["int", "long long", "void*"],
+        "options": {
+          "firstVariadicArg": 2
+        }
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["int"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["int", "int", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["int", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["int", "void*", "long long"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "void*", "void*", "void*", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "int"]
+      },
+      {
+        "returnType": "void*",
+        "parameterTypes": ["int"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["int", "void*", "int", "int", "void*", "int", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "short"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": []
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "void*", "int", "void*", "void*"]
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "void*", "int", "void*"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Cherry-pick of #1804 from 3.30.x to jline-3.x
- Adds reachability-metadata.json with foreign downcall signatures for CLibrary and Kernel32 FFM functions
- Adds native-image CI job and --check smoke test mode to Graal demo