### PR TITLE
fix: skip null returns from signal registration in AbstractUnixSysTerminal

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -104,10 +104,19 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
 
         if (nativeSignals) {
             for (Signal signal : Signal.values()) {
+                Object nativeHandler;
                 if (signalHandler == SignalHandler.SIG_DFL) {
-                    nativeHandlers.put(signal, provider.registerDefaultSignal(signal.name()));
+                    nativeHandler = provider.registerDefaultSignal(signal.name());
                 } else {
-                    nativeHandlers.put(signal, provider.registerSignal(signal.name(), () -> raise(signal)));
+                    nativeHandler = provider.registerSignal(signal.name(), () -> raise(signal));
+                }
+                // Both registration paths can legitimately return null when the
+                // signal is unknown on this platform (e.g. SIGINFO is BSD/macOS
+                // only — the JNI/FFM providers and the sun.misc.Signal fallback
+                // all return null on Linux). Skip the put: ConcurrentHashMap
+                // rejects null values, and there is nothing to unregister later.
+                if (nativeHandler != null) {
+                    nativeHandlers.put(signal, nativeHandler);
                 }
             }
         }
@@ -124,10 +133,16 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
             if (previousNative != null) {
                 provider.unregisterSignal(signal.name(), previousNative);
             }
+            Object nativeHandler;
             if (handler == SignalHandler.SIG_DFL) {
-                nativeHandlers.put(signal, provider.registerDefaultSignal(signal.name()));
+                nativeHandler = provider.registerDefaultSignal(signal.name());
             } else {
-                nativeHandlers.put(signal, provider.registerSignal(signal.name(), () -> raise(signal)));
+                nativeHandler = provider.registerSignal(signal.name(), () -> raise(signal));
+            }
+            // Skip the put if registration declined (unknown signal on this
+            // platform). ConcurrentHashMap rejects null values.
+            if (nativeHandler != null) {
+                nativeHandlers.put(signal, nativeHandler);
             }
         }
         return prev;

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -110,11 +110,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
                 } else {
                     nativeHandler = provider.registerSignal(signal.name(), () -> raise(signal));
                 }
-                // Both registration paths can legitimately return null when the
-                // signal is unknown on this platform (e.g. SIGINFO is BSD/macOS
-                // only — the JNI/FFM providers and the sun.misc.Signal fallback
-                // all return null on Linux). Skip the put: ConcurrentHashMap
-                // rejects null values, and there is nothing to unregister later.
+                // Registration returns null for platform-unsupported signals; ConcurrentHashMap rejects null values
                 if (nativeHandler != null) {
                     nativeHandlers.put(signal, nativeHandler);
                 }
@@ -139,8 +135,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
             } else {
                 nativeHandler = provider.registerSignal(signal.name(), () -> raise(signal));
             }
-            // Skip the put if registration declined (unknown signal on this
-            // platform). ConcurrentHashMap rejects null values.
+            // See constructor — skip null for unsupported signals
             if (nativeHandler != null) {
                 nativeHandlers.put(signal, nativeHandler);
             }


### PR DESCRIPTION
## Summary

`AbstractUnixSysTerminal.nativeHandlers` is a `ConcurrentHashMap`, which rejects null values. Both `TerminalProvider.registerSignal` and `TerminalProvider.registerDefaultSignal` can legitimately return `null` when the requested signal isn't valid on the host platform — `SIGINFO` is BSD/macOS only, and the JNI/FFM providers and the `sun.misc.Signal` fallback (`Signals.registerDefault`) all return `null` for it on Linux.

The bulk registration loop in the constructor (and the `handle()` re-register path) propagate that `null` straight into `ConcurrentHashMap.put`, throwing `NullPointerException`. `TerminalBuilder` catches the failure as a suppressed exception and silently falls back to `DumbTerminal`, so the caller gets a `dumb` type / 0×0 size on every otherwise-fine Linux TTY.

This was the root-cause behind a recent debug session where every TUI demo built on JLine 4.1.0 silently fell back to `DumbTerminal` on Fedora — `TerminalBuilder.builder().system(true).dumb(false).build()` surfaced the NPE in the suppressed chain:

```
java.lang.IllegalStateException: Unable to create a terminal
    at org.jline.terminal.TerminalBuilder.doBuild(TerminalBuilder.java:837)
    at org.jline.terminal.TerminalBuilder.build(TerminalBuilder.java:788)
    …
    Suppressed: java.lang.NullPointerException
        at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1023)
        at org.jline.terminal.impl.AbstractUnixSysTerminal.<init>(AbstractUnixSysTerminal.java:108)
        at org.jline.terminal.impl.ffm.FfmUnixSysTerminal.<init>(FfmUnixSysTerminal.java:46)
        at org.jline.terminal.impl.ffm.FfmTerminalProvider.sysTerminal(FfmTerminalProvider.java:105)
```

## Fix

Hold the registration result in a local, then only `put` it into the map when it's non-null. The registration call itself is unchanged, so no other behavior changes:

- Constructor's `for (Signal signal : Signal.values())` loop
- `handle()` re-registration after a handler swap

Skipping the put is correct because nothing was actually installed — when `doClose` later iterates `nativeHandlers` to call `unregisterSignal`, there's nothing valid to call it on.

## Scope

- `PosixSysTerminal` already uses a `HashMap` (which allows null values) and is unaffected.
- This is the smallest change that unblocks Linux callers without touching the registration API. The `TerminalProvider` contract already permits a null return (the existing `previousNative != null` guard before `unregisterSignal` in the same `handle()` method confirms it).

## Test plan

- [x] `./mvx mvn test -pl terminal` — 279 tests, 0 failures
- [x] Manually verified the upstream symptom: in a real terminal on Fedora 44 / Linux 7.0, `TerminalBuilder.builder().system(true).dumb(false).nativeSignals(true).build()` now returns an `FfmUnixSysTerminal` with the real `$TERM` / size instead of throwing NPE → falling back to dumb.

No regression test included: `AbstractUnixSysTerminal`'s constructor unconditionally opens `new FileInputStream(FileDescriptor.in)`, which clashes with Surefire's std/in pipe and corrupts the forked-test channel. The existing `PosixSysTerminalTest` works around this by passing a mocked `Pty` with injected slave streams — `AbstractUnixSysTerminal` doesn't have an equivalent seam. Happy to add one as a follow-up if you'd like the regression coverage, but it's a slightly larger refactor (extract input/output as constructor parameters) than this surgical fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of native signal registration on Unix terminals to avoid storing null/unsupported registrations.
  * Avoids tracking or attempting to unregister signals the platform does not recognize.
  * Reduces spurious errors during terminal initialization and when updating signal handlers, improving cross-platform stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1869)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->