### PR TITLE
fix: echo preserves backslash before unrecognised escape sequences

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -337,6 +337,7 @@ public class PosixCommands {
                         i += parseUnicodeSequence(arg, i + 1, length, buf);
                         break;
                     default:
+                        buf.append('\\');
                         buf.append(nextChar);
                         break;
                 }

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
@@ -113,6 +113,22 @@ class PosixCommandsTest {
     }
 
     @Test
+    void testEchoMultipleUnrecognizedEscapes() throws Exception {
+        PosixCommands.echo(context, new String[] {"echo", "\\x\\y\\z"});
+
+        String output = out.toString();
+        assertEquals("\\x\\y\\z" + System.lineSeparator(), output);
+    }
+
+    @Test
+    void testEchoMixedRecognizedAndUnrecognizedEscapes() throws Exception {
+        PosixCommands.echo(context, new String[] {"echo", "line1\\nline2\\ttab\\\"quote"});
+
+        String output = out.toString();
+        assertEquals("line1\nline2\ttab\\\"quote" + System.lineSeparator(), output);
+    }
+
+    @Test
     void testClearCommand() {
         // Clear command should not throw an exception
         assertDoesNotThrow(() -> PosixCommands.clear(context, new String[] {"clear"}));

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsTest.java
@@ -104,6 +104,15 @@ class PosixCommandsTest {
     }
 
     @Test
+    void testEchoEscapeSequencePreservesBackslash() throws Exception {
+        PosixCommands.echo(context, new String[] {"echo", "hello \\\"world\\\""});
+
+        String output = out.toString();
+        String expected = "hello \\\"world\\\"" + System.lineSeparator();
+        assertEquals(expected, output);
+    }
+
+    @Test
     void testClearCommand() {
         // Clear command should not throw an exception
         assertDoesNotThrow(() -> PosixCommands.clear(context, new String[] {"clear"}));


### PR DESCRIPTION
## Summary
- Fix `processEscapeSequences` default case to preserve the backslash before unrecognised escape characters like `\"`, matching POSIX echo behavior

Fixes #1863

## Test plan
- [x] Added test `testEchoEscapeSequencePreservesBackslash` verifying `echo 'hello \"world\"'` outputs `hello \"world\"` instead of `hello "world"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * echo now preserves backslashes for unrecognized escape sequences, ensuring literal backslash characters appear in output.
  * Handles multiple consecutive unrecognized escapes correctly (they remain verbatim).
  * Mixed sequences now behave as expected: recognized escapes (e.g., newline, tab) are interpreted while unrecognized/escaped-quote sequences keep their backslashes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->