### PR TITLE
fix: prevent DA response bytes from leaking to parent shell (#1856)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -456,8 +456,15 @@ public abstract class AbstractTerminal implements TerminalExt {
         if (TYPE_DUMB.equals(type) || TYPE_DUMB_COLOR.equals(type)) {
             return false;
         }
-        // Enter raw mode to prevent the terminal response from being echoed.
-        Attributes prev = enterRawMode();
+        // Use minimal attributes to prevent echoing without setting VTIME=1
+        // (which would add 100ms latency per read). VMIN=0, VTIME=0 means
+        // reads return immediately when no data is available.
+        Attributes prev = getAttributes();
+        Attributes probeAttrs = new Attributes(prev);
+        probeAttrs.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO), false);
+        probeAttrs.setControlChar(ControlChar.VMIN, 0);
+        probeAttrs.setControlChar(ControlChar.VTIME, 0);
+        setAttributes(probeAttrs);
         try {
             ProbeResult mode2027 = probeMode2027();
             if (mode2027 == ProbeResult.SUPPORTED) {
@@ -470,6 +477,9 @@ public abstract class AbstractTerminal implements TerminalExt {
             }
             return false;
         } finally {
+            // Drain any remaining terminal response bytes to prevent them
+            // from leaking to the parent shell
+            drainUntilDA1(25, 200);
             setAttributes(prev);
         }
     }
@@ -525,23 +535,23 @@ public abstract class AbstractTerminal implements TerminalExt {
                     // Not DECRPM — likely the DA1 sentinel response,
                     // meaning the terminal does not support DECRQM.
                     // Read remaining DA1 bytes until the 'c' terminator.
-                    drainUntilDA1(timeout);
+                    drainUntilDA1(timeout, 500);
                     return ProbeResult.NOT_SUPPORTED;
                 }
             }
             int ps = reader().read(timeout);
             if (ps < '0' || ps > '4') {
-                drainUntilDA1(timeout);
+                drainUntilDA1(timeout, 500);
                 return ProbeResult.NOT_SUPPORTED;
             }
             int dollar = reader().read(timeout);
             int y = reader().read(timeout);
             if (dollar != '$' || y != 'y') {
-                drainUntilDA1(timeout);
+                drainUntilDA1(timeout, 500);
                 return ProbeResult.NOT_SUPPORTED;
             }
             // Drain the trailing DA1 sentinel response
-            drainUntilDA1(timeout);
+            drainUntilDA1(timeout, 500);
             // Ps: 1=set, 2=reset (can be set), 3=permanently set → supported
             // Ps: 0=not recognized, 4=permanently reset → not supported
             return (ps == '1' || ps == '2' || ps == '3') ? ProbeResult.SUPPORTED : ProbeResult.NOT_SUPPORTED;
@@ -680,18 +690,19 @@ public abstract class AbstractTerminal implements TerminalExt {
     }
 
     /**
-     * Discards input until a DA1 response terminator ('c') is encountered or the reader ends.
+     * Discards input until a DA1 response terminator ('c') is encountered,
+     * the reader ends, or the overall timeout expires.
      *
-     * Reads bytes from the terminal via reader().read(timeout) and stops when the character
-     * 'c' is seen or the reader returns a negative value. IOExceptions during draining are ignored.
-     *
-     * @param timeout the per-read timeout value passed to the reader
+     * @param perReadTimeout timeout for each individual read call
+     * @param overallTimeoutMs maximum total time to spend draining
      */
-    private void drainUntilDA1(long timeout) {
+    private void drainUntilDA1(long perReadTimeout, long overallTimeoutMs) {
         try {
-            int c;
-            while ((c = reader().read(timeout)) >= 0) {
-                if (c == 'c') {
+            long deadline = System.currentTimeMillis() + overallTimeoutMs;
+            long remaining;
+            while ((remaining = deadline - System.currentTimeMillis()) > 0) {
+                int c = reader().read(Math.min(perReadTimeout, remaining));
+                if (c < 0 || c == 'c') {
                     return;
                 }
             }

--- a/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
@@ -133,8 +133,19 @@ public class SixelGraphics implements TerminalGraphics {
 
         org.jline.terminal.Attributes originalAttributes = null;
         try {
-            // Enter raw mode to prevent echo and ensure clean query transmission
-            originalAttributes = terminal.enterRawMode();
+            // Use minimal attributes to prevent echoing without setting VTIME=1
+            // (which would add 100ms latency per read). VMIN=0, VTIME=0 means
+            // reads return immediately when no data is available.
+            originalAttributes = terminal.getAttributes();
+            org.jline.terminal.Attributes probeAttrs = new org.jline.terminal.Attributes(originalAttributes);
+            probeAttrs.setLocalFlags(
+                    java.util.EnumSet.of(
+                            org.jline.terminal.Attributes.LocalFlag.ICANON,
+                            org.jline.terminal.Attributes.LocalFlag.ECHO),
+                    false);
+            probeAttrs.setControlChar(org.jline.terminal.Attributes.ControlChar.VMIN, 0);
+            probeAttrs.setControlChar(org.jline.terminal.Attributes.ControlChar.VTIME, 0);
+            terminal.setAttributes(probeAttrs);
 
             // Send Device Attributes query (same method as lsix command)
             terminal.writer().print("\033[c");
@@ -143,25 +154,38 @@ public class SixelGraphics implements TerminalGraphics {
             // Read response with configurable timeout (default: 200ms for faster response)
             long timeoutMs = Long.parseLong(System.getProperty(GRAPHICS_SIXEL_TIMEOUT, "200"));
             long subsequentTimeoutMs = Long.parseLong(System.getProperty(GRAPHICS_SIXEL_SUBSEQUENT_TIMEOUT, "25"));
+            Boolean result = null;
             String response = readTerminalResponse(terminal, timeoutMs, subsequentTimeoutMs);
             if (response != null) {
                 // Look for code "4" which indicates Sixel graphics support
                 // Response format: ESC[?1;2;4;6;9;15;18;21;22c
                 // Code "4" = Sixel graphics support
-                return response.contains(";4;") || response.contains(";4c");
+                result = response.contains(";4;") || response.contains(";4c");
             }
 
-            return null; // Detection failed/timed out
+            return result;
 
         } catch (Exception e) {
             // If runtime detection fails, return null to fall back to static detection
             return null;
         } finally {
-            // Always restore original terminal attributes
+            // Drain any remaining response bytes to prevent leaking to parent shell,
+            // then restore original terminal attributes
             if (originalAttributes != null) {
                 try {
+                    NonBlockingReader reader = terminal.reader();
+                    long deadline = System.currentTimeMillis() + 200;
+                    long remaining;
+                    while ((remaining = deadline - System.currentTimeMillis()) > 0) {
+                        int c = reader.read(Math.min(25, remaining));
+                        if (c < 0) break;
+                    }
+                } catch (Exception ignored) {
+                    // Best-effort drain
+                }
+                try {
                     terminal.setAttributes(originalAttributes);
-                } catch (Exception e) {
+                } catch (Exception ignored) {
                     // Ignore errors during attribute restoration
                 }
             }


### PR DESCRIPTION
## Summary

Minimal backport of #1857 for the 4.0.x maintenance branch.

- Replace `enterRawMode()` with minimal terminal attributes (ICANON+ECHO off, VMIN=0, VTIME=0) in both `probeGraphemeClusterMode()` and `detectSixelSupportRuntime()` — avoids the 100ms per-read delay caused by VTIME=1
- Add drain in `finally` blocks to consume any remaining DA response bytes before restoring attributes, preventing them from leaking to the parent shell
- Add overall timeout to `drainUntilDA1()` to prevent indefinite hanging if the terminal sends unexpected data

Fixes #1856