### PR TITLE
fix: remove proactive isNativeAccessEnabled() checks from terminal providers

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmTerminalProvider.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.charset.Charset;
@@ -30,10 +31,18 @@ import org.jline.utils.Signals;
 
 public class FfmTerminalProvider implements TerminalProvider {
 
+    @SuppressWarnings("restricted")
     public FfmTerminalProvider() {
-        if (!FfmTerminalProvider.class.getModule().isNativeAccessEnabled()) {
+        // Probe restricted FFM access so the provider fails at load time
+        // when native access is denied (JDK 26+), rather than later during use.
+        // On JDK 24-25, this succeeds with a JVM warning.
+        try {
+            MemorySegment.NULL.reinterpret(0);
+        } catch (UnsupportedOperationException | IllegalCallerException e) {
             throw new UnsupportedOperationException(
-                    "Native access is not enabled for the current module: " + FfmTerminalProvider.class.getModule());
+                    "FFM native access is not available. Use --enable-native-access=ALL-UNNAMED or"
+                            + " --enable-native-access=org.jline.terminal.ffm to enable it.",
+                    e);
         }
     }
 

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniTerminalProvider.java
@@ -11,7 +11,6 @@ package org.jline.terminal.impl.jni;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 
 import org.jline.nativ.JLineNativeLoader;
@@ -55,55 +54,21 @@ public class JniTerminalProvider implements TerminalProvider {
     /**
      * Creates a new JNI terminal provider instance and ensures the native library is loaded.
      * <p>
-     * The constructor first checks that native access is enabled for this module. On JDK 22+,
-     * calling {@code System.load()} without {@code --enable-native-access} produces a warning
-     * (JDK 24+) or throws {@code IllegalCallerException} (JDK 26+). By checking upfront, this
-     * provider fails cleanly and allows {@link TerminalBuilder} to fall back to other providers.
-     *
-     * @throws UnsupportedOperationException if native access is not enabled for this module
+     * Loading the native library via {@link JLineNativeLoader#initialize()} calls
+     * {@code System.loadLibrary()}, which is a restricted operation. On JDK 24-25 this
+     * produces a JVM warning when {@code --enable-native-access} is not set. On future JDKs
+     * where native access is denied by default, the load will fail and
+     * {@link TerminalBuilder} will fall back to other providers.
      */
     public JniTerminalProvider() {
-        checkNativeAccess();
         // Ensure the native library is loaded
-        JLineNativeLoader.initialize();
-    }
-
-    /**
-     * Checks that native access is enabled for this module.
-     * JNI native access restrictions are only enforced from JDK 24+, so the check
-     * is skipped on earlier versions. Uses reflection because
-     * {@code Module.isNativeAccessEnabled()} is not available on all JDK versions.
-     * In GraalVM native images, the check is also skipped since native libraries
-     * are handled at build time.
-     *
-     * @throws UnsupportedOperationException if native access is not enabled
-     */
-    static void checkNativeAccess() {
-        // In GraalVM native images, native libraries are linked at build time,
-        // so runtime native access checks are not applicable
-        if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
-            return;
-        }
-        // JNI native access restrictions are only enforced starting from JDK 24.
-        // Some JDK 21 builds (e.g. 21.0.10) backported Module.isNativeAccessEnabled(),
-        // but it returns false even though JNI works fine without --enable-native-access.
-        // See https://github.com/jline/jline3/issues/1689
-        if (Runtime.version().feature() < 24) {
-            return;
-        }
         try {
-            Method m = Module.class.getMethod("isNativeAccessEnabled");
-            Boolean enabled = (Boolean) m.invoke(JniTerminalProvider.class.getModule());
-            if (!enabled) {
-                throw new UnsupportedOperationException("Native access is not enabled for the current module: "
-                        + JniTerminalProvider.class.getModule());
-            }
-        } catch (NoSuchMethodException e) {
-            // Method not available, no native access restrictions
-        } catch (UnsupportedOperationException e) {
-            throw e;
-        } catch (ReflectiveOperationException e) {
-            // Unexpected reflection error, proceed anyway
+            JLineNativeLoader.initialize();
+        } catch (UnsupportedOperationException | IllegalCallerException e) {
+            throw new UnsupportedOperationException(
+                    "JNI native access is not available. Use --enable-native-access=ALL-UNNAMED or"
+                            + " --enable-native-access=org.jline.terminal.jni to enable it.",
+                    e);
         }
     }
 

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -14,7 +14,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 
 import org.jline.nativ.JLineLibrary;
@@ -663,7 +662,6 @@ public class ExecTerminalProvider implements TerminalProvider {
 
     static class NativeRedirectPipeCreator implements RedirectPipeCreator {
         public NativeRedirectPipeCreator() {
-            checkNativeAccess();
             // Force load the library
             JLineNativeLoader.initialize();
         }
@@ -671,38 +669,6 @@ public class ExecTerminalProvider implements TerminalProvider {
         @Override
         public ProcessBuilder.Redirect newRedirectPipe(FileDescriptor fd) {
             return JLineLibrary.newRedirectPipe(fd);
-        }
-    }
-
-    /**
-     * Checks that native access is enabled for this module.
-     * JNI native access restrictions are only enforced from JDK 24+, so the check
-     * is skipped on earlier versions. Uses reflection because
-     * {@code Module.isNativeAccessEnabled()} is not available on all JDK versions.
-     *
-     * @throws UnsupportedOperationException if native access is not enabled
-     */
-    static void checkNativeAccess() {
-        // JNI native access restrictions are only enforced starting from JDK 24.
-        // Some JDK 21 builds (e.g. 21.0.10) backported Module.isNativeAccessEnabled(),
-        // but it returns false even though JNI works fine without --enable-native-access.
-        // See https://github.com/jline/jline3/issues/1689
-        if (Runtime.version().feature() < 24) {
-            return;
-        }
-        try {
-            Method m = Module.class.getMethod("isNativeAccessEnabled");
-            Boolean enabled = (Boolean) m.invoke(ExecTerminalProvider.class.getModule());
-            if (!enabled) {
-                throw new UnsupportedOperationException("Native access is not enabled for the current module: "
-                        + ExecTerminalProvider.class.getModule());
-            }
-        } catch (NoSuchMethodException e) {
-            // Method not available, no native access restrictions
-        } catch (UnsupportedOperationException e) {
-            throw e;
-        } catch (ReflectiveOperationException e) {
-            // Unexpected reflection error, proceed anyway
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #1846 — tab completion broken on JDK 25 (and 24) without `--enable-native-access`.

On JDK 24-25, `Module.isNativeAccessEnabled()` returns `false` when `--enable-native-access` is not set, even though native calls still succeed in warn mode (JEP 472). The proactive checks in FFM, JNI, and Exec terminal providers caused them to reject themselves unnecessarily. This left only the Exec provider (which cannot detect a Windows TTY), resulting in a silent fallback to a dumb terminal with no tab completion.

**Changes:**
- Remove `isNativeAccessEnabled()` guard from `FfmTerminalProvider` constructor
- Remove `checkNativeAccess()` method and call from `JniTerminalProvider` constructor
- Remove `checkNativeAccess()` method and call from `ExecTerminalProvider.NativeRedirectPipeCreator`

The actual native FFM/JNI calls will naturally fail and be caught by `TerminalBuilder.checkProvider()` on future JDKs where native access is denied by default.

## Test plan

- [x] `mvn test -pl terminal,terminal-ffm,terminal-jni` passes
- [ ] On JDK 25 without `--enable-native-access`, FFM/JNI providers should load (with JVM warnings) and tab completion should work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Terminal providers no longer run upfront native-access prechecks during initialization; native capability is probed at runtime.
  * Construction proceeds more flexibly and surfaces immediate failures when native access is restricted.

* **Bug Fix**
  * Failure messages for restricted native access are clearer and include actionable guidance to enable native access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->