### PR TITLE
fix: skip graphics protocol detection for basic terminal types

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/ITerm2Graphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ITerm2Graphics.java
@@ -58,6 +58,20 @@ public class ITerm2Graphics implements TerminalGraphics {
 
     @Override
     public boolean isSupported(Terminal terminal) {
+        // Basic terminal types cannot support iTerm2 graphics
+        String termType = terminal.getType();
+        if (termType != null) {
+            switch (termType) {
+                case "dumb":
+                case "vt100":
+                case "vt102":
+                case "ansi":
+                    return false;
+                default:
+                    break;
+            }
+        }
+
         // Check for iTerm2
         String termProgram = System.getenv("TERM_PROGRAM");
         if ("iTerm.app".equals(termProgram)) {

--- a/terminal/src/main/java/org/jline/terminal/impl/KittyGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/KittyGraphics.java
@@ -60,6 +60,20 @@ public class KittyGraphics implements TerminalGraphics {
 
     @Override
     public boolean isSupported(Terminal terminal) {
+        // Basic terminal types cannot support Kitty graphics
+        String termType = terminal.getType();
+        if (termType != null) {
+            switch (termType) {
+                case "dumb":
+                case "vt100":
+                case "vt102":
+                case "ansi":
+                    return false;
+                default:
+                    break;
+            }
+        }
+
         // Check TERM_PROGRAM environment variable
         String termProgram = System.getenv("TERM_PROGRAM");
 
@@ -74,7 +88,6 @@ public class KittyGraphics implements TerminalGraphics {
         }
 
         // Check terminal type for Ghostty
-        String termType = terminal.getType();
         if (termType != null && termType.contains("ghostty")) {
             return true;
         }

--- a/terminal/src/test/java/org/jline/terminal/impl/TerminalGraphicsTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/TerminalGraphicsTest.java
@@ -175,6 +175,7 @@ class TerminalGraphicsTest {
     void testBasicTerminalTypesSkipRuntimeDetection() throws IOException {
         String[] basicTermTypes = {"dumb", "vt100", "vt102", "ansi"};
         KittyGraphics kittyGraphics = new KittyGraphics();
+        ITerm2Graphics iterm2Graphics = new ITerm2Graphics();
 
         for (String termType : basicTermTypes) {
             try (Terminal terminal = TerminalBuilder.builder()
@@ -183,6 +184,7 @@ class TerminalGraphicsTest {
                     .build()) {
 
                 assertFalse(kittyGraphics.isSupported(terminal), termType + " should not support Kitty graphics");
+                assertFalse(iterm2Graphics.isSupported(terminal), termType + " should not support iTerm2 graphics");
             }
         }
     }


### PR DESCRIPTION
Basic terminal types (dumb, vt100, vt102, ansi) should never report graphics protocol support, regardless of host terminal environment variables.

Both `KittyGraphics.isSupported()` and `ITerm2Graphics.isSupported()` were checking `System.getenv()` (e.g. `TERM_PROGRAM`, `KITTY_WINDOW_ID`, `ITERM_SESSION_ID`) before considering the terminal type. When running on a Mac with a modern host terminal like iTerm2 or Kitty, these environment variables leak into child processes, causing even a `dumb` terminal to incorrectly report graphics support.

The fix adds an early return for basic terminal types at the top of `isSupported()` in both `KittyGraphics` and `ITerm2Graphics`, before any `System.getenv()` calls. `SixelGraphics` already handled this correctly.

Fixes test failure in `testBasicTerminalTypesSkipRuntimeDetection` on macOS with modern terminals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal graphics support detection: iTerm2 and Kitty now correctly report graphics as unsupported for basic/legacy terminal types (dumb, vt100, vt102, ansi), avoiding attempts to render unsupported graphics.

* **Tests**
  * Expanded coverage to confirm unsupported legacy terminal types are consistently handled across multiple graphics handlers.

* **Performance/Behavior**
  * Refined terminal type handling to make graphics detection quicker and more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->