### PR TITLE
chore: replace Thread.sleep with Awaitility in shell tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
         <jansi.version>2.4.3</jansi.version>
         <juniversalchardet.version>1.0.3</juniversalchardet.version>
         <sshd.version>2.18.0</sshd.version>
+        <awaitility.version>4.3.0</awaitility.version>
         <easymock.version>5.6.0</easymock.version>
         <junit.version>6.1.0</junit.version>
         <gogo.runtime.version>1.1.6</gogo.runtime.version>
@@ -317,6 +318,12 @@
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
                 <version>${easymock.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
             </dependency>
 
             <dependency>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/DefaultCommandDispatcherTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jline.shell.*;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -299,10 +301,7 @@ class DefaultCommandDispatcherTest extends AbstractCommandDispatcherTest {
         try (DefaultCommandDispatcher bgDispatcher = new DefaultCommandDispatcher(terminal, jobManager)) {
             bgDispatcher.addGroup(new SimpleCommandGroup("test", new NoopCommand()));
             bgDispatcher.execute("noop &");
-            // Give the background thread time to complete
-            Thread.sleep(200);
-            // Job should have been created
-            assertFalse(jobManager.jobs().isEmpty());
+            await().atMost(2, TimeUnit.SECONDS).until(() -> !jobManager.jobs().isEmpty());
         }
     }
 

--- a/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
+++ b/shell/src/test/java/org/jline/shell/impl/SignalHandlingTest.java
@@ -17,6 +17,7 @@ import org.jline.shell.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -65,8 +66,7 @@ class SignalHandlingTest extends AbstractCommandDispatcherTest {
         execThread.start();
 
         assertTrue(started.await(2, TimeUnit.SECONDS));
-        // Give the command a moment to start sleeping
-        Thread.sleep(100);
+        await().atMost(2, TimeUnit.SECONDS).until(() -> execThread.getState() == Thread.State.TIMED_WAITING);
 
         dispatcher.interruptCurrentCommand();
 


### PR DESCRIPTION
Replace Thread.sleep() polling patterns with Awaitility for more robust and faster tests. Addresses SonarCloud S2925.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
* Improved reliability of shell-related tests by replacing timing-based waits with deterministic polling for expected conditions.
* Added Awaitility as a test utility and introduced a shared version property to standardize its usage across the build.
* Updated command background execution and signal interrupt tests to verify state changes more consistently.  

## Chores
* Enhanced automated test synchronization to reduce flakiness and increase consistency during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->