### PR TITLE
feat: add custom name parameter to PicocliCommandRegistry

### DIFF
--- a/picocli/src/main/java/org/jline/picocli/PicocliCommandRegistry.java
+++ b/picocli/src/main/java/org/jline/picocli/PicocliCommandRegistry.java
@@ -52,11 +52,12 @@ import picocli.CommandLine.Model.PositionalParamSpec;
 public class PicocliCommandRegistry implements CommandRegistry, CommandGroup {
 
     private final CommandLine commandLine;
+    private final String name;
     private LineReader reader;
 
     @Override
     public String name() {
-        return getClass().getSimpleName();
+        return name;
     }
 
     /**
@@ -66,7 +67,18 @@ public class PicocliCommandRegistry implements CommandRegistry, CommandGroup {
      * @param commandLine the picocli command line whose subcommands to expose
      */
     public PicocliCommandRegistry(CommandLine commandLine) {
+        this(commandLine, null);
+    }
+
+    /**
+     * Creates a new registry wrapping the given picocli {@link CommandLine} with a custom display name.
+     *
+     * @param commandLine the picocli command line whose subcommands to expose
+     * @param name        the display name for this command group (defaults to class name if null)
+     */
+    public PicocliCommandRegistry(CommandLine commandLine, String name) {
         this.commandLine = Objects.requireNonNull(commandLine, "commandLine");
+        this.name = name != null ? name : getClass().getSimpleName();
     }
 
     public void setLineReader(LineReader reader) {


### PR DESCRIPTION
## Problem

`PicocliCommandRegistry.name()` returns `getClass().getSimpleName()` which displays as **"PicocliCommandRegistry"** in shell completion group headers. Applications embedding a PicoCLI command line via JLine's shell want to show a meaningful name (e.g., "Camel", "MyApp").

## Fix

Add a two-arg constructor `PicocliCommandRegistry(CommandLine, String name)` that accepts a custom display name. The existing single-arg constructor defaults to the class name for backwards compatibility.

## Example

```java
// Before: shows "PicocliCommandRegistry" in completions
PicocliCommandRegistry registry = new PicocliCommandRegistry(commandLine);

// After: shows "Camel" in completions
PicocliCommandRegistry registry = new PicocliCommandRegistry(commandLine, "Camel");
```

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PicocliCommandRegistry now allows customization of display names. Users can pass a custom name when creating a registry instance through a new constructor parameter. The registry will use the provided name for display purposes, or fall back to the default naming scheme if no custom name is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->