### PR TITLE
refactor: Remove duplicate code in Shell impl tests

### DIFF
--- a/shell/src/test/java/org/jline/shell/CommandLineTest.java
+++ b/shell/src/test/java/org/jline/shell/CommandLineTest.java
@@ -31,18 +31,4 @@ class CommandLineTest {
         CommandLine cl = new CommandLine("test", "test", "", List.of("test"), CommandLine.Type.COMMAND);
         assertThrows(UnsupportedOperationException.class, () -> cl.args().add("extra"));
     }
-
-    @Test
-    void methodType() {
-        CommandLine cl =
-                new CommandLine("obj.method(", "obj.method", "(", List.of("obj.method"), CommandLine.Type.METHOD);
-        assertEquals(CommandLine.Type.METHOD, cl.type());
-    }
-
-    @Test
-    void syntaxType() {
-        CommandLine cl = new CommandLine(
-                "obj.method(x)", "obj.method", "(x)", List.of("obj.method", "x"), CommandLine.Type.SYNTAX);
-        assertEquals(CommandLine.Type.SYNTAX, cl.type());
-    }
 }

--- a/shell/src/test/java/org/jline/shell/impl/AbstractCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/AbstractCommandDispatcherTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Base-class for tests that use a {@link DefaultCommandDispatcher}.
+ * <p>
+ * This base-class also deals with cleanup of the {@link Terminal} and {@link DefaultCommandDispatcher}.
+ */
+public class AbstractCommandDispatcherTest {
+
+    protected Terminal terminal;
+    protected DefaultCommandDispatcher dispatcher;
+    private final Function<Terminal, DefaultCommandDispatcher> factory;
+
+    /**
+     * Default constructor, creates a simple {@link DefaultCommandDispatcher}.
+     */
+    protected AbstractCommandDispatcherTest() {
+        this(DefaultCommandDispatcher::new);
+    }
+
+    /**
+     * Constructor allowing for customization of the new {@link DefaultCommandDispatcher}.
+     *
+     * @param factory The factory for instantiating custom {@link DefaultCommandDispatcher} instances.
+     */
+    protected AbstractCommandDispatcherTest(Function<Terminal, DefaultCommandDispatcher> factory) {
+        this.factory = factory;
+    }
+
+    @BeforeEach
+    protected void setUp() throws IOException {
+        terminal = TerminalBuilder.builder().dumb(true).build();
+        dispatcher = Objects.requireNonNull(factory.apply(terminal));
+    }
+
+    @AfterEach
+    protected void tearDown() throws IOException {
+        try {
+            if (terminal != null) {
+                terminal.close();
+            }
+        } finally {
+            if (dispatcher != null) {
+                dispatcher.close();
+            }
+        }
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/AbstractCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/AbstractCommandDispatcherTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
  * <p>
  * This base-class also deals with cleanup of the {@link Terminal} and {@link DefaultCommandDispatcher}.
  */
-public class AbstractCommandDispatcherTest {
+public abstract class AbstractCommandDispatcherTest {
 
     protected Terminal terminal;
     protected DefaultCommandDispatcher dispatcher;

--- a/shell/src/test/java/org/jline/shell/impl/AbstractCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/AbstractCommandsTest.java
@@ -48,6 +48,7 @@ public abstract class AbstractCommandsTest extends AbstractCommandDispatcherTest
         super(factory);
     }
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/AbstractCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/AbstractCommandsTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
  * Provides the conveniences of {@link AbstractCommandDispatcherTest}
  * and includes a {@link LineReader} and captured {@link CommandSession}.
  */
-public class AbstractCommandsTest extends AbstractCommandDispatcherTest {
+public abstract class AbstractCommandsTest extends AbstractCommandDispatcherTest {
 
     protected LineReader reader;
     protected CommandSession session;
@@ -54,6 +54,6 @@ public class AbstractCommandsTest extends AbstractCommandDispatcherTest {
         reader = LineReaderBuilder.builder().terminal(terminal).build();
         outCapture = new ByteArrayOutputStream();
         errCapture = new ByteArrayOutputStream();
-        session = new CommandSession(null, System.in, new PrintStream(outCapture), new PrintStream(errCapture));
+        session = new CommandSession(terminal, System.in, new PrintStream(outCapture), new PrintStream(errCapture));
     }
 }

--- a/shell/src/test/java/org/jline/shell/impl/AbstractCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/AbstractCommandsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.function.Function;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.shell.CommandSession;
+import org.jline.terminal.Terminal;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Base-class for tests that want to test {@link org.jline.shell.CommandGroup}s.
+ * <p>
+ * Provides the conveniences of {@link AbstractCommandDispatcherTest}
+ * and includes a {@link LineReader} and captured {@link CommandSession}.
+ */
+public class AbstractCommandsTest extends AbstractCommandDispatcherTest {
+
+    protected LineReader reader;
+    protected CommandSession session;
+    protected ByteArrayOutputStream outCapture;
+    protected ByteArrayOutputStream errCapture;
+
+    /**
+     * Default constructor, creates a simple {@link DefaultCommandDispatcher}.
+     */
+    protected AbstractCommandsTest() {
+        super();
+    }
+
+    /**
+     * Constructor allowing for customization of the new {@link DefaultCommandDispatcher}.
+     *
+     * @param factory The factory for instantiating custom {@link DefaultCommandDispatcher} instances.
+     */
+    protected AbstractCommandsTest(Function<Terminal, DefaultCommandDispatcher> factory) {
+        super(factory);
+    }
+
+    @BeforeEach
+    protected void setUp() throws IOException {
+        super.setUp();
+        reader = LineReaderBuilder.builder().terminal(terminal).build();
+        outCapture = new ByteArrayOutputStream();
+        errCapture = new ByteArrayOutputStream();
+        session = new CommandSession(null, System.in, new PrintStream(outCapture), new PrintStream(errCapture));
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/CommandHighlighterTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/CommandHighlighterTest.java
@@ -12,10 +12,7 @@ import java.io.IOException;
 
 import org.jline.reader.Highlighter;
 import org.jline.shell.CommandSession;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.AttributedString;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,31 +21,15 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for {@link CommandHighlighter}.
  */
-class CommandHighlighterTest {
+class CommandHighlighterTest extends AbstractCommandDispatcherTest {
 
-    private Terminal terminal;
-    private DefaultCommandDispatcher dispatcher;
     private CommandHighlighter highlighter;
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        dispatcher = new DefaultCommandDispatcher(terminal);
+    protected void setUp() throws IOException {
+        super.setUp();
         dispatcher.addGroup(new SimpleCommandGroup("test", new TestEchoCommand()));
         highlighter = new CommandHighlighter(dispatcher);
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        try {
-            if (terminal != null) {
-                terminal.close();
-            }
-        } finally {
-            if (dispatcher != null) {
-                dispatcher.close();
-            }
-        }
     }
 
     static class TestEchoCommand extends AbstractCommand {

--- a/shell/src/test/java/org/jline/shell/impl/CommandHighlighterTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/CommandHighlighterTest.java
@@ -25,6 +25,7 @@ class CommandHighlighterTest extends AbstractCommandDispatcherTest {
 
     private CommandHighlighter highlighter;
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -14,9 +14,6 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import org.jline.shell.*;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -26,15 +23,11 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Integration tests for {@link DefaultCommandDispatcher}.
  */
-class DefaultCommandDispatcherTest {
-
-    private Terminal terminal;
-    private DefaultCommandDispatcher dispatcher;
+class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        dispatcher = new DefaultCommandDispatcher(terminal);
+    protected void setUp() throws IOException {
+        super.setUp();
         dispatcher.addGroup(new SimpleCommandGroup(
                 "test",
                 new EchoCommand(),
@@ -42,19 +35,6 @@ class DefaultCommandDispatcherTest {
                 new UpperCommand(),
                 new NoopCommand(),
                 new ReverseCommand()));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        try {
-            if (terminal != null) {
-                terminal.close();
-            }
-        } finally {
-            if (dispatcher != null) {
-                dispatcher.close();
-            }
-        }
     }
 
     // --- Fixture commands ---

--- a/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
@@ -29,6 +29,7 @@ class DefaultScriptRunnerTest extends AbstractCommandDispatcherTest {
     private DefaultScriptRunner runner;
     private List<String> executedCommands;
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
@@ -15,9 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jline.shell.*;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -27,17 +24,14 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for {@link DefaultScriptRunner}.
  */
-class DefaultScriptRunnerTest {
+class DefaultScriptRunnerTest extends AbstractCommandDispatcherTest {
 
-    private Terminal terminal;
-    private DefaultCommandDispatcher dispatcher;
     private DefaultScriptRunner runner;
     private List<String> executedCommands;
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        dispatcher = new DefaultCommandDispatcher(terminal);
+    protected void setUp() throws IOException {
+        super.setUp();
         runner = new DefaultScriptRunner();
         executedCommands = new ArrayList<>();
 
@@ -50,19 +44,6 @@ class DefaultScriptRunnerTest {
                 return line;
             }
         }));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        try {
-            if (terminal != null) {
-                terminal.close();
-            }
-        } finally {
-            if (dispatcher != null) {
-                dispatcher.close();
-            }
-        }
     }
 
     @Test

--- a/shell/src/test/java/org/jline/shell/impl/HelpCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/HelpCommandsTest.java
@@ -8,15 +8,10 @@
  */
 package org.jline.shell.impl;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 
 import org.jline.shell.Command;
 import org.jline.shell.CommandSession;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,38 +20,16 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for {@link HelpCommands}.
  */
-class HelpCommandsTest {
+class HelpCommandsTest extends AbstractCommandsTest {
 
-    private Terminal terminal;
-    private DefaultCommandDispatcher dispatcher;
     private HelpCommands commands;
-    private CommandSession session;
-    private ByteArrayOutputStream outCapture;
-    private ByteArrayOutputStream errCapture;
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        dispatcher = new DefaultCommandDispatcher(terminal);
+    protected void setUp() throws IOException {
+        super.setUp();
         dispatcher.addGroup(new SimpleCommandGroup("demo", new TestEchoCmd(), new TestUpperCmd()));
         commands = new HelpCommands(dispatcher);
         dispatcher.addGroup(commands);
-        outCapture = new ByteArrayOutputStream();
-        errCapture = new ByteArrayOutputStream();
-        session = new CommandSession(null, System.in, new PrintStream(outCapture), new PrintStream(errCapture));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        try {
-            if (terminal != null) {
-                terminal.close();
-            }
-        } finally {
-            if (dispatcher != null) {
-                dispatcher.close();
-            }
-        }
     }
 
     static class TestEchoCmd extends AbstractCommand {

--- a/shell/src/test/java/org/jline/shell/impl/HelpCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/HelpCommandsTest.java
@@ -24,6 +24,7 @@ class HelpCommandsTest extends AbstractCommandsTest {
 
     private HelpCommands commands;
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/HistoryCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/HistoryCommandsTest.java
@@ -23,6 +23,7 @@ class HistoryCommandsTest extends AbstractCommandsTest {
 
     private HistoryCommands commands;
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/HistoryCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/HistoryCommandsTest.java
@@ -8,17 +8,9 @@
  */
 package org.jline.shell.impl;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 
-import org.jline.reader.LineReader;
-import org.jline.reader.LineReaderBuilder;
 import org.jline.shell.Command;
-import org.jline.shell.CommandSession;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,30 +19,14 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for {@link HistoryCommands}.
  */
-class HistoryCommandsTest {
+class HistoryCommandsTest extends AbstractCommandsTest {
 
-    private Terminal terminal;
-    private LineReader reader;
     private HistoryCommands commands;
-    private CommandSession session;
-    private ByteArrayOutputStream outCapture;
-    private ByteArrayOutputStream errCapture;
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        reader = LineReaderBuilder.builder().terminal(terminal).build();
+    protected void setUp() throws IOException {
+        super.setUp();
         commands = new HistoryCommands(reader);
-        outCapture = new ByteArrayOutputStream();
-        errCapture = new ByteArrayOutputStream();
-        session = new CommandSession(null, System.in, new PrintStream(outCapture), new PrintStream(errCapture));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        if (terminal != null) {
-            terminal.close();
-        }
     }
 
     @Test

--- a/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
@@ -13,9 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.jline.shell.*;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -25,15 +22,11 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for I/O redirection operators (INPUT_REDIRECT, STDERR_REDIRECT, COMBINED_REDIRECT).
  */
-class IORedirectionTest {
-
-    private Terminal terminal;
-    private DefaultCommandDispatcher dispatcher;
+class IORedirectionTest extends AbstractCommandDispatcherTest {
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        dispatcher = new DefaultCommandDispatcher(terminal);
+    protected void setUp() throws IOException {
+        super.setUp();
         dispatcher.addGroup(new SimpleCommandGroup(
                 "test", new CatCommand(), new EchoCommand(), new ErrCommand(), new BothCommand()));
     }
@@ -51,19 +44,6 @@ class IORedirectionTest {
             String msg = String.join(" ", args);
             session.out().println(msg);
             return msg;
-        }
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        try {
-            if (terminal != null) {
-                terminal.close();
-            }
-        } finally {
-            if (dispatcher != null) {
-                dispatcher.close();
-            }
         }
     }
 

--- a/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class IORedirectionTest extends AbstractCommandDispatcherTest {
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/OptionCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/OptionCommandsTest.java
@@ -24,6 +24,7 @@ class OptionCommandsTest extends AbstractCommandsTest {
 
     private OptionCommands commands;
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/OptionCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/OptionCommandsTest.java
@@ -8,18 +8,10 @@
  */
 package org.jline.shell.impl;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 
-import org.jline.reader.LineReader;
 import org.jline.reader.LineReader.Option;
-import org.jline.reader.LineReaderBuilder;
 import org.jline.shell.Command;
-import org.jline.shell.CommandSession;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,30 +20,14 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for {@link OptionCommands}.
  */
-class OptionCommandsTest {
+class OptionCommandsTest extends AbstractCommandsTest {
 
-    private Terminal terminal;
-    private LineReader reader;
     private OptionCommands commands;
-    private CommandSession session;
-    private ByteArrayOutputStream outCapture;
-    private ByteArrayOutputStream errCapture;
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        reader = LineReaderBuilder.builder().terminal(terminal).build();
+    protected void setUp() throws IOException {
+        super.setUp();
         commands = new OptionCommands(reader);
-        outCapture = new ByteArrayOutputStream();
-        errCapture = new ByteArrayOutputStream();
-        session = new CommandSession(null, System.in, new PrintStream(outCapture), new PrintStream(errCapture));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        if (terminal != null) {
-            terminal.close();
-        }
     }
 
     @Test

--- a/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
@@ -14,9 +14,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jline.shell.*;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,29 +22,12 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for signal handling in {@link DefaultCommandDispatcher}.
  */
-class SignalHandlingTest {
-
-    private Terminal terminal;
-    private DefaultCommandDispatcher dispatcher;
+class SignalHandlingTest extends AbstractCommandDispatcherTest {
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        dispatcher = new DefaultCommandDispatcher(terminal);
+    protected void setUp() throws IOException {
+        super.setUp();
         dispatcher.addGroup(new SimpleCommandGroup("test", new SleepCommand(), new EchoCommand()));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        try {
-            if (terminal != null) {
-                terminal.close();
-            }
-        } finally {
-            if (dispatcher != null) {
-                dispatcher.close();
-            }
-        }
     }
 
     static class SleepCommand extends AbstractCommand {

--- a/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class SignalHandlingTest extends AbstractCommandDispatcherTest {
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/SubcommandTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SubcommandTest.java
@@ -12,9 +12,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.jline.shell.*;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,29 +20,12 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for subcommand support in {@link DefaultCommandDispatcher}.
  */
-class SubcommandTest {
-
-    private Terminal terminal;
-    private DefaultCommandDispatcher dispatcher;
+class SubcommandTest extends AbstractCommandDispatcherTest {
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        dispatcher = new DefaultCommandDispatcher(terminal);
+    protected void setUp() throws IOException {
+        super.setUp();
         dispatcher.addGroup(new SimpleCommandGroup("test", new GitCommand()));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        try {
-            if (terminal != null) {
-                terminal.close();
-            }
-        } finally {
-            if (dispatcher != null) {
-                dispatcher.close();
-            }
-        }
     }
 
     /**

--- a/shell/src/test/java/org/jline/shell/impl/SubcommandTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SubcommandTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class SubcommandTest extends AbstractCommandDispatcherTest {
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();

--- a/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
@@ -11,9 +11,6 @@ package org.jline.shell.impl;
 import java.io.IOException;
 
 import org.jline.shell.CommandSession;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,15 +20,15 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests for {@link VariableCommands} and bare variable assignment in
  * {@link DefaultCommandDispatcher}.
  */
-class VariableCommandsTest {
+class VariableCommandsTest extends AbstractCommandsTest {
 
-    private Terminal terminal;
-    private DefaultCommandDispatcher dispatcher;
+    VariableCommandsTest() {
+        super(terminal -> new DefaultCommandDispatcher(terminal, null, null, null, new DefaultLineExpander(), null));
+    }
 
     @BeforeEach
-    void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        dispatcher = new DefaultCommandDispatcher(terminal, null, null, null, new DefaultLineExpander(), null);
+    protected void setUp() throws IOException {
+        super.setUp();
         dispatcher.addGroup(new VariableCommands());
         // Add echo for verification
         dispatcher.addGroup(new SimpleCommandGroup("test", new AbstractCommand("echo") {
@@ -42,19 +39,6 @@ class VariableCommandsTest {
                 return msg;
             }
         }));
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        try {
-            if (terminal != null) {
-                terminal.close();
-            }
-        } finally {
-            if (dispatcher != null) {
-                dispatcher.close();
-            }
-        }
     }
 
     @Test

--- a/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
@@ -26,6 +26,7 @@ class VariableCommandsTest extends AbstractCommandsTest {
         super(terminal -> new DefaultCommandDispatcher(terminal, null, null, null, new DefaultLineExpander(), null));
     }
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();


### PR DESCRIPTION
While prepping a pull for something in the Shell module & looking at the tests I noticed a lot of duplicate code in the Shell tests.
So before creating that pull I prepared this so it can be used for creating future tests.

Also removed superfluous tests in CommandLineTest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated test infrastructure into new shared abstract base classes and refactored many tests to reuse common setup/teardown.
  * Strengthened validation to ensure command-line arguments are immutable (mutations now throw).
  * Removed two redundant test cases replaced by the shared test harness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1868)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->