### PR TITLE
fix: guard ScreenTerminal.poke() against out-of-bounds cursor position

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -274,9 +274,12 @@ public class ScreenTerminal implements Sized {
     }
 
     private void poke(int y, int x, long[] s) {
+        if (x < 0 || x >= columns || y < 0 || y >= rows) {
+            return;
+        }
         int cur = 0;
         int max = s.length;
-        while (cur < max) {
+        while (cur < max && y < rows) {
             int nb = Math.min(columns - x, max - cur);
             System.arraycopy(s, cur, screen[y++], x, nb);
             x = 0;

--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -1768,8 +1768,8 @@ public class ScreenTerminal implements Sized {
     /**
      * Resize the terminal to the given number of columns and rows.
      *
-     * @param columns the target number of columns (2–256)
-     * @param rows    the target number of rows (2–256)
+     * @param columns the target number of columns (2–4096)
+     * @param rows    the target number of rows (2–4096)
      * @return        `true` if the size was changed; `false` if the requested dimensions are out of range
      * @deprecated Use {@link #setSize(Sized)} instead.
      */


### PR DESCRIPTION
## Problem

`ScreenTerminal.poke()` crashes with `ArrayIndexOutOfBoundsException` when called with a negative `x` value:

```
java.lang.ArrayIndexOutOfBoundsException: arraycopy: destination index -1 out of bounds for long[150]
  at java.base/java.lang.System.arraycopy(NMethod)
  at org.jline.builtins.ScreenTerminal.poke(ScreenTerminal.java:280)
  at org.jline.builtins.ScreenTerminal.dumb_echo(ScreenTerminal.java:528)
  at org.jline.builtins.ScreenTerminal.lambda$write$0(ScreenTerminal.java:1969)
```

This happens because `dumb_echo()` can set `cx` directly without clamping (line 516: `cx = cursorLineColumns(c)[1] - 1`). If `cursorLineColumns()` returns `[0, 0]`, then `cx` becomes -1, and `poke()` passes -1 as the `arraycopy` destination offset.

## Fix

Add bounds checks in `poke()` to guard against negative `x`/`y` and `y >= rows`. This is a safety net — the root cause is the unclamped `cx` assignment, but `poke()` should be defensive regardless.

## Context

Discovered while embedding a JLine shell inside Apache Camel's TUI via `ScreenTerminal` + `LineDisciplineTerminal`. The crash occurs when rendering certain command outputs that trigger `dumb_echo` with edge-case cursor positions.

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented out-of-bounds updates to the terminal screen by adding stricter bounds checking to screen operations, reducing the risk of display corruption or crashes when coordinates exceed current dimensions.

* **Documentation**
  * Updated the deprecated terminal resize method documentation to reflect expanded valid ranges for supported column and row sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->