### PR TITLE
chore: upgrade CI build matrix from JDK 24 to JDK 25

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, ubuntu-22.04, windows-latest, macos-latest ]
-        java: [ '22', '24' ]
+        java: [ '22', '25' ]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Upgrade the CI build matrix to test against JDK 25 instead of JDK 24
- The GraalVM native-image job was already using JDK 25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build configuration to test against Java 25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->