### PR TITLE
fix: NonBlockingInputStream recovers after transient EOF

### DIFF
--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -217,11 +217,6 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
                     threadIsReading = false;
                     notify();
                 }
-
-                // If end of stream, exit the loop thread
-                if (byteRead < 0) {
-                    return;
-                }
             }
         } catch (Throwable t) {
             Log.warn("Error in NonBlockingInputStream thread", t);

--- a/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
@@ -326,4 +326,27 @@ class NonBlockingTest {
         assertArrayEquals(payload, result);
         assertTrue(sawBulk, "At least one bulk read (n > 1) should have occurred");
     }
+
+    @Test
+    void testNonBlockingInputStreamRecoverAfterEof() throws IOException {
+        java.io.InputStream in = new java.io.InputStream() {
+            private int callCount = 0;
+
+            @Override
+            public int read() {
+                int n = callCount++;
+                if (n == 0) {
+                    return -1;
+                }
+                return 'A';
+            }
+        };
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("test", in);
+        try {
+            assertEquals(-1, nbis.read(200));
+            assertEquals('A', nbis.read(200));
+        } finally {
+            nbis.close();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Remove the early thread exit in `NonBlockingInputStreamImpl.run()` when the underlying stream returns -1, making it consistent with `NonBlockingReaderImpl` which already continues after -1
- On terminal file descriptors, `FileInputStream.read()` can return -1 (native `read()` returning 0 bytes) without meaning permanent EOF — e.g. when `VMIN=0` / `VTIME=0` or on certain macOS configurations with FFM terminals

This fixes the FFM terminal's `reader().read(timeout)` returning spurious -1 (EOF) values interspersed with real characters, which made the FFM provider unusable for timed-read patterns.

Fixes #1879

## Test plan
- [x] Added `testNonBlockingInputStreamRecoverAfterEof` verifying that after seeing -1, subsequent reads can still return data
- [x] All 13 existing + new NonBlocking tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-blocking input streams now properly recover from end-of-file conditions, allowing subsequent read operations to successfully retrieve new data when it becomes available.

* **Tests**
  * Added test coverage for stream recovery and data retrieval following end-of-file events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->