### PR TITLE
fix: swap rows/columns in openpty winsize constructor call

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -450,7 +450,7 @@ class CLibrary {
                     buf,
                     attr != null ? new termios(attr).segment() : MemorySegment.NULL,
                     size != null
-                            ? new winsize((short) size.getRows(), (short) size.getColumns()).segment()
+                            ? new winsize((short) size.getColumns(), (short) size.getRows()).segment()
                             : MemorySegment.NULL);
             if (res != 0) {
                 throw new UncheckedIOException(new IOException("Unable to call openpty(): return code " + res));

--- a/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
+++ b/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class FfmTest {
@@ -64,6 +65,16 @@ class FfmTest {
             assertNotNull(terminal);
             assertNotNull(terminal.getSize());
         }
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void testWinsizeConstructorArgumentOrder() {
+        short cols = 120;
+        short rows = 40;
+        CLibrary.winsize ws = new CLibrary.winsize(cols, rows);
+        assertEquals(cols, ws.ws_col());
+        assertEquals(rows, ws.ws_row());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fix argument order in `CLibrary.openpty()`: the `winsize` constructor takes `(ws_col, ws_row)` but was called with `(getRows(), getColumns())`, swapping rows and columns.

This is a correctness fix with no behavioral impact in practice, since the pty size is immediately corrected on the next resize event. Not a breaking change.

Fixes #1910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal window size calculation to correctly interpret column and row dimensions in the proper order.

* **Tests**
  * Added test coverage to verify window size dimension handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->