### PR TITLE
refactor: drop the java.logging module dependency and use System.Logger instead

### DIFF
--- a/builtins/src/main/java/module-info.java
+++ b/builtins/src/main/java/module-info.java
@@ -21,7 +21,6 @@
 module org.jline.builtins {
     // Core Java platform
     requires java.base;
-    requires java.logging;
     requires java.management;
 
     // GUI and HTTP server support for SwingTerminal and WebTerminal

--- a/console-ui/src/main/java/module-info.java
+++ b/console-ui/src/main/java/module-info.java
@@ -20,7 +20,6 @@
 module org.jline.console.ui {
     // Core Java platform
     requires java.base;
-    requires java.logging;
 
     // JLine dependencies
     requires transitive org.jline.terminal;

--- a/console/src/main/java/module-info.java
+++ b/console/src/main/java/module-info.java
@@ -33,7 +33,6 @@
 module org.jline.console {
     // Core Java platform
     requires java.base;
-    requires java.logging;
     requires java.desktop;
 
     // JLine dependencies

--- a/jansi-core/src/main/java/module-info.java
+++ b/jansi-core/src/main/java/module-info.java
@@ -21,7 +21,6 @@ module org.jline.jansi.core {
     // Dependencies
     requires transitive org.jline.terminal;
     requires java.base;
-    requires java.logging;
 
     // Export public API
     exports org.jline.jansi;

--- a/native/src/main/java/module-info.java
+++ b/native/src/main/java/module-info.java
@@ -20,7 +20,6 @@
 module org.jline.nativ {
     // Core Java platform
     requires java.base;
-    requires java.logging;
 
     // Export public API
     exports org.jline.nativ;

--- a/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
+++ b/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
@@ -34,14 +34,14 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Manages the loading of JLine's native libraries (*.dll, *.jnilib, *.so) according to the current
@@ -112,7 +112,7 @@ import java.util.logging.Logger;
  */
 public class JLineNativeLoader {
 
-    private static final Logger logger = Logger.getLogger("org.jline");
+    private static final Logger logger = System.getLogger("org.jline");
     private static boolean loaded = false;
     private static String nativeLibraryPath;
     private static String nativeLibrarySourceUrl;
@@ -607,7 +607,7 @@ public class JLineNativeLoader {
 
     private static void log(Level level, String message, Throwable t) {
         if (logger.isLoggable(level)) {
-            if (logger.isLoggable(Level.FINE)) {
+            if (logger.isLoggable(Level.DEBUG)) {
                 logger.log(level, message, t);
             } else {
                 logger.log(level, message + " (caused by: " + t + ", enable debug logging for stacktrace)");

--- a/native/src/main/java/org/jline/nativ/OSInfo.java
+++ b/native/src/main/java/org/jline/nativ/OSInfo.java
@@ -30,10 +30,10 @@ package org.jline.nativ;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.HashMap;
 import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Provides OS name and architecture name.
@@ -57,7 +57,7 @@ public class OSInfo {
     public static final String PPC64 = "ppc64";
     public static final String ARM64 = "arm64";
 
-    private static final Logger logger = Logger.getLogger("org.jline");
+    private static final Logger logger = System.getLogger("org.jline");
     private static final HashMap<String, String> archMapping = new HashMap<>();
 
     static {
@@ -232,7 +232,7 @@ public class OSInfo {
 
     private static void log(Level level, String message, Throwable t) {
         if (logger.isLoggable(level)) {
-            if (logger.isLoggable(Level.FINE)) {
+            if (logger.isLoggable(Level.DEBUG)) {
                 logger.log(level, message, t);
             } else {
                 logger.log(level, message + " (caused by: " + t + ", enable debug logging for stacktrace)");

--- a/prompt/src/main/java/module-info.java
+++ b/prompt/src/main/java/module-info.java
@@ -33,7 +33,6 @@
 module org.jline.prompt {
     // Core Java platform
     requires java.base;
-    requires java.logging;
 
     // JLine dependencies
     requires transitive org.jline.terminal;

--- a/reader/src/main/java/module-info.java
+++ b/reader/src/main/java/module-info.java
@@ -26,7 +26,6 @@ module org.jline.reader {
     // Dependencies
     requires transitive org.jline.terminal;
     requires java.base;
-    requires java.logging;
 
     // Export public API
     exports org.jline.reader;

--- a/reader/src/test/java/org/jline/keymap/BindingReaderTest.java
+++ b/reader/src/test/java/org/jline/keymap/BindingReaderTest.java
@@ -12,10 +12,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.jline.reader.Binding;
 import org.jline.reader.Reference;
@@ -38,13 +34,6 @@ class BindingReaderTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        Handler ch = new ConsoleHandler();
-        ch.setLevel(Level.FINEST);
-        Logger logger = Logger.getLogger("org.jline");
-        logger.addHandler(ch);
-        // Set the handler log level
-        logger.setLevel(Level.INFO);
-
         in = new EofPipedInputStream();
         out = new ByteArrayOutputStream();
         terminal = new DumbTerminal("dumb", "dumb", in, out, StandardCharsets.UTF_8);

--- a/reader/src/test/java/org/jline/keymap/KeyMapTest.java
+++ b/reader/src/test/java/org/jline/keymap/KeyMapTest.java
@@ -13,10 +13,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.jline.reader.Binding;
 import org.jline.reader.Reference;
@@ -51,13 +47,6 @@ class KeyMapTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        Handler ch = new ConsoleHandler();
-        ch.setLevel(Level.FINEST);
-        Logger logger = Logger.getLogger("org.jline");
-        logger.addHandler(ch);
-        // Set the handler log level
-        logger.setLevel(Level.INFO);
-
         in = new EofPipedInputStream();
         out = new ByteArrayOutputStream();
         terminal = new DumbTerminal(in, out);

--- a/reader/src/test/java/org/jline/reader/impl/ReaderTestSupport.java
+++ b/reader/src/test/java/org/jline/reader/impl/ReaderTestSupport.java
@@ -13,10 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.jline.keymap.KeyMap;
 import org.jline.reader.Candidate;
@@ -60,13 +56,6 @@ public abstract class ReaderTestSupport {
 
     @BeforeEach
     public void setUp() throws Exception {
-        Handler ch = new ConsoleHandler();
-        ch.setLevel(Level.FINEST);
-        Logger logger = Logger.getLogger("org.jline");
-        logger.addHandler(ch);
-        // Set the handler log level
-        logger.setLevel(Level.INFO);
-
         in = new EofPipedInputStream();
         out = new ByteArrayOutputStream();
         terminal = new DumbTerminal("terminal", "ansi", in, out, StandardCharsets.UTF_8);

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellCommand.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellCommand.java
@@ -11,9 +11,9 @@ package org.jline.builtins.ssh;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.function.Consumer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
@@ -23,7 +23,7 @@ import org.apache.sshd.server.session.ServerSession;
 
 public class ShellCommand implements Command {
 
-    private static final Logger LOGGER = Logger.getLogger(ShellCommand.class.getName());
+    private static final Logger LOGGER = System.getLogger(ShellCommand.class.getName());
 
     private final Consumer<Ssh.ExecuteParams> execute;
     private final String command;
@@ -68,7 +68,7 @@ public class ShellCommand implements Command {
             execute.accept(new Ssh.ExecuteParams(command, env.getEnv(), session, in, out, err));
         } catch (RuntimeException e) {
             exitStatus = 1;
-            LOGGER.log(Level.SEVERE, "Unable to start shell", e);
+            LOGGER.log(Level.ERROR, "Unable to start shell", e);
             try {
                 Throwable t = (e.getCause() != null) ? e.getCause() : e;
                 err.write(t.toString().getBytes());

--- a/remote-telnet/src/main/java/module-info.java
+++ b/remote-telnet/src/main/java/module-info.java
@@ -35,7 +35,6 @@
 module org.jline.remote.telnet {
     // Core Java platform
     requires java.base;
-    requires java.logging;
 
     // JLine dependencies
     requires transitive org.jline.builtins;

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/Connection.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/Connection.java
@@ -39,10 +39,10 @@ package org.jline.builtins.telnet;
  * POSSIBILITY OF SUCH DAMAGE.
  ***/
 
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Class that implements a connection with this telnet daemon.
@@ -71,7 +71,7 @@ import java.util.logging.Logger;
 @SuppressWarnings("java:S3014")
 public abstract class Connection extends Thread {
 
-    private static final Logger LOG = Logger.getLogger(Connection.class.getName());
+    private static final Logger LOG = System.getLogger(Connection.class.getName());
     private static int number; // unique number for a thread in the thread group
     private boolean dead;
     private List<ConnectionListener> listeners;
@@ -115,14 +115,14 @@ public abstract class Connection extends Thread {
             doRun();
 
         } catch (Exception ex) {
-            LOG.log(Level.SEVERE, "run()", ex); // Handle properly
+            LOG.log(Level.ERROR, "run()", ex); // Handle properly
         } finally {
             // call close if not dead already
             if (!dead) {
                 close();
             }
         }
-        LOG.log(Level.FINE, "run():: Returning from " + this.toString());
+        LOG.log(Level.DEBUG, "run():: Returning from " + this.toString());
     } // run
 
     protected abstract void doRun() throws Exception;
@@ -153,32 +153,32 @@ public abstract class Connection extends Thread {
                 // close i/o
                 doClose();
             } catch (Exception ex) {
-                LOG.log(Level.SEVERE, "close()", ex);
+                LOG.log(Level.ERROR, "close()", ex);
                 // handle
             }
             try {
                 // close socket
                 connectionData.getSocket().close();
             } catch (Exception ex) {
-                LOG.log(Level.SEVERE, "close()", ex);
+                LOG.log(Level.ERROR, "close()", ex);
                 // handle
             }
             try {
                 // register closed connection in ConnectionManager
                 connectionData.getManager().registerClosedConnection(this);
             } catch (Exception ex) {
-                LOG.log(Level.SEVERE, "close()", ex);
+                LOG.log(Level.ERROR, "close()", ex);
                 // handle
             }
             try {
                 // try to interrupt it
                 interrupt();
             } catch (Exception ex) {
-                LOG.log(Level.SEVERE, "close()", ex);
+                LOG.log(Level.ERROR, "close()", ex);
                 // handle
             }
 
-            LOG.log(Level.FINE, "Closed " + this.toString() + " and inactive.");
+            LOG.log(Level.DEBUG, "Closed " + this.toString() + " and inactive.");
         }
     } // close
 

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
@@ -40,6 +40,8 @@ package org.jline.builtins.telnet;
  ***/
 
 import java.io.IOException;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.text.MessageFormat;
@@ -47,8 +49,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Stack;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Class that takes care for active and queued connection.
@@ -62,7 +62,7 @@ import java.util.logging.Logger;
 @SuppressWarnings("java:S3014")
 public abstract class ConnectionManager implements Runnable {
 
-    private static Logger LOG = Logger.getLogger(ConnectionManager.class.getName());
+    private static Logger LOG = System.getLogger(ConnectionManager.class.getName());
     private final List<Connection> openConnections;
     private Thread thread;
     private ThreadGroup threadGroup; // ThreadGroup all connections run in
@@ -168,7 +168,7 @@ public abstract class ConnectionManager implements Runnable {
      * Stops this {@code ConnectionManager}.
      */
     public void stop() {
-        LOG.log(Level.FINE, "stop()::" + this.toString());
+        LOG.log(Level.DEBUG, "stop()::" + this.toString());
         stopping = true;
         // wait for thread to die
         try {
@@ -176,7 +176,7 @@ public abstract class ConnectionManager implements Runnable {
                 thread.join();
             }
         } catch (InterruptedException iex) {
-            LOG.log(Level.SEVERE, "stop()", iex);
+            LOG.log(Level.ERROR, "stop()", iex);
         }
         synchronized (openConnections) {
             for (Connection tc : openConnections) {
@@ -184,12 +184,12 @@ public abstract class ConnectionManager implements Runnable {
                     // maybe write a disgrace to the socket?
                     tc.close();
                 } catch (Exception exc) {
-                    LOG.log(Level.SEVERE, "stop()", exc);
+                    LOG.log(Level.ERROR, "stop()", exc);
                 }
             }
             openConnections.clear();
         }
-        LOG.log(Level.FINE, "stop():: Stopped " + this.toString());
+        LOG.log(Level.DEBUG, "stop():: Stopped " + this.toString());
     } // stop
 
     /**
@@ -199,7 +199,7 @@ public abstract class ConnectionManager implements Runnable {
      * @param insock Socket thats representing the incoming connection.
      */
     public void makeConnection(Socket insock) {
-        LOG.log(Level.FINE, "makeConnection()::" + insock.toString());
+        LOG.log(Level.DEBUG, "makeConnection()::" + insock.toString());
         if (connectionFilter == null || connectionFilter.isAllowed(insock.getInetAddress())) {
             // we create the connection data object at this point to
             // store certain information there.
@@ -211,7 +211,7 @@ public abstract class ConnectionManager implements Runnable {
                 Connection con = createConnection(threadGroup, newCD);
                 // log the newly created connection
                 Object[] args = {openConnections.size() + 1};
-                LOG.info(MessageFormat.format("connection #{0,number,integer} made.", args));
+                LOG.log(Level.INFO, MessageFormat.format("connection #{0,number,integer} made.", args));
                 // register it for being managed
                 synchronized (openConnections) {
                     openConnections.add(con);
@@ -220,7 +220,7 @@ public abstract class ConnectionManager implements Runnable {
                 con.start();
             }
         } else {
-            LOG.info("makeConnection():: Active Filter blocked incoming connection.");
+            LOG.log(Level.INFO, "makeConnection():: Active Filter blocked incoming connection.");
             try {
                 insock.close();
             } catch (IOException ex) {
@@ -252,9 +252,9 @@ public abstract class ConnectionManager implements Runnable {
             } while (!stopping);
 
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "run()", e);
+            LOG.log(Level.ERROR, "run()", e);
         }
-        LOG.log(Level.FINE, "run():: Ran out " + this.toString());
+        LOG.log(Level.DEBUG, "run():: Ran out " + this.toString());
     } // run
 
     private void cleanupClosed() {
@@ -264,7 +264,7 @@ public abstract class ConnectionManager implements Runnable {
         // cleanup loop
         while (!closedConnections.isEmpty()) {
             Connection nextOne = closedConnections.pop();
-            LOG.info("cleanupClosed():: Removing closed connection " + nextOne.toString());
+            LOG.log(Level.INFO, "cleanupClosed():: Removing closed connection " + nextOne.toString());
             synchronized (openConnections) {
                 openConnections.remove(nextOne);
             }
@@ -292,7 +292,7 @@ public abstract class ConnectionManager implements Runnable {
                     // ..and for disconnect
                     if (inactivity > (disconnectTimeout + warningTimeout)) {
                         // this connection needs to be disconnected :)
-                        LOG.log(Level.FINE, "checkOpenConnections():" + conn.toString() + " exceeded total timeout.");
+                        LOG.log(Level.DEBUG, "checkOpenConnections():" + conn.toString() + " exceeded total timeout.");
                         // fire logoff event for shell site cleanup , beware could hog the daemon thread
                         conn.processConnectionEvent(
                                 new ConnectionEvent(conn, ConnectionEvent.Type.CONNECTION_TIMEDOUT));
@@ -301,7 +301,7 @@ public abstract class ConnectionManager implements Runnable {
                         // this connection needs to be warned :)
                         if (!cd.isWarned()) {
                             LOG.log(
-                                    Level.FINE,
+                                    Level.DEBUG,
                                     "checkOpenConnections():" + conn.toString() + " exceeded warning timeout.");
                             cd.setWarned(true);
                             // warning event is fired but beware this could hog the daemon thread!!
@@ -320,7 +320,7 @@ public abstract class ConnectionManager implements Runnable {
             return;
         }
         if (!closedConnections.contains(con)) {
-            LOG.log(Level.FINE, "registerClosedConnection()::" + con.toString());
+            LOG.log(Level.DEBUG, "registerClosedConnection()::" + con.toString());
             closedConnections.push(con);
         }
     } // unregister

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/PortListener.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/PortListener.java
@@ -40,13 +40,13 @@ package org.jline.builtins.telnet;
  ***/
 
 import java.io.IOException;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 import java.text.MessageFormat;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Class that implements a {@code PortListener}.<br>
@@ -59,7 +59,7 @@ import java.util.logging.Logger;
  */
 public class PortListener implements Runnable {
 
-    private static final Logger LOG = Logger.getLogger(PortListener.class.getName());
+    private static final Logger LOG = System.getLogger(PortListener.class.getName());
     private static final String logmsg =
             "Listening to Port {0,number,integer} with a connectivity queue size of {1,number,integer}.";
     private String name;
@@ -119,7 +119,7 @@ public class PortListener implements Runnable {
      * Starts this {@code PortListener}.
      */
     public void start() {
-        LOG.log(Level.FINE, "start()");
+        LOG.log(Level.DEBUG, "start()");
         thread = new Thread(this);
         thread.start();
         available = true;
@@ -130,7 +130,7 @@ public class PortListener implements Runnable {
      * when everything was stopped successfully.
      */
     public void stop() {
-        LOG.log(Level.FINE, "stop()::" + this.toString());
+        LOG.log(Level.DEBUG, "stop()::" + this.toString());
         // flag stop
         stopping = true;
         available = false;
@@ -141,17 +141,17 @@ public class PortListener implements Runnable {
         try {
             serverSocket.close();
         } catch (IOException ex) {
-            LOG.log(Level.SEVERE, "stop()", ex);
+            LOG.log(Level.ERROR, "stop()", ex);
         }
 
         // wait for thread to die
         try {
             thread.join();
         } catch (InterruptedException iex) {
-            LOG.log(Level.SEVERE, "stop()", iex);
+            LOG.log(Level.ERROR, "stop()", iex);
         }
 
-        LOG.info("stop()::Stopped " + this.toString());
+        LOG.log(Level.INFO, "stop()::Stopped " + this.toString());
     } // stop
 
     /**
@@ -171,7 +171,7 @@ public class PortListener implements Runnable {
             serverSocket = new ServerSocket(port, floodProtection, ip != null ? InetAddress.getByName(ip) : null);
 
             // log entry
-            LOG.info(MessageFormat.format(logmsg, port, floodProtection));
+            LOG.log(Level.INFO, MessageFormat.format(logmsg, port, floodProtection));
 
             do {
                 try {
@@ -185,17 +185,17 @@ public class PortListener implements Runnable {
                 } catch (SocketException ex) {
                     if (stopping) {
                         // server socket was closed blocked in accept
-                        LOG.log(Level.FINE, "run(): ServerSocket closed by stop()");
+                        LOG.log(Level.DEBUG, "run(): ServerSocket closed by stop()");
                     } else {
-                        LOG.log(Level.SEVERE, "run()", ex);
+                        LOG.log(Level.ERROR, "run()", ex);
                     }
                 }
             } while (!stopping);
 
         } catch (IOException e) {
-            LOG.log(Level.SEVERE, "run()", e);
+            LOG.log(Level.ERROR, "run()", e);
         }
-        LOG.log(Level.FINE, "run(): returning.");
+        LOG.log(Level.DEBUG, "run(): returning.");
     } // run
 
     /**

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
@@ -43,9 +43,9 @@ import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.net.InetAddress;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Class that represents the TelnetIO implementation. It contains
@@ -287,7 +287,7 @@ public class TelnetIO {
     protected static final int SEND_LOC = 23; // Defines Send Location
     protected static final int AUTHENTICATION = 37; // Defines Authentication
     protected static final int ENCRYPT = 38; // Defines Encryption
-    private static final Logger LOG = Logger.getLogger(TelnetIO.class.getName());
+    private static final Logger LOG = System.getLogger(TelnetIO.class.getName());
     /**
      * Window Size Constants
      */
@@ -436,7 +436,7 @@ public class TelnetIO {
 
             out.close();
         } catch (IOException ex) {
-            LOG.log(Level.SEVERE, "closeOutput()", ex);
+            LOG.log(Level.ERROR, "closeOutput()", ex);
             // handle?
         }
     } // close
@@ -542,10 +542,10 @@ public class TelnetIO {
             // start out, some clients just wait
             if (connectionData.isLineMode()) {
                 iacHandler.doLineModeInit();
-                LOG.log(Level.FINE, "Line mode initialized.");
+                LOG.log(Level.DEBUG, "Line mode initialized.");
             } else {
                 iacHandler.doCharacterModeInit();
-                LOG.log(Level.FINE, "Character mode initialized.");
+                LOG.log(Level.DEBUG, "Character mode initialized.");
             }
             // open for a defined timeout so we read incoming negotiation
             connectionData.getSocket().setSoTimeout(1000);
@@ -559,7 +559,7 @@ public class TelnetIO {
             try {
                 connectionData.getSocket().setSoTimeout(0);
             } catch (Exception ex) {
-                LOG.log(Level.SEVERE, "initTelnetCommunication()", ex);
+                LOG.log(Level.ERROR, "initTelnetCommunication()", ex);
             }
         }
         initializing = false;
@@ -576,7 +576,7 @@ public class TelnetIO {
             write("[" + localAddress.toString() + ":Yes]");
             flush();
         } catch (Exception ex) {
-            LOG.log(Level.SEVERE, "IamHere()", ex);
+            LOG.log(Level.ERROR, "IamHere()", ex);
         }
     } // IamHere
 
@@ -888,7 +888,7 @@ public class TelnetIO {
             // specs. hmmm?
             rawread(); // that should be the is :)
             tmpstr = readIACSETerminatedString(40);
-            LOG.log(Level.FINE, "Reported terminal name " + tmpstr);
+            LOG.log(Level.DEBUG, "Reported terminal name " + tmpstr);
             connectionData.setNegotiatedTerminalType(tmpstr);
         } // handleTTYPE
 
@@ -920,7 +920,7 @@ public class TelnetIO {
             if (WAIT_LM_MODE_ACK) {
                 int mask = rawread();
                 if (mask != (LM_EDIT | LM_TRAPSIG | LM_MODEACK)) {
-                    LOG.log(Level.FINE, "Client violates linemodeack sent: " + mask);
+                    LOG.log(Level.DEBUG, "Client violates linemodeack sent: " + mask);
                 }
                 WAIT_LM_MODE_ACK = false;
             }
@@ -983,7 +983,7 @@ public class TelnetIO {
         } // handleLMForward
 
         public void handleNEWENV() throws IOException {
-            LOG.log(Level.FINE, "handleNEWENV()");
+            LOG.log(Level.DEBUG, "handleNEWENV()");
             int c = rawread();
             switch (c) {
                 case IS:
@@ -1007,7 +1007,7 @@ public class TelnetIO {
          undefined.
         */
         private int readNEVariableName(StringBuffer sbuf) throws IOException {
-            LOG.log(Level.FINE, "readNEVariableName()");
+            LOG.log(Level.DEBUG, "readNEVariableName()");
             int i = -1;
             do {
                 i = rawread();
@@ -1057,7 +1057,7 @@ public class TelnetIO {
           it must be sent as IAC IAC.
         */
         private int readNEVariableValue(StringBuffer sbuf) throws IOException {
-            LOG.log(Level.FINE, "readNEVariableValue()");
+            LOG.log(Level.DEBUG, "readNEVariableValue()");
             // check conditions for first character after VALUE
             int i = rawread();
             if (i == -1) {
@@ -1125,13 +1125,13 @@ public class TelnetIO {
         } // readNEVariableValue
 
         public void readNEVariables() throws IOException {
-            LOG.log(Level.FINE, "readNEVariables()");
+            LOG.log(Level.DEBUG, "readNEVariables()");
             StringBuffer sbuf = new StringBuffer(50);
             int i = rawread();
             if (i == IAC) {
                 // invalid or empty response
                 skipToSE();
-                LOG.log(Level.FINE, "readNEVariables()::INVALID VARIABLE");
+                LOG.log(Level.DEBUG, "readNEVariables()::INVALID VARIABLE");
                 return;
             }
             boolean cont = true;
@@ -1139,29 +1139,29 @@ public class TelnetIO {
                 do {
                     switch (readNEVariableName(sbuf)) {
                         case NE_IN_ERROR:
-                            LOG.log(Level.FINE, "readNEVariables()::NE_IN_ERROR");
+                            LOG.log(Level.DEBUG, "readNEVariables()::NE_IN_ERROR");
                             return;
                         case NE_IN_END:
-                            LOG.log(Level.FINE, "readNEVariables()::NE_IN_END");
+                            LOG.log(Level.DEBUG, "readNEVariables()::NE_IN_END");
                             return;
                         case NE_VAR_DEFINED:
-                            LOG.log(Level.FINE, "readNEVariables()::NE_VAR_DEFINED");
+                            LOG.log(Level.DEBUG, "readNEVariables()::NE_VAR_DEFINED");
                             String str = sbuf.toString();
                             sbuf.delete(0, sbuf.length());
                             switch (readNEVariableValue(sbuf)) {
                                 case NE_IN_ERROR:
-                                    LOG.log(Level.FINE, "readNEVariables()::NE_IN_ERROR");
+                                    LOG.log(Level.DEBUG, "readNEVariables()::NE_IN_ERROR");
                                     return;
                                 case NE_IN_END:
-                                    LOG.log(Level.FINE, "readNEVariables()::NE_IN_END");
+                                    LOG.log(Level.DEBUG, "readNEVariables()::NE_IN_END");
                                     return;
                                 case NE_VAR_DEFINED_EMPTY:
-                                    LOG.log(Level.FINE, "readNEVariables()::NE_VAR_DEFINED_EMPTY");
+                                    LOG.log(Level.DEBUG, "readNEVariables()::NE_VAR_DEFINED_EMPTY");
                                     break;
                                 case NE_VAR_OK:
                                     // add variable
                                     LOG.log(
-                                            Level.FINE,
+                                            Level.DEBUG,
                                             "readNEVariables()::NE_VAR_OK:VAR=" + str + " VAL=" + sbuf.toString());
                                     TelnetIO.this
                                             .connectionData
@@ -1172,7 +1172,7 @@ public class TelnetIO {
                             }
                             break;
                         case NE_VAR_UNDEFINED:
-                            LOG.log(Level.FINE, "readNEVariables()::NE_VAR_UNDEFINED");
+                            LOG.log(Level.DEBUG, "readNEVariables()::NE_VAR_UNDEFINED");
                             break;
                     }
                 } while (cont);
@@ -1180,14 +1180,14 @@ public class TelnetIO {
         } // readVariables
 
         public void handleNEIs() throws IOException {
-            LOG.log(Level.FINE, "handleNEIs()");
+            LOG.log(Level.DEBUG, "handleNEIs()");
             if (isEnabled(NEWENV)) {
                 readNEVariables();
             }
         } // handleNEIs
 
         public void handleNEInfo() throws IOException {
-            LOG.log(Level.FINE, "handleNEInfo()");
+            LOG.log(Level.DEBUG, "handleNEInfo()");
             if (isEnabled(NEWENV)) {
                 readNEVariables();
             }

--- a/style/src/main/java/module-info.java
+++ b/style/src/main/java/module-info.java
@@ -21,7 +21,6 @@
 module org.jline.style {
     // Core Java platform
     requires java.base;
-    requires java.logging;
 
     // JLine dependencies
     requires transitive org.jline.terminal;

--- a/style/src/main/java/org/jline/style/MemoryStyleSource.java
+++ b/style/src/main/java/org/jline/style/MemoryStyleSource.java
@@ -8,11 +8,11 @@
  */
 package org.jline.style;
 
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static java.util.Objects.requireNonNull;
 
@@ -43,7 +43,7 @@ import static java.util.Objects.requireNonNull;
  * @see Styler
  */
 public class MemoryStyleSource implements StyleSource {
-    private static final Logger log = Logger.getLogger(MemoryStyleSource.class.getName());
+    private static final Logger log = System.getLogger(MemoryStyleSource.class.getName());
 
     private final Map<String, Map<String, String>> backing = new ConcurrentHashMap<>();
 
@@ -62,8 +62,8 @@ public class MemoryStyleSource implements StyleSource {
             style = styles.get(name);
         }
 
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest(String.format("Get: [%s] %s -> %s", group, name, style));
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, String.format("Get: [%s] %s -> %s", group, name, style));
         }
 
         return style;
@@ -76,8 +76,8 @@ public class MemoryStyleSource implements StyleSource {
         requireNonNull(style);
         backing.computeIfAbsent(group, k -> new ConcurrentHashMap<>()).put(name, style);
 
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest(String.format("Set: [%s] %s -> %s", group, name, style));
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, String.format("Set: [%s] %s -> %s", group, name, style));
         }
     }
 
@@ -85,8 +85,8 @@ public class MemoryStyleSource implements StyleSource {
     public void remove(final String group) {
         requireNonNull(group);
         if (backing.remove(group) != null) {
-            if (log.isLoggable(Level.FINEST)) {
-                log.finest(String.format("Removed: [%s]", group));
+            if (log.isLoggable(Level.TRACE)) {
+                log.log(Level.TRACE, String.format("Removed: [%s]", group));
             }
         }
     }
@@ -99,8 +99,8 @@ public class MemoryStyleSource implements StyleSource {
         if (styles != null) {
             styles.remove(name);
 
-            if (log.isLoggable(Level.FINEST)) {
-                log.finest(String.format("Removed: [%s] %s", group, name));
+            if (log.isLoggable(Level.TRACE)) {
+                log.log(Level.TRACE, String.format("Removed: [%s] %s", group, name));
             }
         }
     }
@@ -108,7 +108,7 @@ public class MemoryStyleSource implements StyleSource {
     @Override
     public void clear() {
         backing.clear();
-        log.finest("Cleared");
+        log.log(Level.TRACE, "Cleared");
     }
 
     @Override

--- a/style/src/main/java/org/jline/style/StyleBundleInvocationHandler.java
+++ b/style/src/main/java/org/jline/style/StyleBundleInvocationHandler.java
@@ -8,11 +8,11 @@
  */
 package org.jline.style;
 
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.jline.style.StyleBundle.DefaultStyle;
 import org.jline.style.StyleBundle.StyleGroup;
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
  * @since 3.4
  */
 class StyleBundleInvocationHandler implements InvocationHandler {
-    private static final Logger log = Logger.getLogger(StyleBundleInvocationHandler.class.getName());
+    private static final Logger log = System.getLogger(StyleBundleInvocationHandler.class.getName());
 
     private final Class<? extends StyleBundle> type;
 
@@ -101,8 +101,10 @@ class StyleBundleInvocationHandler implements InvocationHandler {
         requireNonNull(resolver);
         requireNonNull(type);
 
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest(String.format("Using style-group: %s for type: %s", resolver.getGroup(), type.getName()));
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(
+                    Level.TRACE,
+                    String.format("Using style-group: %s for type: %s", resolver.getGroup(), type.getName()));
         }
 
         StyleBundleInvocationHandler handler = new StyleBundleInvocationHandler(type, resolver);
@@ -144,8 +146,8 @@ class StyleBundleInvocationHandler implements InvocationHandler {
 
         // resolve the sourced-style, or use the default
         String style = resolver.getSource().get(resolver.getGroup(), styleName);
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest(String.format("Sourced-style: %s -> %s", styleName, style));
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, String.format("Sourced-style: %s -> %s", styleName, style));
         }
 
         if (style == null) {
@@ -158,8 +160,8 @@ class StyleBundleInvocationHandler implements InvocationHandler {
         }
 
         String value = String.valueOf(args[0]);
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest(String.format("Applying style: %s -> %s to: %s", styleName, style, value));
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, String.format("Applying style: %s -> %s to: %s", styleName, style, value));
         }
 
         AttributedStyle astyle = resolver.resolve(style);

--- a/style/src/main/java/org/jline/style/Styler.java
+++ b/style/src/main/java/org/jline/style/Styler.java
@@ -8,8 +8,8 @@
  */
 package org.jline.style;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 
 import org.jline.style.StyleBundle.StyleGroup;
 
@@ -46,7 +46,7 @@ import static java.util.Objects.requireNonNull;
  * @since 3.4
  */
 public class Styler {
-    private static final Logger log = Logger.getLogger(Styler.class.getName());
+    private static final Logger log = System.getLogger(Styler.class.getName());
 
     private static volatile StyleSource source = new NopStyleSource();
 
@@ -96,8 +96,8 @@ public class Styler {
     public static void setSource(final StyleSource source) {
         Styler.source = requireNonNull(source);
 
-        if (log.isLoggable(Level.FINE)) {
-            log.fine("Source: " + source);
+        if (log.isLoggable(Level.DEBUG)) {
+            log.log(Level.DEBUG, "Source: " + source);
         }
     }
 

--- a/terminal-ffm/src/main/java/module-info.java
+++ b/terminal-ffm/src/main/java/module-info.java
@@ -24,7 +24,6 @@ module org.jline.terminal.ffm {
     // Dependencies
     requires transitive org.jline.terminal;
     requires java.base;
-    requires java.logging;
 
     // Export public API
     exports org.jline.terminal.impl.ffm;

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -12,6 +12,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -22,8 +24,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,7 +39,7 @@ import org.jline.utils.OSUtils;
 @SuppressWarnings("restricted")
 class CLibrary {
 
-    private static final Logger logger = Logger.getLogger("org.jline");
+    private static final Logger logger = System.getLogger("org.jline");
 
     // Window sizes.
     // @see <a href="http://man7.org/linux/man-pages/man4/tty_ioctl.4.html">IOCTL_TTY(2) man-page</a>
@@ -339,7 +339,7 @@ class CLibrary {
                 }
                 error = new LinkageError(sb.toString());
                 suppressed.forEach(error::addSuppressed);
-                if (logger.isLoggable(Level.FINE)) {
+                if (logger.isLoggable(Level.DEBUG)) {
                     logger.log(Level.WARNING, error.getMessage(), error);
                 } else {
                     logger.log(Level.WARNING, error.getMessage());

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -8,6 +8,8 @@
  */
 package org.jline.terminal.impl.ffm;
 
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -18,8 +20,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.locks.LockSupport;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Native signal handling via POSIX {@code sigaction()} using the Foreign Function &amp; Memory API.
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
 @SuppressWarnings("restricted")
 class FfmSignalHandler {
 
-    private static final Logger logger = Logger.getLogger("org.jline");
+    private static final Logger logger = System.getLogger("org.jline");
 
     // --- Shared string constants ---
     private static final String SA_HANDLER = "sa_handler";
@@ -176,7 +176,7 @@ class FfmSignalHandler {
                 }
             }
         } catch (Exception | LinkageError t) {
-            logger.log(Level.FINE, "FFM signal handler not available", t);
+            logger.log(Level.DEBUG, "FFM signal handler not available", t);
         }
 
         SIGHUP = sighup;
@@ -255,7 +255,7 @@ class FfmSignalHandler {
 
             int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
             if (res != 0) {
-                logger.log(Level.FINE, "sigaction() failed for signal {0} (signum={1})", new Object[] {name, signum});
+                logger.log(Level.DEBUG, "sigaction() failed for signal {0} (signum={1})", new Object[] {name, signum});
                 restoreHandler(signum, previousHandler);
                 arena.close();
                 return null;
@@ -267,8 +267,8 @@ class FfmSignalHandler {
             Runnable saved = isOurUpcallStub(oldAct) ? previousHandler : null;
             return new Registration(signum, arena, oldAct, saved);
         } catch (Throwable t) {
-            logger.log(Level.FINE, "Error registering FFM signal handler for {0}", name);
-            logger.log(Level.FINE, EXCEPTION_DETAILS, t);
+            logger.log(Level.DEBUG, "Error registering FFM signal handler for {0}", name);
+            logger.log(Level.DEBUG, EXCEPTION_DETAILS, t);
             if (nativeInstalled) {
                 bestEffortRestore(signum, oldAct);
             }
@@ -302,7 +302,7 @@ class FfmSignalHandler {
 
             int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
             if (res != 0) {
-                logger.log(Level.FINE, "sigaction(SIG_DFL) failed for signal {0}", name);
+                logger.log(Level.DEBUG, "sigaction(SIG_DFL) failed for signal {0}", name);
                 arena.close();
                 return null;
             }
@@ -311,8 +311,8 @@ class FfmSignalHandler {
             stopDispatcherIfIdle();
             return new Registration(signum, arena, oldAct, previousHandler);
         } catch (Throwable t) {
-            logger.log(Level.FINE, "Error registering default handler for {0}", name);
-            logger.log(Level.FINE, EXCEPTION_DETAILS, t);
+            logger.log(Level.DEBUG, "Error registering default handler for {0}", name);
+            logger.log(Level.DEBUG, EXCEPTION_DETAILS, t);
             arena.close();
             return null;
         }
@@ -332,7 +332,7 @@ class FfmSignalHandler {
         try {
             int res = (int) sigaction_mh.invoke(reg.signum(), reg.oldAction(), MemorySegment.NULL);
             if (res != 0) {
-                logger.log(Level.FINE, "sigaction() restore failed for signal {0}", name);
+                logger.log(Level.DEBUG, "sigaction() restore failed for signal {0}", name);
                 return;
             }
             // Preserve the previous Java Runnable when the restored native disposition is our stub
@@ -344,8 +344,8 @@ class FfmSignalHandler {
                 stopDispatcherIfIdle();
             }
         } catch (Throwable t) {
-            logger.log(Level.FINE, "Error unregistering FFM signal handler for {0}", name);
-            logger.log(Level.FINE, EXCEPTION_DETAILS, t);
+            logger.log(Level.DEBUG, "Error unregistering FFM signal handler for {0}", name);
+            logger.log(Level.DEBUG, EXCEPTION_DETAILS, t);
         } finally {
             reg.arena().close();
         }

--- a/terminal/pom.xml
+++ b/terminal/pom.xml
@@ -24,6 +24,7 @@
 
     <properties>
         <automatic.module.name>org.jline.terminal</automatic.module.name>
+        <surefire.argLine>--add-opens java.base/java.io=org.jline.nativ --add-opens java.base/java.io=org.jline.terminal --add-modules java.logging --add-reads org.jline.terminal=java.logging</surefire.argLine>
     </properties>
 
     <dependencies>
@@ -53,6 +54,23 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <compilerArgs combine.children="append">
+                                <arg>--add-modules</arg>
+                                <arg>java.logging</arg>
+                                <arg>--add-reads</arg>
+                                <arg>org.jline.terminal=java.logging</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/terminal/src/main/java/module-info.java
+++ b/terminal/src/main/java/module-info.java
@@ -23,7 +23,6 @@ module org.jline.terminal {
     // Dependencies
     requires org.jline.nativ;
     requires java.base;
-    requires java.logging;
     // Optional dependency for terminal graphics support (BufferedImage, ImageIO, etc.)
     // Graphics features will not be available if java.desktop is not present
     // Using 'static transitive' to make it optional but still export types to consumers

--- a/terminal/src/main/java/org/jline/utils/Log.java
+++ b/terminal/src/main/java/org/jline/utils/Log.java
@@ -10,26 +10,32 @@ package org.jline.utils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
 
 /**
  * Internal logging utility for JLine components.
  *
  * <p>
  * The Log class provides a simple logging facility for JLine components, using
- * Java's standard logging API (java.util.logging) under the hood. It offers
- * methods for logging at various levels (trace, debug, info, warn, error) and
- * supports both direct message logging and lazy evaluation through suppliers.
+ * the {@link System.Logger} API under the hood. It offers methods for logging
+ * at various levels (trace, debug, info, warn, error) and supports both direct
+ * message logging and lazy evaluation through suppliers.
+ * </p>
+ *
+ * <p>
+ * Using {@link System.Logger} keeps JLine free of any compile-time dependency on
+ * the {@code java.logging} module, which is desirable for consumers building
+ * trimmed runtime images with {@code jlink}. When the {@code java.logging} module
+ * is present at runtime, the default {@code System.Logger} implementation routes
+ * to {@code java.util.logging}.
  * </p>
  *
  * <p>
  * This class uses a single logger named "org.jline" for all JLine components.
- * The actual log level can be configured through the standard Java logging
- * configuration mechanisms, such as logging.properties files or programmatic
- * configuration of the java.util.logging framework.
+ * The actual log level can be configured through whichever logging backend the
+ * running JVM provides a {@link System.LoggerFinder} for.
  * </p>
  *
  * <p>
@@ -70,22 +76,22 @@ public final class Log {
         // Utility class
     }
 
-    private static final Logger logger = Logger.getLogger("org.jline");
+    private static final Logger logger = System.getLogger("org.jline");
 
     public static void trace(final Object... messages) {
-        log(Level.FINEST, messages);
+        log(Level.TRACE, messages);
     }
 
     public static void trace(Supplier<String> supplier) {
-        log(Level.FINEST, supplier);
+        log(Level.TRACE, supplier);
     }
 
     public static void debug(Supplier<String> supplier) {
-        log(Level.FINE, supplier);
+        log(Level.DEBUG, supplier);
     }
 
     public static void debug(final Object... messages) {
-        log(Level.FINE, messages);
+        log(Level.DEBUG, messages);
     }
 
     public static void info(final Object... messages) {
@@ -97,11 +103,11 @@ public final class Log {
     }
 
     public static void error(final Object... messages) {
-        log(Level.SEVERE, messages);
+        log(Level.ERROR, messages);
     }
 
     public static boolean isDebugEnabled() {
-        return isEnabled(Level.FINE);
+        return isEnabled(Level.DEBUG);
     }
 
     /**
@@ -124,7 +130,14 @@ public final class Log {
         }
     }
 
-    static LogRecord createRecord(final Level level, final Object... messages) {
+    static void log(final Level level, final Supplier<String> message) {
+        logger.log(level, message);
+    }
+
+    static void log(final Level level, final Object... messages) {
+        if (!logger.isLoggable(level)) {
+            return;
+        }
         Throwable cause = null;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);
@@ -137,29 +150,11 @@ public final class Log {
             }
         }
         ps.close();
-        LogRecord r = new LogRecord(level, baos.toString());
-        r.setThrown(cause);
-        return r;
-    }
-
-    static LogRecord createRecord(final Level level, final Supplier<String> message) {
-        return new LogRecord(level, message.get());
-    }
-
-    static void log(final Level level, final Supplier<String> message) {
-        logr(level, () -> createRecord(level, message));
-    }
-
-    static void log(final Level level, final Object... messages) {
-        logr(level, () -> createRecord(level, messages));
-    }
-
-    static void logr(final Level level, final Supplier<LogRecord> record) {
-        if (logger.isLoggable(level)) {
-            // inform record of the logger-name
-            LogRecord tmp = record.get();
-            tmp.setLoggerName(logger.getName());
-            logger.log(tmp);
+        String message = baos.toString();
+        if (cause != null) {
+            logger.log(level, message, cause);
+        } else {
+            logger.log(level, message);
         }
     }
 

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
@@ -10,8 +10,8 @@ package org.jline.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 
 import static org.jline.terminal.TerminalBuilder.PROP_CLOSE_MODE;
 
@@ -77,7 +77,7 @@ public abstract class NonBlockingInputStream extends InputStream {
     public static final int EOF = -1;
     public static final int READ_EXPIRED = -2;
 
-    private static final Logger LOG = Logger.getLogger(NonBlockingInputStream.class.getName());
+    private static final Logger LOG = System.getLogger(NonBlockingInputStream.class.getName());
 
     /**
      * Flag indicating whether this input stream has been closed.

--- a/terminal/src/main/java/org/jline/utils/NonBlockingReader.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingReader.java
@@ -10,8 +10,8 @@ package org.jline.utils;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 
 import static org.jline.terminal.TerminalBuilder.PROP_CLOSE_MODE;
 
@@ -79,7 +79,7 @@ public abstract class NonBlockingReader extends Reader {
     public static final int EOF = -1;
     public static final int READ_EXPIRED = -2;
 
-    private static final Logger LOG = Logger.getLogger(NonBlockingReader.class.getName());
+    private static final Logger LOG = System.getLogger(NonBlockingReader.class.getName());
 
     /**
      * Flag indicating whether this reader has been closed.

--- a/terminal/src/main/java/org/jline/utils/StyleResolver.java
+++ b/terminal/src/main/java/org/jline/utils/StyleResolver.java
@@ -8,10 +8,10 @@
  */
 package org.jline.utils;
 
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.Locale;
 import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static java.util.Objects.requireNonNull;
 import static org.jline.utils.AttributedStyle.*;
@@ -52,7 +52,7 @@ import static org.jline.utils.AttributedStyle.*;
  * @since 3.6
  */
 public class StyleResolver {
-    private static final Logger log = Logger.getLogger(StyleResolver.class.getName());
+    private static final Logger log = System.getLogger(StyleResolver.class.getName());
 
     private final Function<String, String> source;
 
@@ -79,7 +79,7 @@ public class StyleResolver {
             try {
                 return Integer.parseInt(name.substring(1), 16);
             } catch (NumberFormatException e) {
-                log.warning("Invalid hexadecimal color: " + name);
+                log.log(Level.WARNING, "Invalid hexadecimal color: " + name);
                 return null;
             }
         } else {
@@ -120,7 +120,7 @@ public class StyleResolver {
             try {
                 return Colors.rgbColor(name);
             } catch (IllegalArgumentException e) {
-                log.warning("Invalid style-color name: " + name);
+                log.log(Level.WARNING, "Invalid style-color name: " + name);
                 return null;
             }
         }
@@ -175,8 +175,8 @@ public class StyleResolver {
     public AttributedStyle resolve(final String spec) {
         requireNonNull(spec);
 
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest("Resolve: " + spec);
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, "Resolve: " + spec);
         }
 
         int i = spec.indexOf(":-");
@@ -200,8 +200,8 @@ public class StyleResolver {
     public AttributedStyle resolve(final String spec, final String defaultSpec) {
         requireNonNull(spec);
 
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest(String.format("Resolve: %s; default: %s", spec, defaultSpec));
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, String.format("Resolve: %s; default: %s", spec, defaultSpec));
         }
 
         AttributedStyle style = apply(DEFAULT, spec);
@@ -219,8 +219,8 @@ public class StyleResolver {
      * @return the new style
      */
     private AttributedStyle apply(AttributedStyle style, final String spec) {
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest("Apply: " + spec);
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, "Apply: " + spec);
         }
 
         for (String item : spec.split(",")) {
@@ -244,8 +244,8 @@ public class StyleResolver {
     }
 
     private AttributedStyle applyAnsi(final AttributedStyle style, final String spec) {
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest("Apply-ansi: " + spec);
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, "Apply-ansi: " + spec);
         }
 
         return new AttributedStringBuilder()
@@ -262,12 +262,12 @@ public class StyleResolver {
      * @return the new style
      */
     private AttributedStyle applyReference(final AttributedStyle style, final String spec) {
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest("Apply-reference: " + spec);
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, "Apply-reference: " + spec);
         }
 
         if (spec.length() == 1) {
-            log.warning("Invalid style-reference; missing discriminator: " + spec);
+            log.log(Level.WARNING, "Invalid style-reference; missing discriminator: " + spec);
         } else {
             String name = spec.substring(1);
             String resolvedSpec = source.apply(name);
@@ -288,8 +288,8 @@ public class StyleResolver {
      * @return the new style
      */
     private AttributedStyle applyNamed(final AttributedStyle style, final String name) {
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest("Apply-named: " + name);
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, "Apply-named: " + name);
         }
 
         // TODO: consider short aliases for named styles
@@ -331,7 +331,7 @@ public class StyleResolver {
                 return style.hidden();
 
             default:
-                log.warning("Unknown style: " + name);
+                log.log(Level.WARNING, "Unknown style: " + name);
                 return style;
         }
     }
@@ -346,8 +346,8 @@ public class StyleResolver {
      * @return      The new style
      */
     private AttributedStyle applyColor(final AttributedStyle style, final String spec) {
-        if (log.isLoggable(Level.FINEST)) {
-            log.finest("Apply-color: " + spec);
+        if (log.isLoggable(Level.TRACE)) {
+            log.log(Level.TRACE, "Apply-color: " + spec);
         }
 
         // extract color-mode:color-name
@@ -364,7 +364,7 @@ public class StyleResolver {
             case "f":
                 color = color(colorName);
                 if (color == null) {
-                    log.warning("Invalid color-name: " + colorName);
+                    log.log(Level.WARNING, "Invalid color-name: " + colorName);
                     break;
                 }
                 return color >= 0 ? style.foreground(color) : style.foregroundDefault();
@@ -374,7 +374,7 @@ public class StyleResolver {
             case "b":
                 color = color(colorName);
                 if (color == null) {
-                    log.warning("Invalid color-name: " + colorName);
+                    log.log(Level.WARNING, "Invalid color-name: " + colorName);
                     break;
                 }
                 return color >= 0 ? style.background(color) : style.backgroundDefault();
@@ -384,7 +384,7 @@ public class StyleResolver {
             case "f-rgb":
                 color = colorRgb(colorName);
                 if (color == null) {
-                    log.warning("Invalid color-name: " + colorName);
+                    log.log(Level.WARNING, "Invalid color-name: " + colorName);
                     break;
                 }
                 return color >= 0 ? style.foregroundRgb(color) : style.foregroundDefault();
@@ -394,13 +394,13 @@ public class StyleResolver {
             case "b-rgb":
                 color = colorRgb(colorName);
                 if (color == null) {
-                    log.warning("Invalid color-name: " + colorName);
+                    log.log(Level.WARNING, "Invalid color-name: " + colorName);
                     break;
                 }
                 return color >= 0 ? style.backgroundRgb(color) : style.backgroundDefault();
 
             default:
-                log.warning("Invalid color-mode: " + colorMode);
+                log.log(Level.WARNING, "Invalid color-mode: " + colorMode);
         }
         return style;
     }

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -781,7 +781,10 @@ For more complex issues, try these advanced troubleshooting techniques:
 
 ### Enable Debug Logging
 
-JLine uses Java Util Logging (JUL). Enable debug logging to see what's happening:
+JLine logs through the JDK's `System.Logger` facade (part of `java.base`), so it has no
+dependency on the `java.logging` module. On a standard JDK, the default `System.Logger`
+implementation routes to Java Util Logging (JUL), so you can configure JLine's output
+through JUL on the `org.jline` logger:
 
 ```java
 // Configure Java Util Logging
@@ -808,6 +811,17 @@ handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level=FINE
 org.jline.level=FINE
 ```
+
+JLine's levels map to JUL as follows: `error` → `SEVERE`, `warn` → `WARNING`, `info` → `INFO`,
+`debug` → `FINE`, `trace` → `FINER`. Use `org.jline.level=FINE` for debug output, or `FINER`
+(or `FINEST`) to also include trace.
+
+:::note jlink images
+If you build a trimmed runtime image that does not include the `java.logging` module, the JUL
+configuration above has no effect, because `System.Logger` falls back to a minimal built-in
+backend. Add `java.logging` to your image, or register a custom `System.LoggerFinder`, to
+capture JLine's logs there.
+:::
 
 ### Inspect Terminal Capabilities
 


### PR DESCRIPTION
Logging through java.util.logging forces the consumers to depend on the java.logging module. Switch all internal logging to System.Logger (in java.base) and drop "requires java.logging" from every module-info.

Level mapping: FINEST -> TRACE, FINE -> DEBUG, INFO and WARNING stay the same, SEVERE -> ERROR.

Runtime behavior is unchanged. When java.logging is present, System.Logger routes to the "org.jline" JUL logger as before, so existing logging.properties configuration keeps working.

DumbTerminalWarningTest still uses java.util.logging to capture and assert on log records. The unused
  console-handler setup in the reader tests was removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Logging implementation updated from Java Util Logging to JDK System Logger API. Log levels adjusted accordingly (DEBUG, TRACE, ERROR mappings).

* **Documentation**
  * Updated debug logging configuration guide to reflect System Logger implementation and routing through JUL on standard JDK installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->