### PR TITLE
fix: status bar duplication after vertical resize (backport #1860)

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -149,6 +149,13 @@ public class Status {
                     clearStart = Math.min(clearStart, oldScrollRegion + 1);
                 }
                 if (effectiveLines > 0) {
+                    // When the terminal height shrinks, some terminal emulators
+                    // preserve the old bottom status line just above the new
+                    // status area.  Clear one status-height band above the
+                    // status area so the next redraw does not leave duplicates.
+                    if (newRows < oldRows) {
+                        clearStart = Math.min(clearStart, Math.max(0, scrollRegion + 1 - effectiveLines));
+                    }
                     // Account for wrapped status lines when width decreased
                     if (display.columns < oldColumns) {
                         int wrappedPerLine = (oldColumns + display.columns - 1) / display.columns;


### PR DESCRIPTION
Backport of #1860 to jline-3.x.

Clears stale status bar rows when the terminal height shrinks, preventing duplicated status lines above the prompt.