### PR TITLE
chore: configure RB value with nisse

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -Dnisse.source.jgit.dynamicVersion=true
+-Dnisse.source.jgit.dateFormat=iso8601

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>${nisse.jgit.dateIso8601}</project.build.outputTimestamp>
+        <project.build.outputTimestamp>${nisse.jgit.date}</project.build.outputTimestamp>
 
         <java.build.version>22</java.build.version>
         <java.release.version>11</java.release.version>


### PR DESCRIPTION
JLine 4 is not reproducible any more https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/jline/README.md

after digging into why, JLine nisse has been configured for https://github.com/maveniverse/nisse/pull/75 = where `nisse.jgit.dateIso8601` property has been introduced
but later, in https://github.com/maveniverse/nisse/pull/76 , this proerty has been dropped in favor of using again `nisse.jgit.date` but with `nisse.source.jgit.dateFormat=iso8601`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated how the build output timestamp is derived and adjusted the build date-format setting.
  * No functional or dependency changes; build metadata formatting updated only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jline/jline3/pull/1932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->