### PR TITLE
fix: sync LineReader display model on resize (fixes #1940)

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1314,6 +1314,7 @@ public class LineReaderImpl implements LineReader, Flushable {
                 } else {
                     // Status bars reserve terminal rows and need explicit resize
                     // coordination; keep the existing redraw path for that mode.
+                    size = newSize;
                     doDisplay();
                     status.resize(size);
                     redisplay();

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1279,8 +1279,11 @@ public class LineReaderImpl implements LineReader, Flushable {
      * Handle terminal signals that affect the reader's display and terminal state.
      *
      * <p>For SIGWINCH (window change) this checks whether the terminal's character
-     * grid (rows/columns) changed and, if so, recreates the display, resizes the
-     * status bar, resets the cursor to column 0, and triggers a redisplay.
+     * grid (rows/columns) changed and, if so, synchronizes the reader display model
+     * with the resized terminal. Without a status bar, the terminal emulator has
+     * already reflowed the prompt and buffer, so this does not emit repaint output.
+     * With a status bar, the reader keeps the explicit redraw path because status
+     * rows require application coordination.
      *
      * <p>For SIGCONT (continue) this re-enters raw mode, updates the cached size,
      * resizes the active display, enables keypad transmit, redraws the current
@@ -1298,18 +1301,23 @@ public class LineReaderImpl implements LineReader, Flushable {
             // the number of rows/columns.
             Size newSize = terminal.getBufferSize();
             if (newSize.getRows() != size.getRows() || newSize.getColumns() != size.getColumns()) {
-                // Recreate the display to reset cursor tracking. After a resize,
-                // the terminal has reflowed content and the old cursor position
-                // is no longer valid.
-                doDisplay();
                 Status status = Status.getStatus(terminal, false);
-                if (status != null) {
+                if (status == null) {
+                    // The terminal has already reflowed the active reader display to
+                    // the new width. For the normal no-status case, synchronize
+                    // Display's model with that reflowed prompt/buffer without
+                    // emitting output. Repainting here races the terminal emulator's
+                    // own reflow and can leave duplicate prompt fragments or clear
+                    // unrelated scrollback above the active prompt.
+                    size = newSize;
+                    display.resize(size, redisplayLines(size), redisplayCursorPos(size));
+                } else {
+                    // Status bars reserve terminal rows and need explicit resize
+                    // coordination; keep the existing redraw path for that mode.
+                    doDisplay();
                     status.resize(size);
+                    redisplay();
                 }
-                // Position cursor at column 0 to match the new display's
-                // cursor assumption (cursorPos = 0).
-                terminal.puts(Capability.carriage_return);
-                redisplay();
             }
         } else if (signal == Signal.CONT) {
             terminal.enterRawMode();
@@ -1319,6 +1327,43 @@ public class LineReaderImpl implements LineReader, Flushable {
             redrawLine();
             redisplay();
         }
+    }
+
+    private List<AttributedString> redisplayLines(Size targetSize) {
+        List<AttributedString> secondaryPrompts = new ArrayList<>();
+        AttributedString full = getDisplayedBufferWithPrompts(secondaryPrompts);
+        if (targetSize.getColumns() <= 0) {
+            List<AttributedString> lines = new ArrayList<>();
+            lines.add(full);
+            return lines;
+        }
+        return full.columnSplitLength(terminal, targetSize.getColumns(), true, display.delayLineWrap());
+    }
+
+    private int redisplayCursorPos(Size targetSize) {
+        if (targetSize.getColumns() <= 0) {
+            return 0;
+        }
+
+        List<AttributedString> secondaryPrompts = new ArrayList<>();
+        getDisplayedBufferWithPrompts(secondaryPrompts);
+
+        AttributedStringBuilder sb = new AttributedStringBuilder().tabs(getTabWidth());
+        sb.append(prompt);
+        String buffer = buf.upToCursor();
+        if (maskingCallback != null) {
+            buffer = maskingCallback.display(buffer);
+        }
+        sb.append(insertSecondaryPrompts(new AttributedString(buffer), secondaryPrompts, false));
+        List<AttributedString> promptLines = sb.toAttributedString()
+                .columnSplitLength(terminal, targetSize.getColumns(), false, display.delayLineWrap());
+        if (promptLines.isEmpty()) {
+            return 0;
+        }
+
+        int cursorRow = promptLines.size() - 1;
+        int cursorColumn = promptLines.get(cursorRow).columnLength(terminal);
+        return targetSize.cursorPos(cursorRow, cursorColumn);
     }
 
     @SuppressWarnings("unchecked")

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1279,11 +1279,11 @@ public class LineReaderImpl implements LineReader, Flushable {
      * Handle terminal signals that affect the reader's display and terminal state.
      *
      * <p>For SIGWINCH (window change) this checks whether the terminal's character
-     * grid (rows/columns) changed and, if so, synchronizes the reader display model
-     * with the resized terminal. Without a status bar, the terminal emulator has
-     * already reflowed the prompt and buffer, so this does not emit repaint output.
-     * With a status bar, the reader keeps the explicit redraw path because status
-     * rows require application coordination.
+     * grid (rows/columns) changed and, if so, resizes the reader display model.
+     * Without a status bar, the terminal emulator has already reflowed the prompt
+     * and buffer, so this does not emit repaint output. With a status bar, the
+     * reader keeps the explicit redraw path because status rows require application
+     * coordination.
      *
      * <p>For SIGCONT (continue) this re-enters raw mode, updates the cached size,
      * resizes the active display, enables keypad transmit, redraws the current
@@ -1304,13 +1304,13 @@ public class LineReaderImpl implements LineReader, Flushable {
                 Status status = Status.getStatus(terminal, false);
                 if (status == null || status.size() == 0) {
                     // The terminal has already reflowed the active reader display to
-                    // the new width. When no status rows are active, synchronize
-                    // Display's model with that reflowed prompt/buffer without
-                    // emitting output. Repainting here races the terminal emulator's
-                    // own reflow and can leave duplicate prompt fragments or clear
-                    // unrelated scrollback above the active prompt.
+                    // the new width. When no status rows are active, resize Display's
+                    // existing rendered model without emitting output. Repainting here
+                    // races the terminal emulator's own reflow and can leave duplicate
+                    // prompt fragments or clear unrelated scrollback above the active
+                    // prompt.
                     size = newSize;
-                    display.resize(size, redisplayLines(size), redisplayCursorPos(size));
+                    display.resize(size);
                 } else {
                     // Status bars reserve terminal rows and need explicit resize
                     // coordination; keep the existing redraw path for that mode.
@@ -1327,43 +1327,6 @@ public class LineReaderImpl implements LineReader, Flushable {
             redrawLine();
             redisplay();
         }
-    }
-
-    private List<AttributedString> redisplayLines(Size targetSize) {
-        List<AttributedString> secondaryPrompts = new ArrayList<>();
-        AttributedString full = getDisplayedBufferWithPrompts(secondaryPrompts);
-        if (targetSize.getColumns() <= 0) {
-            List<AttributedString> lines = new ArrayList<>();
-            lines.add(full);
-            return lines;
-        }
-        return full.columnSplitLength(terminal, targetSize.getColumns(), true, display.delayLineWrap());
-    }
-
-    private int redisplayCursorPos(Size targetSize) {
-        if (targetSize.getColumns() <= 0) {
-            return 0;
-        }
-
-        List<AttributedString> secondaryPrompts = new ArrayList<>();
-        getDisplayedBufferWithPrompts(secondaryPrompts);
-
-        AttributedStringBuilder sb = new AttributedStringBuilder().tabs(getTabWidth());
-        sb.append(prompt);
-        String buffer = buf.upToCursor();
-        if (maskingCallback != null) {
-            buffer = maskingCallback.display(buffer);
-        }
-        sb.append(insertSecondaryPrompts(new AttributedString(buffer), secondaryPrompts, false));
-        List<AttributedString> promptLines = sb.toAttributedString()
-                .columnSplitLength(terminal, targetSize.getColumns(), false, display.delayLineWrap());
-        if (promptLines.isEmpty()) {
-            return 0;
-        }
-
-        int cursorRow = promptLines.size() - 1;
-        int cursorColumn = promptLines.get(cursorRow).columnLength(terminal);
-        return targetSize.cursorPos(cursorRow, cursorColumn);
     }
 
     @SuppressWarnings("unchecked")

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -1302,9 +1302,9 @@ public class LineReaderImpl implements LineReader, Flushable {
             Size newSize = terminal.getBufferSize();
             if (newSize.getRows() != size.getRows() || newSize.getColumns() != size.getColumns()) {
                 Status status = Status.getStatus(terminal, false);
-                if (status == null) {
+                if (status == null || status.size() == 0) {
                     // The terminal has already reflowed the active reader display to
-                    // the new width. For the normal no-status case, synchronize
+                    // the new width. When no status rows are active, synchronize
                     // Display's model with that reflowed prompt/buffer without
                     // emitting output. Repainting here races the terminal emulator's
                     // own reflow and can leave duplicate prompt fragments or clear

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderResizeTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderResizeTest.java
@@ -8,7 +8,6 @@
  */
 package org.jline.reader.impl;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -16,7 +15,7 @@ import java.util.Arrays;
 
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
-import org.jline.terminal.impl.DumbTerminal;
+import org.jline.terminal.impl.LineDisciplineTerminal;
 import org.jline.utils.Status;
 import org.junit.jupiter.api.Test;
 
@@ -27,8 +26,7 @@ class LineReaderResizeTest {
     @Test
     void winchRedisplayDoesNotDuplicateMultiRowPromptBuffer() throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        try (Terminal terminal = new DumbTerminal(
-                "terminal", "ansi", new ByteArrayInputStream(new byte[0]), output, StandardCharsets.UTF_8)) {
+        try (Terminal terminal = new LineDisciplineTerminal("terminal", "ansi", output, StandardCharsets.UTF_8)) {
             terminal.setSize(Size.of(20, 8));
             ExposedLineReader reader = new ExposedLineReader(terminal);
             output.reset();
@@ -71,8 +69,7 @@ class LineReaderResizeTest {
     @Test
     void winchWithEmptyStatusDoesNotRedrawPromptBuffer() throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        try (Terminal terminal = new DumbTerminal(
-                "terminal", "ansi", new ByteArrayInputStream(new byte[0]), output, StandardCharsets.UTF_8)) {
+        try (Terminal terminal = new LineDisciplineTerminal("terminal", "ansi", output, StandardCharsets.UTF_8)) {
             terminal.setSize(Size.of(20, 8));
             Status status = Status.getStatus(terminal);
             ExposedLineReader reader = new ExposedLineReader(terminal);

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderResizeTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderResizeTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.DumbTerminal;
+import org.jline.utils.Status;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -50,16 +51,46 @@ class LineReaderResizeTest {
             assertEquals(1, screen.count("-- user --"), screen::dump);
             assertEquals(1, screen.count(previousOutput), screen::dump);
 
-            // A height-only resize avoids depending on terminal emulator text reflow;
-            // the active prompt+buffer is already multi-row because the prompt has a newline and the input wraps.
-            terminal.setSize(Size.of(20, 9));
-            screen.resize(20, 9);
+            terminal.setSize(Size.of(18, 9));
+            screen.resize(18, 9);
             reader.handleWinch();
             terminal.flush();
-            screen.write(output.toString(StandardCharsets.UTF_8));
+            assertEquals("", output.toString(StandardCharsets.UTF_8), "WINCH should not repaint without status rows");
+            output.reset();
+
+            reader.redisplay();
+            terminal.flush();
+            assertEquals(
+                    "", output.toString(StandardCharsets.UTF_8), "resized display model should already be current");
 
             assertEquals(1, screen.count("-- user --"), screen::dump);
             assertEquals(1, screen.count(previousOutput), screen::dump);
+        }
+    }
+
+    @Test
+    void winchWithEmptyStatusDoesNotRedrawPromptBuffer() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (Terminal terminal = new DumbTerminal(
+                "terminal", "ansi", new ByteArrayInputStream(new byte[0]), output, StandardCharsets.UTF_8)) {
+            terminal.setSize(Size.of(20, 8));
+            Status status = Status.getStatus(terminal);
+            ExposedLineReader reader = new ExposedLineReader(terminal);
+            output.reset();
+
+            assertEquals(0, status.size());
+
+            reader.setPrompt("-- user --\n");
+            reader.getBuffer().write("abc def ghi jkl mno pqr");
+            reader.redisplay();
+            terminal.flush();
+            output.reset();
+
+            terminal.setSize(Size.of(18, 9));
+            reader.handleWinch();
+            terminal.flush();
+
+            assertEquals("", output.toString(StandardCharsets.UTF_8));
         }
     }
 

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderResizeTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderResizeTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.DumbTerminal;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LineReaderResizeTest {
+
+    @Test
+    void winchRedisplayDoesNotDuplicateMultiRowPromptBuffer() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (Terminal terminal = new DumbTerminal(
+                "terminal", "ansi", new ByteArrayInputStream(new byte[0]), output, StandardCharsets.UTF_8)) {
+            terminal.setSize(Size.of(20, 8));
+            ExposedLineReader reader = new ExposedLineReader(terminal);
+            output.reset();
+
+            reader.setPrompt("-- user --\n");
+            reader.getBuffer().write("abc def ghi jkl mno pqr");
+
+            MiniScreen screen = new MiniScreen(20, 8);
+            String previousOutput = "previous output";
+            terminal.writer().print(previousOutput + "\r\n");
+            terminal.flush();
+            screen.write(output.toString(StandardCharsets.UTF_8));
+            output.reset();
+
+            reader.redisplay();
+            terminal.flush();
+            screen.write(output.toString(StandardCharsets.UTF_8));
+            output.reset();
+
+            assertEquals(1, screen.count("-- user --"), screen::dump);
+            assertEquals(1, screen.count(previousOutput), screen::dump);
+
+            // A height-only resize avoids depending on terminal emulator text reflow;
+            // the active prompt+buffer is already multi-row because the prompt has a newline and the input wraps.
+            terminal.setSize(Size.of(20, 9));
+            screen.resize(20, 9);
+            reader.handleWinch();
+            terminal.flush();
+            screen.write(output.toString(StandardCharsets.UTF_8));
+
+            assertEquals(1, screen.count("-- user --"), screen::dump);
+            assertEquals(1, screen.count(previousOutput), screen::dump);
+        }
+    }
+
+    private static final class ExposedLineReader extends LineReaderImpl {
+        private ExposedLineReader(Terminal terminal) throws IOException {
+            super(terminal);
+        }
+
+        private void handleWinch() {
+            handleSignal(Terminal.Signal.WINCH);
+        }
+    }
+
+    private static final class MiniScreen {
+        private int columns;
+        private int rows;
+        private char[][] cells;
+        private int row;
+        private int column;
+
+        private MiniScreen(int columns, int rows) {
+            this.columns = columns;
+            this.rows = rows;
+            this.cells = blankCells(rows, columns);
+        }
+
+        private void resize(int newColumns, int newRows) {
+            char[][] resized = blankCells(newRows, newColumns);
+            int rowsToCopy = Math.min(rows, newRows);
+            int columnsToCopy = Math.min(columns, newColumns);
+            for (int r = 0; r < rowsToCopy; r++) {
+                System.arraycopy(cells[r], 0, resized[r], 0, columnsToCopy);
+            }
+            cells = resized;
+            rows = newRows;
+            columns = newColumns;
+            row = Math.min(row, rows - 1);
+            column = Math.min(column, columns - 1);
+        }
+
+        private void write(String data) {
+            int index = 0;
+            while (index < data.length()) {
+                char ch = data.charAt(index++);
+                if (ch == '\u001B') {
+                    index = consumeEscape(data, index);
+                } else if (ch == '\r') {
+                    column = 0;
+                } else if (ch == '\n') {
+                    newline();
+                } else if (ch >= ' ') {
+                    put(ch);
+                }
+            }
+        }
+
+        private int count(String needle) {
+            int total = 0;
+            for (String line : lines()) {
+                int from = 0;
+                int found;
+                while ((found = line.indexOf(needle, from)) >= 0) {
+                    total++;
+                    from = found + needle.length();
+                }
+            }
+            return total;
+        }
+
+        private String dump() {
+            return String.join("\n", lines());
+        }
+
+        private String[] lines() {
+            String[] lines = new String[rows];
+            for (int r = 0; r < rows; r++) {
+                lines[r] = new String(cells[r]);
+            }
+            return lines;
+        }
+
+        private int consumeEscape(String data, int index) {
+            if (index >= data.length()) {
+                return index;
+            }
+            char ch = data.charAt(index++);
+            if (ch != '[') {
+                return index;
+            }
+
+            int paramsStart = index;
+            while (index < data.length()) {
+                ch = data.charAt(index++);
+                if (ch >= '@' && ch <= '~') {
+                    handleCsi(data.substring(paramsStart, index - 1), ch);
+                    return index;
+                }
+            }
+            return index;
+        }
+
+        private void handleCsi(String params, char command) {
+            if (params.startsWith("?")) {
+                return;
+            }
+            int value = firstParam(params, 1);
+            switch (command) {
+                case 'A':
+                    row = Math.max(0, row - value);
+                    break;
+                case 'B':
+                    row = Math.min(rows - 1, row + value);
+                    break;
+                case 'C':
+                    column = Math.min(columns - 1, column + value);
+                    break;
+                case 'D':
+                    column = Math.max(0, column - value);
+                    break;
+                case 'H':
+                case 'f':
+                    moveTo(params);
+                    break;
+                case 'J':
+                    if (value == 0) {
+                        clearToEndOfScreen();
+                    } else if (value == 2) {
+                        cells = blankCells(rows, columns);
+                        row = 0;
+                        column = 0;
+                    }
+                    break;
+                case 'K':
+                    clearToEndOfLine();
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private int firstParam(String params, int defaultValue) {
+            if (params.isEmpty()) {
+                return defaultValue;
+            }
+            String first = params.split(";", -1)[0];
+            if (first.isEmpty()) {
+                return defaultValue;
+            }
+            try {
+                return Integer.parseInt(first);
+            } catch (NumberFormatException e) {
+                return defaultValue;
+            }
+        }
+
+        private void moveTo(String params) {
+            String[] parts = params.split(";", -1);
+            int targetRow = parseParam(parts, 0, 1) - 1;
+            int targetColumn = parseParam(parts, 1, 1) - 1;
+            row = Math.max(0, Math.min(rows - 1, targetRow));
+            column = Math.max(0, Math.min(columns - 1, targetColumn));
+        }
+
+        private int parseParam(String[] parts, int index, int defaultValue) {
+            if (index >= parts.length || parts[index].isEmpty()) {
+                return defaultValue;
+            }
+            try {
+                return Integer.parseInt(parts[index]);
+            } catch (NumberFormatException e) {
+                return defaultValue;
+            }
+        }
+
+        private void put(char ch) {
+            cells[row][column] = ch;
+            column++;
+            if (column >= columns) {
+                column = 0;
+                newline();
+            }
+        }
+
+        private void newline() {
+            if (row < rows - 1) {
+                row++;
+            } else {
+                for (int r = 1; r < rows; r++) {
+                    System.arraycopy(cells[r], 0, cells[r - 1], 0, columns);
+                }
+                Arrays.fill(cells[rows - 1], ' ');
+            }
+        }
+
+        private void clearToEndOfScreen() {
+            clearToEndOfLine();
+            for (int r = row + 1; r < rows; r++) {
+                Arrays.fill(cells[r], ' ');
+            }
+        }
+
+        private void clearToEndOfLine() {
+            Arrays.fill(cells[row], column, columns, ' ');
+        }
+
+        private static char[][] blankCells(int rows, int columns) {
+            char[][] blank = new char[rows][columns];
+            for (char[] row : blank) {
+                Arrays.fill(row, ' ');
+            }
+            return blank;
+        }
+    }
+}

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -193,24 +193,6 @@ public class Display implements Sized {
     }
 
     /**
-     * Resize the display and synchronize its model with content already reflowed by the terminal.
-     *
-     * <p>Terminal resize events can reflow already-rendered content without any bytes being emitted by the
-     * application. Callers that can recompute the reflowed visible lines can use this overload to keep the display
-     * model synchronized without repainting and without clearing surrounding scrollback.</p>
-     *
-     * @param sized the target display dimensions; its rows and columns are applied to the display
-     * @param lines the lines that are already visible after terminal reflow
-     * @param cursorPos the current cursor position in the resized display's wrapped-line coordinates
-     */
-    public void resize(Sized sized, List<AttributedString> lines, int cursorPos) {
-        resize(sized);
-        oldLines.clear();
-        oldLines.addAll(lines);
-        this.cursorPos = Math.max(0, cursorPos);
-    }
-
-    /**
      * Resize the display to the specified number of rows and columns.
      *
      * This updates the display geometry, rewraps previously rendered lines to the new
@@ -230,6 +212,7 @@ public class Display implements Sized {
             rows = 1;
         }
         if (this.rows != rows || this.columns != columns) {
+            int cursorOffset = cursorOffsetInRenderedLines();
             this.rows = rows;
             this.columns = columns;
             this.columns1 = columns + 1;
@@ -237,6 +220,7 @@ public class Display implements Sized {
                     .columnSplitLength(terminal, columns, true, delayLineWrap());
             oldLines.clear();
             oldLines.addAll(split);
+            cursorPos = cursorPositionInReflowedLines(cursorOffset);
         }
         // When the terminal buffer is wider than the visible window (e.g. Windows with
         // a wide screen buffer), auto-wrap occurs at the buffer width, not the visible
@@ -249,6 +233,52 @@ public class Display implements Sized {
             this.wrapAtEol = this.terminalWrapAtEol;
             this.delayedWrapAtEol = this.terminalDelayedWrapAtEol;
         }
+    }
+
+    private int cursorOffsetInRenderedLines() {
+        if (columns1 <= 0 || cursorPos <= 0 || oldLines.isEmpty()) {
+            return 0;
+        }
+        int cursorRow = cursorPos / columns1;
+        int cursorColumn = cursorPos % columns1;
+        int offset = 0;
+        int rowsBeforeCursor = Math.min(cursorRow, oldLines.size());
+        for (int row = 0; row < rowsBeforeCursor; row++) {
+            offset += oldLines.get(row).length();
+        }
+        if (cursorRow < oldLines.size()) {
+            offset += oldLines.get(cursorRow)
+                    .columnSubSequence(terminal, 0, cursorColumn)
+                    .length();
+        }
+        return offset;
+    }
+
+    private int cursorPositionInReflowedLines(int cursorOffset) {
+        int remaining = Math.max(0, cursorOffset);
+        for (int row = 0; row < oldLines.size(); row++) {
+            AttributedString line = oldLines.get(row);
+            int length = line.length();
+            boolean hardLineEnd = length > 0 && line.charAt(length - 1) == '\n';
+            if (remaining < length || (remaining == length && (!hardLineEnd || row == oldLines.size() - 1))) {
+                return cursorPositionAtLineOffset(row, line, remaining);
+            }
+            remaining -= length;
+        }
+        if (oldLines.isEmpty()) {
+            return 0;
+        }
+        int lastRow = oldLines.size() - 1;
+        AttributedString lastLine = oldLines.get(lastRow);
+        return cursorPositionAtLineOffset(lastRow, lastLine, lastLine.length());
+    }
+
+    private int cursorPositionAtLineOffset(int row, AttributedString line, int lineOffset) {
+        int prefixEnd = lineOffset;
+        if (prefixEnd > 0 && line.charAt(prefixEnd - 1) == '\n') {
+            prefixEnd--;
+        }
+        return row * columns1 + line.subSequence(0, prefixEnd).columnLength(terminal);
     }
 
     /**

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -193,6 +193,24 @@ public class Display implements Sized {
     }
 
     /**
+     * Resize the display and synchronize its model with content already reflowed by the terminal.
+     *
+     * <p>Terminal resize events can reflow already-rendered content without any bytes being emitted by the
+     * application. Callers that can recompute the reflowed visible lines can use this overload to keep the display
+     * model synchronized without repainting and without clearing surrounding scrollback.</p>
+     *
+     * @param sized the target display dimensions; its rows and columns are applied to the display
+     * @param lines the lines that are already visible after terminal reflow
+     * @param cursorPos the current cursor position in the resized display's wrapped-line coordinates
+     */
+    public void resize(Sized sized, List<AttributedString> lines, int cursorPos) {
+        resize(sized);
+        oldLines.clear();
+        oldLines.addAll(lines);
+        this.cursorPos = Math.max(0, cursorPos);
+    }
+
+    /**
      * Resize the display to the specified number of rows and columns.
      *
      * This updates the display geometry, rewraps previously rendered lines to the new

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -260,6 +260,8 @@ public class Display implements Sized {
             AttributedString line = oldLines.get(row);
             int length = line.length();
             boolean hardLineEnd = length > 0 && line.charAt(length - 1) == '\n';
+            // For hard line ends (\n), when remaining == length the cursor sits at the
+            // start of the next line, so we continue rather than stopping here.
             if (remaining < length || (remaining == length && (!hardLineEnd || row == oldLines.size() - 1))) {
                 return cursorPositionAtLineOffset(row, line, remaining);
             }

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -77,6 +77,40 @@ class DisplayTest {
         }
     }
 
+    @Test
+    void resizeReflowsCursorWithRenderedLines() throws IOException {
+        int rows = 12;
+        int oldCols = 80;
+        int newCols = 49;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, oldCols, rows)) {
+            Display display = new Display(terminal, false);
+            display.resize(Size.of(oldCols, rows));
+
+            String command = "./validation/manual/jline-readline-state-diagnostics.scala";
+            AttributedString rendered = new AttributedString("-- user --\n" + command + "\n> " + command);
+            List<AttributedString> oldLines =
+                    rendered.columnSplitLength(terminal, oldCols, true, display.delayLineWrap());
+            int oldCursor = Size.of(oldCols, rows)
+                    .cursorPos(
+                            oldLines.size() - 1,
+                            oldLines.get(oldLines.size() - 1).columnLength(terminal));
+            display.update(oldLines, oldCursor);
+
+            List<AttributedString> expectedLines =
+                    rendered.columnSplitLength(terminal, newCols, true, display.delayLineWrap());
+            int expectedCursor = Size.of(newCols, rows)
+                    .cursorPos(
+                            expectedLines.size() - 1,
+                            expectedLines.get(expectedLines.size() - 1).columnLength(terminal));
+
+            terminal.resizeScreen(newCols, rows);
+            display.resize(terminal);
+
+            assertEquals(expectedLines, display.oldLines);
+            assertEquals(expectedCursor, display.cursorPos);
+        }
+    }
+
     static class VirtualTerminal extends LineDisciplineTerminal {
         private final ScreenTerminal virtual;
         private final OutputStream masterInputOutput;


### PR DESCRIPTION
## Summary

- Avoid repainting the active `LineReader` prompt on `WINCH` when no status bar is active.
- Synchronize `Display`'s resized model and cursor position with the prompt/buffer that the terminal emulator has already reflowed.
- Keep the explicit redraw path for status-bar mode, where application-managed rows still require coordination.
- Add a regression covering a multi-row prompt/buffer resize without duplicating prompt text or clearing previous output.

Fixes #1940.

## Validation

- Manual terminal validation with a multiline prompt and wrapped input: resize no longer leaves duplicated prompt/input fragments.
- `./mvx mvn -pl reader -am -Dtest=LineReaderResizeTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvx mvn -pl terminal -am -Dtest=StatusTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvx mvn -pl reader -am -Dtest=LineReaderTest,TerminalReaderTest,LineReaderResizeTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvx mvn --no-transfer-progress verify` was attempted locally and stopped in `jline-terminal` on the pre-existing/environmental `TerminalGraphicsTest.testBasicTerminalTypesSkipRuntimeDetection` failure (`dumb should not support Kitty graphics`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal resize handling to preserve the cursor position across reflow.
  * Prevents duplicated multi-line prompts/output after terminal resize.
  * Avoids unnecessary full redraws on resize when no status bar is present; triggers a full redisplay when a status bar is active.
* **Tests**
  * Added coverage for WINCH/resize behavior, including multi-row wrapped prompts, empty status regions, and deterministic screen verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->