### PR TITLE
fix: use confined arenas instead of auto arenas in FFM CLibrary

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -60,12 +60,12 @@ class CLibrary {
 
         private final MemorySegment seg;
 
-        winsize() {
-            seg = Arena.ofAuto().allocate(LAYOUT);
+        winsize(Arena arena) {
+            seg = arena.allocate(LAYOUT);
         }
 
-        winsize(short ws_col, short ws_row) {
-            this();
+        winsize(Arena arena, short ws_col, short ws_row) {
+            this(arena);
             ws_col(ws_col);
             ws_row(ws_row);
         }
@@ -157,12 +157,12 @@ class CLibrary {
 
         private final MemorySegment seg;
 
-        termios() {
-            seg = Arena.ofAuto().allocate(LAYOUT);
+        termios(Arena arena) {
+            seg = arena.allocate(LAYOUT);
         }
 
-        termios(Attributes t) {
-            this();
+        termios(Arena arena, Attributes t) {
+            this(arena);
             TermiosData data = TermiosMapping.forCurrentPlatform().toTermios(t);
             c_iflag(data.iflag());
             c_oflag(data.oflag());
@@ -374,8 +374,8 @@ class CLibrary {
     }
 
     static Size getTerminalSize(int fd) {
-        try {
-            winsize ws = new winsize();
+        try (Arena arena = Arena.ofConfined()) {
+            winsize ws = new winsize(arena);
             int res = (int) ioctl.invoke(fd, (long) TIOCGWINSZ, ws.segment());
             return Size.of(ws.ws_col(), ws.ws_row());
         } catch (Throwable e) {
@@ -384,8 +384,8 @@ class CLibrary {
     }
 
     static void setTerminalSize(int fd, Sized size) {
-        try {
-            winsize ws = new winsize();
+        try (Arena arena = Arena.ofConfined()) {
+            winsize ws = new winsize(arena);
             ws.ws_row((short) size.getRows());
             ws.ws_col((short) size.getColumns());
             int res = (int) ioctl.invoke(fd, TIOCSWINSZ, ws.segment());
@@ -395,8 +395,8 @@ class CLibrary {
     }
 
     static Attributes getAttributes(int fd) {
-        try {
-            termios t = new termios();
+        try (Arena arena = Arena.ofConfined()) {
+            termios t = new termios(arena);
             int res = (int) tcgetattr.invoke(fd, t.segment());
             return t.asAttributes();
         } catch (Throwable e) {
@@ -405,8 +405,8 @@ class CLibrary {
     }
 
     static void setAttributes(int fd, Attributes attr) {
-        try {
-            termios t = new termios(attr);
+        try (Arena arena = Arena.ofConfined()) {
+            termios t = new termios(arena, attr);
             int res = (int) tcsetattr.invoke(fd, TermiosData.TCSANOW, t.segment());
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call tcsetattr()", e);
@@ -422,8 +422,8 @@ class CLibrary {
     }
 
     static String ttyName(int fd) {
-        try {
-            MemorySegment buf = Arena.ofAuto().allocate(64);
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment buf = arena.allocate(64);
             int res = (int) ttyname_r.invoke(fd, buf, buf.byteSize());
             byte[] data = buf.toArray(ValueLayout.JAVA_BYTE);
             int len = 0;
@@ -440,17 +440,17 @@ class CLibrary {
         if (openptyError != null) {
             throw openptyError;
         }
-        try {
-            MemorySegment buf = Arena.ofAuto().allocate(64);
-            MemorySegment master = Arena.ofAuto().allocate(ValueLayout.JAVA_INT);
-            MemorySegment slave = Arena.ofAuto().allocate(ValueLayout.JAVA_INT);
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment buf = arena.allocate(64);
+            MemorySegment master = arena.allocate(ValueLayout.JAVA_INT);
+            MemorySegment slave = arena.allocate(ValueLayout.JAVA_INT);
             int res = (int) openptyHandle.invoke(
                     master,
                     slave,
                     buf,
-                    attr != null ? new termios(attr).segment() : MemorySegment.NULL,
+                    attr != null ? new termios(arena, attr).segment() : MemorySegment.NULL,
                     size != null
-                            ? new winsize((short) size.getColumns(), (short) size.getRows()).segment()
+                            ? new winsize(arena, (short) size.getColumns(), (short) size.getRows()).segment()
                             : MemorySegment.NULL);
             if (res != 0) {
                 throw new UncheckedIOException(new IOException("Unable to call openpty(): return code " + res));

--- a/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
+++ b/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
@@ -11,6 +11,7 @@ package org.jline.terminal.impl.ffm;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.foreign.Arena;
 import java.nio.charset.Charset;
 
 import org.jline.terminal.Attributes;
@@ -70,17 +71,19 @@ class FfmTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void testWinsizeConstructorArgumentOrder() {
-        short cols = 120;
-        short rows = 40;
-        CLibrary.winsize ws = new CLibrary.winsize(cols, rows);
-        assertEquals(cols, ws.ws_col());
-        assertEquals(rows, ws.ws_row());
+        try (Arena arena = Arena.ofConfined()) {
+            short cols = 120;
+            short rows = 40;
+            CLibrary.winsize ws = new CLibrary.winsize(arena, cols, rows);
+            assertEquals(cols, ws.ws_col());
+            assertEquals(rows, ws.ws_row());
+        }
     }
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void checkStructLayout() {
-        try (java.lang.foreign.Arena arena = java.lang.foreign.Arena.ofConfined()) {
+        try (Arena arena = Arena.ofConfined()) {
             assertNotNull(new Kernel32.KEY_EVENT_RECORD(arena));
             assertNotNull(new Kernel32.MOUSE_EVENT_RECORD(arena));
             assertNotNull(new Kernel32.WINDOW_BUFFER_SIZE_RECORD(arena));


### PR DESCRIPTION
## Summary
- Replace `Arena.ofAuto()` with `Arena.ofConfined()` in try-with-resources blocks across all syscall wrappers in `CLibrary`
- Pass an `Arena` parameter to `winsize`/`termios` constructors instead of letting them allocate their own auto arena
- Native memory is now released deterministically on block exit, eliminating JVM Cleaner pressure under high-frequency polling

Fixes #1872

## Test plan
- [x] `./mvx mvn test -pl terminal-ffm -B` — all tests pass
- [x] Verified no external callers of `winsize`/`termios` constructors (both are package-private)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Native memory for terminal operations now uses confined, per-call arenas to improve safety and stability.
  * Terminal size and attribute handling allocate temporary arena-scoped buffers during native calls.
* **Tests**
  * Unit tests updated to use the new arena-based constructors and scoped allocation patterns for terminal size/attribute checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->