### PR TITLE
fix: use parser for command argument splitting

### DIFF
--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -17,6 +17,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
+import org.jline.reader.Parser;
+import org.jline.reader.impl.DefaultParser;
 import org.jline.reader.impl.completer.ArgumentCompleter;
 import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
@@ -58,6 +60,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
     private final LineExpander lineExpander;
     private final ScriptRunner scriptRunner;
     private volatile Thread commandThread;
+    private final Parser parser = new DefaultParser();
 
     /**
      * Creates a new dispatcher for the given terminal.
@@ -648,7 +651,11 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             throw new UnknownCommandException("Unknown command: " + cmdName);
         }
 
-        String[] args = argsStr.isEmpty() ? new String[0] : argsStr.split("\\s+");
+        String[] args = argsStr.isEmpty()
+                ? new String[0]
+                : parser.parse(argsStr, argsStr.length(), Parser.ParseContext.ACCEPT_LINE)
+                        .words()
+                        .toArray(String[]::new);
 
         if (args.length > 0 && !cmd.subcommands().isEmpty()) {
             Command sub = cmd.subcommands().get(args[0]);

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -11,7 +11,9 @@ package org.jline.shell.impl;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jline.shell.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,6 +132,19 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
         @Override
         public Object execute(CommandSession session, String[] args) {
             return null;
+        }
+    }
+
+    static class ArgTestGroup extends SimpleCommandGroup {
+        ArgTestGroup(AtomicBoolean run, List<String> match) {
+            super("argstest", new AbstractCommand("argstest") {
+                @Override
+                public Object execute(CommandSession session, String[] args) {
+                    assertEquals(match, List.of(args));
+                    run.set(true);
+                    return null;
+                }
+            });
         }
     }
 
@@ -293,5 +308,37 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
         Pipeline pipeline = Pipeline.of("echo test").pipe("upper").build();
         Object result = dispatcher.execute(pipeline);
         assertEquals("TEST", result);
+    }
+
+    private void testArgs(String cmdArgs, List<String> match) throws Exception {
+        AtomicBoolean completed = new AtomicBoolean();
+        dispatcher.addGroup(new ArgTestGroup(completed, match));
+        dispatcher.execute("argstest " + cmdArgs);
+        assertTrue(completed.get());
+    }
+
+    @Test
+    void simpleArgTest() throws Exception {
+        testArgs("\"arg test\"", List.of("arg test"));
+    }
+
+    @Test
+    void simpleArgDoubleEscapeTest() throws Exception {
+        testArgs("\"\\\"test\"\\\"", List.of("\"test\""));
+    }
+
+    @Test
+    void simpleArgTwoArgsTest() throws Exception {
+        testArgs("\"test\" \"arg two\"", List.of("test", "arg two"));
+    }
+
+    @Test
+    void simpleArgSingleQuoteTest() throws Exception {
+        testArgs("'test arg'", List.of("test arg"));
+    }
+
+    @Test
+    void simpleArgCommandTest() throws Exception {
+        testArgs("\"echo 'test arg'\"", List.of("echo 'test arg'"));
     }
 }

--- a/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
@@ -116,7 +116,7 @@ class DefaultScriptRunnerTest extends AbstractCommandDispatcherTest {
         CommandSession session = dispatcher.session();
         session.setWorkingDirectory(tempDir);
 
-        dispatcher.execute("source " + script);
+        dispatcher.execute("source \"" + script.toString().replace("\\", "\\\\") + "\"");
 
         assertEquals(1, executedCommands.size());
         assertEquals("sourced", executedCommands.get(0));


### PR DESCRIPTION
## Summary
- Fix command argument parsing in `DefaultCommandDispatcher` to properly handle quoted strings
- Previously arguments were split on whitespace, causing `"part1 part2"` to be parsed as `["\"part1", "part2\""]` instead of `["part1 part2"]`
- Use `Parser.parse()` instead of `String.split()` for argument tokenization

Minimal bug-fix cherry-pick from #1876 (authored by @Elec332), keeping only the parsing fix and tests — the API additions (new constructors, parser injection, `ShellBuilder` wiring) remain in #1876 for 4.2.0.

## Test plan
- [x] Existing `DefaultCommandDispatcherTest` tests pass (27/27)
- [x] New argument parsing tests cover: quoted strings, escaped quotes, multiple args, single quotes, nested command-like strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced command argument parsing to correctly handle quoted strings, escaped characters, nested/command-like arguments, and Windows-style paths — reducing mis-parsed arguments and improving shell command reliability.
  * Improved handling of script/source paths containing spaces and backslashes.

* **Tests**
  * Added tests covering quoting, escaping, multi-argument parsing, single quotes, and script path quoting to ensure correct behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->