### PR TITLE
fix: clamp cx in dumb_echo to prevent out-of-bounds cursor position

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -482,7 +482,7 @@ public class ScreenTerminal implements Sized {
                 ctrl_CR();
                 ctrl_LF();
             } else {
-                cx = cursorLineColumns(c)[1] - 1;
+                cx = Math.max(0, Math.min(columns - 1, cursorLineColumns(c)[1] - 1));
             }
         }
         if (vt100_mode_insert) {


### PR DESCRIPTION
The assignment `cx = cursorLineColumns(c)[1] - 1` in `dumb_echo` can produce -1 when `cursorLineColumns` returns 0, violating the invariant `0 <= cx < columns`. This adds a clamp using the same `Math.max(0, Math.min(columns - 1, ...))` pattern already used elsewhere in the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor positioning issue when displaying wide characters near terminal line boundaries. When auto-wrapping is enabled and a wide character would overflow the line end, the cursor position is now properly clamped to the terminal's last valid column, preventing invalid position values that could exceed the terminal's width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->