### PR TITLE
fix: use POSIX cfmakeraw defaults (VMIN=1, VTIME=0) in enterRawMode

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -221,13 +221,7 @@ public abstract class AbstractTerminal implements TerminalExt {
         Attributes newAttr = new Attributes(prvAttr);
         newAttr.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO, LocalFlag.IEXTEN), false);
         newAttr.setInputFlags(EnumSet.of(InputFlag.IXON, InputFlag.ICRNL, InputFlag.INLCR), false);
-        // Blocking single-byte read — matches POSIX cfmakeraw(3). The
-        // previous setting (VMIN=0, VTIME=1) made the kernel return zero
-        // bytes after a 100 ms idle window; on the JVM, FileInputStream.read()
-        // turns that into -1 (EOF), so any input pump reading from
-        // FileDescriptor.in saw a spurious EOF on every empty tick.
-        // NonBlockingReader.read(timeoutMs) layers its own polling on top
-        // and remains correct with this blocking termios.
+        // POSIX cfmakeraw(3) defaults — VMIN=0/VTIME=1 made FileInputStream.read() see EOF on every 100 ms idle tick.
         newAttr.setControlChar(ControlChar.VMIN, 1);
         newAttr.setControlChar(ControlChar.VTIME, 0);
         setAttributes(newAttr);

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -221,8 +221,15 @@ public abstract class AbstractTerminal implements TerminalExt {
         Attributes newAttr = new Attributes(prvAttr);
         newAttr.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO, LocalFlag.IEXTEN), false);
         newAttr.setInputFlags(EnumSet.of(InputFlag.IXON, InputFlag.ICRNL, InputFlag.INLCR), false);
-        newAttr.setControlChar(ControlChar.VMIN, 0);
-        newAttr.setControlChar(ControlChar.VTIME, 1);
+        // Blocking single-byte read — matches POSIX cfmakeraw(3). The
+        // previous setting (VMIN=0, VTIME=1) made the kernel return zero
+        // bytes after a 100 ms idle window; on the JVM, FileInputStream.read()
+        // turns that into -1 (EOF), so any input pump reading from
+        // FileDescriptor.in saw a spurious EOF on every empty tick.
+        // NonBlockingReader.read(timeoutMs) layers its own polling on top
+        // and remains correct with this blocking termios.
+        newAttr.setControlChar(ControlChar.VMIN, 1);
+        newAttr.setControlChar(ControlChar.VTIME, 0);
         setAttributes(newAttr);
         return prvAttr;
     }

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -11,8 +11,10 @@ package org.jline.terminal.impl;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
+import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.ControlChar;
 import org.jline.terminal.Terminal.Signal;
 import org.jline.terminal.Terminal.SignalHandler;
 import org.jline.terminal.spi.Pty;
@@ -72,6 +74,38 @@ class PosixSysTerminalTest {
             assertEquals(Signal.values().length, terminal.nativeHandlers.size());
             terminal.handle(Signal.INT, prev);
             assertEquals(Signal.values().length, terminal.nativeHandlers.size());
+        }
+    }
+
+    @Test
+    void testEnterRawModeBlocksUntilOneByte() throws Exception {
+        // Regression: enterRawMode used to set VMIN=0/VTIME=1, which makes
+        // the kernel return zero bytes after a 100 ms idle window. The JVM's
+        // FileInputStream.read() turns that zero-byte read into -1 (EOF),
+        // so any input pump reading from FileDescriptor.in saw a spurious
+        // EOF on every empty tick. The POSIX cfmakeraw(3) defaults
+        // (VMIN=1, VTIME=0) make read() block until at least one byte is
+        // available, which is what every JLine caller of enterRawMode
+        // actually wants — NonBlockingReader.read(timeoutMs) layers its
+        // own polling on top.
+        Pty pty = EasyMock.createNiceMock(Pty.class);
+        EasyMock.expect(pty.getAttr()).andReturn(new Attributes()).anyTimes();
+        EasyMock.expect(pty.getSlaveInput())
+                .andReturn(new ByteArrayInputStream(new byte[0]))
+                .anyTimes();
+        EasyMock.expect(pty.getSlaveOutput())
+                .andReturn(new ByteArrayOutputStream())
+                .anyTimes();
+        Capture<Attributes> applied = EasyMock.newCapture();
+        pty.setAttr(EasyMock.capture(applied));
+        EasyMock.expectLastCall().anyTimes();
+        EasyMock.replay(pty);
+        try (PosixSysTerminal terminal =
+                new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
+            terminal.enterRawMode();
+            Attributes raw = applied.getValue();
+            assertEquals(1, raw.getControlChar(ControlChar.VMIN));
+            assertEquals(0, raw.getControlChar(ControlChar.VTIME));
         }
     }
 

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -79,15 +79,7 @@ class PosixSysTerminalTest {
 
     @Test
     void testEnterRawModeBlocksUntilOneByte() throws Exception {
-        // Regression: enterRawMode used to set VMIN=0/VTIME=1, which makes
-        // the kernel return zero bytes after a 100 ms idle window. The JVM's
-        // FileInputStream.read() turns that zero-byte read into -1 (EOF),
-        // so any input pump reading from FileDescriptor.in saw a spurious
-        // EOF on every empty tick. The POSIX cfmakeraw(3) defaults
-        // (VMIN=1, VTIME=0) make read() block until at least one byte is
-        // available, which is what every JLine caller of enterRawMode
-        // actually wants — NonBlockingReader.read(timeoutMs) layers its
-        // own polling on top.
+        // Regression: VMIN=0/VTIME=1 made FileInputStream.read() return -1 (EOF) on every 100 ms idle tick.
         Pty pty = EasyMock.createNiceMock(Pty.class);
         EasyMock.expect(pty.getAttr()).andReturn(new Attributes()).anyTimes();
         EasyMock.expect(pty.getSlaveInput())


### PR DESCRIPTION
## Summary

`AbstractTerminal.enterRawMode` sets `VMIN=0, VTIME=1`, which tells the kernel to return zero bytes from `read()` after a 100 ms idle window. On the JVM, `FileInputStream.read()` translates that zero-byte return into `-1` (EOF) — so any input pump reading from `FileDescriptor.in` sees a spurious EOF on every empty 100 ms tick and shuts its read loop down immediately. Anything backed by a plain `FileInputStream` (the FFM provider's input stream, the JNI Pty slave input, any user pump that doesn't first wrap in `NonBlockingReader`) hits this.

Switch to `VMIN=1, VTIME=0` — the POSIX `cfmakeraw(3)` defaults — which makes `read()` block until at least one byte is available.

## Why this is safe for existing callers

`NonBlockingReader.read(timeoutMs)` and `NonBlockingInputStream.read(timeout)` layer their own Java-level polling / timeout on top of the underlying blocking read, so the timeout semantics every JLine caller actually wants are preserved:

* `LineReaderImpl` reads via `terminal.reader().read(timeout)` → `NonBlockingReader`
* `Less`, `Tmux`, `TTop`, `ConsoleUI`, `DefaultPrompter` — same pattern

The previous `VMIN=0, VTIME=1` was effectively making the kernel race the Java polling layer: the kernel returns "0 bytes after 100 ms" while the Java polling layer is also computing its own deadline. The kernel signal is the one that breaks: it surfaces as EOF on `FileInputStream`-backed reads, which the polling layer can't recover from.

Internally `cfmakeraw(3)` on every Unix uses `VMIN=1, VTIME=0` for exactly this reason — it's the de-facto "raw cbreak" default.

## Scope

Single one-line behavioural change in `AbstractTerminal.enterRawMode`. No API changes; no caller code changes.

## Test plan

- [x] `./mvx mvn -pl terminal test -Dtest='PosixSysTerminalTest'` → 5/5 pass (including the new regression test)
- [x] `./mvx mvn -pl terminal test` → 279/280 pass; the single failure (`TerminalGraphicsTest.testBasicTerminalTypesSkipRuntimeDetection`) is pre-existing on `master` and unrelated to termios
- [x] New regression test `testEnterRawModeBlocksUntilOneByte` captures the `Attributes` passed to `Pty.setAttr` after `enterRawMode()` and asserts `VMIN == 1, VTIME == 0` — this would have failed before the fix

## Context

Found while debugging a TUI app built on JLine 4.1.0 that was carrying a `fixupBlockingRawMode()` workaround in its own code:

```kotlin
public fun fixupBlockingRawMode(jline: org.jline.terminal.Terminal) {
    val attrs = jline.attributes
    attrs.setControlChar(Attributes.ControlChar.VMIN, 1)
    attrs.setControlChar(Attributes.ControlChar.VTIME, 0)
    jline.attributes = attrs
}
```

Every reader pump on the user's side had to call this immediately after `terminal.enterRawMode()` or it'd shut down on the first idle tick. Folding the right behaviour into `enterRawMode` itself lets downstream users delete that workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spurious EOF errors during idle terminal operations in raw mode, improving stability when using blocking single-byte reads.

* **Tests**
  * Added a regression test to ensure raw mode blocks until a single byte is available and preserves expected terminal behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1871)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->