### PR TITLE
chore: bump mvx to 0.13.0

### DIFF
--- a/.mvx/mvx.properties
+++ b/.mvx/mvx.properties
@@ -4,7 +4,7 @@
 # The version of mvx to download and use
 # Can be a specific version (e.g., "1.0.0") or "latest" for the most recent release
 # For development, use "dev" when you have a local mvx-dev binary
-mvxVersion=0.12.4
+mvxVersion=0.13.0
 
 # Alternative download URL (optional)
 # If not specified, defaults to GitHub releases


### PR DESCRIPTION
Bumps mvx from 0.12.4 to 0.13.0.

## Changes in mvx 0.13.0

- **fix:** detect archive type from magic bytes when file extension is ambiguous (fixes gnodet/mvx#66) — Windows JDK downloads (.zip) were being treated as gzip
- **fix:** remove auto-install from IsInstalled to prevent download loops (fixes gnodet/mvx#67) — JDK would re-download 10+ times before proceeding
- **feat:** skip auto-setup for help/version/info-only commands — `mvx --help` now works without downloading tools

Release: https://github.com/gnodet/mvx/releases/tag/v0.13.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated framework version from 0.12.4 to 0.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->