### PR TITLE
fix: fixed Display oldLines being set as possible immutable lists

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +82,7 @@ public class Display implements Sized {
 
     protected final Terminal terminal;
     protected final boolean fullScreen;
-    protected List<AttributedString> oldLines = Collections.emptyList();
+    protected List<AttributedString> oldLines = new ArrayList<>();
     protected int cursorPos;
     protected int columns;
     protected int columns1; // columns+1
@@ -216,8 +215,8 @@ public class Display implements Sized {
             this.rows = rows;
             this.columns = columns;
             this.columns1 = columns + 1;
-            oldLines = AttributedString.join(AttributedString.EMPTY, oldLines)
-                    .columnSplitLength(terminal, columns, true, delayLineWrap());
+            oldLines = new ArrayList<>(AttributedString.join(AttributedString.EMPTY, oldLines)
+                    .columnSplitLength(terminal, columns, true, delayLineWrap()));
         }
         // When the terminal buffer is wider than the visible window (e.g. Windows with
         // a wide screen buffer), auto-wrap occurs at the buffer width, not the visible
@@ -261,7 +260,7 @@ public class Display implements Sized {
      * before {@code reset()}.</p>
      */
     public void reset() {
-        oldLines = Collections.emptyList();
+        oldLines = new ArrayList<>();
     }
 
     /**
@@ -611,7 +610,7 @@ public class Display implements Sized {
         if (cursorPos != targetCursorPos) {
             moveVisualCursorTo(targetCursorPos < 0 ? currentPos : targetCursorPos, newLines);
         }
-        oldLines = newLines;
+        oldLines = new ArrayList<>(newLines);
         ensureDefaultAnsiStyle();
 
         if (useByteMode && byteBuilder.length() > 0) {

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -610,7 +610,8 @@ public class Display implements Sized {
         if (cursorPos != targetCursorPos) {
             moveVisualCursorTo(targetCursorPos < 0 ? currentPos : targetCursorPos, newLines);
         }
-        oldLines = new ArrayList<>(newLines);
+        oldLines.clear();
+        oldLines.addAll(newLines);
         ensureDefaultAnsiStyle();
 
         if (useByteMode && byteBuilder.length() > 0) {

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -82,7 +82,7 @@ public class Display implements Sized {
 
     protected final Terminal terminal;
     protected final boolean fullScreen;
-    protected List<AttributedString> oldLines = new ArrayList<>();
+    protected final List<AttributedString> oldLines = new ArrayList<>();
     protected int cursorPos;
     protected int columns;
     protected int columns1; // columns+1
@@ -215,8 +215,10 @@ public class Display implements Sized {
             this.rows = rows;
             this.columns = columns;
             this.columns1 = columns + 1;
-            oldLines = new ArrayList<>(AttributedString.join(AttributedString.EMPTY, oldLines)
-                    .columnSplitLength(terminal, columns, true, delayLineWrap()));
+            List<AttributedString> split = AttributedString.join(AttributedString.EMPTY, oldLines)
+                    .columnSplitLength(terminal, columns, true, delayLineWrap());
+            oldLines.clear();
+            oldLines.addAll(split);
         }
         // When the terminal buffer is wider than the visible window (e.g. Windows with
         // a wide screen buffer), auto-wrap occurs at the buffer width, not the visible
@@ -260,7 +262,7 @@ public class Display implements Sized {
      * before {@code reset()}.</p>
      */
     public void reset() {
-        oldLines = new ArrayList<>();
+        oldLines.clear();
     }
 
     /**

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -30,8 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.jline.utils.InfoCmp.Capability.enter_ca_mode;
 import static org.jline.utils.InfoCmp.Capability.exit_ca_mode;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class DisplayTest {
 
@@ -268,6 +267,30 @@ class DisplayTest {
             assertEquals('a', (char) screen[10 + cols * 1], "col 10 row 1 should be unchanged");
             assertEquals('a', (char) screen[0 + cols * 1], "col 0 row 1 should be unchanged");
             assertEquals('a', (char) screen[39 + cols * 1], "col 39 row 1 should be unchanged");
+        }
+    }
+
+    @Test
+    void testUpdateImmutableList() throws IOException {
+        int rows = 5;
+        int cols = 40;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+            List<AttributedString> lines = new ArrayList<>();
+            lines.add(new AttributedString("test1"));
+            lines.add(new AttributedString("test2"));
+            lines.add(new AttributedString("test3"));
+
+            assertDoesNotThrow(() -> display.update(List.copyOf(lines), 0));
+            lines.set(2, new AttributedString("3test"));
+            assertDoesNotThrow(() -> display.update(List.copyOf(lines), 0));
+            lines.add(new AttributedString("test4"));
+            assertDoesNotThrow(() -> display.update(List.copyOf(lines), 0));
+            display.clear();
+            lines.set(0, new AttributedString("non empty line"));
+            assertDoesNotThrow(() -> display.update(List.copyOf(lines), 0));
         }
     }
 


### PR DESCRIPTION
Display directly sets the `oldLines` to the List that was provided in the update() method.
This list may be a live-list used to routinely update a display, causing unwanted side-effects.

e.g.
```
display.update(lines, 0);
display.clear();
lines.set(2, .....);
-> the lines array was cleared, so error
```
This also causes errors when calling `display.update()` with an immutable list.

Scroll detection also modifies the List, so changing display.clear() to simply set `oldLines` to a new empty list does not fix the whole issue, hence my choice to always copy the provided list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Display now safely handles immutable or reused line data by updating its internal line cache in place, preventing errors and stale/aliased output.

* **Tests**
  * Added a test ensuring Display accepts immutable snapshots and remains stable across clear/update cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->