### PR TITLE
fix: keep polling the terminal probe response past a spurious EOF

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -650,19 +650,23 @@ public abstract class AbstractTerminal implements TerminalExt {
      */
     private int readCprColumn(long timeout) throws IOException {
         NonBlockingReader in = reader();
+        // Use a single wall-clock deadline so the spurious EOF a non-blocking
+        // slave-tty read produces while the CPR reply is in flight does not abort
+        // the read early (see readProbeChar).
+        long deadline = System.currentTimeMillis() + timeout;
         int c;
         // Skip until ESC
-        while ((c = in.read(timeout)) != '\033') {
+        while ((c = readProbeChar(in, deadline)) != '\033') {
             if (c < 0) return -1;
         }
-        if (in.read(timeout) != '[') return -1;
+        if (readProbeChar(in, deadline) != '[') return -1;
         // Skip row digits until ';'
-        while ((c = in.read(timeout)) != ';') {
+        while ((c = readProbeChar(in, deadline)) != ';') {
             if (c < 0 || c == 'R') return -1;
         }
         // Read column digits until 'R'
         int col = 0;
-        while ((c = in.read(timeout)) != 'R') {
+        while ((c = readProbeChar(in, deadline)) != 'R') {
             if (c < '0' || c > '9') return -1;
             col = col * 10 + (c - '0');
         }
@@ -677,17 +681,44 @@ public abstract class AbstractTerminal implements TerminalExt {
         }
     }
 
+    /**
+     * Reads the next probe-response character, polling until {@code deadline}.
+     *
+     * <p>The probe runs with {@code VMIN=0/VTIME=0}, so a slave-tty read with no
+     * data yet surfaces as a spurious EOF ({@code -1}) while the reply is still in
+     * flight; a read timeout ({@code -2}) is likewise not terminal. Both are
+     * treated as "nothing yet" and retried until the deadline, rather than
+     * aborting on the first one (which would let the late reply leak to the
+     * console once echo is restored).
+     *
+     * @return a character {@code >= 0}, or {@code -1} once the deadline elapses
+     */
+    static int readProbeChar(NonBlockingReader in, long deadline) throws IOException {
+        long remaining;
+        while ((remaining = deadline - System.currentTimeMillis()) > 0) {
+            int c = in.read(remaining);
+            if (c >= 0) {
+                return c;
+            }
+            // EOF (-1) or READ_EXPIRED (-2): no data yet, pace the poll and retry.
+            try {
+                Thread.sleep(Math.min(2, remaining));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return -1;
+            }
+        }
+        return -1;
+    }
+
     String readTerminalResponse() {
         long initialTimeout = getLongProperty(TerminalBuilder.PROP_PROBE_TIMEOUT, 200);
-        long subsequentTimeout = getLongProperty(TerminalBuilder.PROP_DRAIN_TIMEOUT, 25);
         NonBlockingReader in = reader();
+        long deadline = System.currentTimeMillis() + initialTimeout;
+        StringBuilder response = new StringBuilder();
         try {
-            StringBuilder response = new StringBuilder();
-            long deadline = System.currentTimeMillis() + initialTimeout;
-            long timeout = initialTimeout;
             int c;
-
-            while ((c = in.read(timeout)) >= 0) {
+            while ((c = readProbeChar(in, deadline)) >= 0) {
                 response.append((char) c);
 
                 // Complete DA1 response: ESC[?...c or ESC[...c
@@ -697,26 +728,19 @@ public abstract class AbstractTerminal implements TerminalExt {
                 }
 
                 if (response.length() > 200) break;
-
-                long remaining = deadline - System.currentTimeMillis();
-                if (remaining <= 0) break;
-                timeout = Math.min(subsequentTimeout, remaining);
             }
-
-            return response.length() > 0 ? response.toString() : null;
         } catch (IOException ignored) {
             // Best-effort read; errors are expected when the stream is closed
-            return null;
         }
+        return response.length() > 0 ? response.toString() : null;
     }
 
     static void drainInput(NonBlockingReader reader, long overallTimeoutMs, int stopChar) {
         try {
             long deadline = System.currentTimeMillis() + overallTimeoutMs;
-            long remaining;
-            while ((remaining = deadline - System.currentTimeMillis()) > 0) {
-                int c = reader.read(remaining);
-                if (c < 0 || c == stopChar) return;
+            int c;
+            while ((c = readProbeChar(reader, deadline)) >= 0) {
+                if (c == stopChar) return;
             }
         } catch (IOException ignored) {
             // Best-effort drain; errors are expected when the stream is closed

--- a/terminal/src/test/java/org/jline/terminal/impl/TerminalProbeResponseLeakTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/TerminalProbeResponseLeakTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.jline.utils.NonBlockingReader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the grapheme-cluster / DA1 probe leaking its response to
+ * the console.
+ *
+ * <p>On native (FFM/JNI) system terminals the probe runs with VMIN=0/VTIME=0,
+ * so a slave-tty {@code read()} that finds no data yet returns zero bytes --
+ * which {@code FileInputStream} surfaces as a spurious EOF ({@code -1}) even
+ * though the terminal's reply is merely still in flight (even a sub-millisecond
+ * round trip loses the race against the non-blocking read). The probe read
+ * loops used to abort on that first negative result, give up, restore
+ * cooked-mode/echo, and let the late-arriving reply echo to the console. They
+ * must instead keep polling until the probe deadline.</p>
+ *
+ * @see AbstractTerminal#readProbeChar(NonBlockingReader, long)
+ */
+class TerminalProbeResponseLeakTest {
+
+    /**
+     * A {@link NonBlockingReader} that replays a fixed script of return values,
+     * reproducing the spurious EOF ({@code -1}) a non-blocking
+     * {@code FileInputStream} emits before the terminal's reply lands. Once the
+     * script is exhausted every read returns {@code exhausted}.
+     */
+    private static final class ScriptedReader extends NonBlockingReader {
+        private final Deque<Integer> script = new ArrayDeque<>();
+        private final int exhausted;
+
+        ScriptedReader(int exhausted, int... values) {
+            this.exhausted = exhausted;
+            for (int v : values) {
+                script.add(v);
+            }
+        }
+
+        boolean isExhausted() {
+            return script.isEmpty();
+        }
+
+        @Override
+        protected int read(long timeout, boolean isPeek) {
+            Integer next = isPeek ? script.peekFirst() : script.pollFirst();
+            return next != null ? next : exhausted;
+        }
+
+        @Override
+        public int readBuffered(char[] b, int off, int len, long timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    @Test
+    void readProbeCharPollsPastTransientEof() throws IOException {
+        // Three spurious EOFs, then 'X'. Must not give up on the first EOF.
+        ScriptedReader in = new ScriptedReader(
+                NonBlockingReader.READ_EXPIRED,
+                NonBlockingReader.EOF,
+                NonBlockingReader.EOF,
+                NonBlockingReader.EOF,
+                'X');
+        long deadline = System.currentTimeMillis() + 1000;
+        assertEquals('X', AbstractTerminal.readProbeChar(in, deadline));
+    }
+
+    @Test
+    void readProbeCharReturnsEofOnlyAfterDeadline() throws IOException {
+        // Nothing but spurious EOFs: poll until the deadline, then report -1
+        // rather than bailing on the first one.
+        ScriptedReader in = new ScriptedReader(NonBlockingReader.EOF);
+        long start = System.currentTimeMillis();
+        assertEquals(-1, AbstractTerminal.readProbeChar(in, start + 50));
+        assertTrue(
+                System.currentTimeMillis() - start >= 40,
+                "should have polled until the deadline, not returned on the first EOF");
+    }
+
+    @Test
+    void probeCapturesResponseDespiteTransientEof() throws Exception {
+        // The reply (DECRPM "mode 2027 set" + DA1 sentinel) is preceded by
+        // spurious EOFs, as on a real ssh/native terminal where the round trip
+        // loses the race against the non-blocking read.
+        String reply = "\033[?2027;1$y\033[?64c";
+        int[] script = new int[3 + reply.length()];
+        script[0] = NonBlockingReader.EOF;
+        script[1] = NonBlockingReader.EOF;
+        script[2] = NonBlockingReader.EOF;
+        for (int i = 0; i < reply.length(); i++) {
+            script[3 + i] = reply.charAt(i);
+        }
+
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        ScriptedReader in = new ScriptedReader(NonBlockingReader.READ_EXPIRED, script);
+        try (LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8) {
+                    @Override
+                    public NonBlockingReader reader() {
+                        return in;
+                    }
+                }) {
+            // Before the fix this returned false: the first spurious EOF aborted
+            // the read, the reply was never consumed, and it leaked to the console.
+            assertTrue(terminal.supportsGraphemeClusterMode());
+            // The probe query was still emitted to the terminal.
+            assertTrue(masterOutput.toString(StandardCharsets.UTF_8).contains("\033[?2027$p"));
+            // The whole reply was consumed, so nothing is left to leak.
+            assertTrue(in.isExhausted());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes capability-probe responses leaking onto the console as stray escape sequences (on startup and at every prompt):
```
^[[?2027;3$y^[[?61;4;6;7;...c
```

Regression from #1856, affecting native (FFM/JNI) system terminals, most visibly over ssh.

## Root cause

The probe sets `VMIN=0/VTIME=0`, writes `CSI ? 2027 $ p` + a DA1 sentinel, and reads the reply via a `FileInputStream` on the pty slave fd. With `VMIN=0/VTIME=0`, a `read()` with no data yet returns 0 bytes, which `FileInputStream` maps to EOF (-1). The read loops treated that first `-1` as end-of-stream, gave up, restored `ECHO`, and the reply (arriving microseconds later) was echoed and left buffered. It's a race against the first non-blocking read, not the timeout, so it reproduces even at <1 ms RTT.

## Fix

Add `readProbeChar(in, deadline)`, which polls to the probe deadline and treats `EOF (-1)` / `READ_EXPIRED (-2)` as "nothing yet" rather than aborting. Route `readTerminalResponse`, `drainInput` and `readCprColumn` through it. Probe attributes are left unchanged, so this doesn't reintroduce the `VTIME>0` idle-tick EOF that #1871 warns about.

Behavior change: a non-responding terminal now polls for the full `probe.timeout` (~200 ms) before giving up, instead of returning instantly.

## Testing

`TerminalProbeResponseLeakTest`: a scripted `NonBlockingReader` emits spurious EOFs before the reply (the real pipe reader blocks correctly and can't reproduce the `FileInputStream` false-EOF). The main test fails before this change (probe returns `false`, reply leaks), passes after; two unit tests cover the helper. Also verified manually over ssh with a snapshot build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal probing robustness: The terminal now correctly handles late-arriving response bytes during grapheme cluster detection without treating them as failures.
  * Enhanced non-blocking I/O handling to ensure reliable terminal response parsing under transient conditions.

* **Tests**
  * Added comprehensive regression tests for terminal probe behavior with various I/O scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->