### PR TITLE
chore: add dependabot for 4.0.x maintenance branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,18 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "4.0.x"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "4.0.x"
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
     target-branch: "jline-3.x"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- Add maven and github-actions dependabot entries for the `4.0.x` maintenance branch
- Matches the existing configuration for `master` and `jline-3.x`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to check for updates daily across Maven and GitHub Actions ecosystems on the 4.0.x release branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->