### PR TITLE
fix: DefaultParser preserves backslashes inside quotes

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
@@ -731,12 +731,12 @@ public class DefaultParser implements Parser {
             return false;
         }
         char quoteChar = line.charAt(quoteStart);
-        if (quoteChar == '\'') {
-            return true;
-        }
         if (pos + 1 < line.length()) {
             char next = line.charAt(pos + 1);
-            return next != quoteChar && next != '\\' && next != '$' && next != '`';
+            if (quoteChar == '\'') {
+                return next != '\'';
+            }
+            return next != quoteChar && next != '\\' && next != '$' && next != '`' && next != '\n';
         }
         return false;
     }

--- a/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultParser.java
@@ -535,7 +535,7 @@ public class DefaultParser implements Parser {
                 } else if (quoteStart < 0 && !lineCommented && isCommentDelim(line, i, blockCommentEnd)) {
                     current.append(line.charAt(i));
                     blockCommentInRightOrder = false;
-                } else if (!isEscapeChar(line, i)) {
+                } else if (!isEscapeChar(line, i) || isLiteralEscapeInQuote(line, i, quoteStart)) {
                     current.append(line.charAt(i));
                     if (quoteStart < 0) {
                         bracketChecker.check(line, i);
@@ -724,6 +724,21 @@ public class DefaultParser implements Parser {
             return false;
         }
         return isEscapeChar(buffer, pos - 1);
+    }
+
+    private boolean isLiteralEscapeInQuote(final CharSequence line, final int pos, final int quoteStart) {
+        if (quoteStart < 0) {
+            return false;
+        }
+        char quoteChar = line.charAt(quoteStart);
+        if (quoteChar == '\'') {
+            return true;
+        }
+        if (pos + 1 < line.length()) {
+            char next = line.charAt(pos + 1);
+            return next != quoteChar && next != '\\' && next != '$' && next != '`';
+        }
+        return false;
     }
 
     /**

--- a/reader/src/test/java/org/jline/reader/impl/DefaultParserTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/DefaultParserTest.java
@@ -67,6 +67,42 @@ class DefaultParserTest {
     }
 
     @Test
+    void testBackslashPreservedInSingleQuotes() {
+        DefaultParser parser = new DefaultParser();
+        CompletingParsedLine line = (CompletingParsedLine) parser.parse("source 'C:\\windows\\path'", 0);
+        assertNotNull(line);
+        assertEquals(2, line.words().size());
+        assertEquals("C:\\windows\\path", line.words().get(1));
+    }
+
+    @Test
+    void testBackslashPreservedInDoubleQuotes() {
+        DefaultParser parser = new DefaultParser();
+        CompletingParsedLine line = (CompletingParsedLine) parser.parse("source \"C:\\windows\\path\"", 0);
+        assertNotNull(line);
+        assertEquals(2, line.words().size());
+        assertEquals("C:\\windows\\path", line.words().get(1));
+    }
+
+    @Test
+    void testBackslashBeforeQuoteInDoubleQuotes() {
+        DefaultParser parser = new DefaultParser();
+        CompletingParsedLine line = (CompletingParsedLine) parser.parse("echo \"hello \\\"world\\\"\"", 0);
+        assertNotNull(line);
+        assertEquals(2, line.words().size());
+        assertEquals("hello \"world\"", line.words().get(1));
+    }
+
+    @Test
+    void testBackslashStrippedOutsideQuotes() {
+        DefaultParser parser = new DefaultParser();
+        CompletingParsedLine line = (CompletingParsedLine) parser.parse("echo a\\b\\c", 0);
+        assertNotNull(line);
+        assertEquals(2, line.words().size());
+        assertEquals("abc", line.words().get(1));
+    }
+
+    @Test
     void testSplitLine() {
         DefaultParser parser = new DefaultParser();
         CompletingParsedLine line =


### PR DESCRIPTION
## Summary
- Inside single quotes, backslash is now always preserved as literal text (matching bash behavior)
- Inside double quotes, backslash is only treated as escape before special characters (`"`, `\`, `$`, `` ` ``); for all other characters, it is preserved literally
- Outside quotes, behavior is unchanged (backslash escapes the next character)

This fixes Windows paths enclosed in quotes like `"C:\windows\path"` being incorrectly parsed as `C:windowspath`.

Fixes #1877

## Test plan
- [x] `testBackslashPreservedInSingleQuotes`: `'C:\windows\path'` → `C:\windows\path`
- [x] `testBackslashPreservedInDoubleQuotes`: `"C:\windows\path"` → `C:\windows\path`
- [x] `testBackslashBeforeQuoteInDoubleQuotes`: `"hello \"world\""` → `hello "world"` (escape still works for `"`)
- [x] `testBackslashStrippedOutsideQuotes`: `a\b\c` → `abc` (unchanged behavior)
- [x] All existing DefaultParser tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Escape characters inside quoted strings are now preserved more consistently across single and double quotes, improving token content handling.

* **Tests**
  * Added tests covering backslash behavior in single quotes, double quotes, escaped-quote contexts, and outside quotes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->