### PR TITLE
Fix status bar duplication after vertical resize

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -159,6 +159,13 @@ public class Status {
                     clearStart = Math.min(clearStart, oldScrollRegion + 1);
                 }
                 if (effectiveLines > 0) {
+                    // When the terminal height shrinks, some terminal emulators
+                    // preserve the old bottom status line just above the new
+                    // status area.  Clear one status-height band above the
+                    // status area so the next redraw does not leave duplicates.
+                    if (newRows < oldRows) {
+                        clearStart = Math.min(clearStart, Math.max(0, scrollRegion + 1 - effectiveLines));
+                    }
                     // Account for wrapped status lines when width decreased
                     if (display.columns < oldColumns) {
                         int wrappedPerLine = (oldColumns + display.columns - 1) / display.columns;


### PR DESCRIPTION
## Summary

Fix stale status bar rows after vertical terminal resize.

When the terminal height shrinks, some terminal emulators keep the old bottom status line just above the new status area. JLine then redraws the status bar at the new bottom row, which leaves duplicated status bar rows in the main terminal area.

This change clears one status-height band above the new status area during `Status.resize(...)` when the terminal height shrinks.

before : 
<img width="1030" height="297" alt="image" src="https://github.com/user-attachments/assets/1df712f5-f1cb-44df-a599-a7350ca8ab9b" />

after : 
<img width="912" height="231" alt="image" src="https://github.com/user-attachments/assets/1ce7fd48-85b0-4664-a74e-a1d6eda8c679" />



## Reproduction

A small app using `Status` with `LineReader.readLine()` can reproduce the issue:

```java
Terminal terminal = TerminalBuilder.builder()
        .name("jline-status-resize-repro")
        .system(true)
        .dumb(false)
        .exec(true)
        .build();

Status status = Status.getStatus(terminal, true);

LineReader reader = LineReaderBuilder.builder()
        .terminal(terminal)
        .appName("jline-status-resize-repro")
        .build();

reader.getWidgets().put(LineReader.CALLBACK_INIT, () -> {
    status.update(
            Collections.singletonList(new AttributedString("viins | 1:0 | NOLOG | NOLOG")),
            true);
    return true;
});

while (true) {
    String line = reader.readLine("SQL> ");
    if (line == null || "exit".equalsIgnoreCase(line.trim())) {
        break;
    }
    reader.printAbove("accepted: " + line);
}

Steps:

Run the reproducer in macOS Terminal.
Wait at the SQL> prompt with the status bar visible.
Resize the terminal vertically smaller/larger.
Before this fix, duplicate status bar rows can remain above the prompt.
After this fix, the stale status row is cleared and only the bottom status bar remains.


Fix
Status.resize(Size) already clears old status remnants when the width decreases or the terminal height grows.

This patch adds the missing shrink case:

detect when the new terminal row count is smaller than the old row count
move clearStart up by one status-height band above the new status area
clear those rows before reapplying the scroll region
Validation
Manually verified with the standalone reproducer:

vertical resize smaller/larger no longer leaves duplicated status bar rows
horizontal resize behavior remains unchanged
prompt remains usable after resize


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal resize handling when decreasing terminal height with active status output, ensuring proper cleanup of leftover status content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

