### PR TITLE
fix: clear ISIG in enterRawMode to match cfmakeraw(3)

### DIFF
--- a/prompt/src/test/java/org/jline/prompt/PromptCancelTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PromptCancelTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.prompt;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.jline.reader.UserInterruptException;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+class PromptCancelTest {
+
+    private static final byte CTRL_C = 0x03;
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+    private static final long INPUT_DELAY_MS = 200;
+
+    @Test
+    void list() throws Exception {
+        try (Fixture f = new Fixture()) {
+            PromptBuilder b = f.prompter.newBuilder();
+            b.createListPrompt()
+                    .name("pick")
+                    .message("Pick one")
+                    .newItem("a")
+                    .text("Alpha")
+                    .add()
+                    .newItem("b")
+                    .text("Bravo")
+                    .add()
+                    .addPrompt();
+            assertCancels(f, b.build());
+        }
+    }
+
+    @Test
+    void checkbox() throws Exception {
+        try (Fixture f = new Fixture()) {
+            PromptBuilder b = f.prompter.newBuilder();
+            b.createCheckboxPrompt()
+                    .name("toppings")
+                    .message("Pick toppings")
+                    .newItem("cheese")
+                    .text("Cheese")
+                    .add()
+                    .newItem("ham")
+                    .text("Ham")
+                    .add()
+                    .addPrompt();
+            assertCancels(f, b.build());
+        }
+    }
+
+    @Test
+    void choice() throws Exception {
+        try (Fixture f = new Fixture()) {
+            PromptBuilder b = f.prompter.newBuilder();
+            b.createChoicePrompt()
+                    .name("color")
+                    .message("Pick a color")
+                    .newChoice("red")
+                    .text("Red")
+                    .key('r')
+                    .add()
+                    .newChoice("green")
+                    .text("Green")
+                    .key('g')
+                    .add()
+                    .addPrompt();
+            assertCancels(f, b.build());
+        }
+    }
+
+    @Test
+    void confirm() throws Exception {
+        try (Fixture f = new Fixture()) {
+            PromptBuilder b = f.prompter.newBuilder();
+            b.createConfirmPrompt().name("agree").message("Do you agree?").addPrompt();
+            assertCancels(f, b.build());
+        }
+    }
+
+    private static void assertCancels(Fixture f, List<Prompt> prompts) {
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            f.sendCtrlCAfter(INPUT_DELAY_MS);
+            assertThrows(UserInterruptException.class, () -> f.prompter.prompt(List.of(), prompts));
+        });
+    }
+
+    private static final class Fixture implements AutoCloseable {
+        final PipedOutputStream feeder;
+        final Terminal terminal;
+        final Prompter prompter;
+        volatile Thread sender;
+
+        Fixture() throws Exception {
+            PipedInputStream in = new PipedInputStream();
+            this.feeder = new PipedOutputStream(in);
+            this.terminal = TerminalBuilder.builder()
+                    .type("ansi")
+                    .streams(in, new ByteArrayOutputStream())
+                    .build();
+            terminal.setSize(Size.of(160, 80));
+            this.prompter = PrompterFactory.create(terminal);
+        }
+
+        // Delay so prompt() can call enterRawMode() first, else the pump consumes 0x03 as
+        // VINTR under cooked-mode attributes. Block until interrupted so PipedInputStream
+        // does not raise "Write end dead" before the keymap matches.
+        void sendCtrlCAfter(long delayMillis) {
+            sender = new Thread(
+                    () -> {
+                        try {
+                            TimeUnit.MILLISECONDS.sleep(delayMillis);
+                            feeder.write(CTRL_C);
+                            feeder.flush();
+                            Thread.sleep(Long.MAX_VALUE);
+                        } catch (Exception ignored) {
+                        }
+                    },
+                    "ctrl-c-sender");
+            sender.setDaemon(true);
+            sender.start();
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (sender != null) {
+                sender.interrupt();
+            }
+            try {
+                terminal.close();
+            } finally {
+                feeder.close();
+            }
+        }
+    }
+}

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -219,7 +219,10 @@ public abstract class AbstractTerminal implements TerminalExt {
     public Attributes enterRawMode() {
         Attributes prvAttr = getAttributes();
         Attributes newAttr = new Attributes(prvAttr);
-        newAttr.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO, LocalFlag.IEXTEN), false);
+        // POSIX cfmakeraw(3) also clears ISIG so Ctrl+C/Ctrl+\/Ctrl+Z arrive as 0x03/0x1c/0x1a
+        // characters rather than as signals. This is required for raw-mode readers (for example,
+        // prompters in the jline-prompt module) whose keymaps bind those bytes to CANCEL/INTERRUPT operations.
+        newAttr.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO, LocalFlag.IEXTEN, LocalFlag.ISIG), false);
         newAttr.setInputFlags(EnumSet.of(InputFlag.IXON, InputFlag.ICRNL, InputFlag.INLCR), false);
         // POSIX cfmakeraw(3) defaults — VMIN=0/VTIME=1 made FileInputStream.read() see EOF on every 100 ms idle tick.
         newAttr.setControlChar(ControlChar.VMIN, 1);


### PR DESCRIPTION
#1871 brought VMIN/VTIME in line with POSIX cfmakeraw(3) but left ISIG set. Raw-mode readers that bind Ctrl+C in their keymap never see 0x03. This affects the list/checkbox/choice/confirm prompts in the jline-prompt module.

Adds PromptCancelTest covering list, checkbox, choice and confirm.

Fixes #1900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated tests to confirm Ctrl-C (interrupt) cancels interactive prompts (list, checkbox, choice, confirm) reliably.

* **Bug Fixes**
  * Improved terminal raw-mode handling so Ctrl-character signals are delivered and handled correctly, reducing missed or delayed interrupt behavior in interactive sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->