### PR TITLE
feat(prompt): add optional per-item footer to list and checkbox prompts

### DIFF
--- a/demo/src/main/java/org/jline/demo/examples/PromptFooterExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/PromptFooterExample.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.demo.examples;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.jline.prompt.*;
+import org.jline.reader.UserInterruptException;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * Demonstrates the per-item footer of list and checkbox prompts.
+ *
+ * <p>Each item may declare a {@code footer(...)}. While that item is focused, its footer is shown
+ * dimmed in a fixed-height pane below the list. The pane is sized to the tallest footer among the
+ * items so the list does not shift as the selection moves, and footers may span multiple lines
+ * (explicit {@code \n} and/or automatic wrapping to the terminal width). The maximum pane height is
+ * configurable via {@link PrompterConfig#footerMaxRows()}.
+ */
+public class PromptFooterExample {
+
+    public static void main(String[] args) throws IOException {
+        try (Terminal terminal = TerminalBuilder.builder().build()) {
+            PrintWriter writer = terminal.writer();
+            if (Terminal.TYPE_DUMB.equals(terminal.getType()) || Terminal.TYPE_DUMB_COLOR.equals(terminal.getType())) {
+                writer.println("Dumb terminal detected. This demo needs a real terminal.");
+                writer.flush();
+                return;
+            }
+
+            Prompter prompter = PrompterFactory.create(terminal);
+
+            List<AttributedString> header = new ArrayList<>();
+            header.add(new AttributedStringBuilder()
+                    .style(AttributedStyle.DEFAULT.italic().foreground(AttributedStyle.GREEN))
+                    .append("JLine Prompt footer demo")
+                    .toAttributedString());
+            header.add(new AttributedString("Move up and down to see the dimmed footer change for the focused item."));
+
+            PromptBuilder promptBuilder = prompter.newBuilder();
+
+            promptBuilder
+                    .createListPrompt()
+                    .name("type")
+                    .message("Select the installation type")
+                    .newItem("full")
+                    .text("Full installation")
+                    .footer("Installs all available components, including the optional and extra data files.")
+                    .add()
+                    .newItem("standard")
+                    .text("Standard installation")
+                    .footer("Installs the recommended set of components for most users.")
+                    .add()
+                    .newItem("custom")
+                    .text("Custom installation")
+                    .footer("Lets you choose exactly which components are installed on the next screen.\n"
+                            + "Pick this if you want to exclude optional parts or save disk space.")
+                    .add()
+                    .addPrompt();
+
+            promptBuilder
+                    .createCheckboxPrompt()
+                    .name("components")
+                    .message("Select components")
+                    .newItem("core")
+                    .text("Core files")
+                    .checked(true)
+                    .footer("Mandatory runtime files. Required by every installation type.")
+                    .add()
+                    .newItem("docs")
+                    .text("Documentation")
+                    .footer("Offline HTML manuals and API reference.")
+                    .add()
+                    .newItem("samples")
+                    .text("Sample projects")
+                    .footer("Example projects you can open and build to learn the tool.")
+                    .add()
+                    .addPrompt();
+
+            Map<String, ? extends PromptResult<? extends Prompt>> result =
+                    prompter.prompt(header, promptBuilder.build());
+
+            writer.println("Installation type: " + ((ListResult) result.get("type")).getSelectedId());
+            writer.println("Components: " + ((CheckboxResult) result.get("components")).getSelectedIds());
+            writer.flush();
+        } catch (UserInterruptException e) {
+            // cancelled by the user, nothing to do
+        }
+    }
+}

--- a/prompt/src/main/java/org/jline/prompt/CheckboxBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/CheckboxBuilder.java
@@ -54,6 +54,18 @@ public interface CheckboxBuilder extends BaseBuilder<CheckboxBuilder> {
     CheckboxBuilder disabledText(String disabledText);
 
     /**
+     * Set the footer text for the current item. The footer is shown dimmed below the checkbox list
+     * while this item is focused. Newlines split it into multiple lines, and long lines wrap to the
+     * terminal width. The footer pane has a fixed height, so the list does not shift between items.
+     *
+     * @param footer the footer text, or {@code null}/empty for none
+     * @return this builder
+     */
+    default CheckboxBuilder footer(String footer) {
+        return this;
+    }
+
+    /**
      * Add the current item to the list.
      *
      * @return this builder

--- a/prompt/src/main/java/org/jline/prompt/ListBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/ListBuilder.java
@@ -46,6 +46,18 @@ public interface ListBuilder extends BaseBuilder<ListBuilder> {
     ListBuilder disabledText(String disabledText);
 
     /**
+     * Set the footer text for the current item. The footer is shown dimmed below the list while
+     * this item is focused. Newlines split it into multiple lines and long lines wrap to the
+     * terminal width; the footer pane has a fixed height so the list does not shift between items.
+     *
+     * @param footer the footer text, or {@code null}/empty for none
+     * @return this builder
+     */
+    default ListBuilder footer(String footer) {
+        return this;
+    }
+
+    /**
      * Add the current item to the list.
      *
      * @return this builder

--- a/prompt/src/main/java/org/jline/prompt/PromptItem.java
+++ b/prompt/src/main/java/org/jline/prompt/PromptItem.java
@@ -54,4 +54,13 @@ public interface PromptItem {
     default String getDisabledText() {
         return "";
     }
+
+    /**
+     * Optional footer text shown dimmed below a list or checkbox while this item is focused.
+     *
+     * @return the footer text, or {@code null}/empty for no footer
+     */
+    default String getFooter() {
+        return null;
+    }
 }

--- a/prompt/src/main/java/org/jline/prompt/PrompterConfig.java
+++ b/prompt/src/main/java/org/jline/prompt/PrompterConfig.java
@@ -160,8 +160,19 @@ public interface PrompterConfig {
     String CB = ".cb";
     /** Error message style */
     String ERROR = ".er";
+    /** Footer/description text style (dimmed) */
+    String FO = ".fo";
 
     default AttributedStyle style(String style) {
         return styleResolver().resolve(style);
+    }
+
+    /**
+     * Maximum height, in rows, of the dimmed footer pane shown below list and checkbox prompts.
+     *
+     * @return the maximum footer pane height in rows
+     */
+    default int footerMaxRows() {
+        return 6;
     }
 }

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxBuilder.java
@@ -33,6 +33,7 @@ public class DefaultCheckboxBuilder implements CheckboxBuilder {
     private boolean currentItemChecked;
     private boolean currentItemDisabled;
     private String currentItemDisabledText;
+    private String currentItemFooter;
     private int pageSize = 0;
     private boolean showPageIndicator = true;
     private int minSelections = 0;
@@ -86,6 +87,7 @@ public class DefaultCheckboxBuilder implements CheckboxBuilder {
         this.currentItemChecked = false;
         this.currentItemDisabled = false;
         this.currentItemDisabledText = null;
+        this.currentItemFooter = null;
         return this;
     }
 
@@ -134,6 +136,12 @@ public class DefaultCheckboxBuilder implements CheckboxBuilder {
         return this;
     }
 
+    @Override
+    public CheckboxBuilder footer(String footer) {
+        this.currentItemFooter = footer;
+        return this;
+    }
+
     /**
      * Add the current item to the list.
      *
@@ -142,13 +150,19 @@ public class DefaultCheckboxBuilder implements CheckboxBuilder {
     public CheckboxBuilder add() {
         if (currentItemId != null) {
             DefaultCheckboxItem item = new DefaultCheckboxItem(
-                    currentItemId, currentItemText, currentItemChecked, currentItemDisabled, currentItemDisabledText);
+                    currentItemId,
+                    currentItemText,
+                    currentItemChecked,
+                    currentItemDisabled,
+                    currentItemDisabledText,
+                    currentItemFooter);
             items.add(item);
             currentItemId = null;
             currentItemText = null;
             currentItemChecked = false;
             currentItemDisabled = false;
             currentItemDisabledText = null;
+            currentItemFooter = null;
         }
         return this;
     }

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxItem.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultCheckboxItem.java
@@ -20,21 +20,28 @@ public class DefaultCheckboxItem implements CheckboxItem {
     private final boolean checked;
     private final boolean disabled;
     private final String disabledText;
+    private final String footer;
 
-    public DefaultCheckboxItem(String name, String text, boolean checked, boolean disabled, String disabledText) {
+    public DefaultCheckboxItem(
+            String name, String text, boolean checked, boolean disabled, String disabledText, String footer) {
         this.name = name;
         this.text = text;
         this.checked = checked;
         this.disabled = disabled;
         this.disabledText = disabledText;
+        this.footer = footer;
+    }
+
+    public DefaultCheckboxItem(String name, String text, boolean checked, boolean disabled, String disabledText) {
+        this(name, text, checked, disabled, disabledText, null);
     }
 
     public DefaultCheckboxItem(String name, String text, boolean checked) {
-        this(name, text, checked, false, null);
+        this(name, text, checked, false, null, null);
     }
 
     public DefaultCheckboxItem(String name, String text) {
-        this(name, text, false, false, null);
+        this(name, text, false, false, null, null);
     }
 
     @Override
@@ -60,6 +67,11 @@ public class DefaultCheckboxItem implements CheckboxItem {
     @Override
     public String getDisabledText() {
         return disabledText;
+    }
+
+    @Override
+    public String getFooter() {
+        return footer;
     }
 
     @Override

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultListBuilder.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultListBuilder.java
@@ -32,6 +32,7 @@ public class DefaultListBuilder implements ListBuilder {
     private String currentItemText;
     private boolean currentItemDisabled;
     private String currentItemDisabledText;
+    private String currentItemFooter;
     private int pageSize = 0;
     private boolean showPageIndicator = true;
     private boolean filterable = true;
@@ -82,6 +83,7 @@ public class DefaultListBuilder implements ListBuilder {
         this.currentItemText = null;
         this.currentItemDisabled = false;
         this.currentItemDisabledText = null;
+        this.currentItemFooter = null;
         return this;
     }
 
@@ -118,6 +120,12 @@ public class DefaultListBuilder implements ListBuilder {
         return this;
     }
 
+    @Override
+    public ListBuilder footer(String footer) {
+        this.currentItemFooter = footer;
+        return this;
+    }
+
     /**
      * Add the current item to the list.
      *
@@ -125,13 +133,14 @@ public class DefaultListBuilder implements ListBuilder {
      */
     public ListBuilder add() {
         if (currentItemId != null) {
-            DefaultListItem item =
-                    new DefaultListItem(currentItemId, currentItemText, currentItemDisabled, currentItemDisabledText);
+            DefaultListItem item = new DefaultListItem(
+                    currentItemId, currentItemText, currentItemDisabled, currentItemDisabledText, currentItemFooter);
             items.add(item);
             currentItemId = null;
             currentItemText = null;
             currentItemDisabled = false;
             currentItemDisabledText = null;
+            currentItemFooter = null;
         }
         return this;
     }

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultListItem.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultListItem.java
@@ -19,16 +19,22 @@ public class DefaultListItem implements ListItem {
     private final String text;
     private final boolean disabled;
     private final String disabledText;
+    private final String footer;
 
-    public DefaultListItem(String name, String text, boolean disabled, String disabledText) {
+    public DefaultListItem(String name, String text, boolean disabled, String disabledText, String footer) {
         this.name = name;
         this.text = text;
         this.disabled = disabled;
         this.disabledText = disabledText;
+        this.footer = footer;
+    }
+
+    public DefaultListItem(String name, String text, boolean disabled, String disabledText) {
+        this(name, text, disabled, disabledText, null);
     }
 
     public DefaultListItem(String name, String text) {
-        this(name, text, false, null);
+        this(name, text, false, null, null);
     }
 
     @Override
@@ -49,6 +55,11 @@ public class DefaultListItem implements ListItem {
     @Override
     public String getDisabledText() {
         return disabledText;
+    }
+
+    @Override
+    public String getFooter() {
+        return footer;
     }
 
     @Override

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,6 +45,7 @@ import org.jline.terminal.Terminal;
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.Display;
+import org.jline.utils.WCWidth;
 
 import static org.jline.keymap.KeyMap.*;
 import static org.jline.utils.InfoCmp.Capability.*;
@@ -76,6 +78,25 @@ public class DefaultPrompter implements Prompter {
 
     // First row where items start (after header and message)
     private int firstItemRow;
+
+    // Height (in rows) of the dimmed footer pane below a list/checkbox, or 0 when no item declares a
+    // footer.
+    private int footerAreaHeight = 0;
+
+    // The items whose footers are shown in the pane
+    private List<? extends PromptItem> footerItems = Collections.emptyList();
+
+    // Wrapped footer lines per item, cached for footerCacheWidth and rebuilt when the width changes.
+    private final Map<PromptItem, List<String>> footerCache = new IdentityHashMap<>();
+
+    // Terminal width the footer cache/height were built for, or -1 when not yet built.
+    private int footerCacheWidth = -1;
+
+    // Column at which footer text starts
+    private int footerIndent = 0;
+
+    // Upper bound on the footer pane height
+    private int footerMaxRows = 6;
 
     // Sentinel exception used to signal Escape key press during readLine
     private static final EndOfFileException ESCAPE_EOF = new EndOfFileException("escape");
@@ -1057,6 +1078,8 @@ public class DefaultPrompter implements Prompter {
 
         // Find first selectable item
         firstItemRow = (header != null ? header.size() : 0) + 1;
+        // The footer pane is derived from all items and sized lazily at render time
+        footerItems = allItems;
         int selectRow = nextRow(firstItemRow - 1, firstItemRow, filteredItems);
 
         // Interactive selection loop
@@ -1170,6 +1193,7 @@ public class DefaultPrompter implements Prompter {
         // Initialize display
         resetDisplay();
         firstItemRow = (header != null ? header.size() : 0) + 1;
+        footerItems = allItems;
         range = null;
 
         // Filtering state
@@ -1438,7 +1462,7 @@ public class DefaultPrompter implements Prompter {
             asb.append(createMessage(prompt.getMessage(), null));
             out.add(asb.toAttributedString());
 
-            computeListRange(selectRow, items.size(), 0);
+            computeListRange(selectRow, items.size(), 0, false);
             for (int i = range.first; i < range.last && i < items.size(); i++) {
                 out.add(buildSingleItemLine(items.get(i), i + firstItemRow == selectRow, true));
             }
@@ -1796,9 +1820,12 @@ public class DefaultPrompter implements Prompter {
             List<AttributedString> header, String message, List<ListItem> items, int cursorRow, ListPrompt prompt) {
         size = terminal.getSize();
         display.resize(size);
-        display.update(
-                buildListDisplayLines(header, message, items, cursorRow, prompt),
-                size.cursorPos(Math.min(size.getRows() - 1, firstItemRow + items.size()), 0));
+        List<AttributedString> lines = buildListDisplayLines(header, message, items, cursorRow, prompt);
+        // when a footer pane is shown, park the cursor on the last rendered row below the footer
+        int cursorLine = footerAreaHeight > 0
+                ? Math.min(size.getRows() - 1, lines.size() - 1)
+                : Math.min(size.getRows() - 1, firstItemRow + items.size());
+        display.update(lines, size.cursorPos(cursorLine, 0));
     }
 
     /**
@@ -1808,13 +1835,16 @@ public class DefaultPrompter implements Prompter {
             List<AttributedString> header, String message, List<ListItem> items, int cursorRow, ListPrompt prompt) {
         List<AttributedString> out = new ArrayList<>(header != null ? header : new ArrayList<>());
 
+        footerIndent = display.wcwidth(config.indicator()) + 1;
+        ensureFooterLayout(size.getColumns());
+
         // Add message line
         AttributedStringBuilder asb = new AttributedStringBuilder();
         asb.append(message);
         out.add(asb.toAttributedString());
 
         // Single column layout with pagination
-        computeListRange(cursorRow, items.size(), prompt.getPageSize());
+        computeListRange(cursorRow, items.size(), prompt.getPageSize(), prompt.showPageIndicator());
         for (int i = range.first; i < range.last; i++) {
             if (items.isEmpty() || i > items.size() - 1) {
                 break;
@@ -1828,6 +1858,8 @@ public class DefaultPrompter implements Prompter {
                     .styled(config.style(PrompterConfig.ME), "(Move up and down to reveal more choices)")
                     .toAttributedString());
         }
+
+        appendFooterForFocused(out, items, cursorRow);
 
         return out;
     }
@@ -1949,9 +1981,13 @@ public class DefaultPrompter implements Prompter {
             CheckboxPrompt prompt) {
         size = terminal.getSize();
         display.resize(size);
-        display.update(
-                buildCheckboxDisplayLines(header, message, items, cursorRow, selectedIds, prompt),
-                size.cursorPos(Math.min(size.getRows() - 1, firstItemRow + items.size()), 0));
+        List<AttributedString> lines =
+                buildCheckboxDisplayLines(header, message, items, cursorRow, selectedIds, prompt);
+        // when a footer pane is shown, park the cursor on the last rendered row below the footer
+        int cursorLine = footerAreaHeight > 0
+                ? Math.min(size.getRows() - 1, lines.size() - 1)
+                : Math.min(size.getRows() - 1, firstItemRow + items.size());
+        display.update(lines, size.cursorPos(cursorLine, 0));
     }
 
     /**
@@ -1965,6 +2001,9 @@ public class DefaultPrompter implements Prompter {
             Set<String> selectedIds,
             CheckboxPrompt prompt) {
         List<AttributedString> out = new ArrayList<>(header != null ? header : new ArrayList<>());
+
+        footerIndent = display.wcwidth(config.indicator()) + 1 + display.wcwidth(config.checkedBox()) + 1;
+        ensureFooterLayout(size.getColumns());
 
         // Add message line with selection constraints hint
         AttributedStringBuilder asb = new AttributedStringBuilder();
@@ -1985,7 +2024,7 @@ public class DefaultPrompter implements Prompter {
         out.add(asb.toAttributedString());
 
         // Single column layout with pagination
-        computeListRange(cursorRow, items.size(), prompt.getPageSize());
+        computeListRange(cursorRow, items.size(), prompt.getPageSize(), prompt.showPageIndicator());
         for (int i = range.first; i < range.last; i++) {
             if (items.isEmpty() || i > items.size() - 1) {
                 break;
@@ -1999,6 +2038,8 @@ public class DefaultPrompter implements Prompter {
                     .styled(config.style(PrompterConfig.ME), "(Move up and down to reveal more choices)")
                     .toAttributedString());
         }
+
+        appendFooterForFocused(out, items, cursorRow);
 
         return out;
     }
@@ -2121,19 +2162,26 @@ public class DefaultPrompter implements Prompter {
     /**
      * Compute the visible range of items based on cursor position, terminal size, and page size.
      */
-    private void computeListRange(int cursorRow, int itemsSize, int pageSize) {
+    private void computeListRange(int cursorRow, int itemsSize, int pageSize, boolean showPageIndicator) {
         if (range != null && range.first <= cursorRow - firstItemRow && range.last - 1 > cursorRow - firstItemRow) {
             return;
         }
         range = new ListRange(0, itemsSize);
 
-        // Determine effective page size
+        // Determine effective page size.
         int effectivePageSize;
-        if (pageSize > 0) {
+        if (footerAreaHeight > 0) {
+            int maxFit = size.getRows() - firstItemRow - footerReservedRows();
+            effectivePageSize = pageSize > 0 ? Math.min(pageSize, maxFit) : maxFit;
+            if (showPageIndicator && effectivePageSize < itemsSize) {
+                effectivePageSize -= 1;
+            }
+        } else if (pageSize > 0) {
             effectivePageSize = pageSize;
         } else {
             effectivePageSize = size.getRows() - firstItemRow;
         }
+        effectivePageSize = Math.max(1, effectivePageSize);
 
         if (effectivePageSize < itemsSize) {
             int itemId = cursorRow - firstItemRow;
@@ -2186,5 +2234,144 @@ public class DefaultPrompter implements Prompter {
      */
     private void resetDisplay() {
         size = terminal.getSize();
+        footerAreaHeight = 0;
+        footerItems = Collections.emptyList();
+        footerCache.clear();
+        footerCacheWidth = -1;
+        footerIndent = 0;
+        footerMaxRows = Math.max(0, config.footerMaxRows());
+    }
+
+    /**
+     * Number of rows reserved below the items for the footer pane, including a one-row separator,
+     * or 0 when no footer is shown.
+     */
+    private int footerReservedRows() {
+        return footerAreaHeight > 0 ? footerAreaHeight + 1 : 0;
+    }
+
+    /**
+     * (Re)build the footer layout for the given terminal width
+     */
+    private void ensureFooterLayout(int width) {
+        if (width == footerCacheWidth) {
+            return;
+        }
+        footerCacheWidth = width;
+        footerCache.clear();
+        range = null;
+        int max = 0;
+        for (PromptItem item : footerItems) {
+            List<String> lines = wrapFooter(item.getFooter(), width);
+            footerCache.put(item, lines);
+            if (lines.size() > max) {
+                max = lines.size();
+            }
+        }
+        footerAreaHeight = Math.min(max, footerMaxRows);
+    }
+
+    /**
+     * Resolve the focused item from the visible list and append its footer pane
+     */
+    private void appendFooterForFocused(List<AttributedString> out, List<? extends PromptItem> items, int cursorRow) {
+        if (footerAreaHeight <= 0) {
+            return;
+        }
+        int idx = cursorRow - firstItemRow;
+        PromptItem focused = idx >= 0 && idx < items.size() ? items.get(idx) : null;
+        if (focused == null) {
+            return;
+        }
+        out.add(AttributedString.EMPTY); // separator
+        List<String> lines = footerCache.get(focused);
+        if (lines == null) {
+            lines = wrapFooter(focused.getFooter(), footerCacheWidth);
+        }
+        for (int i = 0; i < footerAreaHeight; i++) {
+            if (i < lines.size()) {
+                AttributedStringBuilder asb = new AttributedStringBuilder();
+                for (int s = 0; s < footerIndent; s++) {
+                    asb.append(' ');
+                }
+                asb.styled(config.style(PrompterConfig.FO), lines.get(i));
+                out.add(asb.toAttributedString());
+            } else {
+                out.add(AttributedString.EMPTY);
+            }
+        }
+    }
+
+    /**
+     * Wrap a footer string into display lines measured in terminal columns
+     */
+    private List<String> wrapFooter(String footer, int width) {
+        List<String> lines = new ArrayList<>();
+        if (footer == null || footer.isEmpty()) {
+            return lines;
+        }
+        int avail = Math.max(1, width - footerIndent);
+        for (String segment : footer.split("\n", -1)) {
+            StringBuilder line = new StringBuilder();
+            int lineCols = 0;
+            for (String word : segment.split(" ")) {
+                for (String atom : breakToWidth(word, avail)) {
+                    int atomCols = columnWidth(atom);
+                    if (line.length() == 0) {
+                        line.append(atom);
+                        lineCols = atomCols;
+                    } else if (lineCols + 1 + atomCols <= avail) {
+                        line.append(' ').append(atom);
+                        lineCols += 1 + atomCols;
+                    } else {
+                        lines.add(line.toString());
+                        line.setLength(0);
+                        line.append(atom);
+                        lineCols = atomCols;
+                    }
+                }
+            }
+            lines.add(line.toString());
+        }
+        return lines;
+    }
+
+    /** Split a word into chunks each at most {@code maxCols} terminal columns */
+    private List<String> breakToWidth(String word, int maxCols) {
+        List<String> chunks = new ArrayList<>();
+        if (columnWidth(word) <= maxCols) {
+            chunks.add(word);
+            return chunks;
+        }
+        int i = 0;
+        int n = word.length();
+        while (i < n) {
+            int cols = 0;
+            int j = i;
+            while (j < n) {
+                int cp = word.codePointAt(j);
+                int w = Math.max(0, WCWidth.wcwidth(cp));
+                if (cols + w > maxCols && j > i) {
+                    break;
+                }
+                cols += w;
+                j += Character.charCount(cp);
+            }
+            chunks.add(word.substring(i, j));
+            i = j;
+        }
+        return chunks;
+    }
+
+    /** Terminal column width of a string. */
+    private int columnWidth(String s) {
+        int cols = 0;
+        int i = 0;
+        while (i < s.length()) {
+            int cp = s.codePointAt(i);
+            cols += Math.max(0, WCWidth.wcwidth(cp));
+            i += Character.charCount(cp);
+        }
+        return cols;
     }
 }

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompterConfig.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompterConfig.java
@@ -64,6 +64,7 @@ public class DefaultPrompterConfig implements PrompterConfig {
      *   <li><code>.cu</code> - cursor/indicator style</li>
      *   <li><code>.be</code> - box element style (checked/unchecked boxes)</li>
      *   <li><code>.bd</code> - disabled/unavailable item style</li>
+     *   <li><code>.fo</code> - footer/description style (dimmed)</li>
      * </ul>
      *
      * @param indicator the indicator character/string
@@ -85,7 +86,7 @@ public class DefaultPrompterConfig implements PrompterConfig {
             StyleResolver resolver,
             boolean cancellableFirstPrompt) {
         if (resolver == null) {
-            String defaultColors = "cu=36:be=32:bd=37:pr=32:me=1:an=36:se=36:cb=100:er=31";
+            String defaultColors = "cu=36:be=32:bd=37:pr=32:me=1:an=36:se=36:cb=100:er=31:fo=90";
             String envColors = System.getenv("PROMPTER_COLORS");
             String colors = envColors != null ? envColors : defaultColors;
 

--- a/prompt/src/test/java/org/jline/prompt/PrompterListExecutionTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PrompterListExecutionTest.java
@@ -292,4 +292,226 @@ class PrompterListExecutionTest {
         ChoiceResult result = (ChoiceResult) results.get("size");
         assertEquals("large", result.getSelectedId());
     }
+
+    @Test
+    void testListPromptShowsFooterForFocusedItemOnly() throws Exception {
+        // Select the first item immediately, so only "red" is ever focused.
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write("\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal =
+                TerminalBuilder.builder().type("ansi").streams(in, out).build();
+        terminal.setSize(Size.of(160, 80));
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createListPrompt()
+                .name("color")
+                .message("Choose a color:")
+                .newItem("red")
+                .text("Red")
+                .footer("RED_FOOTER warm tone")
+                .add()
+                .newItem("green")
+                .text("Green")
+                .footer("GREEN_FOOTER calm tone")
+                .add()
+                .newItem("blue")
+                .text("Blue")
+                .footer("BLUE_FOOTER cool tone")
+                .add()
+                .addPrompt();
+
+        ListResult result = (ListResult)
+                prompter.prompt(Collections.emptyList(), builder.build()).get("color");
+        assertEquals("red", result.getSelectedId());
+
+        String rendered = out.toString("UTF-8");
+        // The focused item's footer is shown ...
+        assertTrue(rendered.contains("RED_FOOTER"), "focused item footer should be rendered");
+        // ... while a never-focused item's footer is not (the pane tracks focus, it is not always-on).
+        assertFalse(rendered.contains("BLUE_FOOTER"), "unfocused item footer should not be rendered");
+    }
+
+    @Test
+    void testListPromptFooterFollowsFocus() throws Exception {
+        // Down, Down, Enter -> focus moves red -> green -> blue.
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write("\033[B\033[B\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal =
+                TerminalBuilder.builder().type("ansi").streams(in, out).build();
+        terminal.setSize(Size.of(160, 80));
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createListPrompt()
+                .name("color")
+                .message("Choose a color:")
+                .newItem("red")
+                .text("Red")
+                .footer("RED_FOOTER warm tone")
+                .add()
+                .newItem("green")
+                .text("Green")
+                .footer("GREEN_FOOTER calm tone")
+                .add()
+                .newItem("blue")
+                .text("Blue")
+                .footer("BLUE_FOOTER cool tone")
+                .add()
+                .addPrompt();
+
+        ListResult result = (ListResult)
+                prompter.prompt(Collections.emptyList(), builder.build()).get("color");
+        assertEquals("blue", result.getSelectedId());
+
+        String rendered = out.toString("UTF-8");
+        // Footer was shown for the initially focused item and for the finally focused item.
+        assertTrue(rendered.contains("RED_FOOTER"), "initial footer should be rendered");
+        assertTrue(rendered.contains("BLUE_FOOTER"), "footer should follow focus to the last item");
+    }
+
+    @Test
+    void testListPromptMultiLineFooter() throws Exception {
+        // Focus the first item, whose footer has an explicit line break.
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write("\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal =
+                TerminalBuilder.builder().type("ansi").streams(in, out).build();
+        terminal.setSize(Size.of(160, 80));
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createListPrompt()
+                .name("color")
+                .message("Choose a color:")
+                .newItem("red")
+                .text("Red")
+                .footer("Alpha footer line\nBravo footer line")
+                .add()
+                .newItem("green")
+                .text("Green")
+                .add()
+                .addPrompt();
+
+        ListResult result = (ListResult)
+                prompter.prompt(Collections.emptyList(), builder.build()).get("color");
+        assertEquals("red", result.getSelectedId());
+
+        String rendered = out.toString("UTF-8");
+        assertTrue(rendered.contains("Alpha footer line"), "first footer line should be rendered");
+        assertTrue(rendered.contains("Bravo footer line"), "second footer line should be rendered");
+    }
+
+    @Test
+    void testCheckboxPromptShowsFooterForFocusedItemOnly() throws Exception {
+        // Enter immediately, so only the first checkbox item is ever focused.
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write("\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal =
+                TerminalBuilder.builder().type("ansi").streams(in, out).build();
+        terminal.setSize(Size.of(160, 80));
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createCheckboxPrompt()
+                .name("toppings")
+                .message("Select toppings:")
+                .newItem("cheese")
+                .text("Cheese")
+                .footer("Footer for cheese")
+                .add()
+                .newItem("pepperoni")
+                .text("Pepperoni")
+                .footer("Footer for pepperoni")
+                .add()
+                .newItem("mushrooms")
+                .text("Mushrooms")
+                .footer("Footer for mushrooms")
+                .add()
+                .addPrompt();
+
+        prompter.prompt(Collections.emptyList(), builder.build());
+
+        String rendered = out.toString("UTF-8");
+        assertTrue(rendered.contains("Footer for cheese"), "focused checkbox footer should be rendered");
+        assertFalse(rendered.contains("Footer for mushrooms"), "unfocused checkbox footer should not be rendered");
+    }
+
+    @Test
+    void testListPromptWithFootersOnShortTerminalStillRendersItems() throws Exception {
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write("\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal =
+                TerminalBuilder.builder().type("ansi").streams(in, out).build();
+        terminal.setSize(Size.of(160, 3));
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createListPrompt()
+                .name("color")
+                .message("Choose a color:")
+                .newItem("red")
+                .text("Red")
+                .footer("Footer red")
+                .add()
+                .newItem("green")
+                .text("Green")
+                .footer("Footer green")
+                .add()
+                .newItem("blue")
+                .text("Blue")
+                .footer("Footer blue")
+                .add()
+                .addPrompt();
+
+        ListResult result = (ListResult)
+                prompter.prompt(Collections.emptyList(), builder.build()).get("color");
+        assertEquals("red", result.getSelectedId());
+        String rendered = out.toString("UTF-8");
+        assertTrue(
+                rendered.contains("Red") || rendered.contains("Green") || rendered.contains("Blue"),
+                "at least one item must render on a short terminal (clamp prevents an empty list)");
+    }
+
+    @Test
+    void testListPromptFilterWithFootersSelectsMatch() throws Exception {
+        // Filtering down to a single match while footers are present must still select correctly.
+        Prompter prompter = createPrompter("blue\n");
+        PromptBuilder builder = prompter.newBuilder()
+                .createListPrompt()
+                .name("color")
+                .message("Choose a color:")
+                .newItem("red")
+                .text("Red")
+                .footer("Footer red")
+                .add()
+                .newItem("green")
+                .text("Green")
+                .footer("Footer green")
+                .add()
+                .newItem("blue")
+                .text("Blue")
+                .footer("Footer blue")
+                .add()
+                .addPrompt();
+
+        ListResult result = (ListResult)
+                prompter.prompt(Collections.emptyList(), builder.build()).get("color");
+        assertEquals("blue", result.getSelectedId());
+    }
 }


### PR DESCRIPTION
List and checkbox items often need a per-option description. Today there is nowhere to put it. You can fold it into the item label, which clutters the list and wraps badly. The choice prompt can do this through its help key, but only on demand and only in the keyed choice model.

This adds an optional footer for list and checkbox prompts. Each item can set a footer. While an item is focused, its footer shows dimmed in a fixed-height pane below the list. The pane is sized to the tallest footer among the items, so the list does not shift as the selection moves.

## API
- `PromptItem.getFooter()`, default null, inherited by list and checkbox items                                                                                              
- `ListBuilder.footer(String)` and `CheckboxBuilder.footer(String)`
- `PrompterConfig.footerMaxRows()`, default 6, bounds the pane height
- new `.fo` style (`PrompterConfig.FO`) for footer text, default dim grey (`fo=90`)

## Behavior
- footers can span multiple lines, via explicit newlines and wrapping to the terminal width
- width is measured in display columns, so wide and CJK text wrap correctly and a codepoint is never split
- fully inert when no item sets a footer. prompts that do not use it render exactly as before
- the page range reserves the footer rows, plus the page-indicator row when paginating, so items and footer fit without scrolling. the visible page is clamped to at least one item
- footer height and wrapped lines are cached per width, so they follow terminal resizes without re-wrapping on every keystroke

## Tests
`PrompterListExecutionTest` covers focus tracking, multi-line footers, checkbox footers, filtering, and the short-terminal clamp.
  
  ## Demo
`PromptFooterExample`, run with `./mvx demo PromptFooterExample`. Arrow up and down to watch the footer track the focused item.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Item footers for list and checkbox prompts — dimmed text shown beneath the currently focused item
  * Multi-line footers with terminal-width-aware wrapping, fixed footer pane height, and configurable max footer rows
  * New example demonstrating footer usage in selection prompts
* **Styling**
  * Added a footer/description style key (fo) and default color mapping
* **Tests**
  * Integration tests validating footer rendering, focus-following, multi-line behavior, and short-terminal handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->