### PR TITLE
chore: backport nisse RB config fix from #1932

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -Dnisse.source.jgit.dynamicVersion=true
+-Dnisse.source.jgit.dateFormat=iso8601

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>${nisse.jgit.dateIso8601}</project.build.outputTimestamp>
+        <project.build.outputTimestamp>${nisse.jgit.date}</project.build.outputTimestamp>
 
         <java.build.version>22</java.build.version>
         <java.release.version>11</java.release.version>


### PR DESCRIPTION
Backport of #1932 to 4.0.x.

The `nisse.jgit.dateIso8601` property was removed in newer versions of the Nisse Maven extension. This updates the config to use `nisse.jgit.date` with `nisse.source.jgit.dateFormat=iso8601` instead, restoring reproducible builds.