### PR TITLE
fix: validate version format in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,15 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
           fingerprint: ${{ secrets.GPG_KEY_FINGERPRINT }}
 
+      - name: Validate version
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: '$version' (expected X.Y.Z)"
+            exit 1
+          fi
+          echo "Version validated: $version"
+
       - name: Release
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -74,10 +83,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           MVX_USE_SYSTEM_JAVA: true
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
           gh extension install valeriobelli/gh-milestone
-          version=${{ steps.version.outputs.version }}
+          version="$RELEASE_VERSION"
           echo "Trying to find milestone $version"
           milestone=$(gh milestone list --json id,title,state  --jq "map_values(select(.title == \"${version}\" and .state == \"OPEN\")).[].number")
           if [ ! -z "$milestone" ]; then
@@ -108,7 +118,7 @@ jobs:
             exit 1
           fi          
           
-          version=${{ steps.version.outputs.version }}
+          version="$RELEASE_VERSION"
 
           # Check if release drafter already created a draft release for this version
           draft_tag=$(gh api repos/${{ github.repository }}/releases \


### PR DESCRIPTION
Add explicit validation of the version output against a strict semver pattern before it is consumed in the deploy and post-release steps. This addresses a potential template injection vector flagged by security scanners.

Changes:
- Add a "Validate version" step that checks the version matches `^[0-9]+\.[0-9]+\.[0-9]+$` before proceeding
- Replace direct `${{ steps.version.outputs.version }}` interpolation in the Post release step's `run:` block with an environment variable (`RELEASE_VERSION`) to avoid template injection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened release validation to prevent invalid version formats from being released
  * Improved release workflow stability and reliability through enhanced environment variable handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->