### PR TITLE
fix: prevent DA response bytes from leaking to parent shell (#1856)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -372,6 +372,9 @@ public interface Terminal extends Closeable, Flushable {
      * This is the standard way to read input from this terminal.
      * The reader is non blocking.
      *
+     * <p>The returned reader is owned by this terminal and will be closed
+     * when the terminal is closed. Callers should not close it directly.</p>
+     *
      * @return The non blocking reader
      */
     NonBlockingReader reader();
@@ -379,6 +382,9 @@ public interface Terminal extends Closeable, Flushable {
     /**
      * Retrieve the <code>Writer</code> for this terminal.
      * This is the standard way to write to this terminal.
+     *
+     * <p>The returned writer is owned by this terminal and will be closed
+     * when the terminal is closed. Callers should not close it directly.</p>
      *
      * @return The writer
      */
@@ -435,6 +441,9 @@ public interface Terminal extends Closeable, Flushable {
      * terminal input stream directly. In the usual cases,
      * use the {@link #reader()} instead.
      *
+     * <p>The returned stream is owned by this terminal and will be closed
+     * when the terminal is closed. Callers should not close it directly.</p>
+     *
      * @return The input stream
      *
      * @see #reader()
@@ -446,6 +455,9 @@ public interface Terminal extends Closeable, Flushable {
      * In some rare cases, there may be a need to access the
      * terminal output stream directly. In the usual cases,
      * use the {@link #writer()} instead.
+     *
+     * <p>The returned stream is owned by this terminal and will be closed
+     * when the terminal is closed. Callers should not close it directly.</p>
      *
      * @return The output stream
      *

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -251,13 +251,10 @@ public final class TerminalBuilder {
 
     public static final String PROP_GRAPHEME_CLUSTER = "org.jline.terminal.graphemeCluster";
 
-    // Graphics protocol properties
-    public static final String GRAPHICS_SIXEL_TIMEOUT = "org.jline.terminal.graphics.sixel.timeout";
-    public static final String GRAPHICS_SIXEL_SUBSEQUENT_TIMEOUT =
-            "org.jline.terminal.graphics.sixel.subsequent.timeout";
-    public static final String GRAPHICS_KITTY_TIMEOUT = "org.jline.terminal.graphics.kitty.timeout";
-    public static final String GRAPHICS_KITTY_SUBSEQUENT_TIMEOUT =
-            "org.jline.terminal.graphics.kitty.subsequent.timeout";
+    // Timeout for terminal probe queries (DECRQM, DA1, DSR/CPR)
+    public static final String PROP_PROBE_TIMEOUT = "org.jline.terminal.probe.timeout";
+    // Subsequent read timeout for consuming terminal response bytes
+    public static final String PROP_DRAIN_TIMEOUT = "org.jline.terminal.drain.timeout";
 
     //
     // Terminal output control

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -11,6 +11,7 @@ package org.jline.terminal.impl;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import org.jline.terminal.Attributes.InputFlag;
 import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Cursor;
 import org.jline.terminal.MouseEvent;
+import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.spi.TerminalExt;
 import org.jline.utils.AttributedCharSequence;
 import org.jline.utils.ColorPalette;
@@ -35,6 +37,7 @@ import org.jline.utils.Curses;
 import org.jline.utils.InfoCmp;
 import org.jline.utils.InfoCmp.Capability;
 import org.jline.utils.Log;
+import org.jline.utils.NonBlockingReader;
 import org.jline.utils.Status;
 import org.jline.utils.WCWidth;
 
@@ -456,9 +459,6 @@ public abstract class AbstractTerminal implements TerminalExt {
         if (TYPE_DUMB.equals(type) || TYPE_DUMB_COLOR.equals(type)) {
             return false;
         }
-        // Use minimal attributes to prevent echoing without setting VTIME=1
-        // (which would add 100ms latency per read). VMIN=0, VTIME=0 means
-        // reads return immediately when no data is available.
         Attributes prev = getAttributes();
         Attributes probeAttrs = new Attributes(prev);
         probeAttrs.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO), false);
@@ -477,9 +477,8 @@ public abstract class AbstractTerminal implements TerminalExt {
             }
             return false;
         } finally {
-            // Drain any remaining terminal response bytes to prevent them
-            // from leaking to the parent shell
-            drainUntilDA1(25, 200);
+            long drainTimeout = getLongProperty(TerminalBuilder.PROP_DRAIN_TIMEOUT, 25);
+            drainInput(reader(), drainTimeout, -1);
             setAttributes(prev);
         }
     }
@@ -516,48 +515,22 @@ public abstract class AbstractTerminal implements TerminalExt {
         if ("Apple_Terminal".equals(termProgram)) {
             return ProbeResult.NOT_SUPPORTED;
         }
-        try {
-            // Send DECRQM query for mode 2027 followed by DA1 as sentinel
-            writer().write("\033[?2027$p\033[c");
-            writer().flush();
-
-            // Read response — both DECRPM and DA1 start with ESC [ ?
-            // DECRPM: ESC [ ? 2 0 2 7 ; Ps $ y
-            // DA1:    ESC [ ? Pp ; ... c
-            long timeout = 100;
-            if (reader().peek(timeout) < 0) {
-                return ProbeResult.NO_RESPONSE;
-            }
-            int[] expected = {'\033', '[', '?', '2', '0', '2', '7', ';'};
-            for (int e : expected) {
-                int c = reader().read(timeout);
-                if (c != e) {
-                    // Not DECRPM — likely the DA1 sentinel response,
-                    // meaning the terminal does not support DECRQM.
-                    // Read remaining DA1 bytes until the 'c' terminator.
-                    drainUntilDA1(timeout, 500);
-                    return ProbeResult.NOT_SUPPORTED;
-                }
-            }
-            int ps = reader().read(timeout);
-            if (ps < '0' || ps > '4') {
-                drainUntilDA1(timeout, 500);
-                return ProbeResult.NOT_SUPPORTED;
-            }
-            int dollar = reader().read(timeout);
-            int y = reader().read(timeout);
-            if (dollar != '$' || y != 'y') {
-                drainUntilDA1(timeout, 500);
-                return ProbeResult.NOT_SUPPORTED;
-            }
-            // Drain the trailing DA1 sentinel response
-            drainUntilDA1(timeout, 500);
-            // Ps: 1=set, 2=reset (can be set), 3=permanently set → supported
-            // Ps: 0=not recognized, 4=permanently reset → not supported
-            return (ps == '1' || ps == '2' || ps == '3') ? ProbeResult.SUPPORTED : ProbeResult.NOT_SUPPORTED;
-        } catch (IOException e) {
+        // Send DECRQM query for mode 2027 followed by DA1 as sentinel.
+        // readTerminalResponse() reads until the DA1 terminator 'c', capturing
+        // both the DECRPM (ESC[?2027;Ps$y) and the DA1 response.
+        writer().write("\033[?2027$p\033[c");
+        writer().flush();
+        String response = readTerminalResponse();
+        if (response == null) {
             return ProbeResult.NO_RESPONSE;
         }
+        // DECRPM: ESC[?2027;Ps$y where Ps: 1=set, 2=reset (can be set), 3=permanently set
+        if (response.contains("\033[?2027;1$y")
+                || response.contains("\033[?2027;2$y")
+                || response.contains("\033[?2027;3$y")) {
+            return ProbeResult.SUPPORTED;
+        }
+        return ProbeResult.NOT_SUPPORTED;
     }
 
     /**
@@ -594,20 +567,21 @@ public abstract class AbstractTerminal implements TerminalExt {
         // observed together).  A flag probe alone catches partial support.
         String flagEmoji = "\uD83C\uDDEB\uD83C\uDDF7"; // 🇫🇷 French flag
         String zwjEmoji = "\uD83D\uDC69\u200D\uD83D\uDD2C"; // 👩‍🔬 woman scientist
+        long timeout = getLongProperty(TerminalBuilder.PROP_PROBE_TIMEOUT, 200);
         try {
             // Query current cursor column so we can compute displacement
             // rather than relying on the cursor starting at column 1
             puts(Capability.user7);
             writer().flush();
-            int startCol = readCprColumn(200);
+            int startCol = readCprColumn(timeout);
             if (startCol < 0) {
                 return false;
             }
 
             // --- Flag probe ---
-            int flagCol = probeEmojiWidth(flagEmoji, startCol);
+            int flagCol = probeEmojiWidth(flagEmoji, startCol, timeout);
             // --- ZWJ probe ---
-            int zwjCol = probeEmojiWidth(zwjEmoji, startCol);
+            int zwjCol = probeEmojiWidth(zwjEmoji, startCol, timeout);
 
             // Grouped emoji → 2-column displacement; ungrouped → 4
             groupsRegionalIndicators = (flagCol - startCol == 2);
@@ -637,13 +611,14 @@ public abstract class AbstractTerminal implements TerminalExt {
      * Writes a single emoji to the terminal, queries cursor position via
      * DSR/CPR, then cleans up. Returns the 1-based column value.
      */
-    private int probeEmojiWidth(String emoji, int startCol) throws IOException {
+    private int probeEmojiWidth(String emoji, int startCol, long timeout) throws IOException {
+        PrintWriter out = writer();
         puts(Capability.save_cursor);
-        writer().write(emoji);
+        out.write(emoji);
         puts(Capability.user7); // DSR — request cursor position
-        writer().flush();
+        out.flush();
 
-        int col = readCprColumn(200);
+        int col = readCprColumn(timeout);
 
         // Erase the probe glyphs: rewind, overwrite the occupied cells with
         // spaces, then rewind again to leave the cursor in the original saved position.
@@ -651,13 +626,13 @@ public abstract class AbstractTerminal implements TerminalExt {
         int width = col - startCol;
         if (width > 0) {
             for (int i = 0; i < width; i++) {
-                writer().write(' ');
+                out.write(' ');
             }
             puts(Capability.restore_cursor);
         } else {
             puts(Capability.clr_eol);
         }
-        writer().flush();
+        out.flush();
         return col;
     }
 
@@ -670,56 +645,91 @@ public abstract class AbstractTerminal implements TerminalExt {
      * parsed.</p>
      */
     private int readCprColumn(long timeout) throws IOException {
+        NonBlockingReader in = reader();
         int c;
         // Skip until ESC
-        while ((c = reader().read(timeout)) != '\033') {
+        while ((c = in.read(timeout)) != '\033') {
             if (c < 0) return -1;
         }
-        if (reader().read(timeout) != '[') return -1;
+        if (in.read(timeout) != '[') return -1;
         // Skip row digits until ';'
-        while ((c = reader().read(timeout)) != ';') {
+        while ((c = in.read(timeout)) != ';') {
             if (c < 0 || c == 'R') return -1;
         }
         // Read column digits until 'R'
         int col = 0;
-        while ((c = reader().read(timeout)) != 'R') {
+        while ((c = in.read(timeout)) != 'R') {
             if (c < '0' || c > '9') return -1;
             col = col * 10 + (c - '0');
         }
         return col;
     }
 
-    /**
-     * Discards input until a DA1 response terminator ('c') is encountered,
-     * the reader ends, or the overall timeout expires.
-     *
-     * @param perReadTimeout timeout for each individual read call
-     * @param overallTimeoutMs maximum total time to spend draining
-     */
-    private void drainUntilDA1(long perReadTimeout, long overallTimeoutMs) {
+    static long getLongProperty(String key, long defaultValue) {
+        try {
+            return Math.max(0L, Long.parseLong(System.getProperty(key, Long.toString(defaultValue))));
+        } catch (NumberFormatException ignored) {
+            return defaultValue;
+        }
+    }
+
+    String readTerminalResponse() {
+        long initialTimeout = getLongProperty(TerminalBuilder.PROP_PROBE_TIMEOUT, 200);
+        long subsequentTimeout = getLongProperty(TerminalBuilder.PROP_DRAIN_TIMEOUT, 25);
+        NonBlockingReader in = reader();
+        try {
+            StringBuilder response = new StringBuilder();
+            long deadline = System.currentTimeMillis() + initialTimeout;
+            long timeout = initialTimeout;
+            int c;
+
+            while ((c = in.read(timeout)) >= 0) {
+                response.append((char) c);
+
+                // Complete DA1 response: ESC[?...c or ESC[...c
+                String responseStr = response.toString();
+                if (responseStr.contains("\033[") && responseStr.endsWith("c")) {
+                    return responseStr;
+                }
+
+                if (response.length() > 200) break;
+
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) break;
+                timeout = Math.min(subsequentTimeout, remaining);
+            }
+
+            return response.length() > 0 ? response.toString() : null;
+        } catch (IOException ignored) {
+            // Best-effort read; errors are expected when the stream is closed
+            return null;
+        }
+    }
+
+    static void drainInput(NonBlockingReader reader, long overallTimeoutMs, int stopChar) {
         try {
             long deadline = System.currentTimeMillis() + overallTimeoutMs;
             long remaining;
             while ((remaining = deadline - System.currentTimeMillis()) > 0) {
-                int c = reader().read(Math.min(perReadTimeout, remaining));
-                if (c < 0 || c == 'c') {
-                    return;
-                }
+                int c = reader.read(remaining);
+                if (c < 0 || c == stopChar) return;
             }
         } catch (IOException ignored) {
+            // Best-effort drain; errors are expected when the stream is closed
         }
     }
 
     /** {@inheritDoc} */
     @Override
     public boolean setGraphemeClusterMode(boolean enable, boolean force) {
+        PrintWriter out = writer();
         if (force) {
             graphemeClusterModeSupported = true;
             // If Mode 2027 was active via escape sequences, disable it
             // before switching to native mode
             if (!enable && graphemeClusterModeEnabled && !graphemeClusterNative) {
-                writer().write("\033[?2027l");
-                writer().flush();
+                out.write("\033[?2027l");
+                out.flush();
             }
             graphemeClusterNative = true;
             graphemeClusterModeEnabled = enable;
@@ -729,8 +739,8 @@ public abstract class AbstractTerminal implements TerminalExt {
         }
         if (supportsGraphemeClusterMode()) {
             if (!graphemeClusterNative) {
-                writer().write(enable ? "\033[?2027h" : "\033[?2027l");
-                writer().flush();
+                out.write(enable ? "\033[?2027h" : "\033[?2027l");
+                out.flush();
                 // Mode 2027 handles all emoji categories
                 groupsRegionalIndicators = enable;
                 groupsZwjSequences = enable;

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -456,8 +456,15 @@ public abstract class AbstractTerminal implements TerminalExt {
         if (TYPE_DUMB.equals(type) || TYPE_DUMB_COLOR.equals(type)) {
             return false;
         }
-        // Enter raw mode to prevent the terminal response from being echoed.
-        Attributes prev = enterRawMode();
+        // Use minimal attributes to prevent echoing without setting VTIME=1
+        // (which would add 100ms latency per read). VMIN=0, VTIME=0 means
+        // reads return immediately when no data is available.
+        Attributes prev = getAttributes();
+        Attributes probeAttrs = new Attributes(prev);
+        probeAttrs.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO), false);
+        probeAttrs.setControlChar(ControlChar.VMIN, 0);
+        probeAttrs.setControlChar(ControlChar.VTIME, 0);
+        setAttributes(probeAttrs);
         try {
             ProbeResult mode2027 = probeMode2027();
             if (mode2027 == ProbeResult.SUPPORTED) {
@@ -470,6 +477,9 @@ public abstract class AbstractTerminal implements TerminalExt {
             }
             return false;
         } finally {
+            // Drain any remaining terminal response bytes to prevent them
+            // from leaking to the parent shell
+            drainUntilDA1(25, 200);
             setAttributes(prev);
         }
     }
@@ -525,23 +535,23 @@ public abstract class AbstractTerminal implements TerminalExt {
                     // Not DECRPM — likely the DA1 sentinel response,
                     // meaning the terminal does not support DECRQM.
                     // Read remaining DA1 bytes until the 'c' terminator.
-                    drainUntilDA1(timeout);
+                    drainUntilDA1(timeout, 500);
                     return ProbeResult.NOT_SUPPORTED;
                 }
             }
             int ps = reader().read(timeout);
             if (ps < '0' || ps > '4') {
-                drainUntilDA1(timeout);
+                drainUntilDA1(timeout, 500);
                 return ProbeResult.NOT_SUPPORTED;
             }
             int dollar = reader().read(timeout);
             int y = reader().read(timeout);
             if (dollar != '$' || y != 'y') {
-                drainUntilDA1(timeout);
+                drainUntilDA1(timeout, 500);
                 return ProbeResult.NOT_SUPPORTED;
             }
             // Drain the trailing DA1 sentinel response
-            drainUntilDA1(timeout);
+            drainUntilDA1(timeout, 500);
             // Ps: 1=set, 2=reset (can be set), 3=permanently set → supported
             // Ps: 0=not recognized, 4=permanently reset → not supported
             return (ps == '1' || ps == '2' || ps == '3') ? ProbeResult.SUPPORTED : ProbeResult.NOT_SUPPORTED;
@@ -680,18 +690,19 @@ public abstract class AbstractTerminal implements TerminalExt {
     }
 
     /**
-     * Discards input until a DA1 response terminator ('c') is encountered or the reader ends.
+     * Discards input until a DA1 response terminator ('c') is encountered,
+     * the reader ends, or the overall timeout expires.
      *
-     * Reads bytes from the terminal via reader().read(timeout) and stops when the character
-     * 'c' is seen or the reader returns a negative value. IOExceptions during draining are ignored.
-     *
-     * @param timeout the per-read timeout value passed to the reader
+     * @param perReadTimeout timeout for each individual read call
+     * @param overallTimeoutMs maximum total time to spend draining
      */
-    private void drainUntilDA1(long timeout) {
+    private void drainUntilDA1(long perReadTimeout, long overallTimeoutMs) {
         try {
-            int c;
-            while ((c = reader().read(timeout)) >= 0) {
-                if (c == 'c') {
+            long deadline = System.currentTimeMillis() + overallTimeoutMs;
+            long remaining;
+            while ((remaining = deadline - System.currentTimeMillis()) > 0) {
+                int c = reader().read(Math.min(perReadTimeout, remaining));
+                if (c < 0 || c == 'c') {
                     return;
                 }
             }

--- a/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
@@ -133,8 +133,19 @@ public class SixelGraphics implements TerminalGraphics {
 
         org.jline.terminal.Attributes originalAttributes = null;
         try {
-            // Enter raw mode to prevent echo and ensure clean query transmission
-            originalAttributes = terminal.enterRawMode();
+            // Use minimal attributes to prevent echoing without setting VTIME=1
+            // (which would add 100ms latency per read). VMIN=0, VTIME=0 means
+            // reads return immediately when no data is available.
+            originalAttributes = terminal.getAttributes();
+            org.jline.terminal.Attributes probeAttrs = new org.jline.terminal.Attributes(originalAttributes);
+            probeAttrs.setLocalFlags(
+                    java.util.EnumSet.of(
+                            org.jline.terminal.Attributes.LocalFlag.ICANON,
+                            org.jline.terminal.Attributes.LocalFlag.ECHO),
+                    false);
+            probeAttrs.setControlChar(org.jline.terminal.Attributes.ControlChar.VMIN, 0);
+            probeAttrs.setControlChar(org.jline.terminal.Attributes.ControlChar.VTIME, 0);
+            terminal.setAttributes(probeAttrs);
 
             // Send Device Attributes query (same method as lsix command)
             terminal.writer().print("\033[c");
@@ -143,25 +154,38 @@ public class SixelGraphics implements TerminalGraphics {
             // Read response with configurable timeout (default: 200ms for faster response)
             long timeoutMs = Long.parseLong(System.getProperty(GRAPHICS_SIXEL_TIMEOUT, "200"));
             long subsequentTimeoutMs = Long.parseLong(System.getProperty(GRAPHICS_SIXEL_SUBSEQUENT_TIMEOUT, "25"));
+            Boolean result = null;
             String response = readTerminalResponse(terminal, timeoutMs, subsequentTimeoutMs);
             if (response != null) {
                 // Look for code "4" which indicates Sixel graphics support
                 // Response format: ESC[?1;2;4;6;9;15;18;21;22c
                 // Code "4" = Sixel graphics support
-                return response.contains(";4;") || response.contains(";4c");
+                result = response.contains(";4;") || response.contains(";4c");
             }
 
-            return null; // Detection failed/timed out
+            return result;
 
         } catch (Exception e) {
             // If runtime detection fails, return null to fall back to static detection
             return null;
         } finally {
-            // Always restore original terminal attributes
+            // Drain any remaining response bytes to prevent leaking to parent shell,
+            // then restore original terminal attributes
             if (originalAttributes != null) {
                 try {
+                    NonBlockingReader reader = terminal.reader();
+                    long deadline = System.currentTimeMillis() + 200;
+                    long remaining;
+                    while ((remaining = deadline - System.currentTimeMillis()) > 0) {
+                        int c = reader.read(Math.min(25, remaining));
+                        if (c < 0) break;
+                    }
+                } catch (Exception ignored) {
+                    // Best-effort drain
+                }
+                try {
                     terminal.setAttributes(originalAttributes);
-                } catch (Exception e) {
+                } catch (Exception ignored) {
                     // Ignore errors during attribute restoration
                 }
             }

--- a/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
@@ -16,16 +16,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import javax.imageio.ImageIO;
 
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.ControlChar;
+import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Terminal;
-import org.jline.utils.NonBlockingReader;
-
-import static org.jline.terminal.TerminalBuilder.GRAPHICS_SIXEL_SUBSEQUENT_TIMEOUT;
-import static org.jline.terminal.TerminalBuilder.GRAPHICS_SIXEL_TIMEOUT;
+import org.jline.terminal.TerminalBuilder;
 
 /**
  * Implementation of the Sixel Graphics Protocol.
@@ -131,65 +132,44 @@ public class SixelGraphics implements TerminalGraphics {
             return null; // Skip runtime detection, fall back to static detection
         }
 
-        org.jline.terminal.Attributes originalAttributes = null;
+        Attributes originalAttributes = null;
+        Boolean result = null;
         try {
-            // Use minimal attributes to prevent echoing without setting VTIME=1
-            // (which would add 100ms latency per read). VMIN=0, VTIME=0 means
-            // reads return immediately when no data is available.
             originalAttributes = terminal.getAttributes();
-            org.jline.terminal.Attributes probeAttrs = new org.jline.terminal.Attributes(originalAttributes);
-            probeAttrs.setLocalFlags(
-                    java.util.EnumSet.of(
-                            org.jline.terminal.Attributes.LocalFlag.ICANON,
-                            org.jline.terminal.Attributes.LocalFlag.ECHO),
-                    false);
-            probeAttrs.setControlChar(org.jline.terminal.Attributes.ControlChar.VMIN, 0);
-            probeAttrs.setControlChar(org.jline.terminal.Attributes.ControlChar.VTIME, 0);
+            Attributes probeAttrs = new Attributes(originalAttributes);
+            probeAttrs.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO), false);
+            probeAttrs.setControlChar(ControlChar.VMIN, 0);
+            probeAttrs.setControlChar(ControlChar.VTIME, 0);
             terminal.setAttributes(probeAttrs);
 
-            // Send Device Attributes query (same method as lsix command)
+            // Send Device Attributes query
             terminal.writer().print("\033[c");
             terminal.writer().flush();
 
-            // Read response with configurable timeout (default: 200ms for faster response)
-            long timeoutMs = Long.parseLong(System.getProperty(GRAPHICS_SIXEL_TIMEOUT, "200"));
-            long subsequentTimeoutMs = Long.parseLong(System.getProperty(GRAPHICS_SIXEL_SUBSEQUENT_TIMEOUT, "25"));
-            Boolean result = null;
-            String response = readTerminalResponse(terminal, timeoutMs, subsequentTimeoutMs);
+            // Read response with configurable timeout
+            String response = ((AbstractTerminal) terminal).readTerminalResponse();
             if (response != null) {
-                // Look for code "4" which indicates Sixel graphics support
-                // Response format: ESC[?1;2;4;6;9;15;18;21;22c
+                // Response format: ESC[?Pp;Ps1;Ps2;...c
                 // Code "4" = Sixel graphics support
-                result = response.contains(";4;") || response.contains(";4c");
+                result = response.contains(";4;")
+                        || response.contains(";4c")
+                        || response.contains("?4;")
+                        || response.contains("?4c");
             }
-
-            return result;
-
         } catch (Exception e) {
             // If runtime detection fails, return null to fall back to static detection
-            return null;
         } finally {
-            // Drain any remaining response bytes to prevent leaking to parent shell,
-            // then restore original terminal attributes
+            long drainTimeout = AbstractTerminal.getLongProperty(TerminalBuilder.PROP_DRAIN_TIMEOUT, 25);
+            AbstractTerminal.drainInput(terminal.reader(), drainTimeout, -1);
             if (originalAttributes != null) {
                 try {
-                    NonBlockingReader reader = terminal.reader();
-                    long deadline = System.currentTimeMillis() + 200;
-                    long remaining;
-                    while ((remaining = deadline - System.currentTimeMillis()) > 0) {
-                        int c = reader.read(Math.min(25, remaining));
-                        if (c < 0) break;
-                    }
-                } catch (Exception ignored) {
-                    // Best-effort drain
-                }
-                try {
                     terminal.setAttributes(originalAttributes);
-                } catch (Exception ignored) {
+                } catch (Exception e) {
                     // Ignore errors during attribute restoration
                 }
             }
         }
+        return result;
     }
 
     /**
@@ -721,40 +701,4 @@ public class SixelGraphics implements TerminalGraphics {
      * @param timeoutMs timeout in milliseconds
      * @return the response string, or null if timeout/error
      */
-    private static String readTerminalResponse(Terminal terminal, long timeoutMs, long subsequentTimeoutMs)
-            throws IOException {
-        try {
-            NonBlockingReader reader = terminal.reader();
-            StringBuilder response = new StringBuilder();
-
-            long startTime = System.currentTimeMillis();
-            int c;
-
-            // Read characters until we get a complete response or timeout
-            while ((c = reader.read(timeoutMs)) >= 0) {
-                response.append((char) c);
-
-                // Check if we have a complete Device Attributes response
-                // Format: ESC[?...c or ESC[...c
-                String responseStr = response.toString();
-                if (responseStr.contains("\033[") && responseStr.endsWith("c")) {
-                    return responseStr;
-                }
-
-                // Safety check: don't read forever
-                if (response.length() > 200 || (System.currentTimeMillis() - startTime) > timeoutMs) {
-                    break;
-                }
-
-                // Use shorter timeout for subsequent characters (configurable)
-                timeoutMs = subsequentTimeoutMs;
-            }
-
-            // Return what we got, even if incomplete
-            return response.length() > 0 ? response.toString() : null;
-
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Fixes #1856 — `TerminalGraphicsManager.getBestProtocol()` leaks DA response bytes to the parent shell.

This PR is structured as two commits for merge/rebase (not squash):

### Commit 1: `fix: prevent DA response bytes from leaking to parent shell (#1856)`

Minimal fix targeting the core bug:

- **Minimal probe attributes**: Use `ICANON=false, ECHO=false, VMIN=0, VTIME=0` instead of `enterRawMode()` — avoids the 100ms VTIME=1 delay that made draining unreliable
- **Drain in finally blocks**: Both `probeGraphemeClusterMode()` and `detectSixelSupportRuntime()` now drain pending DA1 responses in their finally blocks
- **`drainUntilDA1(perReadTimeout, overallTimeoutMs)`**: New two-parameter drain method with an overall timeout to prevent infinite loops if no DA1 response arrives
- **All existing callers updated** to use the new two-parameter signature

### Commit 2: `refactor: unify terminal probe response handling`

Follow-up refactoring that improves the probe infrastructure:

- **`readTerminalResponse()`**: Instance method on AbstractTerminal with two-timeout pattern (long initial wait, short subsequent reads), configurable via system properties
- **`drainInput(reader, timeout, stopChar)`**: Unified static drain method with optional stop character
- **`probeMode2027()` simplified**: Uses string matching (`contains()`) instead of regex parsing
- **SixelGraphics delegates** to AbstractTerminal's shared methods instead of duplicating logic
- **System properties**: `org.jline.terminal.probe.timeout` (200ms default), `org.jline.terminal.drain.timeout` (25ms default), replacing four separate sixel/kitty timeout properties
- **Javadoc**: Added ownership documentation to `Terminal.reader()`, `writer()`, `input()`, `output()`