### PR TITLE
fix: correct inverted bounds check in readBuffered methods (3.x backport)

### DIFF
--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
@@ -222,7 +222,7 @@ public abstract class NonBlockingInputStream extends InputStream {
     public int readBuffered(byte[] b, int off, int len, long timeout) throws IOException {
         if (b == null) {
             throw new NullPointerException();
-        } else if (off < 0 || len < 0 || off + len < b.length) {
+        } else if (off < 0 || len < 0 || len > b.length - off) {
             throw new IllegalArgumentException();
         } else if (len == 0) {
             return 0;

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpReader.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpReader.java
@@ -110,7 +110,7 @@ public class NonBlockingPumpReader extends NonBlockingReader {
     public int readBuffered(char[] b, int off, int len, long timeout) throws IOException {
         if (b == null) {
             throw new NullPointerException();
-        } else if (off < 0 || len < 0 || off + len < b.length) {
+        } else if (off < 0 || len < 0 || len > b.length - off) {
             throw new IllegalArgumentException();
         } else if (len == 0) {
             return 0;


### PR DESCRIPTION
## Summary

Cherry-pick of #1853 to `jline-3.x` maintenance branch.

- Fix inverted bounds check `off + len < b.length` → `len > b.length - off` in `readBuffered()` methods
- The old condition rejected valid calls (buffer larger than needed) and accepted invalid ones (off + len overflows the buffer)
- Affects `NonBlockingInputStream` and `NonBlockingPumpReader`