### PR TITLE
fix: ensure cursor position after alternate screen init

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -359,6 +359,7 @@ public class Less {
                 // Use alternate buffer
                 if (!noInit) {
                     terminal.puts(Capability.enter_ca_mode);
+                    terminal.puts(Capability.cursor_home);
                 }
                 if (!noKeypad) {
                     terminal.puts(Capability.keypad_xmit);
@@ -366,6 +367,7 @@ public class Less {
                 terminal.writer().flush();
 
                 display.clear();
+                display.reset();
                 display(false);
                 checkInterrupted();
 

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -334,6 +334,7 @@ public class Display implements Sized {
 
         if (reset) {
             puts(Capability.clear_screen);
+            puts(Capability.cursor_address, 0, 0);
             oldLines.clear();
             cursorPos = 0;
             reset = false;


### PR DESCRIPTION
## Summary
- Fixes #1883 — Less initial render can open mostly blank on Windows
- On Windows terminals, entering alternate screen mode (`enter_ca_mode`) may not reliably reset the cursor to (0,0), causing Display's cursor tracking to diverge from the physical cursor position
- Sends `cursor_home` explicitly after `enter_ca_mode` in Less to ensure deterministic cursor positioning in the alternate screen buffer
- Adds `cursor_address(0, 0)` after `clear_screen` in Display's reset path as an absolute positioning fallback
- Calls `display.reset()` in Less to clear stale display state, matching Nano's initialization pattern

## Test plan
- [ ] Verify on Windows Terminal: run the reproduction scenario from #1883 (print wall of text, then open Less on the same content) — initial viewport should show content at the top
- [ ] Verify on Linux/macOS: Less behavior unchanged (the additional cursor_home/cursor_address are redundant but harmless on these platforms)
- [ ] Run existing tests: `./mvx mvn test -pl terminal,builtins -B`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal initialization and cursor positioning for the less pager command to ensure proper display rendering and cursor placement during terminal operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->