### PR TITLE
fix: terminal.close() blocks when pump thread is reading stdin

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -33,6 +33,8 @@ import org.jline.utils.FastBufferedOutputStream;
 import org.jline.utils.NonBlocking;
 import org.jline.utils.NonBlockingInputStream;
 import org.jline.utils.NonBlockingReader;
+import org.jline.utils.NonCloseableInputStream;
+import org.jline.utils.NonCloseableOutputStream;
 import org.jline.utils.ShutdownHooks;
 import org.jline.utils.ShutdownHooks.Task;
 
@@ -52,6 +54,12 @@ import org.jline.utils.ShutdownHooks.Task;
  * <pre>
  *   Terminal → AbstractTerminal → AbstractUnixSysTerminal → subclass → native call
  * </pre>
+ *
+ * <p><strong>Important:</strong> the underlying system streams ({@code FileDescriptor.in},
+ * {@code FileDescriptor.out}/{@code err}) are wrapped in {@link NonCloseableInputStream} /
+ * {@link NonCloseableOutputStream}. Closing the terminal will shut down the pump thread and
+ * release resources, but will <em>not</em> close the shared file descriptors. This prevents
+ * breaking {@code System.in}/{@code System.out} for the rest of the JVM.</p>
  */
 public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
 
@@ -89,7 +97,8 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
         this.originalAttributes = originalAttributes;
         this.nativeSignals = nativeSignals;
 
-        this.input = NonBlocking.nonBlocking(getName(), new FileInputStream(FileDescriptor.in));
+        this.input =
+                NonBlocking.nonBlocking(getName(), new NonCloseableInputStream(new FileInputStream(FileDescriptor.in)));
         FileDescriptor outFd;
         if (systemStream == SystemStream.Output) {
             outFd = FileDescriptor.out;
@@ -98,7 +107,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
         } else {
             throw new IllegalArgumentException("Invalid system stream for output: " + systemStream);
         }
-        this.output = new FastBufferedOutputStream(new FileOutputStream(outFd));
+        this.output = new FastBufferedOutputStream(new NonCloseableOutputStream(new FileOutputStream(outFd)));
         this.reader = NonBlocking.nonBlocking(getName(), input, inputEncoding());
         this.writer = new PrintWriter(new OutputStreamWriter(output, outputEncoding()));
 
@@ -246,7 +255,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
                         unblock.setControlChar(ControlChar.VTIME, 1);
                         doSetAttributes(unblock);
                     } finally {
-                        input.shutdown();
+                        input.close();
                     }
                 } finally {
                     try {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntConsumer;
 
 import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.ControlChar;
+import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Cursor;
 import org.jline.terminal.Size;
 import org.jline.terminal.Sized;
@@ -231,9 +233,24 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
                 super.doClose();
             } finally {
                 try {
-                    doSetAttributes(originalAttributes);
+                    // Before restoring original terminal attributes, switch to
+                    // non-canonical mode with VMIN=0/VTIME=1 so any pump thread
+                    // blocked in a native read() on stdin will time out within
+                    // 100 ms. On macOS, a blocked read() on a tty can prevent
+                    // tcsetattr() from completing, so the pump thread must exit
+                    // its read() before we restore original attributes.
+                    Attributes unblock = doGetAttributes();
+                    unblock.setLocalFlag(LocalFlag.ICANON, false);
+                    unblock.setControlChar(ControlChar.VMIN, 0);
+                    unblock.setControlChar(ControlChar.VTIME, 1);
+                    doSetAttributes(unblock);
+                    input.shutdown();
                 } finally {
-                    reader.close();
+                    try {
+                        doSetAttributes(originalAttributes);
+                    } finally {
+                        reader.close();
+                    }
                 }
             }
         }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -22,8 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntConsumer;
 
 import org.jline.terminal.Attributes;
-import org.jline.terminal.Attributes.ControlChar;
-import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Cursor;
 import org.jline.terminal.Size;
 import org.jline.terminal.Sized;
@@ -242,21 +240,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
                 super.doClose();
             } finally {
                 try {
-                    // Before restoring original terminal attributes, switch to
-                    // non-canonical mode with VMIN=0/VTIME=1 so any pump thread
-                    // blocked in a native read() on stdin will time out within
-                    // 100 ms. On macOS, a blocked read() on a tty can prevent
-                    // tcsetattr() from completing, so the pump thread must exit
-                    // its read() before we restore original attributes.
-                    try {
-                        Attributes unblock = doGetAttributes();
-                        unblock.setLocalFlag(LocalFlag.ICANON, false);
-                        unblock.setControlChar(ControlChar.VMIN, 0);
-                        unblock.setControlChar(ControlChar.VTIME, 1);
-                        doSetAttributes(unblock);
-                    } finally {
-                        input.close();
-                    }
+                    input.close();
                 } finally {
                     try {
                         doSetAttributes(originalAttributes);

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -239,12 +239,15 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
                     // 100 ms. On macOS, a blocked read() on a tty can prevent
                     // tcsetattr() from completing, so the pump thread must exit
                     // its read() before we restore original attributes.
-                    Attributes unblock = doGetAttributes();
-                    unblock.setLocalFlag(LocalFlag.ICANON, false);
-                    unblock.setControlChar(ControlChar.VMIN, 0);
-                    unblock.setControlChar(ControlChar.VTIME, 1);
-                    doSetAttributes(unblock);
-                    input.shutdown();
+                    try {
+                        Attributes unblock = doGetAttributes();
+                        unblock.setLocalFlag(LocalFlag.ICANON, false);
+                        unblock.setControlChar(ControlChar.VMIN, 0);
+                        unblock.setControlChar(ControlChar.VTIME, 1);
+                        doSetAttributes(unblock);
+                    } finally {
+                        input.shutdown();
+                    }
                 } finally {
                     try {
                         doSetAttributes(originalAttributes);

--- a/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/DumbTerminalProvider.java
@@ -11,8 +11,6 @@ package org.jline.terminal.impl;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FilterInputStream;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -24,6 +22,8 @@ import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
+import org.jline.utils.NonCloseableInputStream;
+import org.jline.utils.NonCloseableOutputStream;
 
 /**
  * Terminal provider implementation for dumb terminals.
@@ -126,36 +126,5 @@ public class DumbTerminalProvider implements TerminalProvider {
     @Override
     public String toString() {
         return "TerminalProvider[" + name() + "]";
-    }
-
-    /**
-     * Wrapper that prevents closing the underlying input stream.
-     * Used for system streams (System.in) to prevent closing the FileDescriptor.
-     */
-    private static class NonCloseableInputStream extends FilterInputStream {
-        NonCloseableInputStream(InputStream in) {
-            super(in);
-        }
-
-        @Override
-        public void close() throws IOException {
-            // Do not close the underlying stream
-        }
-    }
-
-    /**
-     * Wrapper that prevents closing the underlying output stream.
-     * Used for system streams (System.out/err) to prevent closing the FileDescriptor.
-     */
-    private static class NonCloseableOutputStream extends FilterOutputStream {
-        NonCloseableOutputStream(OutputStream out) {
-            super(out);
-        }
-
-        @Override
-        public void close() throws IOException {
-            // Flush but do not close the underlying stream
-            flush();
-        }
     }
 }

--- a/terminal/src/main/java/org/jline/terminal/impl/exec/ExecPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/exec/ExecPty.java
@@ -31,6 +31,8 @@ import org.jline.terminal.impl.AbstractPty;
 import org.jline.terminal.spi.Pty;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
+import org.jline.utils.NonCloseableInputStream;
+import org.jline.utils.NonCloseableOutputStream;
 import org.jline.utils.OSUtils;
 
 import static org.jline.utils.ExecHelper.exec;
@@ -154,15 +156,17 @@ public class ExecPty extends AbstractPty implements Pty {
 
     @Override
     protected InputStream doGetSlaveInput() throws IOException {
-        return systemStream != null ? new FileInputStream(FileDescriptor.in) : new FileInputStream(getName());
+        return systemStream != null
+                ? new NonCloseableInputStream(new FileInputStream(FileDescriptor.in))
+                : new FileInputStream(getName());
     }
 
     @Override
     public OutputStream getSlaveOutput() throws IOException {
         return systemStream == SystemStream.Output
-                ? new FileOutputStream(FileDescriptor.out)
+                ? new NonCloseableOutputStream(new FileOutputStream(FileDescriptor.out))
                 : systemStream == SystemStream.Error
-                        ? new FileOutputStream(FileDescriptor.err)
+                        ? new NonCloseableOutputStream(new FileOutputStream(FileDescriptor.err))
                         : new FileOutputStream(getName());
     }
 

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -59,25 +59,38 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
     }
 
     /**
-     * Shuts down the thread that is handling blocking I/O. Note that if the
-     * thread is currently blocked waiting for I/O it will not actually
-     * shut down until the I/O is received.
+     * Shuts down the thread that is handling blocking I/O. Sets
+     * {@code threadIsReading} to false, interrupts the thread (to wake it
+     * from a {@code wait()} call), and waits briefly for the thread to exit.
+     *
+     * <p>If the thread is blocked in a native {@code read()} call, the
+     * interrupt alone may not unblock it — callers can set VMIN=0/VTIME=1
+     * on the terminal beforehand to force the read to time out.</p>
      */
-    public synchronized void shutdown() {
-        if (thread != null) {
-            notify();
+    public void shutdown() {
+        Thread t;
+        synchronized (this) {
+            t = thread;
+            if (t != null) {
+                threadIsReading = false;
+                t.interrupt();
+                notify();
+            }
+        }
+        if (t != null) {
+            try {
+                t.join(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 
     @Override
     public void close() throws IOException {
-        /*
-         * The underlying input stream is closed first. This means that if the
-         * I/O thread was blocked waiting on input, it will be woken for us.
-         */
-        super.close(); // Mark as closed in base class
-        in.close();
+        super.close();
         shutdown();
+        in.close();
     }
 
     /**

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -80,6 +80,9 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
         if (t != null) {
             try {
                 t.join(500);
+                if (t.isAlive()) {
+                    Log.warn("Pump thread did not exit within 500ms");
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -89,8 +89,11 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
     @Override
     public void close() throws IOException {
         super.close();
-        shutdown();
-        in.close();
+        try {
+            in.close();
+        } finally {
+            shutdown();
+        }
     }
 
     /**

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -64,8 +64,8 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
      * from a {@code wait()} call), and waits briefly for the thread to exit.
      *
      * <p>If the thread is blocked in a native {@code read()} call, the
-     * interrupt alone may not unblock it — callers can set VMIN=0/VTIME=1
-     * on the terminal beforehand to force the read to time out.</p>
+     * interrupt may not unblock it. The thread will exit on its next
+     * iteration once the read completes naturally.</p>
      */
     public void shutdown() {
         Thread t;

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -31,10 +31,8 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
     private int b = READ_EXPIRED; // Recently read byte
 
     private String name;
-    private boolean threadIsReading = false;
     private IOException exception = null;
-    private long threadDelay = 60 * 1000;
-    private Thread thread;
+    private final PumpThread pump = new PumpThread(60_000);
 
     /**
      * Creates a <code>NonBlockingReader</code> out of a normal blocking
@@ -49,44 +47,8 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
         this.name = name;
     }
 
-    private synchronized void startReadingThreadIfNeeded() {
-        if (thread == null) {
-            thread = new Thread(this::run);
-            thread.setName(name + " non blocking reader thread");
-            thread.setDaemon(true);
-            thread.start();
-        }
-    }
-
-    /**
-     * Shuts down the thread that is handling blocking I/O. Sets
-     * {@code threadIsReading} to false, interrupts the thread (to wake it
-     * from a {@code wait()} call), and waits briefly for the thread to exit.
-     *
-     * <p>If the thread is blocked in a native {@code read()} call, the
-     * interrupt may not unblock it. The thread will exit on its next
-     * iteration once the read completes naturally.</p>
-     */
     public void shutdown() {
-        Thread t;
-        synchronized (this) {
-            t = thread;
-            if (t != null) {
-                threadIsReading = false;
-                t.interrupt();
-                notify();
-            }
-        }
-        if (t != null) {
-            try {
-                t.join(50);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            synchronized (this) {
-                thread = null;
-            }
-        }
+        pump.shutdown(this);
     }
 
     @Override
@@ -95,7 +57,7 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
         try {
             in.close();
         } finally {
-            shutdown();
+            pump.shutdown(this);
         }
     }
 
@@ -129,15 +91,15 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
          */
         if (b >= -1) {
             assert exception == null;
-        } else if (!isPeek && timeout <= 0L && !threadIsReading) {
+        } else if (!isPeek && timeout <= 0L && !pump.isReading()) {
             b = in.read();
         } else {
             /*
              * If the thread isn't reading already, then ask it to do so.
              */
-            if (!threadIsReading) {
-                threadIsReading = true;
-                startReadingThreadIfNeeded();
+            if (!pump.isReading()) {
+                pump.setReading(true);
+                pump.startIfNeeded(this::run, name);
                 notifyAll();
             }
 
@@ -196,20 +158,20 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
                  * and the accessing thread.
                  */
                 synchronized (this) {
-                    needToRead = this.threadIsReading;
+                    needToRead = pump.isReading();
 
                     try {
                         /*
                          * Nothing to do? Then wait.
                          */
                         if (!needToRead) {
-                            wait(threadDelay);
+                            wait(pump.idleTimeout());
                         }
                     } catch (InterruptedException e) {
                         /* IGNORED */
                     }
 
-                    needToRead = this.threadIsReading;
+                    needToRead = pump.isReading();
                     if (!needToRead) {
                         return;
                     }
@@ -233,7 +195,7 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
                 synchronized (this) {
                     exception = failure;
                     b = byteRead;
-                    threadIsReading = false;
+                    pump.setReading(false);
                     notify();
                 }
             }
@@ -242,8 +204,7 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
         } finally {
             Log.debug("NonBlockingInputStream shutdown");
             synchronized (this) {
-                thread = null;
-                threadIsReading = false;
+                pump.clearThread();
             }
         }
     }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -32,7 +32,7 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
 
     private String name;
     private IOException exception = null;
-    private final PumpThread pump = new PumpThread(60_000);
+    private final PumpThread pump;
 
     /**
      * Creates a <code>NonBlockingReader</code> out of a normal blocking
@@ -42,13 +42,15 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
      * @param name The stream name
      * @param in The reader to wrap
      */
+    @SuppressWarnings("this-escape")
     public NonBlockingInputStreamImpl(String name, InputStream in) {
         this.in = in;
         this.name = name;
+        this.pump = new PumpThread(this, 60_000);
     }
 
     public void shutdown() {
-        pump.shutdown(this);
+        pump.shutdown();
     }
 
     @Override
@@ -57,7 +59,7 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
         try {
             in.close();
         } finally {
-            pump.shutdown(this);
+            pump.shutdown();
         }
     }
 
@@ -148,7 +150,6 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
 
     private void run() {
         pump.runLoop(
-                this,
                 in::read,
                 (value, failure) -> {
                     exception = failure;

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -79,12 +79,12 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
         }
         if (t != null) {
             try {
-                t.join(500);
-                if (t.isAlive()) {
-                    Log.warn("Pump thread did not exit within 500ms");
-                }
+                t.join(50);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+            }
+            synchronized (this) {
+                thread = null;
             }
         }
     }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -147,65 +147,13 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
     }
 
     private void run() {
-        Log.debug("NonBlockingInputStream start");
-        boolean needToRead;
-
-        try {
-            while (true) {
-
-                /*
-                 * Synchronize to grab variables accessed by both this thread
-                 * and the accessing thread.
-                 */
-                synchronized (this) {
-                    needToRead = pump.isReading();
-
-                    try {
-                        /*
-                         * Nothing to do? Then wait.
-                         */
-                        if (!needToRead) {
-                            wait(pump.idleTimeout());
-                        }
-                    } catch (InterruptedException e) {
-                        /* IGNORED */
-                    }
-
-                    needToRead = pump.isReading();
-                    if (!needToRead) {
-                        return;
-                    }
-                }
-
-                /*
-                 * We're not shutting down, but we need to read. This cannot
-                 * happen while we are holding the lock (which we aren't now).
-                 */
-                int byteRead = READ_EXPIRED;
-                IOException failure = null;
-                try {
-                    byteRead = in.read();
-                } catch (IOException e) {
-                    failure = e;
-                }
-
-                /*
-                 * Re-grab the lock to update the state.
-                 */
-                synchronized (this) {
+        pump.runLoop(
+                this,
+                in::read,
+                (value, failure) -> {
                     exception = failure;
-                    b = byteRead;
-                    pump.setReading(false);
-                    notify();
-                }
-            }
-        } catch (Throwable t) {
-            Log.warn("Error in NonBlockingInputStream thread", t);
-        } finally {
-            Log.debug("NonBlockingInputStream shutdown");
-            synchronized (this) {
-                pump.clearThread();
-            }
-        }
+                    b = value;
+                },
+                "NonBlockingInputStream");
     }
 }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
@@ -62,25 +62,34 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
     }
 
     /**
-     * Shuts down the thread that is handling blocking I/O. Note that if the
-     * thread is currently blocked waiting for I/O it will not actually
-     * shut down until the I/O is received.
+     * Shuts down the thread that is handling blocking I/O. Sets
+     * {@code threadIsReading} to false, interrupts the thread (to wake it
+     * from a {@code wait()} call), and waits briefly for the thread to exit.
      */
-    public synchronized void shutdown() {
-        if (thread != null) {
-            notify();
+    public void shutdown() {
+        Thread t;
+        synchronized (this) {
+            t = thread;
+            if (t != null) {
+                threadIsReading = false;
+                t.interrupt();
+                notify();
+            }
+        }
+        if (t != null) {
+            try {
+                t.join(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 
     @Override
     public void close() throws IOException {
-        /*
-         * The underlying input stream is closed first. This means that if the
-         * I/O thread was blocked waiting on input, it will be woken for us.
-         */
-        super.close(); // Mark as closed in base class
-        in.close();
+        super.close();
         shutdown();
+        in.close();
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
@@ -79,6 +79,9 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
         if (t != null) {
             try {
                 t.join(500);
+                if (t.isAlive()) {
+                    Log.warn("Pump thread did not exit within 500ms");
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
@@ -88,8 +88,11 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
     @Override
     public void close() throws IOException {
         super.close();
-        shutdown();
-        in.close();
+        try {
+            in.close();
+        } finally {
+            shutdown();
+        }
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
@@ -184,70 +184,14 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
     }
 
     private void run() {
-        Log.debug("NonBlockingReader start");
-        boolean needToRead;
-
-        try {
-            while (true) {
-
-                /*
-                 * Synchronize to grab variables accessed by both this thread
-                 * and the accessing thread.
-                 */
-                synchronized (this) {
-                    needToRead = pump.isReading();
-
-                    try {
-                        /*
-                         * Nothing to do? Then wait.
-                         */
-                        if (!needToRead) {
-                            wait(pump.idleTimeout());
-                        }
-                    } catch (InterruptedException e) {
-                        /* IGNORED */
-                    }
-
-                    needToRead = pump.isReading();
-                    if (!needToRead) {
-                        return;
-                    }
-                }
-
-                /*
-                 * We're not shutting down, but we need to read. This cannot
-                 * happen while we are holding the lock (which we aren't now).
-                 */
-                int charRead = READ_EXPIRED;
-                IOException failure = null;
-                try {
-                    charRead = in.read();
-                    //                    if (charRead < 0) {
-                    //                        continue;
-                    //                    }
-                } catch (IOException e) {
-                    failure = e;
-                    //                    charRead = -1;
-                }
-
-                /*
-                 * Re-grab the lock to update the state.
-                 */
-                synchronized (this) {
+        pump.runLoop(
+                this,
+                in::read,
+                (value, failure) -> {
                     exception = failure;
-                    ch = charRead;
-                    pump.setReading(false);
-                    notify();
-                }
-            }
-        } catch (Throwable t) {
-            Log.warn("Error in NonBlockingReader thread", t);
-        } finally {
-            Log.debug("NonBlockingReader shutdown");
-            synchronized (this) {
-                pump.clearThread();
-            }
-        }
+                    ch = value;
+                },
+                "NonBlockingReader");
     }
 
     public synchronized void clear() throws IOException {

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
@@ -34,10 +34,8 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
     private int ch = READ_EXPIRED; // Recently read character
 
     private String name;
-    private boolean threadIsReading = false;
     private IOException exception = null;
-    private long threadDelay = 60 * 1000;
-    private Thread thread;
+    private final PumpThread pump = new PumpThread(60_000);
 
     /**
      * Creates a <code>NonBlockingReader</code> out of a normal blocking
@@ -52,40 +50,8 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
         this.name = name;
     }
 
-    private synchronized void startReadingThreadIfNeeded() {
-        if (thread == null) {
-            thread = new Thread(this::run);
-            thread.setName(name + " non blocking reader thread");
-            thread.setDaemon(true);
-            thread.start();
-        }
-    }
-
-    /**
-     * Shuts down the thread that is handling blocking I/O. Sets
-     * {@code threadIsReading} to false, interrupts the thread (to wake it
-     * from a {@code wait()} call), and waits briefly for the thread to exit.
-     */
     public void shutdown() {
-        Thread t;
-        synchronized (this) {
-            t = thread;
-            if (t != null) {
-                threadIsReading = false;
-                t.interrupt();
-                notify();
-            }
-        }
-        if (t != null) {
-            try {
-                t.join(50);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            synchronized (this) {
-                thread = null;
-            }
-        }
+        pump.shutdown(this);
     }
 
     @Override
@@ -94,7 +60,7 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
         try {
             in.close();
         } finally {
-            shutdown();
+            pump.shutdown(this);
         }
     }
 
@@ -120,7 +86,7 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
             b[0] = (char) ch;
             ch = READ_EXPIRED;
             return 1;
-        } else if (!threadIsReading && timeout <= 0) {
+        } else if (!pump.isReading() && timeout <= 0) {
             return in.read(b, off, len);
         } else {
             // TODO: rework implementation to read as much as possible
@@ -162,15 +128,15 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
          */
         if (ch >= -1) {
             assert exception == null;
-        } else if (!isPeek && timeout <= 0L && !threadIsReading) {
+        } else if (!isPeek && timeout <= 0L && !pump.isReading()) {
             ch = in.read();
         } else {
             /*
              * If the thread isn't reading already, then ask it to do so.
              */
-            if (!threadIsReading) {
-                threadIsReading = true;
-                startReadingThreadIfNeeded();
+            if (!pump.isReading()) {
+                pump.setReading(true);
+                pump.startIfNeeded(this::run, name);
                 notifyAll();
             }
 
@@ -229,20 +195,20 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
                  * and the accessing thread.
                  */
                 synchronized (this) {
-                    needToRead = this.threadIsReading;
+                    needToRead = pump.isReading();
 
                     try {
                         /*
                          * Nothing to do? Then wait.
                          */
                         if (!needToRead) {
-                            wait(threadDelay);
+                            wait(pump.idleTimeout());
                         }
                     } catch (InterruptedException e) {
                         /* IGNORED */
                     }
 
-                    needToRead = this.threadIsReading;
+                    needToRead = pump.isReading();
                     if (!needToRead) {
                         return;
                     }
@@ -270,7 +236,7 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
                 synchronized (this) {
                     exception = failure;
                     ch = charRead;
-                    threadIsReading = false;
+                    pump.setReading(false);
                     notify();
                 }
             }
@@ -279,8 +245,7 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
         } finally {
             Log.debug("NonBlockingReader shutdown");
             synchronized (this) {
-                thread = null;
-                threadIsReading = false;
+                pump.clearThread();
             }
         }
     }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
@@ -78,12 +78,12 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
         }
         if (t != null) {
             try {
-                t.join(500);
-                if (t.isAlive()) {
-                    Log.warn("Pump thread did not exit within 500ms");
-                }
+                t.join(50);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+            }
+            synchronized (this) {
+                thread = null;
             }
         }
     }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReaderImpl.java
@@ -35,7 +35,7 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
 
     private String name;
     private IOException exception = null;
-    private final PumpThread pump = new PumpThread(60_000);
+    private final PumpThread pump;
 
     /**
      * Creates a <code>NonBlockingReader</code> out of a normal blocking
@@ -45,13 +45,15 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
      * @param name The reader name
      * @param in The reader to wrap
      */
+    @SuppressWarnings("this-escape")
     public NonBlockingReaderImpl(String name, Reader in) {
         this.in = in;
         this.name = name;
+        this.pump = new PumpThread(this, 60_000);
     }
 
     public void shutdown() {
-        pump.shutdown(this);
+        pump.shutdown();
     }
 
     @Override
@@ -60,7 +62,7 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
         try {
             in.close();
         } finally {
-            pump.shutdown(this);
+            pump.shutdown();
         }
     }
 
@@ -185,7 +187,6 @@ public class NonBlockingReaderImpl extends NonBlockingReader {
 
     private void run() {
         pump.runLoop(
-                this,
                 in::read,
                 (value, failure) -> {
                     exception = failure;

--- a/terminal/src/main/java/org/jline/utils/NonCloseableInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonCloseableInputStream.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Wrapper that prevents closing the underlying input stream.
+ * Used for system streams ({@code System.in}) to prevent closing
+ * the shared {@code FileDescriptor}.
+ */
+public class NonCloseableInputStream extends FilterInputStream {
+
+    public NonCloseableInputStream(InputStream in) {
+        super(in);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Do not close the underlying stream
+    }
+}

--- a/terminal/src/main/java/org/jline/utils/NonCloseableOutputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonCloseableOutputStream.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Wrapper that prevents closing the underlying output stream.
+ * Used for system streams ({@code System.out}/{@code System.err}) to prevent
+ * closing the shared {@code FileDescriptor}.
+ */
+public class NonCloseableOutputStream extends FilterOutputStream {
+
+    public NonCloseableOutputStream(OutputStream out) {
+        super(out);
+    }
+
+    @Override
+    public void close() throws IOException {
+        flush();
+    }
+}

--- a/terminal/src/main/java/org/jline/utils/PumpThread.java
+++ b/terminal/src/main/java/org/jline/utils/PumpThread.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+/**
+ * Manages the lifecycle of a background pump thread used by
+ * {@link NonBlockingInputStreamImpl} and {@link NonBlockingReaderImpl}.
+ *
+ * <p>All state-access methods ({@link #isReading()}, {@link #setReading(boolean)},
+ * {@link #startIfNeeded}, {@link #clearThread()}) must be called while the caller
+ * holds the monitor on the owning NonBlocking* instance.
+ * {@link #shutdown} manages its own synchronization on the provided lock.</p>
+ */
+final class PumpThread {
+
+    private final long idleTimeout;
+    private Thread thread;
+    private boolean reading;
+
+    PumpThread(long idleTimeout) {
+        this.idleTimeout = idleTimeout;
+    }
+
+    void startIfNeeded(Runnable task, String name) {
+        if (thread == null) {
+            thread = new Thread(task);
+            thread.setName(name + " non blocking reader thread");
+            thread.setDaemon(true);
+            thread.start();
+        }
+    }
+
+    void shutdown(Object lock) {
+        Thread t;
+        synchronized (lock) {
+            t = thread;
+            if (t != null) {
+                reading = false;
+                t.interrupt();
+                lock.notify();
+            }
+        }
+        if (t != null) {
+            try {
+                t.join(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            synchronized (lock) {
+                thread = null;
+            }
+        }
+    }
+
+    boolean isReading() {
+        return reading;
+    }
+
+    void setReading(boolean reading) {
+        this.reading = reading;
+    }
+
+    long idleTimeout() {
+        return idleTimeout;
+    }
+
+    void clearThread() {
+        thread = null;
+        reading = false;
+    }
+}

--- a/terminal/src/main/java/org/jline/utils/PumpThread.java
+++ b/terminal/src/main/java/org/jline/utils/PumpThread.java
@@ -8,6 +8,8 @@
  */
 package org.jline.utils;
 
+import java.io.IOException;
+
 /**
  * Manages the lifecycle of a background pump thread used by
  * {@link NonBlockingInputStreamImpl} and {@link NonBlockingReaderImpl}.
@@ -18,6 +20,16 @@ package org.jline.utils;
  * {@link #shutdown} manages its own synchronization on the provided lock.</p>
  */
 final class PumpThread {
+
+    @FunctionalInterface
+    interface IoReader {
+        int read() throws IOException;
+    }
+
+    @FunctionalInterface
+    interface ResultHandler {
+        void accept(int value, IOException failure);
+    }
 
     private final long idleTimeout;
     private Thread thread;
@@ -54,6 +66,51 @@ final class PumpThread {
             }
             synchronized (lock) {
                 thread = null;
+            }
+        }
+    }
+
+    void runLoop(Object lock, IoReader reader, ResultHandler handler, String logName) {
+        Log.debug(logName + " start");
+        boolean needToRead;
+
+        try {
+            while (true) {
+                synchronized (lock) {
+                    needToRead = reading;
+                    try {
+                        if (!needToRead) {
+                            lock.wait(idleTimeout);
+                        }
+                    } catch (InterruptedException e) {
+                        /* IGNORED */
+                    }
+                    needToRead = reading;
+                    if (!needToRead) {
+                        return;
+                    }
+                }
+
+                int value = NonBlockingInputStream.READ_EXPIRED;
+                IOException failure = null;
+                try {
+                    value = reader.read();
+                } catch (IOException e) {
+                    failure = e;
+                }
+
+                synchronized (lock) {
+                    handler.accept(value, failure);
+                    reading = false;
+                    lock.notify();
+                }
+            }
+        } catch (Throwable t) {
+            Log.warn("Error in " + logName + " thread", t);
+        } finally {
+            Log.debug(logName + " shutdown");
+            synchronized (lock) {
+                clearThread();
             }
         }
     }

--- a/terminal/src/main/java/org/jline/utils/PumpThread.java
+++ b/terminal/src/main/java/org/jline/utils/PumpThread.java
@@ -16,8 +16,8 @@ import java.io.IOException;
  *
  * <p>All state-access methods ({@link #isReading()}, {@link #setReading(boolean)},
  * {@link #startIfNeeded}, {@link #clearThread()}) must be called while the caller
- * holds the monitor on the owning NonBlocking* instance.
- * {@link #shutdown} manages its own synchronization on the provided lock.</p>
+ * holds the monitor on {@link #lock} (the owning NonBlocking* instance).
+ * {@link #shutdown} manages its own synchronization.</p>
  */
 final class PumpThread {
 
@@ -31,11 +31,13 @@ final class PumpThread {
         void accept(int value, IOException failure);
     }
 
+    private final Object lock;
     private final long idleTimeout;
     private Thread thread;
     private boolean reading;
 
-    PumpThread(long idleTimeout) {
+    PumpThread(Object lock, long idleTimeout) {
+        this.lock = lock;
         this.idleTimeout = idleTimeout;
     }
 
@@ -48,14 +50,14 @@ final class PumpThread {
         }
     }
 
-    void shutdown(Object lock) {
+    void shutdown() {
         Thread t;
         synchronized (lock) {
             t = thread;
             if (t != null) {
                 reading = false;
                 t.interrupt();
-                lock.notify();
+                lock.notifyAll();
             }
         }
         if (t != null) {
@@ -70,7 +72,7 @@ final class PumpThread {
         }
     }
 
-    void runLoop(Object lock, IoReader reader, ResultHandler handler, String logName) {
+    void runLoop(IoReader reader, ResultHandler handler, String logName) {
         Log.debug(logName + " start");
         boolean needToRead;
 
@@ -83,7 +85,8 @@ final class PumpThread {
                             lock.wait(idleTimeout);
                         }
                     } catch (InterruptedException e) {
-                        /* IGNORED */
+                        Thread.currentThread().interrupt();
+                        return;
                     }
                     needToRead = reading;
                     if (!needToRead) {
@@ -102,7 +105,7 @@ final class PumpThread {
                 synchronized (lock) {
                     handler.accept(value, failure);
                     reading = false;
-                    lock.notify();
+                    lock.notifyAll();
                 }
             }
         } catch (Throwable t) {

--- a/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
@@ -9,16 +9,26 @@
 package org.jline.utils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -347,6 +357,194 @@ class NonBlockingTest {
             assertEquals('A', nbis.read(200));
         } finally {
             nbis.close();
+        }
+    }
+
+    // --- Pump thread shutdown/close lifecycle tests ---
+
+    @Test
+    @Timeout(5)
+    void testInputStreamShutdownTerminatesPumpThread() throws Exception {
+        LatchInputStream in = new LatchInputStream();
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("shutdown-test", in);
+
+        assertEquals(NonBlockingInputStream.READ_EXPIRED, nbis.read(100));
+        assertTrue(in.waitUntilBlocked(), "Pump thread should be blocked in read");
+        Thread pumpThread = findThread("shutdown-test non blocking reader thread");
+        assertNotNull(pumpThread, "Pump thread should have been started");
+
+        in.release();
+        nbis.shutdown();
+        pumpThread.join(2000);
+        assertFalse(pumpThread.isAlive(), "Pump thread should have exited after shutdown");
+    }
+
+    @Test
+    @Timeout(5)
+    void testInputStreamCloseStopsPumpAndMarksClosed() throws Exception {
+        LatchInputStream in = new LatchInputStream();
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("close-test", in);
+
+        assertEquals(NonBlockingInputStream.READ_EXPIRED, nbis.read(100));
+        assertTrue(in.waitUntilBlocked(), "Pump thread should be blocked in read");
+        Thread pumpThread = findThread("close-test non blocking reader thread");
+        assertNotNull(pumpThread);
+
+        in.release();
+        nbis.close();
+        pumpThread.join(2000);
+        assertFalse(pumpThread.isAlive(), "Pump thread should have exited after close");
+        assertThrows(ClosedException.class, () -> nbis.read(100));
+    }
+
+    @Test
+    @Timeout(5)
+    void testInputStreamCloseWithNonCloseableDoesNotCloseUnderlying() throws Exception {
+        LatchInputStream tracking = new LatchInputStream();
+        NonCloseableInputStream wrapper = new NonCloseableInputStream(tracking);
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("noncloseable-test", wrapper);
+
+        assertEquals(NonBlockingInputStream.READ_EXPIRED, nbis.read(100));
+        assertTrue(tracking.waitUntilBlocked(), "Pump thread should be blocked in read");
+
+        tracking.release();
+        nbis.close();
+        assertFalse(tracking.closed.get(), "Underlying stream should not be closed through NonCloseable wrapper");
+        assertThrows(ClosedException.class, () -> nbis.read(100));
+    }
+
+    @Test
+    @Timeout(5)
+    void testReaderShutdownTerminatesPumpThread() throws Exception {
+        LatchReader reader = new LatchReader();
+        NonBlockingReaderImpl nbr = new NonBlockingReaderImpl("reader-shutdown-test", reader);
+
+        assertEquals(NonBlockingReader.READ_EXPIRED, nbr.read(100));
+        assertTrue(reader.waitUntilBlocked(), "Pump thread should be blocked in read");
+        Thread pumpThread = findThread("reader-shutdown-test non blocking reader thread");
+        assertNotNull(pumpThread, "Pump thread should have been started");
+
+        reader.release();
+        nbr.shutdown();
+        pumpThread.join(2000);
+        assertFalse(pumpThread.isAlive(), "Pump thread should have exited after shutdown");
+    }
+
+    @Test
+    @Timeout(5)
+    void testReaderCloseStopsPumpAndMarksClosed() throws Exception {
+        LatchReader reader = new LatchReader();
+        NonBlockingReaderImpl nbr = new NonBlockingReaderImpl("reader-close-test", reader);
+
+        assertEquals(NonBlockingReader.READ_EXPIRED, nbr.read(100));
+        assertTrue(reader.waitUntilBlocked(), "Pump thread should be blocked in read");
+        Thread pumpThread = findThread("reader-close-test non blocking reader thread");
+        assertNotNull(pumpThread);
+
+        reader.release();
+        nbr.close();
+        pumpThread.join(2000);
+        assertFalse(pumpThread.isAlive(), "Pump thread should have exited after close");
+        assertThrows(ClosedException.class, () -> nbr.read(100));
+    }
+
+    @Test
+    @Timeout(5)
+    void testCloseFromAnotherThreadDoesNotHang() throws Exception {
+        LatchInputStream in = new LatchInputStream();
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("cross-thread-test", in);
+
+        AtomicReference<Throwable> readError = new AtomicReference<>();
+        CountDownLatch readStarted = new CountDownLatch(1);
+
+        Thread readThread = new Thread(() -> {
+            try {
+                readStarted.countDown();
+                nbis.read(10_000);
+            } catch (ClosedException | InterruptedIOException e) {
+                // Expected
+            } catch (Throwable t) {
+                readError.set(t);
+            }
+        });
+        readThread.start();
+
+        assertTrue(readStarted.await(1, TimeUnit.SECONDS));
+        assertTrue(in.waitUntilBlocked(), "Pump thread should be blocked in read");
+
+        in.release();
+        nbis.close();
+        readThread.join(2000);
+        assertFalse(readThread.isAlive(), "Read thread should have exited after close");
+        assertNull(readError.get(), "Read thread should not have thrown unexpected error");
+    }
+
+    private static Thread findThread(String name) {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(t -> t.getName().equals(name))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static class LatchInputStream extends InputStream {
+        private final CountDownLatch blocked = new CountDownLatch(1);
+        private final CountDownLatch released = new CountDownLatch(1);
+        final AtomicBoolean closed = new AtomicBoolean(false);
+
+        @Override
+        public int read() throws IOException {
+            blocked.countDown();
+            try {
+                released.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new InterruptedIOException();
+            }
+            return -1;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed.set(true);
+            released.countDown();
+        }
+
+        void release() {
+            released.countDown();
+        }
+
+        boolean waitUntilBlocked() throws InterruptedException {
+            return blocked.await(2, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class LatchReader extends Reader {
+        private final CountDownLatch blocked = new CountDownLatch(1);
+        private final CountDownLatch released = new CountDownLatch(1);
+
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            blocked.countDown();
+            try {
+                released.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new InterruptedIOException();
+            }
+            return -1;
+        }
+
+        @Override
+        public void close() throws IOException {
+            released.countDown();
+        }
+
+        void release() {
+            released.countDown();
+        }
+
+        boolean waitUntilBlocked() throws InterruptedException {
+            return blocked.await(2, TimeUnit.SECONDS);
         }
     }
 }

--- a/terminal/src/test/java/org/jline/utils/NonCloseableStreamTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonCloseableStreamTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NonCloseableStreamTest {
+
+    @Test
+    void inputStreamCloseDoesNotCloseUnderlying() throws IOException {
+        TrackingInputStream underlying = new TrackingInputStream(new byte[] {1, 2, 3});
+        NonCloseableInputStream wrapper = new NonCloseableInputStream(underlying);
+
+        wrapper.close();
+
+        assertFalse(underlying.closed, "Underlying stream should not be closed");
+        assertEquals(1, wrapper.read(), "Should still be readable after close");
+    }
+
+    @Test
+    void inputStreamDelegatesReads() throws IOException {
+        byte[] data = {10, 20, 30, 40};
+        NonCloseableInputStream wrapper = new NonCloseableInputStream(new ByteArrayInputStream(data));
+
+        assertEquals(10, wrapper.read());
+        byte[] buf = new byte[3];
+        assertEquals(3, wrapper.read(buf));
+        assertArrayEquals(new byte[] {20, 30, 40}, buf);
+    }
+
+    @Test
+    void outputStreamCloseFlushesButDoesNotClose() throws IOException {
+        TrackingOutputStream underlying = new TrackingOutputStream();
+        NonCloseableOutputStream wrapper = new NonCloseableOutputStream(underlying);
+
+        wrapper.write(new byte[] {1, 2, 3});
+        wrapper.close();
+
+        assertTrue(underlying.flushed, "Underlying stream should be flushed on close");
+        assertFalse(underlying.closed, "Underlying stream should not be closed");
+    }
+
+    @Test
+    void outputStreamStillWritableAfterClose() throws IOException {
+        TrackingOutputStream underlying = new TrackingOutputStream();
+        NonCloseableOutputStream wrapper = new NonCloseableOutputStream(underlying);
+
+        wrapper.close();
+        wrapper.write(42);
+
+        assertFalse(underlying.closed, "Underlying stream should not be closed");
+        assertArrayEquals(new byte[] {42}, underlying.toByteArray());
+    }
+
+    private static class TrackingInputStream extends InputStream {
+        private final byte[] data;
+        private int pos = 0;
+        boolean closed = false;
+
+        TrackingInputStream(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public int read() {
+            return pos < data.length ? data[pos++] & 0xFF : -1;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    private static class TrackingOutputStream extends ByteArrayOutputStream {
+        boolean closed = false;
+        boolean flushed = false;
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+
+        @Override
+        public void flush() throws IOException {
+            flushed = true;
+            super.flush();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1909. Also fixes [tamboui#354](https://github.com/tamboui/tamboui/issues/354).

On macOS, `terminal.close()` hangs when a pump thread is blocked in a native `read()` on stdin. The `close()` syscall on a file descriptor blocks if another thread is in a `read()` on the same FD, causing a deadlock between the main thread (in `FileDescriptor.close0()`) and the pump thread (in `FileInputStream.read0()`).

### Root cause

This is a regression introduced by #1576 / #1577 ("Enforce terminal closure", shipped in **4.0.0** and **3.30.7**). That commit changed `reader.shutdown()` to `reader.close()` in `PosixSysTerminal.doClose()`, removing the explicit `// Do not call reader.close()` comment. The old code deliberately called only `shutdown()` to avoid closing `FileDescriptor.in`.

With `reader.close()`, the close chain now reaches `NonBlockingInputStreamImpl.close()` → `in.close()` → `FileInputStream.close()` → `FileDescriptor.close0()`, which deadlocks with the pump thread's in-progress `read0()` on the same FD. On macOS, `close()` on an FD blocks if another thread is in `read()` on that FD.

### Changes

**New utility classes** (`org.jline.utils`):
- `NonCloseableInputStream` — wraps an `InputStream`, `close()` is a no-op. Prevents closing the shared `FileDescriptor`.
- `NonCloseableOutputStream` — wraps an `OutputStream`, `close()` flushes but does not close the underlying stream.

**`AbstractUnixSysTerminal`**:
- Wrap `FileDescriptor.in` with `NonCloseableInputStream` and `FileDescriptor.out`/`err` with `NonCloseableOutputStream` so `close()` never reaches `FileDescriptor.close0()`.
- Reorder `doClose()`: now explicitly calls `input.close()` before `doSetAttributes(originalAttributes)` then `reader.close()`, each in nested try/finally blocks.
- Added javadoc noting the NonCloseable wrapping and its purpose.

**`ExecPty`**:
- Same NonCloseable wrapping for system stream FDs in `doGetSlaveInput()` and `getSlaveOutput()`. Device-file paths (`getName()`) are not wrapped — those are non-shared FDs.

**`DumbTerminalProvider`**:
- Removed private inner `NonCloseableInputStream`/`NonCloseableOutputStream` classes, replaced with the shared utilities.

**`NonBlockingInputStreamImpl`** and **`NonBlockingReaderImpl`** (parallel changes):
- `shutdown()` rewritten: captures thread reference, sets `threadIsReading = false`, interrupts the thread (wakes it from `wait()`), then `join(50ms)` outside the lock. Sets `thread = null` after join to prevent the second `shutdown()` call in the close chain from waiting again.
- `close()` rewritten: `in.close()` / `super.close()` in try block, `shutdown()` in finally — ensures shutdown always runs even if close throws.
- Updated javadoc on `shutdown()`.

**Tests**:
- `NonCloseableStreamTest` — 4 tests: close doesn't close underlying stream, reads/writes still work after close, output is flushed on close.
- `NonBlockingTest` — 7 new lifecycle tests using `LatchInputStream`/`LatchReader` helpers: shutdown terminates pump thread, close stops pump and marks closed, NonCloseable wrapper prevents underlying close, cross-thread close doesn't hang. All tests have `@Timeout(5)`.

### How it works

With `NonCloseable` wrappers, `reader.close()` can now be called safely (preserving #1576's enforce-closure behavior) without reaching `FileDescriptor.close0()`. The pump thread is a daemon thread — if blocked in a native `read()` when `shutdown()` is called, the `join(50ms)` times out and the thread exits on its next iteration once the read completes naturally, or when the JVM shuts down.

### Test results (manual, macOS FFM terminal)

| Version | `close()` behavior |
|---|---|
| 4.1.2 (before fix) | Hangs indefinitely — `FAIL: close() is still hanging after 3s!` |
| 4.1.3-SNAPSHOT (after fix) | Completes in ~59ms — `PASS: terminal closed cleanly` |

## Test plan

- [x] `NonCloseableStreamTest` — 4 tests for wrapper behavior
- [x] `NonBlockingTest` — 7 lifecycle tests for shutdown/close pump thread management
- [x] All 292 terminal module tests pass
- [x] Manual test: program reads from FFM terminal then calls `close()` from another thread — exits cleanly in ~59ms