### PR TITLE
chore: add security policy (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 4.1.x   | ✅ Yes             |
+| 4.0.x   | ✅ Yes             |
+| 3.x     | ✅ Security fixes  |
+| < 3.0   | ❌ No              |
+
+## Reporting a Vulnerability
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, use one of the following methods:
+
+1. **GitHub Private Vulnerability Reporting** (preferred):
+   Go to the [Security Advisories](https://github.com/jline/jline3/security/advisories) page
+   and click **"Report a vulnerability"**.
+
+2. **Email**: Send details to [gnodet@gmail.com](mailto:gnodet@gmail.com).
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected version(s)
+- Any potential impact assessment
+
+### Response timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial assessment**: Within 1 week
+- **Fix timeline**: Depends on severity, but we aim for patches within 30 days for critical issues
+
+### Disclosure
+
+We follow coordinated disclosure. We will work with you on a timeline for public disclosure
+after a fix is available.


### PR DESCRIPTION
Add a SECURITY.md with:
- Supported versions (4.1.x, 4.0.x, 3.x security fixes)
- GitHub Private Vulnerability Reporting (already enabled)
- Email contact for vulnerability reports
- Response timeline (48h acknowledgment, 1 week assessment, 30 days for critical fixes)
- Coordinated disclosure policy

Requested by CERT-PL in #1945.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a comprehensive security policy document detailing supported software versions, vulnerability reporting instructions, and coordinated disclosure process. Users can report security issues via GitHub security advisories (preferred) or email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->