### PR TITLE
fix: fix command argument parsing in DefaultCommandDispatcher

### DIFF
--- a/shell/src/main/java/org/jline/shell/CommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/CommandDispatcher.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.util.List;
 
 import org.jline.reader.Completer;
+import org.jline.reader.SyntaxError;
 import org.jline.terminal.Terminal;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
@@ -139,7 +140,7 @@ public interface CommandDispatcher extends AutoCloseable {
      * @param exception the exception to trace
      */
     default void trace(Throwable exception) {
-        if (exception instanceof UnknownCommandException) {
+        if (exception instanceof UnknownCommandException || exception instanceof SyntaxError) {
             AttributedStringBuilder asb = new AttributedStringBuilder();
             asb.styled(errorStyle(), exception.getMessage());
             asb.toAttributedString().println(terminal());

--- a/shell/src/main/java/org/jline/shell/ShellBuilder.java
+++ b/shell/src/main/java/org/jline/shell/ShellBuilder.java
@@ -406,22 +406,22 @@ public class ShellBuilder {
             ownTerminal = true;
         }
 
+        // Create parser
+        Parser p = this.parser;
+        if (p == null) {
+            p = new DefaultParser();
+        }
+
         // Create or use provided dispatcher
         CommandDispatcher disp = this.dispatcher;
         if (disp == null) {
             disp = new DefaultCommandDispatcher(
-                    term, jobManager, pipelineParser, aliasManager, lineExpander, scriptRunner);
+                    term, jobManager, pipelineParser, aliasManager, lineExpander, scriptRunner, p);
         }
 
         // Add groups to dispatcher
         for (CommandGroup group : groups) {
             disp.addGroup(group);
-        }
-
-        // Create parser
-        Parser p = this.parser;
-        if (p == null) {
-            p = new DefaultParser();
         }
 
         // Determine highlighter

--- a/shell/src/main/java/org/jline/shell/ShellBuilder.java
+++ b/shell/src/main/java/org/jline/shell/ShellBuilder.java
@@ -406,17 +406,11 @@ public class ShellBuilder {
             ownTerminal = true;
         }
 
-        // Create parser
-        Parser p = this.parser;
-        if (p == null) {
-            p = new DefaultParser();
-        }
-
         // Create or use provided dispatcher
         CommandDispatcher disp = this.dispatcher;
         if (disp == null) {
             disp = new DefaultCommandDispatcher(
-                    term, jobManager, pipelineParser, aliasManager, lineExpander, scriptRunner, p);
+                    term, jobManager, pipelineParser, aliasManager, lineExpander, scriptRunner, this.parser);
         }
 
         // Add groups to dispatcher
@@ -433,7 +427,7 @@ public class ShellBuilder {
 
         // Build LineReader
         LineReaderBuilder readerBuilder =
-                LineReaderBuilder.builder().terminal(term).parser(p).completer(disp.completer());
+                LineReaderBuilder.builder().terminal(term).parser(this.parser).completer(disp.completer());
 
         if (hl != null) {
             readerBuilder.highlighter(hl);

--- a/shell/src/main/java/org/jline/shell/ShellBuilder.java
+++ b/shell/src/main/java/org/jline/shell/ShellBuilder.java
@@ -406,11 +406,17 @@ public class ShellBuilder {
             ownTerminal = true;
         }
 
+        // Create parser
+        Parser p = this.parser;
+        if (p == null) {
+            p = new DefaultParser();
+        }
+
         // Create or use provided dispatcher
         CommandDispatcher disp = this.dispatcher;
         if (disp == null) {
             disp = new DefaultCommandDispatcher(
-                    term, jobManager, pipelineParser, aliasManager, lineExpander, scriptRunner, this.parser);
+                    term, jobManager, pipelineParser, aliasManager, lineExpander, scriptRunner, p);
         }
 
         // Add groups to dispatcher
@@ -427,7 +433,7 @@ public class ShellBuilder {
 
         // Build LineReader
         LineReaderBuilder readerBuilder =
-                LineReaderBuilder.builder().terminal(term).parser(this.parser).completer(disp.completer());
+                LineReaderBuilder.builder().terminal(term).parser(p).completer(disp.completer());
 
         if (hl != null) {
             readerBuilder.highlighter(hl);

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -17,10 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
-<<<<<<< HEAD
-=======
 import org.jline.reader.LineReader;
->>>>>>> 614e1c70 (Fix command argument parsing)
 import org.jline.reader.Parser;
 import org.jline.reader.impl.DefaultParser;
 import org.jline.reader.impl.completer.ArgumentCompleter;
@@ -693,12 +690,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
 
         String[] args = argsStr.isEmpty()
                 ? new String[0]
-<<<<<<< HEAD
                 : parser.parse(argsStr, argsStr.length(), Parser.ParseContext.ACCEPT_LINE)
-=======
-                : this.parser
-                        .parse(argsStr, argsStr.length(), Parser.ParseContext.ACCEPT_LINE)
->>>>>>> 614e1c70 (Fix command argument parsing)
                         .words()
                         .toArray(String[]::new);
 

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -17,6 +17,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
+<<<<<<< HEAD
+=======
+import org.jline.reader.LineReader;
+>>>>>>> 614e1c70 (Fix command argument parsing)
 import org.jline.reader.Parser;
 import org.jline.reader.impl.DefaultParser;
 import org.jline.reader.impl.completer.ArgumentCompleter;
@@ -60,7 +64,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
     private final LineExpander lineExpander;
     private final ScriptRunner scriptRunner;
     private volatile Thread commandThread;
-    private final Parser parser = new DefaultParser();
+    private final Parser parser;
 
     /**
      * Creates a new dispatcher for the given terminal.
@@ -69,6 +73,15 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
      */
     public DefaultCommandDispatcher(Terminal terminal) {
         this(terminal, null, null, null);
+    }
+
+    /**
+     * Creates a new dispatcher for the given reader.
+     *
+     * @param reader the reader
+     */
+    public DefaultCommandDispatcher(LineReader reader) {
+        this(reader.getTerminal(), null, null, null, null, null, reader.getParser());
     }
 
     /**
@@ -121,7 +134,30 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
             AliasManager aliasManager,
             LineExpander lineExpander,
             ScriptRunner scriptRunner) {
-        this.terminal = terminal;
+        this(terminal, jobManager, pipelineParser, aliasManager, lineExpander, scriptRunner, null);
+    }
+
+    /**
+     * Creates a new dispatcher with all configuration options including line expansion,
+     * script execution and parser.
+     *
+     * @param terminal the terminal
+     * @param jobManager the job manager, or null for no job control
+     * @param pipelineParser the pipeline parser, or null for the default parser
+     * @param aliasManager the alias manager, or null for no alias support
+     * @param lineExpander the line expander, or null for no variable expansion
+     * @param scriptRunner the script runner, or null for no script support
+     * @param parser the argument parser, or null for the default parser
+     */
+    public DefaultCommandDispatcher(
+            Terminal terminal,
+            JobManager jobManager,
+            PipelineParser pipelineParser,
+            AliasManager aliasManager,
+            LineExpander lineExpander,
+            ScriptRunner scriptRunner,
+            Parser parser) {
+        this.terminal = Objects.requireNonNull(terminal);
         this.session = new CommandSession(terminal);
         this.pipelineParser = pipelineParser != null ? pipelineParser : new PipelineParser();
         this.jobManager = jobManager instanceof DefaultJobManager ? (DefaultJobManager) jobManager : null;
@@ -134,6 +170,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
         if (this.aliasManager != null) {
             groups.add(new AliasCommands(aliasManager));
         }
+        this.parser = parser != null ? parser : new DefaultParser();
     }
 
     @Override
@@ -640,6 +677,9 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
     private Object[] resolveCommand(String cmdLine, String flipArgs) {
         String[] parts = cmdLine.trim().split("\\s+", 2);
         String cmdName = parts[0];
+        if (!this.parser.validCommandName(cmdName)) {
+            throw new UnknownCommandException("Invalid command: " + cmdName);
+        }
         String argsStr = parts.length > 1 ? parts[1] : "";
 
         if (flipArgs != null) {
@@ -653,7 +693,12 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
 
         String[] args = argsStr.isEmpty()
                 ? new String[0]
+<<<<<<< HEAD
                 : parser.parse(argsStr, argsStr.length(), Parser.ParseContext.ACCEPT_LINE)
+=======
+                : this.parser
+                        .parse(argsStr, argsStr.length(), Parser.ParseContext.ACCEPT_LINE)
+>>>>>>> 614e1c70 (Fix command argument parsing)
                         .words()
                         .toArray(String[]::new);
 

--- a/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
+++ b/shell/src/main/java/org/jline/shell/impl/DefaultCommandDispatcher.java
@@ -541,7 +541,7 @@ public class DefaultCommandDispatcher implements CommandDispatcher {
                 Object[] resolved = resolveCommand(cmdLine, s == 0 ? flipArgs : null);
                 commands[s] = (Command) resolved[0];
                 argsArrays[s] = (String[]) resolved[1];
-            } catch (UnknownCommandException e) {
+            } catch (RuntimeException | Error e) {
                 closePumps(pumps);
                 throw e;
             }

--- a/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultScriptRunnerTest.java
@@ -116,7 +116,7 @@ class DefaultScriptRunnerTest extends AbstractCommandDispatcherTest {
         CommandSession session = dispatcher.session();
         session.setWorkingDirectory(tempDir);
 
-        dispatcher.execute("source \"" + script.toString().replace("\\", "\\\\") + "\"");
+        dispatcher.execute("source \"" + script + "\"");
 
         assertEquals(1, executedCommands.size());
         assertEquals("sourced", executedCommands.get(0));


### PR DESCRIPTION
## Summary

Fixes command argument parsing in `DefaultCommandDispatcher`. Previously, arguments were split on whitespace using `split("\\s+")`, so `"part1 part2"` was parsed as `["\"part1", "part2\""]` instead of `["part1 part2"]`. Now uses the shell's `Parser` (typically `DefaultParser`) for proper quoted-argument handling.

Based on #1876 by @Elec332 — rebased onto master and fixed CI/review issues.

### Changes

- **`DefaultCommandDispatcher`**: accept a `Parser` in a new constructor overload; use it for argument splitting in `resolveCommand()` instead of naive `split("\\s+")`. Add `validCommandName()` check before command lookup. Add `DefaultCommandDispatcher(LineReader)` convenience constructor.
- **`CommandDispatcher.trace()`**: handle `SyntaxError` with styled output (no stack trace), consistent with `UnknownCommandException`.
- **`ShellBuilder`**: create a single shared `Parser` instance for both `DefaultCommandDispatcher` and `LineReader`.
- **`resolveAllCommands()`**: broaden catch to `RuntimeException | Error` to propagate `SyntaxError` from parser.

### Fixes over #1876

- Rebased onto latest master (resolved merge conflicts)
- Fixed Windows CI failure: quoted script path in `sourceCommand` test to handle backslashes
- Shared parser instance between dispatcher and reader (per review feedback)

## Test plan

- [x] All existing shell tests pass
- [x] `sourceCommand` test works on all platforms (path properly quoted)

Closes #1876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syntax error reporting: error messages now display with styled formatting instead of full stack traces.

* **Improvements**
  * Enhanced command name validation with clearer error messaging for invalid commands.
  * Improved error handling in pipeline command execution for better reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->