### PR TITLE
fix: clear ISIG in enterRawMode so Ctrl+C reaches raw-mode readers

### DIFF
--- a/prompt/src/test/java/org/jline/prompt/PromptCancelTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PromptCancelTest.java
@@ -11,151 +11,143 @@ package org.jline.prompt;
 import java.io.ByteArrayOutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.util.Collections;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.jline.reader.UserInterruptException;
-import org.jline.terminal.Attributes;
-import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
-/**
- * Tests that Ctrl+C (byte 0x03) during prompts throws {@link UserInterruptException}.
- *
- * <p>ISIG must be cleared before writing the byte, otherwise the line discipline
- * consumes it as a signal rather than forwarding it to the binding reader.
- * In production, {@code enterRawMode()} clears ISIG; in tests we clear it
- * manually before feeding the byte into the pipe.
- */
 class PromptCancelTest {
 
-    private static final byte CTRL_C = 3;
-
-    private Terminal createTerminal(PipedInputStream in, ByteArrayOutputStream out) throws Exception {
-        Terminal terminal =
-                TerminalBuilder.builder().type("ansi").streams(in, out).build();
-        terminal.setSize(Size.of(160, 80));
-        Attributes attr = terminal.getAttributes();
-        attr.setLocalFlag(LocalFlag.ISIG, false);
-        terminal.setAttributes(attr);
-        return terminal;
-    }
+    private static final byte CTRL_C = 0x03;
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+    private static final long INPUT_DELAY_MS = 200;
 
     @Test
-    void testListPromptCtrlCThrowsUserInterrupt() throws Exception {
-        PipedInputStream in = new PipedInputStream();
-        PipedOutputStream outIn = new PipedOutputStream(in);
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-        try (Terminal terminal = createTerminal(in, out)) {
-            Prompter prompter = PrompterFactory.create(terminal);
-
-            PromptBuilder builder = prompter.newBuilder();
-            builder.createListPrompt()
-                    .name("x")
+    void list() throws Exception {
+        try (Fixture f = new Fixture()) {
+            PromptBuilder b = f.prompter.newBuilder();
+            b.createListPrompt()
+                    .name("pick")
                     .message("Pick one")
                     .newItem("a")
-                    .text("a")
+                    .text("Alpha")
                     .add()
                     .newItem("b")
-                    .text("b")
+                    .text("Bravo")
                     .add()
                     .addPrompt();
-
-            List<Prompt> prompts = builder.build();
-
-            outIn.write(CTRL_C);
-            outIn.flush();
-
-            assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+            assertCancels(f, b.build());
         }
     }
 
     @Test
-    void testCheckboxPromptCtrlCThrowsUserInterrupt() throws Exception {
-        PipedInputStream in = new PipedInputStream();
-        PipedOutputStream outIn = new PipedOutputStream(in);
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-        try (Terminal terminal = createTerminal(in, out)) {
-            Prompter prompter = PrompterFactory.create(terminal);
-
-            PromptBuilder builder = prompter.newBuilder();
-            builder.createCheckboxPrompt()
-                    .name("items")
-                    .message("Select items")
-                    .newItem("x")
-                    .text("X")
+    void checkbox() throws Exception {
+        try (Fixture f = new Fixture()) {
+            PromptBuilder b = f.prompter.newBuilder();
+            b.createCheckboxPrompt()
+                    .name("toppings")
+                    .message("Pick toppings")
+                    .newItem("cheese")
+                    .text("Cheese")
                     .add()
-                    .newItem("y")
-                    .text("Y")
+                    .newItem("ham")
+                    .text("Ham")
                     .add()
                     .addPrompt();
-
-            List<Prompt> prompts = builder.build();
-
-            outIn.write(CTRL_C);
-            outIn.flush();
-
-            assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+            assertCancels(f, b.build());
         }
     }
 
     @Test
-    void testConfirmPromptCtrlCThrowsUserInterrupt() throws Exception {
-        PipedInputStream in = new PipedInputStream();
-        PipedOutputStream outIn = new PipedOutputStream(in);
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-        try (Terminal terminal = createTerminal(in, out)) {
-            Prompter prompter = PrompterFactory.create(terminal);
-
-            PromptBuilder builder = prompter.newBuilder();
-            builder.createConfirmPrompt().name("ok").message("Continue?").addPrompt();
-
-            List<Prompt> prompts = builder.build();
-
-            outIn.write(CTRL_C);
-            outIn.flush();
-
-            assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+    void choice() throws Exception {
+        try (Fixture f = new Fixture()) {
+            PromptBuilder b = f.prompter.newBuilder();
+            b.createChoicePrompt()
+                    .name("color")
+                    .message("Pick a color")
+                    .newChoice("red")
+                    .text("Red")
+                    .key('r')
+                    .add()
+                    .newChoice("green")
+                    .text("Green")
+                    .key('g')
+                    .add()
+                    .addPrompt();
+            assertCancels(f, b.build());
         }
     }
 
     @Test
-    void testChoicePromptCtrlCThrowsUserInterrupt() throws Exception {
-        PipedInputStream in = new PipedInputStream();
-        PipedOutputStream outIn = new PipedOutputStream(in);
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
+    void confirm() throws Exception {
+        try (Fixture f = new Fixture()) {
+            PromptBuilder b = f.prompter.newBuilder();
+            b.createConfirmPrompt().name("agree").message("Do you agree?").addPrompt();
+            assertCancels(f, b.build());
+        }
+    }
 
-        try (Terminal terminal = createTerminal(in, out)) {
-            Prompter prompter = PrompterFactory.create(terminal);
+    private static void assertCancels(Fixture f, List<Prompt> prompts) {
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            f.sendCtrlCAfter(INPUT_DELAY_MS);
+            assertThrows(UserInterruptException.class, () -> f.prompter.prompt(List.of(), prompts));
+        });
+    }
 
-            PromptBuilder builder = prompter.newBuilder();
-            builder.createChoicePrompt()
-                    .name("choice")
-                    .message("Pick one")
-                    .newChoice("a")
-                    .text("A")
-                    .key('a')
-                    .add()
-                    .newChoice("b")
-                    .text("B")
-                    .key('b')
-                    .add()
-                    .addPrompt();
+    private static final class Fixture implements AutoCloseable {
+        final PipedOutputStream feeder;
+        final Terminal terminal;
+        final Prompter prompter;
+        volatile Thread sender;
 
-            List<Prompt> prompts = builder.build();
+        Fixture() throws Exception {
+            PipedInputStream in = new PipedInputStream();
+            this.feeder = new PipedOutputStream(in);
+            this.terminal = TerminalBuilder.builder()
+                    .type("ansi")
+                    .streams(in, new ByteArrayOutputStream())
+                    .build();
+            terminal.setSize(Size.of(160, 80));
+            this.prompter = PrompterFactory.create(terminal);
+        }
 
-            outIn.write(CTRL_C);
-            outIn.flush();
+        // Delay so prompt() can call enterRawMode() first, else the pump consumes 0x03 as
+        // VINTR under cooked-mode attributes. Block until interrupted so PipedInputStream
+        // does not raise "Write end dead" before the keymap matches.
+        void sendCtrlCAfter(long delayMillis) {
+            sender = new Thread(
+                    () -> {
+                        try {
+                            TimeUnit.MILLISECONDS.sleep(delayMillis);
+                            feeder.write(CTRL_C);
+                            feeder.flush();
+                            Thread.sleep(Long.MAX_VALUE);
+                        } catch (Exception ignored) {
+                        }
+                    },
+                    "ctrl-c-sender");
+            sender.setDaemon(true);
+            sender.start();
+        }
 
-            assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+        @Override
+        public void close() throws Exception {
+            if (sender != null) {
+                sender.interrupt();
+            }
+            try {
+                terminal.close();
+            } finally {
+                feeder.close();
+            }
         }
     }
 }

--- a/prompt/src/test/java/org/jline/prompt/PromptCancelTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PromptCancelTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.prompt;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.Collections;
+import java.util.List;
+
+import org.jline.reader.UserInterruptException;
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.LocalFlag;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that Ctrl+C (byte 0x03) during prompts throws {@link UserInterruptException}.
+ *
+ * <p>ISIG must be cleared before writing the byte, otherwise the line discipline
+ * consumes it as a signal rather than forwarding it to the binding reader.
+ * In production, {@code enterRawMode()} clears ISIG; in tests we clear it
+ * manually before feeding the byte into the pipe.
+ */
+class PromptCancelTest {
+
+    private static final byte CTRL_C = 3;
+
+    private Terminal createTerminal(PipedInputStream in, ByteArrayOutputStream out) throws Exception {
+        Terminal terminal =
+                TerminalBuilder.builder().type("ansi").streams(in, out).build();
+        terminal.setSize(Size.of(160, 80));
+        // Clear ISIG so 0x03 passes through the line discipline as a raw byte
+        Attributes attr = terminal.getAttributes();
+        attr.setLocalFlag(LocalFlag.ISIG, false);
+        terminal.setAttributes(attr);
+        return terminal;
+    }
+
+    @Test
+    void testListPromptCtrlCThrowsUserInterrupt() throws Exception {
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal = createTerminal(in, out);
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createListPrompt()
+                .name("x")
+                .message("Pick one")
+                .newItem("a")
+                .text("a")
+                .add()
+                .newItem("b")
+                .text("b")
+                .add()
+                .addPrompt();
+
+        List<Prompt> prompts = builder.build();
+
+        outIn.write(CTRL_C);
+        outIn.flush();
+
+        assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+    }
+
+    @Test
+    void testCheckboxPromptCtrlCThrowsUserInterrupt() throws Exception {
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal = createTerminal(in, out);
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createCheckboxPrompt()
+                .name("items")
+                .message("Select items")
+                .newItem("x")
+                .text("X")
+                .add()
+                .newItem("y")
+                .text("Y")
+                .add()
+                .addPrompt();
+
+        List<Prompt> prompts = builder.build();
+
+        outIn.write(CTRL_C);
+        outIn.flush();
+
+        assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+    }
+
+    @Test
+    void testConfirmPromptCtrlCThrowsUserInterrupt() throws Exception {
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal = createTerminal(in, out);
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createConfirmPrompt().name("ok").message("Continue?").addPrompt();
+
+        List<Prompt> prompts = builder.build();
+
+        outIn.write(CTRL_C);
+        outIn.flush();
+
+        assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+    }
+
+    @Test
+    void testChoicePromptCtrlCThrowsUserInterrupt() throws Exception {
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal = createTerminal(in, out);
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createChoicePrompt()
+                .name("choice")
+                .message("Pick one")
+                .newChoice("a")
+                .text("A")
+                .key('a')
+                .add()
+                .newChoice("b")
+                .text("B")
+                .key('b')
+                .add()
+                .addPrompt();
+
+        List<Prompt> prompts = builder.build();
+
+        outIn.write(CTRL_C);
+        outIn.flush();
+
+        assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+    }
+}

--- a/prompt/src/test/java/org/jline/prompt/PromptCancelTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PromptCancelTest.java
@@ -40,7 +40,6 @@ class PromptCancelTest {
         Terminal terminal =
                 TerminalBuilder.builder().type("ansi").streams(in, out).build();
         terminal.setSize(Size.of(160, 80));
-        // Clear ISIG so 0x03 passes through the line discipline as a raw byte
         Attributes attr = terminal.getAttributes();
         attr.setLocalFlag(LocalFlag.ISIG, false);
         terminal.setAttributes(attr);
@@ -53,27 +52,28 @@ class PromptCancelTest {
         PipedOutputStream outIn = new PipedOutputStream(in);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        Terminal terminal = createTerminal(in, out);
-        Prompter prompter = PrompterFactory.create(terminal);
+        try (Terminal terminal = createTerminal(in, out)) {
+            Prompter prompter = PrompterFactory.create(terminal);
 
-        PromptBuilder builder = prompter.newBuilder();
-        builder.createListPrompt()
-                .name("x")
-                .message("Pick one")
-                .newItem("a")
-                .text("a")
-                .add()
-                .newItem("b")
-                .text("b")
-                .add()
-                .addPrompt();
+            PromptBuilder builder = prompter.newBuilder();
+            builder.createListPrompt()
+                    .name("x")
+                    .message("Pick one")
+                    .newItem("a")
+                    .text("a")
+                    .add()
+                    .newItem("b")
+                    .text("b")
+                    .add()
+                    .addPrompt();
 
-        List<Prompt> prompts = builder.build();
+            List<Prompt> prompts = builder.build();
 
-        outIn.write(CTRL_C);
-        outIn.flush();
+            outIn.write(CTRL_C);
+            outIn.flush();
 
-        assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+            assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+        }
     }
 
     @Test
@@ -82,27 +82,28 @@ class PromptCancelTest {
         PipedOutputStream outIn = new PipedOutputStream(in);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        Terminal terminal = createTerminal(in, out);
-        Prompter prompter = PrompterFactory.create(terminal);
+        try (Terminal terminal = createTerminal(in, out)) {
+            Prompter prompter = PrompterFactory.create(terminal);
 
-        PromptBuilder builder = prompter.newBuilder();
-        builder.createCheckboxPrompt()
-                .name("items")
-                .message("Select items")
-                .newItem("x")
-                .text("X")
-                .add()
-                .newItem("y")
-                .text("Y")
-                .add()
-                .addPrompt();
+            PromptBuilder builder = prompter.newBuilder();
+            builder.createCheckboxPrompt()
+                    .name("items")
+                    .message("Select items")
+                    .newItem("x")
+                    .text("X")
+                    .add()
+                    .newItem("y")
+                    .text("Y")
+                    .add()
+                    .addPrompt();
 
-        List<Prompt> prompts = builder.build();
+            List<Prompt> prompts = builder.build();
 
-        outIn.write(CTRL_C);
-        outIn.flush();
+            outIn.write(CTRL_C);
+            outIn.flush();
 
-        assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+            assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+        }
     }
 
     @Test
@@ -111,18 +112,19 @@ class PromptCancelTest {
         PipedOutputStream outIn = new PipedOutputStream(in);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        Terminal terminal = createTerminal(in, out);
-        Prompter prompter = PrompterFactory.create(terminal);
+        try (Terminal terminal = createTerminal(in, out)) {
+            Prompter prompter = PrompterFactory.create(terminal);
 
-        PromptBuilder builder = prompter.newBuilder();
-        builder.createConfirmPrompt().name("ok").message("Continue?").addPrompt();
+            PromptBuilder builder = prompter.newBuilder();
+            builder.createConfirmPrompt().name("ok").message("Continue?").addPrompt();
 
-        List<Prompt> prompts = builder.build();
+            List<Prompt> prompts = builder.build();
 
-        outIn.write(CTRL_C);
-        outIn.flush();
+            outIn.write(CTRL_C);
+            outIn.flush();
 
-        assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+            assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+        }
     }
 
     @Test
@@ -131,28 +133,29 @@ class PromptCancelTest {
         PipedOutputStream outIn = new PipedOutputStream(in);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        Terminal terminal = createTerminal(in, out);
-        Prompter prompter = PrompterFactory.create(terminal);
+        try (Terminal terminal = createTerminal(in, out)) {
+            Prompter prompter = PrompterFactory.create(terminal);
 
-        PromptBuilder builder = prompter.newBuilder();
-        builder.createChoicePrompt()
-                .name("choice")
-                .message("Pick one")
-                .newChoice("a")
-                .text("A")
-                .key('a')
-                .add()
-                .newChoice("b")
-                .text("B")
-                .key('b')
-                .add()
-                .addPrompt();
+            PromptBuilder builder = prompter.newBuilder();
+            builder.createChoicePrompt()
+                    .name("choice")
+                    .message("Pick one")
+                    .newChoice("a")
+                    .text("A")
+                    .key('a')
+                    .add()
+                    .newChoice("b")
+                    .text("B")
+                    .key('b')
+                    .add()
+                    .addPrompt();
 
-        List<Prompt> prompts = builder.build();
+            List<Prompt> prompts = builder.build();
 
-        outIn.write(CTRL_C);
-        outIn.flush();
+            outIn.write(CTRL_C);
+            outIn.flush();
 
-        assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+            assertThrows(UserInterruptException.class, () -> prompter.prompt(Collections.emptyList(), prompts));
+        }
     }
 }

--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -163,6 +163,7 @@ public interface LineReader {
     String INFER_NEXT_HISTORY = "infer-next-history";
     String INSERT_COMMENT = "insert-comment";
     String INSERT_LAST_WORD = "insert-last-word";
+    String INTERRUPT = "interrupt";
     String KILL_BUFFER = "kill-buffer";
     String KILL_LINE = "kill-line";
     String KILL_REGION = "kill-region";

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -2508,9 +2508,13 @@ public class LineReaderImpl implements LineReader, Flushable {
             buf.clear();
             println();
             redrawLine();
-            //            state = State.INTERRUPT;
             return false;
         }
+        return true;
+    }
+
+    protected boolean interrupt() {
+        state = State.INTERRUPT;
         return true;
     }
 
@@ -4094,6 +4098,7 @@ public class LineReaderImpl implements LineReader, Flushable {
         addBuiltinWidget(widgets, INSERT_CLOSE_PAREN, this::insertCloseParen);
         addBuiltinWidget(widgets, INSERT_CLOSE_SQUARE, this::insertCloseSquare);
         addBuiltinWidget(widgets, INSERT_COMMENT, this::insertComment);
+        addBuiltinWidget(widgets, INTERRUPT, this::interrupt);
         addBuiltinWidget(widgets, KILL_BUFFER, this::killBuffer);
         addBuiltinWidget(widgets, KILL_LINE, this::killLine);
         addBuiltinWidget(widgets, KILL_REGION, this::killRegion);
@@ -6594,6 +6599,7 @@ public class LineReaderImpl implements LineReader, Flushable {
             Attributes attr = terminal.getAttributes();
             bindConsoleChars(keyMaps.get(EMACS), attr);
             bindConsoleChars(keyMaps.get(VIINS), attr);
+            bindConsoleChars(keyMaps.get(VICMD), attr);
         }
         // Put default
         for (KeyMap<Binding> keyMap : keyMaps.values()) {
@@ -6942,6 +6948,7 @@ public class LineReaderImpl implements LineReader, Flushable {
             rebind(keyMap, BACKWARD_KILL_WORD, ctrl('W'), (char) attr.getControlChar(ControlChar.VWERASE));
             rebind(keyMap, KILL_WHOLE_LINE, ctrl('U'), (char) attr.getControlChar(ControlChar.VKILL));
             rebind(keyMap, QUOTED_INSERT, ctrl('V'), (char) attr.getControlChar(ControlChar.VLNEXT));
+            rebind(keyMap, INTERRUPT, ctrl('C'), (char) attr.getControlChar(ControlChar.VINTR));
         }
     }
 

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -219,7 +219,7 @@ public abstract class AbstractTerminal implements TerminalExt {
     public Attributes enterRawMode() {
         Attributes prvAttr = getAttributes();
         Attributes newAttr = new Attributes(prvAttr);
-        newAttr.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO, LocalFlag.IEXTEN), false);
+        newAttr.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO, LocalFlag.IEXTEN, LocalFlag.ISIG), false);
         newAttr.setInputFlags(EnumSet.of(InputFlag.IXON, InputFlag.ICRNL, InputFlag.INLCR), false);
         // POSIX cfmakeraw(3) defaults — VMIN=0/VTIME=1 made FileInputStream.read() see EOF on every 100 ms idle tick.
         newAttr.setControlChar(ControlChar.VMIN, 1);

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -219,6 +219,9 @@ public abstract class AbstractTerminal implements TerminalExt {
     public Attributes enterRawMode() {
         Attributes prvAttr = getAttributes();
         Attributes newAttr = new Attributes(prvAttr);
+        // POSIX cfmakeraw(3) also clears ISIG so Ctrl+C/Ctrl+\/Ctrl+Z arrive as 0x03/0x1c/0x1a
+        // characters rather than as signals. This is required for raw-mode readers (for example,
+        // prompters in the jline-prompt module) whose keymaps bind those bytes to CANCEL/INTERRUPT operations.
         newAttr.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO, LocalFlag.IEXTEN, LocalFlag.ISIG), false);
         newAttr.setInputFlags(EnumSet.of(InputFlag.IXON, InputFlag.ICRNL, InputFlag.INLCR), false);
         // POSIX cfmakeraw(3) defaults — VMIN=0/VTIME=1 made FileInputStream.read() see EOF on every 100 ms idle tick.


### PR DESCRIPTION
## Summary

Fixes #1900

- Clear `ISIG` in `enterRawMode()` to match POSIX `cfmakeraw(3)`, so Ctrl+C delivers byte `0x03` to the input buffer instead of generating SIGINT. This fixes the deadlock where `DefaultPrompter.prompt()` hangs on JVM shutdown because `VMIN=1` blocks the read indefinitely and no signal handler is registered.
- Add an `INTERRUPT` widget to `LineReaderImpl` bound to `VINTR` (typically Ctrl+C), so that `readLine()` still throws `UserInterruptException` through the keymap rather than relying on the now-cleared SIGINT signal.
- Apply `bindConsoleChars` to VICMD keymap so vi command mode also picks up the VINTR binding.

## Test plan

- [x] New `PromptCancelTest` verifies Ctrl+C throws `UserInterruptException` for list, checkbox, confirm, and choice prompts
- [x] Existing `PrompterExecutionTest` and `PrompterListExecutionTest` pass (no regression in normal prompt flow)
- [x] All `reader` module tests pass (205 tests, 0 failures)
- [x] All `prompt` module tests pass (62 tests, 0 failures)
- [x] Full build with spotless check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests ensuring Ctrl+C (interrupt) is delivered and aborts prompts (lists, checkboxes, confirms, choices).

* **Bug Fixes**
  * Prompts now reliably abort on Ctrl+C.
  * Terminal raw mode behavior adjusted so signal-generating keys are delivered consistently as input.
  * Ctrl+C interrupt recognized across more editing modes for uniform keybinding behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->