### PR TITLE
refactor: make exit command a regular, configurable command

### DIFF
--- a/shell/src/main/java/org/jline/shell/CommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/CommandDispatcher.java
@@ -143,9 +143,11 @@ public interface CommandDispatcher extends AutoCloseable {
             AttributedStringBuilder asb = new AttributedStringBuilder();
             asb.styled(errorStyle(), exception.getMessage());
             asb.toAttributedString().println(terminal());
+            terminal().flush();
             return;
         }
         exception.printStackTrace(terminal().writer());
+        terminal().flush();
     }
 
     /**

--- a/shell/src/main/java/org/jline/shell/ExitShellException.java
+++ b/shell/src/main/java/org/jline/shell/ExitShellException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell;
+
+/**
+ * This exception is thrown by commands (e.g. an exit command)
+ * to indicate that the shell should exit.
+ * <p>
+ * If a message is provided it will be printed to the terminal when the shell exits.
+ */
+public class ExitShellException extends RuntimeException {
+
+    private static final long serialVersionUID = 9147467891877904413L;
+
+    public ExitShellException() {
+        super();
+    }
+
+    public ExitShellException(String message) {
+        super(message);
+    }
+}

--- a/shell/src/main/java/org/jline/shell/ExitShellException.java
+++ b/shell/src/main/java/org/jline/shell/ExitShellException.java
@@ -18,11 +18,32 @@ public class ExitShellException extends RuntimeException {
 
     private static final long serialVersionUID = 9147467891877904413L;
 
+    private final int exitCode;
+
     public ExitShellException() {
+        this(0);
+    }
+
+    public ExitShellException(int exitCode) {
         super();
+        this.exitCode = exitCode;
     }
 
     public ExitShellException(String message) {
+        this(message, 0);
+    }
+
+    public ExitShellException(String message, int exitCode) {
         super(message);
+        this.exitCode = exitCode;
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
     }
 }

--- a/shell/src/main/java/org/jline/shell/Shell.java
+++ b/shell/src/main/java/org/jline/shell/Shell.java
@@ -84,7 +84,7 @@ public class Shell implements AutoCloseable {
     /**
      * Runs the interactive REPL loop.
      * <p>
-     * This method blocks until the user exits (via EOF or an "exit"/"quit" command),
+     * This method blocks until the user exits (e.g. via EOF or an exit command),
      * or until {@link #stop()} is called.
      *
      * @throws Exception if initialization or execution fails
@@ -119,22 +119,27 @@ public class Shell implements AutoCloseable {
                     String prompt = promptSupplier.get();
                     String rightPrompt = rightPromptSupplier != null ? rightPromptSupplier.get() : null;
                     line = reader.readLine(prompt, rightPrompt, (MaskingCallback) null, null);
-                    if (line == null) {
-                        break;
-                    }
-
-                    line = line.trim();
-                    if (line.isEmpty()) {
-                        continue;
-                    }
-
-                    dispatcher.execute(line);
                 } catch (UserInterruptException e) {
                     // Ctrl-C: clear line, continue
-                    //noinspection UnnecessaryContinue
                     continue;
                 } catch (EndOfFileException e) {
                     // Ctrl-D: exit
+                    break;
+                }
+
+                if (line == null) {
+                    break;
+                }
+
+                line = line.trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+
+                try {
+                    dispatcher.execute(line);
+                } catch (EndOfFileException e) {
+                    // exit
                     break;
                 } catch (Exception e) {
                     dispatcher.trace(e);

--- a/shell/src/main/java/org/jline/shell/Shell.java
+++ b/shell/src/main/java/org/jline/shell/Shell.java
@@ -119,27 +119,22 @@ public class Shell implements AutoCloseable {
                     String prompt = promptSupplier.get();
                     String rightPrompt = rightPromptSupplier != null ? rightPromptSupplier.get() : null;
                     line = reader.readLine(prompt, rightPrompt, (MaskingCallback) null, null);
+
+                    if (line == null) {
+                        break;
+                    }
+
+                    line = line.trim();
+                    if (line.isEmpty()) {
+                        continue;
+                    }
+
+                    dispatcher.execute(line);
                 } catch (UserInterruptException e) {
                     // Ctrl-C: clear line, continue
                     continue;
                 } catch (EndOfFileException e) {
                     // Ctrl-D: exit
-                    break;
-                }
-
-                if (line == null) {
-                    break;
-                }
-
-                line = line.trim();
-                if (line.isEmpty()) {
-                    continue;
-                }
-
-                try {
-                    dispatcher.execute(line);
-                } catch (EndOfFileException e) {
-                    // exit
                     break;
                 } catch (Exception e) {
                     dispatcher.trace(e);

--- a/shell/src/main/java/org/jline/shell/Shell.java
+++ b/shell/src/main/java/org/jline/shell/Shell.java
@@ -119,22 +119,30 @@ public class Shell implements AutoCloseable {
                     String prompt = promptSupplier.get();
                     String rightPrompt = rightPromptSupplier != null ? rightPromptSupplier.get() : null;
                     line = reader.readLine(prompt, rightPrompt, (MaskingCallback) null, null);
-
-                    if (line == null) {
-                        break;
-                    }
-
-                    line = line.trim();
-                    if (line.isEmpty()) {
-                        continue;
-                    }
-
-                    dispatcher.execute(line);
                 } catch (UserInterruptException e) {
                     // Ctrl-C: clear line, continue
                     continue;
                 } catch (EndOfFileException e) {
                     // Ctrl-D: exit
+                    break;
+                }
+
+                if (line == null) {
+                    break;
+                }
+
+                line = line.trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+
+                try {
+                    dispatcher.execute(line);
+                } catch (ExitShellException e) {
+                    if (e.getMessage() != null) {
+                        terminal.writer().println(e.getMessage());
+                        terminal.flush();
+                    }
                     break;
                 } catch (Exception e) {
                     dispatcher.trace(e);

--- a/shell/src/main/java/org/jline/shell/Shell.java
+++ b/shell/src/main/java/org/jline/shell/Shell.java
@@ -119,30 +119,23 @@ public class Shell implements AutoCloseable {
                     String prompt = promptSupplier.get();
                     String rightPrompt = rightPromptSupplier != null ? rightPromptSupplier.get() : null;
                     line = reader.readLine(prompt, rightPrompt, (MaskingCallback) null, null);
+                    if (line == null) {
+                        break;
+                    }
+
+                    line = line.trim();
+                    if (line.isEmpty()) {
+                        continue;
+                    }
+
+                    dispatcher.execute(line);
                 } catch (UserInterruptException e) {
                     // Ctrl-C: clear line, continue
+                    //noinspection UnnecessaryContinue
                     continue;
                 } catch (EndOfFileException e) {
                     // Ctrl-D: exit
                     break;
-                }
-
-                if (line == null) {
-                    break;
-                }
-
-                line = line.trim();
-                if (line.isEmpty()) {
-                    continue;
-                }
-
-                // Built-in exit/quit
-                if ("exit".equals(line) || "quit".equals(line)) {
-                    break;
-                }
-
-                try {
-                    dispatcher.execute(line);
                 } catch (Exception e) {
                     dispatcher.trace(e);
                 } finally {

--- a/shell/src/main/java/org/jline/shell/ShellBuilder.java
+++ b/shell/src/main/java/org/jline/shell/ShellBuilder.java
@@ -73,6 +73,7 @@ public class ShellBuilder {
     private ScriptRunner scriptRunner;
     private boolean enableScriptCommands;
     private boolean enableVariableCommands;
+    private boolean enableExitCommands = true;
 
     ShellBuilder() {}
 
@@ -389,6 +390,17 @@ public class ShellBuilder {
     }
 
     /**
+     * Enables or disables built-in exit commands ({@code exit}, {@code quit}).
+     *
+     * @param enable true to enable
+     * @return this builder
+     */
+    public ShellBuilder exitCommands(boolean enable) {
+        this.enableExitCommands = enable;
+        return this;
+    }
+
+    /**
      * Builds the {@link Shell} instance.
      * <p>
      * If no terminal is provided, a system terminal is created. If no dispatcher
@@ -460,6 +472,9 @@ public class ShellBuilder {
         }
         if (enableVariableCommands) {
             disp.addGroup(new org.jline.shell.impl.VariableCommands());
+        }
+        if (enableExitCommands) {
+            disp.addGroup(new org.jline.shell.impl.ExitCommands());
         }
 
         // Apply variables

--- a/shell/src/main/java/org/jline/shell/ShellBuilder.java
+++ b/shell/src/main/java/org/jline/shell/ShellBuilder.java
@@ -74,6 +74,7 @@ public class ShellBuilder {
     private boolean enableScriptCommands;
     private boolean enableVariableCommands;
     private boolean enableExitCommands = true;
+    private String exitMessage = null;
 
     ShellBuilder() {}
 
@@ -401,6 +402,18 @@ public class ShellBuilder {
     }
 
     /**
+     * Sets the message that will be printed to the terminal when the exit command is called.
+     * Also enables the exit command if it was disabled.
+     *
+     * @param message The message to be printed upon exit
+     * @return this builder
+     */
+    public ShellBuilder exitMessage(String message) {
+        this.exitMessage = message;
+        return exitCommands(true);
+    }
+
+    /**
      * Builds the {@link Shell} instance.
      * <p>
      * If no terminal is provided, a system terminal is created. If no dispatcher
@@ -474,7 +487,7 @@ public class ShellBuilder {
             disp.addGroup(new org.jline.shell.impl.VariableCommands());
         }
         if (enableExitCommands) {
-            disp.addGroup(new org.jline.shell.impl.ExitCommands());
+            disp.addGroup(new org.jline.shell.impl.ExitCommands(exitMessage));
         }
 
         // Apply variables

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -376,7 +376,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
                 session.setLastExitCode(0);
             } catch (EndOfFileException e) {
-                session.setLastExitCode(1);
+                session.setLastExitCode(0);
                 throw e;
             } catch (Exception e) {
                 session.setLastExitCode(1);

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -366,28 +366,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 }
             }
 
-            Object lastResult;
-            String lastOutput;
-            try {
-                lastResult = cmd.execute(session, args);
-                if (captureOutput) {
-                    session.out().flush();
-                }
-                lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
-                session.setLastExitCode(0);
-            } catch (EndOfFileException e) {
-                session.setLastExitCode(0);
-                throw e;
-            } catch (Exception e) {
-                session.setLastExitCode(1);
-                lastResult = null;
-                lastOutput = null;
-                if (op != Operator.AND && op != Operator.OR && op != Operator.SEQUENCE) {
-                    throw e;
-                }
-            }
-
-            return new Object[] {lastResult, lastOutput};
+            return runCommandStage(cmd, session, args, captureOutput, capture, op, false);
         } finally {
             session.setOut(originalOut);
             session.setErr(originalErr);
@@ -453,27 +432,14 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                     createStageSessions(groupStages, pumps, firstIn, outErr[0], outErr[1], inputRedirects);
             threads = startProducers(commands, stageSessions, argsArrays);
 
-            // Run last stage in current thread
-            Object lastResult;
-            String lastOutput;
-            try {
-                lastResult = commands[n - 1].execute(stageSessions[n - 1], argsArrays[n - 1]);
-                if (captureLastOutput) {
-                    stageSessions[n - 1].out().flush();
-                }
-                lastOutput = resolveOutputString(captureLastOutput ? lastCapture : null, lastResult);
-                session.setLastExitCode(0);
-            } catch (Exception e) {
-                session.setLastExitCode(1);
-                if (lastGroupOp == Operator.AND || lastGroupOp == Operator.OR || lastGroupOp == Operator.SEQUENCE) {
-                    lastResult = null;
-                    lastOutput = null;
-                } else {
-                    throw e;
-                }
-            }
-
-            return new Object[] {lastResult, lastOutput};
+            return runCommandStage(
+                    commands[n - 1],
+                    stageSessions[n - 1],
+                    argsArrays[n - 1],
+                    captureLastOutput,
+                    lastCapture,
+                    lastGroupOp,
+                    true);
         } finally {
             closePumps(pumps);
             joinProducers(threads);
@@ -483,6 +449,59 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             }
             closeStreams(redirectStream, inputRedirects);
         }
+    }
+
+    /**
+     * Executes a single command as part of a stage.
+     *
+     * @param stageCmd The command to be run
+     * @param stageSession The session of this stage
+     * @param stageArgs The arguments for this command
+     * @param captureOutput Whether the output should be captured
+     * @param capture The last capture
+     * @param op The operation for this command
+     * @param multi Whether this command is being run as part of a pipe group
+     * @return a two-element array: {@code [result, output]} from the last stage
+     * @throws Exception if the command fails and the error should propagate
+     */
+    private Object[] runCommandStage(
+            Command stageCmd,
+            CommandSession stageSession,
+            String[] stageArgs,
+            boolean captureOutput,
+            ByteArrayOutputStream capture,
+            Operator op,
+            boolean multi)
+            throws Exception {
+        Object lastResult;
+        String lastOutput;
+        try {
+            lastResult = stageCmd.execute(stageSession, stageArgs);
+            if (captureOutput) {
+                stageSession.out().flush();
+            }
+            lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
+            session.setLastExitCode(0);
+        } catch (EndOfFileException e) {
+            session.setLastExitCode(0);
+            // Last command in a pipe chain.
+            // Exit does not count here per bash convention.
+            if (op == null && multi) {
+                lastResult = null;
+                lastOutput = null;
+            } else {
+                throw e;
+            }
+        } catch (Exception e) {
+            session.setLastExitCode(1);
+            lastResult = null;
+            lastOutput = null;
+            if (op != Operator.AND && op != Operator.OR && op != Operator.SEQUENCE) {
+                throw e;
+            }
+        }
+
+        return new Object[] {lastResult, lastOutput};
     }
 
     /**

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -17,7 +17,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
-import org.jline.reader.EndOfFileException;
 import org.jline.reader.impl.completer.ArgumentCompleter;
 import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
@@ -482,7 +481,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             }
             lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
             session.setLastExitCode(0);
-        } catch (EndOfFileException e) {
+        } catch (ExitShellException e) {
             session.setLastExitCode(0);
             // Last command in a pipe chain.
             // Exit does not count here per bash convention.

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
+import org.jline.reader.EndOfFileException;
 import org.jline.reader.impl.completer.ArgumentCompleter;
 import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
@@ -126,10 +127,10 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         this.lineExpander = lineExpander;
         this.scriptRunner = scriptRunner;
         if (this.jobManager != null) {
-            groups.add(new JobCommands(jobManager));
+            this.groups.add(new JobCommands(jobManager));
         }
         if (this.aliasManager != null) {
-            groups.add(new AliasCommands(aliasManager));
+            this.groups.add(new AliasCommands(aliasManager));
         }
     }
 
@@ -374,6 +375,9 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 }
                 lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
                 session.setLastExitCode(0);
+            } catch (EndOfFileException e) {
+                session.setLastExitCode(1);
+                throw e;
             } catch (Exception e) {
                 session.setLastExitCode(1);
                 lastResult = null;

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
+import org.jline.reader.EndOfFileException;
 import org.jline.reader.impl.completer.ArgumentCompleter;
 import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
@@ -482,7 +483,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             lastOutput = resolveOutputString(captureOutput ? capture : null, lastResult);
             session.setLastExitCode(0);
         } catch (ExitShellException e) {
-            session.setLastExitCode(0);
+            session.setLastExitCode(e.getExitCode());
             // Last command in a pipe chain.
             // Exit does not count here per bash convention.
             if (op == null && multi) {
@@ -491,6 +492,9 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             } else {
                 throw e;
             }
+        } catch (EndOfFileException e) {
+            session.setLastExitCode(0);
+            throw e;
         } catch (Exception e) {
             session.setLastExitCode(1);
             lastResult = null;

--- a/shell/src/main/java/org/jline/shell/impl/ExitCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/ExitCommands.java
@@ -10,8 +10,8 @@ package org.jline.shell.impl;
 
 import java.util.List;
 
-import org.jline.reader.EndOfFileException;
 import org.jline.shell.CommandSession;
+import org.jline.shell.ExitShellException;
 
 /**
  * Built-in exit command.
@@ -23,14 +23,21 @@ import org.jline.shell.CommandSession;
 public class ExitCommands extends SimpleCommandGroup {
 
     public ExitCommands() {
-        super("exit", List.of(new ExitCommand()));
+        this(null);
+    }
+
+    public ExitCommands(String message) {
+        super("exit", List.of(new ExitCommand(message)));
     }
 
     private static class ExitCommand extends AbstractCommand {
 
-        private ExitCommand() {
+        private ExitCommand(String message) {
             super("exit", "quit");
+            this.message = message;
         }
+
+        private final String message;
 
         @Override
         public String description() {
@@ -39,7 +46,7 @@ public class ExitCommands extends SimpleCommandGroup {
 
         @Override
         public Object execute(CommandSession session, String[] args) {
-            throw new EndOfFileException();
+            throw new ExitShellException(this.message);
         }
     }
 }

--- a/shell/src/main/java/org/jline/shell/impl/ExitCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/ExitCommands.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.util.List;
+
+import org.jline.reader.EndOfFileException;
+import org.jline.shell.CommandSession;
+
+/**
+ * Built-in exit command.
+ * <p>
+ * Provides the exit command used for exiting the current shell.
+ *
+ * @since 4.1
+ */
+public class ExitCommands extends SimpleCommandGroup {
+
+    public ExitCommands() {
+        super("exit", List.of(new SetOptCommand()));
+    }
+
+    private static class SetOptCommand extends AbstractCommand {
+
+        private SetOptCommand() {
+            super("exit", "quit");
+        }
+
+        @Override
+        public String description() {
+            return "Exit the current shell";
+        }
+
+        @Override
+        public Object execute(CommandSession session, String[] args) {
+            throw new EndOfFileException();
+        }
+    }
+}

--- a/shell/src/main/java/org/jline/shell/impl/ExitCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/ExitCommands.java
@@ -23,12 +23,12 @@ import org.jline.shell.CommandSession;
 public class ExitCommands extends SimpleCommandGroup {
 
     public ExitCommands() {
-        super("exit", List.of(new SetOptCommand()));
+        super("exit", List.of(new ExitCommand()));
     }
 
-    private static class SetOptCommand extends AbstractCommand {
+    private static class ExitCommand extends AbstractCommand {
 
-        private SetOptCommand() {
+        private ExitCommand() {
             super("exit", "quit");
         }
 

--- a/shell/src/main/java/org/jline/shell/impl/ExitCommands.java
+++ b/shell/src/main/java/org/jline/shell/impl/ExitCommands.java
@@ -46,7 +46,11 @@ public class ExitCommands extends SimpleCommandGroup {
 
         @Override
         public Object execute(CommandSession session, String[] args) {
-            throw new ExitShellException(this.message);
+            int exitCode = 0;
+            if (args.length > 0) {
+                exitCode = Integer.parseInt(args[0]);
+            }
+            throw new ExitShellException(this.message, exitCode);
         }
     }
 }

--- a/shell/src/test/java/org/jline/shell/AbstractTerminalTest.java
+++ b/shell/src/test/java/org/jline/shell/AbstractTerminalTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Base-class for tests that use a {@link Terminal}.
+ * <p>
+ * This base-class also deals with cleanup of the {@link Terminal}.
+ */
+public abstract class AbstractTerminalTest {
+
+    protected PipedOutputStream terminalInput;
+    private PipedInputStream terminalStream;
+    protected Terminal terminal;
+    protected ByteArrayOutputStream terminalOutput;
+
+    @BeforeEach
+    protected void setUp() throws IOException {
+        terminalInput = new PipedOutputStream();
+        terminalStream = new PipedInputStream(terminalInput);
+        terminalOutput = new ByteArrayOutputStream();
+        terminal = TerminalBuilder.builder()
+                .dumb(true)
+                .streams(terminalStream, terminalOutput)
+                .build();
+    }
+
+    @AfterEach
+    protected void tearDown() throws IOException {
+        try {
+            if (terminal != null) {
+                terminal.close();
+            }
+        } finally {
+            try {
+                if (terminalInput != null) {
+                    terminalInput.close();
+                }
+            } finally {
+                if (terminalStream != null) {
+                    terminalStream.close();
+                }
+            }
+        }
+    }
+}

--- a/shell/src/test/java/org/jline/shell/ShellBuilderTest.java
+++ b/shell/src/test/java/org/jline/shell/ShellBuilderTest.java
@@ -113,6 +113,24 @@ class ShellBuilderTest extends AbstractTerminalTest {
     }
 
     /**
+     * Test that the exit command exits a {@link Shell} with a custom message.
+     */
+    @Test
+    void customExitShellCommand() throws IOException {
+        String msg = "test shell exit message";
+        terminalInput.write("exit\n".getBytes());
+        try (Shell shell = Shell.builder()
+                .terminal(terminal)
+                .exitCommands(false)
+                .exitMessage(msg)
+                .build()) {
+            assertTimeoutPreemptively(Duration.of(2000, ChronoUnit.MILLIS), shell::run);
+        }
+        // Also contains echoed command & reader prefixes
+        assertTrue(terminalOutput.toString().contains(msg));
+    }
+
+    /**
      * Test that the exit command in a {@link Shell} can be disabled.
      */
     @Test

--- a/shell/src/test/java/org/jline/shell/ShellBuilderTest.java
+++ b/shell/src/test/java/org/jline/shell/ShellBuilderTest.java
@@ -8,13 +8,15 @@
  */
 package org.jline.shell;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jline.reader.LineReader;
 import org.jline.shell.impl.AbstractCommand;
 import org.jline.shell.impl.SimpleCommandGroup;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,12 +24,11 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for {@link ShellBuilder} and {@link Shell}.
  */
-class ShellBuilderTest {
+class ShellBuilderTest extends AbstractTerminalTest {
 
     @Test
     void builderCreatesShellWithDefaults() throws Exception {
-        try (Terminal terminal = TerminalBuilder.builder().dumb(true).build();
-                Shell shell = Shell.builder().terminal(terminal).build()) {
+        try (Shell shell = Shell.builder().terminal(terminal).build()) {
             assertNotNull(shell);
             assertSame(terminal, shell.terminal());
             assertNotNull(shell.reader());
@@ -37,33 +38,27 @@ class ShellBuilderTest {
 
     @Test
     void builderAcceptsCustomPrompt() throws Exception {
-        try (Terminal terminal = TerminalBuilder.builder().dumb(true).build();
-                Shell shell =
-                        Shell.builder().terminal(terminal).prompt("test> ").build()) {
+        try (Shell shell = Shell.builder().terminal(terminal).prompt("test> ").build()) {
             assertNotNull(shell);
         }
     }
 
     @Test
     void builderAcceptsPromptSupplier() throws Exception {
-        try (Terminal terminal = TerminalBuilder.builder().dumb(true).build();
-                Shell shell = Shell.builder()
-                        .terminal(terminal)
-                        .prompt(() -> "dynamic> ")
-                        .build()) {
+        try (Shell shell =
+                Shell.builder().terminal(terminal).prompt(() -> "dynamic> ").build()) {
             assertNotNull(shell);
         }
     }
 
     @Test
     void builderAcceptsVariablesAndOptions() throws Exception {
-        try (Terminal terminal = TerminalBuilder.builder().dumb(true).build();
-                Shell shell = Shell.builder()
-                        .terminal(terminal)
-                        .variable(LineReader.SECONDARY_PROMPT_PATTERN, "%M> ")
-                        .variable(LineReader.INDENTATION, 4)
-                        .option(LineReader.Option.INSERT_BRACKET, true)
-                        .build()) {
+        try (Shell shell = Shell.builder()
+                .terminal(terminal)
+                .variable(LineReader.SECONDARY_PROMPT_PATTERN, "%M> ")
+                .variable(LineReader.INDENTATION, 4)
+                .option(LineReader.Option.INSERT_BRACKET, true)
+                .build()) {
             assertNotNull(shell);
             assertEquals(4, shell.reader().getVariable(LineReader.INDENTATION));
             assertTrue(shell.reader().isSet(LineReader.Option.INSERT_BRACKET));
@@ -73,11 +68,8 @@ class ShellBuilderTest {
     @Test
     void builderAcceptsHistoryFile() throws Exception {
         Path historyFile = Path.of(System.getProperty("java.io.tmpdir"), "test-history");
-        try (Terminal terminal = TerminalBuilder.builder().dumb(true).build();
-                Shell shell = Shell.builder()
-                        .terminal(terminal)
-                        .historyFile(historyFile)
-                        .build()) {
+        try (Shell shell =
+                Shell.builder().terminal(terminal).historyFile(historyFile).build()) {
             assertNotNull(shell);
         }
     }
@@ -91,8 +83,7 @@ class ShellBuilderTest {
             }
         };
         CommandGroup group = new SimpleCommandGroup("test", echo);
-        try (Terminal terminal = TerminalBuilder.builder().dumb(true).build();
-                Shell shell = Shell.builder().terminal(terminal).groups(group).build()) {
+        try (Shell shell = Shell.builder().terminal(terminal).groups(group).build()) {
             assertNotNull(shell);
             assertNotNull(shell.dispatcher().findCommand("echo"));
         }
@@ -101,13 +92,58 @@ class ShellBuilderTest {
     @Test
     void builderAcceptsOnReaderReady() throws Exception {
         boolean[] called = {false};
-        try (Terminal terminal = TerminalBuilder.builder().dumb(true).build();
-                Shell shell = Shell.builder()
-                        .terminal(terminal)
-                        .onReaderReady(reader -> called[0] = true)
-                        .build()) {
+        try (Shell shell = Shell.builder()
+                .terminal(terminal)
+                .onReaderReady(reader -> called[0] = true)
+                .build()) {
             assertNotNull(shell);
             assertTrue(called[0]);
+        }
+    }
+
+    /**
+     * Test that the exit command exits a {@link Shell} with default settings.
+     */
+    @Test
+    void exitShellCommand() throws IOException {
+        terminalInput.write("exit\n".getBytes());
+        try (Shell shell = Shell.builder().terminal(terminal).build()) {
+            assertTimeoutPreemptively(Duration.of(2000, ChronoUnit.MILLIS), shell::run);
+        }
+    }
+
+    /**
+     * Test that the exit command in a {@link Shell} can be disabled.
+     */
+    @Test
+    void noExitShellCommand() throws Exception {
+        AtomicBoolean stopped = new AtomicBoolean(false);
+        try (Shell shell =
+                Shell.builder().terminal(terminal).exitCommands(false).build()) {
+            terminalInput.write("exit\n".getBytes(terminal.encoding()));
+            terminalInput.flush();
+            Thread shellThread = Thread.currentThread();
+            Thread thread = new Thread(
+                    () -> {
+                        try {
+                            Thread.sleep(2000);
+                            stopped.set(true);
+                            shell.stop();
+                            shellThread.interrupt();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } catch (Exception e) {
+                            // Ignore
+                        }
+                    },
+                    "shell-stop-test-thread");
+            thread.start();
+            shell.run();
+            if (thread.isAlive()) {
+                thread.interrupt();
+                thread.join();
+            }
+            assertTrue(stopped.get(), "Shell should ignore the 'exit' command.");
         }
     }
 }

--- a/shell/src/test/java/org/jline/shell/impl/AbstractCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/AbstractCommandDispatcherTest.java
@@ -11,8 +11,8 @@ package org.jline.shell.impl;
 import java.io.*;
 import java.util.Objects;
 
+import org.jline.shell.AbstractTerminalTest;
 import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -21,23 +21,14 @@ import org.junit.jupiter.api.BeforeEach;
  * <p>
  * This base-class also deals with cleanup of the {@link Terminal} and {@link DefaultCommandDispatcher}.
  */
-public abstract class AbstractCommandDispatcherTest {
+public abstract class AbstractCommandDispatcherTest extends AbstractTerminalTest {
 
-    protected PipedOutputStream terminalInput;
-    private PipedInputStream terminalStream;
-    protected Terminal terminal;
     protected DefaultCommandDispatcher dispatcher;
-    protected ByteArrayOutputStream terminalOutput;
 
+    @Override
     @BeforeEach
     protected void setUp() throws IOException {
-        terminalInput = new PipedOutputStream();
-        terminalStream = new PipedInputStream(terminalInput);
-        terminalOutput = new ByteArrayOutputStream();
-        terminal = TerminalBuilder.builder()
-                .dumb(true)
-                .streams(terminalStream, terminalOutput)
-                .build();
+        super.setUp();
         dispatcher = Objects.requireNonNull(createDispatcher());
     }
 
@@ -48,26 +39,13 @@ public abstract class AbstractCommandDispatcherTest {
         return new DefaultCommandDispatcher(terminal);
     }
 
+    @Override
     @AfterEach
     protected void tearDown() throws IOException {
         try {
-            try {
-                if (terminal != null) {
-                    terminal.close();
-                }
-            } finally {
-                if (dispatcher != null) {
-                    dispatcher.close();
-                }
-            }
+            dispatcher.close();
         } finally {
-            try {
-                terminalInput.close();
-            } finally {
-                if (terminalStream != null) {
-                    terminalStream.close();
-                }
-            }
+            super.tearDown();
         }
     }
 }

--- a/shell/src/test/java/org/jline/shell/impl/AbstractCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/AbstractCommandDispatcherTest.java
@@ -8,9 +8,8 @@
  */
 package org.jline.shell.impl;
 
-import java.io.IOException;
+import java.io.*;
 import java.util.Objects;
-import java.util.function.Function;
 
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
@@ -24,41 +23,50 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public abstract class AbstractCommandDispatcherTest {
 
+    protected PipedOutputStream terminalInput;
+    private PipedInputStream terminalStream;
     protected Terminal terminal;
     protected DefaultCommandDispatcher dispatcher;
-    private final Function<Terminal, DefaultCommandDispatcher> factory;
-
-    /**
-     * Default constructor, creates a simple {@link DefaultCommandDispatcher}.
-     */
-    protected AbstractCommandDispatcherTest() {
-        this(DefaultCommandDispatcher::new);
-    }
-
-    /**
-     * Constructor allowing for customization of the new {@link DefaultCommandDispatcher}.
-     *
-     * @param factory The factory for instantiating custom {@link DefaultCommandDispatcher} instances.
-     */
-    protected AbstractCommandDispatcherTest(Function<Terminal, DefaultCommandDispatcher> factory) {
-        this.factory = factory;
-    }
+    protected ByteArrayOutputStream terminalOutput;
 
     @BeforeEach
     protected void setUp() throws IOException {
-        terminal = TerminalBuilder.builder().dumb(true).build();
-        dispatcher = Objects.requireNonNull(factory.apply(terminal));
+        terminalInput = new PipedOutputStream();
+        terminalStream = new PipedInputStream(terminalInput);
+        terminalOutput = new ByteArrayOutputStream();
+        terminal = TerminalBuilder.builder()
+                .dumb(true)
+                .streams(terminalStream, terminalOutput)
+                .build();
+        dispatcher = Objects.requireNonNull(createDispatcher());
+    }
+
+    /**
+     * The factory for instantiating custom {@link DefaultCommandDispatcher} instances.
+     */
+    protected DefaultCommandDispatcher createDispatcher() {
+        return new DefaultCommandDispatcher(terminal);
     }
 
     @AfterEach
     protected void tearDown() throws IOException {
         try {
-            if (terminal != null) {
-                terminal.close();
+            try {
+                if (terminal != null) {
+                    terminal.close();
+                }
+            } finally {
+                if (dispatcher != null) {
+                    dispatcher.close();
+                }
             }
         } finally {
-            if (dispatcher != null) {
-                dispatcher.close();
+            try {
+                terminalInput.close();
+            } finally {
+                if (terminalStream != null) {
+                    terminalStream.close();
+                }
             }
         }
     }

--- a/shell/src/test/java/org/jline/shell/impl/AbstractCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/AbstractCommandsTest.java
@@ -11,12 +11,10 @@ package org.jline.shell.impl;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.function.Function;
 
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.shell.CommandSession;
-import org.jline.terminal.Terminal;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
@@ -31,22 +29,6 @@ public abstract class AbstractCommandsTest extends AbstractCommandDispatcherTest
     protected CommandSession session;
     protected ByteArrayOutputStream outCapture;
     protected ByteArrayOutputStream errCapture;
-
-    /**
-     * Default constructor, creates a simple {@link DefaultCommandDispatcher}.
-     */
-    protected AbstractCommandsTest() {
-        super();
-    }
-
-    /**
-     * Constructor allowing for customization of the new {@link DefaultCommandDispatcher}.
-     *
-     * @param factory The factory for instantiating custom {@link DefaultCommandDispatcher} instances.
-     */
-    protected AbstractCommandsTest(Function<Terminal, DefaultCommandDispatcher> factory) {
-        super(factory);
-    }
 
     @Override
     @BeforeEach

--- a/shell/src/test/java/org/jline/shell/impl/CommandHighlighterTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/CommandHighlighterTest.java
@@ -11,7 +11,6 @@ package org.jline.shell.impl;
 import java.io.IOException;
 
 import org.jline.reader.Highlighter;
-import org.jline.shell.CommandSession;
 import org.jline.utils.AttributedString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,17 +30,6 @@ class CommandHighlighterTest extends AbstractCommandDispatcherTest {
         super.setUp();
         dispatcher.addGroup(new SimpleCommandGroup("test", new TestEchoCommand()));
         highlighter = new CommandHighlighter(dispatcher);
-    }
-
-    static class TestEchoCommand extends AbstractCommand {
-        TestEchoCommand() {
-            super("echo");
-        }
-
-        @Override
-        public Object execute(CommandSession session, String[] args) {
-            return String.join(" ", args);
-        }
     }
 
     @Test

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
+import org.jline.reader.EndOfFileException;
 import org.jline.shell.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,30 +32,29 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
         super.setUp();
         dispatcher.addGroup(new SimpleCommandGroup(
                 "test",
-                new EchoCommand(),
+                new TestEchoCommand(),
                 new FailCommand(),
                 new UpperCommand(),
                 new NoopCommand(),
-                new ReverseCommand()));
+                new ReverseCommand(),
+                new ExitCommand()));
     }
 
     // --- Fixture commands ---
 
-    static class EchoCommand extends AbstractCommand {
-        EchoCommand() {
-            super("echo");
+    static class ExitCommand extends AbstractCommand {
+        ExitCommand() {
+            super("exit");
         }
 
         @Override
         public String description() {
-            return "Echo arguments";
+            return "Exits shell";
         }
 
         @Override
-        public Object execute(CommandSession session, String[] args) {
-            String msg = String.join(" ", args);
-            session.out().println(msg);
-            return msg;
+        public Object execute(CommandSession session, String[] args) throws Exception {
+            throw new EndOfFileException();
         }
     }
 
@@ -207,6 +207,27 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
     }
 
     @Test
+    void pipeExitRunsNext() throws Exception {
+        Object result = dispatcher.execute("exit | echo recovered");
+        assertEquals("recovered", result);
+    }
+
+    @Test
+    void andStillExits() {
+        assertThrows(EndOfFileException.class, () -> dispatcher.execute("exit && echo test"));
+    }
+
+    @Test
+    void orStillExits() {
+        assertThrows(EndOfFileException.class, () -> dispatcher.execute("exit || echo test"));
+    }
+
+    @Test
+    void sequenceStillExits() {
+        assertThrows(EndOfFileException.class, () -> dispatcher.execute("exit ; echo test"));
+    }
+
+    @Test
     void sequenceOperator() throws Exception {
         Object result = dispatcher.execute("echo first ; echo second");
         assertEquals("second", result);
@@ -262,7 +283,7 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
         AliasManager aliasManager = new DefaultAliasManager();
         aliasManager.setAlias("hi", "echo hello");
         DefaultCommandDispatcher aliasDispatcher = new DefaultCommandDispatcher(terminal, null, null, aliasManager);
-        aliasDispatcher.addGroup(new SimpleCommandGroup("test", new EchoCommand()));
+        aliasDispatcher.addGroup(new SimpleCommandGroup("test", new TestEchoCommand()));
         Object result = aliasDispatcher.execute("hi");
         assertEquals("hello", result);
     }
@@ -271,7 +292,7 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
     void customPipelineParser() throws Exception {
         PipelineParser custom = new PipelineParser(Map.of("==>", Pipeline.Operator.PIPE));
         DefaultCommandDispatcher customDispatcher = new DefaultCommandDispatcher(terminal, null, custom, null);
-        customDispatcher.addGroup(new SimpleCommandGroup("test", new EchoCommand(), new UpperCommand()));
+        customDispatcher.addGroup(new SimpleCommandGroup("test", new TestEchoCommand(), new UpperCommand()));
         Object result = customDispatcher.execute("echo hello ==> upper");
         assertEquals("HELLO", result);
     }

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -228,6 +228,27 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
     }
 
     @Test
+    void pipeToExitDoesNothing() throws Exception {
+        assertNull(dispatcher.execute("echo test | exit"));
+        assertEquals(0, terminalOutput.toByteArray().length);
+    }
+
+    @Test
+    void andExitExits() {
+        assertThrows(EndOfFileException.class, () -> dispatcher.execute("echo test && exit"));
+    }
+
+    @Test
+    void orExitAfterFailExits() {
+        assertThrows(EndOfFileException.class, () -> dispatcher.execute("fail || exit"));
+    }
+
+    @Test
+    void sequenceStillExits2() {
+        assertThrows(EndOfFileException.class, () -> dispatcher.execute("echo test ; exit"));
+    }
+
+    @Test
     void sequenceOperator() throws Exception {
         Object result = dispatcher.execute("echo first ; echo second");
         assertEquals("second", result);

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -13,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-import org.jline.reader.EndOfFileException;
 import org.jline.shell.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,7 +53,7 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
 
         @Override
         public Object execute(CommandSession session, String[] args) throws Exception {
-            throw new EndOfFileException();
+            throw new ExitShellException();
         }
     }
 
@@ -214,17 +213,17 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
 
     @Test
     void andStillExits() {
-        assertThrows(EndOfFileException.class, () -> dispatcher.execute("exit && echo test"));
+        assertThrows(ExitShellException.class, () -> dispatcher.execute("exit && echo test"));
     }
 
     @Test
     void orStillExits() {
-        assertThrows(EndOfFileException.class, () -> dispatcher.execute("exit || echo test"));
+        assertThrows(ExitShellException.class, () -> dispatcher.execute("exit || echo test"));
     }
 
     @Test
     void sequenceStillExits() {
-        assertThrows(EndOfFileException.class, () -> dispatcher.execute("exit ; echo test"));
+        assertThrows(ExitShellException.class, () -> dispatcher.execute("exit ; echo test"));
     }
 
     @Test
@@ -235,17 +234,17 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
 
     @Test
     void andExitExits() {
-        assertThrows(EndOfFileException.class, () -> dispatcher.execute("echo test && exit"));
+        assertThrows(ExitShellException.class, () -> dispatcher.execute("echo test && exit"));
     }
 
     @Test
     void orExitAfterFailExits() {
-        assertThrows(EndOfFileException.class, () -> dispatcher.execute("fail || exit"));
+        assertThrows(ExitShellException.class, () -> dispatcher.execute("fail || exit"));
     }
 
     @Test
     void sequenceStillExits2() {
-        assertThrows(EndOfFileException.class, () -> dispatcher.execute("echo test ; exit"));
+        assertThrows(ExitShellException.class, () -> dispatcher.execute("echo test ; exit"));
     }
 
     @Test

--- a/shell/src/test/java/org/jline/shell/impl/ExitCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/ExitCommandsTest.java
@@ -10,8 +10,8 @@ package org.jline.shell.impl;
 
 import java.io.IOException;
 
-import org.jline.reader.EndOfFileException;
 import org.jline.shell.Command;
+import org.jline.shell.ExitShellException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,30 +33,30 @@ class ExitCommandsTest extends AbstractCommandsTest {
     }
 
     /**
-     * Test that the exit command throws the expected {@link EndOfFileException}.
+     * Test that the exit command throws the expected {@link ExitShellException}.
      */
     @Test
     void exitCommand() {
         Command cmd = commands.command("exit");
         assertNotNull(cmd);
-        assertThrows(EndOfFileException.class, () -> cmd.execute(session, new String[0]));
+        assertThrows(ExitShellException.class, () -> cmd.execute(session, new String[0]));
     }
 
     /**
-     * Test that the exit command throws the expected {@link EndOfFileException} when called from a dispatcher.
+     * Test that the exit command throws the expected {@link ExitShellException} when called from a dispatcher.
      */
     @Test
     void exitCommandFull() {
-        assertThrows(EndOfFileException.class, () -> dispatcher.execute("exit"));
+        assertThrows(ExitShellException.class, () -> dispatcher.execute("exit"));
     }
 
     /**
-     * Test that the quit alias throws the expected {@link EndOfFileException}.
+     * Test that the quit alias throws the expected {@link ExitShellException}.
      */
     @Test
     void quitAliasCommand() {
         Command cmd = commands.command("quit");
         assertNotNull(cmd);
-        assertThrows(EndOfFileException.class, () -> cmd.execute(session, new String[0]));
+        assertThrows(ExitShellException.class, () -> cmd.execute(session, new String[0]));
     }
 }

--- a/shell/src/test/java/org/jline/shell/impl/ExitCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/ExitCommandsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jline.reader.EndOfFileException;
+import org.jline.shell.Command;
+import org.jline.shell.Shell;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ExitCommands}.
+ */
+public class ExitCommandsTest extends AbstractCommandsTest {
+
+    private ExitCommands commands;
+
+    @Override
+    @BeforeEach
+    protected void setUp() throws IOException {
+        super.setUp();
+        commands = new ExitCommands();
+        dispatcher.addGroup(commands);
+    }
+
+    /**
+     * Test that the exit command throws the expected {@link EndOfFileException}.
+     */
+    @Test
+    void exitCommand() {
+        Command cmd = commands.command("exit");
+        assertNotNull(cmd);
+        assertThrows(EndOfFileException.class, () -> cmd.execute(session, new String[0]));
+    }
+
+    /**
+     * Test that the exit command throws the expected {@link EndOfFileException} when called from a dispatcher.
+     */
+    @Test
+    void exitCommandFull() {
+        assertThrows(EndOfFileException.class, () -> dispatcher.execute("exit"));
+    }
+
+    /**
+     * Test that the quit alias throws the expected {@link EndOfFileException}.
+     */
+    @Test
+    void quitAliasCommand() {
+        Command cmd = commands.command("quit");
+        assertNotNull(cmd);
+        assertThrows(EndOfFileException.class, () -> cmd.execute(session, new String[0]));
+    }
+
+    /**
+     * Test that the exit command exits a {@link Shell} with default settings.
+     */
+    @Test
+    void exitShellCommand() throws IOException {
+        terminalInput.write("exit\n".getBytes());
+        try (Shell shell = Shell.builder().terminal(terminal).build()) {
+            assertTimeoutPreemptively(Duration.of(1000, ChronoUnit.MILLIS), shell::run);
+        }
+    }
+
+    /**
+     * Test that the exit command in a {@link Shell} can be disabled.
+     */
+    @Test
+    void noExitShellCommand() throws Exception {
+        AtomicBoolean stopped = new AtomicBoolean(false);
+        try (Shell shell =
+                Shell.builder().terminal(terminal).exitCommands(false).build()) {
+            terminalInput.write("exit\n".getBytes(terminal.encoding()));
+            terminalInput.flush();
+            Thread shellThread = Thread.currentThread();
+            Thread thread = new Thread(
+                    () -> {
+                        try {
+                            Thread.sleep(1000);
+                            stopped.set(true);
+                            shell.stop();
+                            shellThread.interrupt();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } catch (Exception e) {
+                            // Ignore
+                        }
+                    },
+                    "shell-stop-test-thread");
+            thread.start();
+            shell.run();
+            if (thread.isAlive()) {
+                thread.interrupt();
+                thread.join();
+            }
+            assertTrue(stopped.get(), "Shell should ignore the 'exit' command.");
+        }
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/ExitCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/ExitCommandsTest.java
@@ -9,13 +9,9 @@
 package org.jline.shell.impl;
 
 import java.io.IOException;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jline.reader.EndOfFileException;
 import org.jline.shell.Command;
-import org.jline.shell.Shell;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -62,51 +58,5 @@ public class ExitCommandsTest extends AbstractCommandsTest {
         Command cmd = commands.command("quit");
         assertNotNull(cmd);
         assertThrows(EndOfFileException.class, () -> cmd.execute(session, new String[0]));
-    }
-
-    /**
-     * Test that the exit command exits a {@link Shell} with default settings.
-     */
-    @Test
-    void exitShellCommand() throws IOException {
-        terminalInput.write("exit\n".getBytes());
-        try (Shell shell = Shell.builder().terminal(terminal).build()) {
-            assertTimeoutPreemptively(Duration.of(1000, ChronoUnit.MILLIS), shell::run);
-        }
-    }
-
-    /**
-     * Test that the exit command in a {@link Shell} can be disabled.
-     */
-    @Test
-    void noExitShellCommand() throws Exception {
-        AtomicBoolean stopped = new AtomicBoolean(false);
-        try (Shell shell =
-                Shell.builder().terminal(terminal).exitCommands(false).build()) {
-            terminalInput.write("exit\n".getBytes(terminal.encoding()));
-            terminalInput.flush();
-            Thread shellThread = Thread.currentThread();
-            Thread thread = new Thread(
-                    () -> {
-                        try {
-                            Thread.sleep(1000);
-                            stopped.set(true);
-                            shell.stop();
-                            shellThread.interrupt();
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                        } catch (Exception e) {
-                            // Ignore
-                        }
-                    },
-                    "shell-stop-test-thread");
-            thread.start();
-            shell.run();
-            if (thread.isAlive()) {
-                thread.interrupt();
-                thread.join();
-            }
-            assertTrue(stopped.get(), "Shell should ignore the 'exit' command.");
-        }
     }
 }

--- a/shell/src/test/java/org/jline/shell/impl/ExitCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/ExitCommandsTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for {@link ExitCommands}.
  */
-public class ExitCommandsTest extends AbstractCommandsTest {
+class ExitCommandsTest extends AbstractCommandsTest {
 
     private ExitCommands commands;
 

--- a/shell/src/test/java/org/jline/shell/impl/HelpCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/HelpCommandsTest.java
@@ -28,25 +28,9 @@ class HelpCommandsTest extends AbstractCommandsTest {
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();
-        dispatcher.addGroup(new SimpleCommandGroup("demo", new TestEchoCmd(), new TestUpperCmd()));
+        dispatcher.addGroup(new SimpleCommandGroup("demo", new TestEchoCommand(), new TestUpperCmd()));
         commands = new HelpCommands(dispatcher);
         dispatcher.addGroup(commands);
-    }
-
-    static class TestEchoCmd extends AbstractCommand {
-        TestEchoCmd() {
-            super("echo");
-        }
-
-        @Override
-        public String description() {
-            return "Echo arguments to output";
-        }
-
-        @Override
-        public Object execute(CommandSession session, String[] args) {
-            return String.join(" ", args);
-        }
     }
 
     static class TestUpperCmd extends AbstractCommand {

--- a/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/IORedirectionTest.java
@@ -29,23 +29,7 @@ class IORedirectionTest extends AbstractCommandDispatcherTest {
     protected void setUp() throws IOException {
         super.setUp();
         dispatcher.addGroup(new SimpleCommandGroup(
-                "test", new CatCommand(), new EchoCommand(), new ErrCommand(), new BothCommand()));
-    }
-
-    /**
-     * Echoes arguments to output.
-     */
-    static class EchoCommand extends AbstractCommand {
-        EchoCommand() {
-            super("echo");
-        }
-
-        @Override
-        public Object execute(CommandSession session, String[] args) {
-            String msg = String.join(" ", args);
-            session.out().println(msg);
-            return msg;
-        }
+                "test", new CatCommand(), new TestEchoCommand(), new ErrCommand(), new BothCommand()));
     }
 
     /**

--- a/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
@@ -28,7 +28,7 @@ class SignalHandlingTest extends AbstractCommandDispatcherTest {
     @BeforeEach
     protected void setUp() throws IOException {
         super.setUp();
-        dispatcher.addGroup(new SimpleCommandGroup("test", new SleepCommand(), new EchoCommand()));
+        dispatcher.addGroup(new SimpleCommandGroup("test", new SleepCommand(), new TestEchoCommand()));
     }
 
     static class SleepCommand extends AbstractCommand {
@@ -41,19 +41,6 @@ class SignalHandlingTest extends AbstractCommandDispatcherTest {
             long millis = args.length > 0 ? Long.parseLong(args[0]) : 5000;
             Thread.sleep(millis);
             return "slept";
-        }
-    }
-
-    static class EchoCommand extends AbstractCommand {
-        EchoCommand() {
-            super("echo");
-        }
-
-        @Override
-        public Object execute(CommandSession session, String[] args) {
-            String msg = String.join(" ", args);
-            session.out().println(msg);
-            return msg;
         }
     }
 

--- a/shell/src/test/java/org/jline/shell/impl/SimpleCommandGroupTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SimpleCommandGroupTest.java
@@ -20,12 +20,7 @@ class SimpleCommandGroupTest {
 
     @Test
     void groupContainsCommands() {
-        Command echo = new AbstractCommand("echo", "e") {
-            @Override
-            public Object execute(CommandSession session, String[] args) {
-                return String.join(" ", args);
-            }
-        };
+        Command echo = new TestEchoCommand();
 
         SimpleCommandGroup group = new SimpleCommandGroup("test", echo);
         assertEquals("test", group.name());

--- a/shell/src/test/java/org/jline/shell/impl/TestEchoCommand.java
+++ b/shell/src/test/java/org/jline/shell/impl/TestEchoCommand.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.shell.impl;
+
+import org.jline.shell.CommandSession;
+
+/**
+ * Echoes arguments to output.
+ */
+public class TestEchoCommand extends AbstractCommand {
+    public TestEchoCommand() {
+        super("echo");
+    }
+
+    @Override
+    public String description() {
+        return "Echo arguments to output";
+    }
+
+    @Override
+    public Object execute(CommandSession session, String[] args) {
+        String msg = String.join(" ", args);
+        session.out().println(msg);
+        return msg;
+    }
+}

--- a/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/VariableCommandsTest.java
@@ -22,10 +22,6 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class VariableCommandsTest extends AbstractCommandsTest {
 
-    VariableCommandsTest() {
-        super(terminal -> new DefaultCommandDispatcher(terminal, null, null, null, new DefaultLineExpander(), null));
-    }
-
     @Override
     @BeforeEach
     protected void setUp() throws IOException {
@@ -40,6 +36,11 @@ class VariableCommandsTest extends AbstractCommandsTest {
                 return msg;
             }
         }));
+    }
+
+    @Override
+    protected DefaultCommandDispatcher createDispatcher() {
+        return new DefaultCommandDispatcher(terminal, null, null, null, new DefaultLineExpander(), null);
     }
 
     @Test


### PR DESCRIPTION
Make the exit command an optional command that can be disabled, implemented as all other commands without special treatment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable built-in "exit" command (alias "quit") to terminate shell sessions (enabled by default).

* **Behavior Changes**
  * REPL input flow refined: EOF/interruption and dispatch now handled together; empty lines skipped earlier.
  * "exit"/"quit" are processed via normal command dispatch instead of being special-cased.

* **Tests**
  * Added/updated tests, shared terminal fixtures, and a reusable echo test command.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1870)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->