### PR TITLE
fix: restore signal handling when ISIG is cleared (#1942)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -177,6 +177,21 @@ public final class TerminalBuilder {
     //
 
     public static final String PROP_NON_BLOCKING_READS = "org.jline.terminal.pty.nonBlockingReads";
+    /**
+     * When {@code true} (the default), system terminals intercept signal control characters
+     * (VINTR, VQUIT, VSUSP) in software and raise the corresponding {@link Terminal.Signal}
+     * when ISIG is cleared (raw mode). This restores {@code terminal.handle(Signal.INT, ...)}
+     * behavior that was lost when {@code enterRawMode()} started clearing ISIG.
+     * <p>
+     * Set to {@code false} for pure native terminal behavior where no automatic signal
+     * translation occurs — the application must handle raw bytes itself.
+     * <p>
+     * The default may change to {@code false} in a future release (4.2 or later).
+     *
+     * @since 4.1.4
+     */
+    public static final String PROP_SOFTWARE_SIGNALS = "org.jline.terminal.softwareSignals";
+
     public static final String PROP_COLOR_DISTANCE = "org.jline.utils.colorDistance";
     public static final String PROP_DISABLE_ALTERNATE_CHARSET = "org.jline.utils.disableAlternateCharset";
 

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -11,6 +11,7 @@ package org.jline.terminal.impl;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -35,6 +36,8 @@ import org.jline.utils.NonCloseableInputStream;
 import org.jline.utils.NonCloseableOutputStream;
 import org.jline.utils.ShutdownHooks;
 import org.jline.utils.ShutdownHooks.Task;
+
+import static org.jline.terminal.TerminalBuilder.PROP_SOFTWARE_SIGNALS;
 
 /**
  * Base class for flattened POSIX system terminals that bypass the PTY abstraction.
@@ -74,6 +77,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
     private final NonBlockingReader reader;
     private final PrintWriter writer;
     final Map<Signal, Object> nativeHandlers = new ConcurrentHashMap<>();
+    private volatile Attributes cachedAttributes;
     private final Task closer;
 
     @SuppressWarnings({"this-escape", "squid:S107"})
@@ -94,9 +98,12 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
         this.systemStream = systemStream;
         this.originalAttributes = originalAttributes;
         this.nativeSignals = nativeSignals;
+        boolean softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "true"));
 
+        InputStream stdin = new NonCloseableInputStream(new FileInputStream(FileDescriptor.in));
         this.input =
-                NonBlocking.nonBlocking(getName(), new NonCloseableInputStream(new FileInputStream(FileDescriptor.in)));
+                NonBlocking.nonBlocking(getName(), softwareSignals ? new SignalInterceptingInputStream(stdin) : stdin);
+        cachedAttributes = new Attributes(originalAttributes);
         FileDescriptor outFd;
         if (systemStream == SystemStream.Output) {
             outFd = FileDescriptor.out;
@@ -163,13 +170,16 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
     @Override
     public Attributes getAttributes() {
         checkClosed();
-        return doGetAttributes();
+        Attributes attr = doGetAttributes();
+        cachedAttributes = attr;
+        return attr;
     }
 
     @Override
     public void setAttributes(Attributes attr) {
         checkClosed();
         doSetAttributes(attr);
+        cachedAttributes = new Attributes(attr);
     }
 
     @Override
@@ -283,5 +293,65 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
             size = null;
         }
         return getKind() + "[" + "name='" + name + '\'' + ", type='" + type + '\'' + ", size='" + size + '\'' + ']';
+    }
+
+    /**
+     * Wraps the raw stdin to intercept signal control characters when ISIG is cleared
+     * (raw mode). Unlike {@link LineDisciplineTerminal#doProcessInputByte} which
+     * <em>consumes</em> signal bytes (they never reach the reader), this wrapper
+     * <em>passes them through</em> — the byte is returned to the caller after raising
+     * the signal. This is intentional: in raw mode the LineReader's INTERRUPT widget
+     * also needs to see {@code 0x03} via its keymap binding.
+     */
+    private class SignalInterceptingInputStream extends FilterInputStream {
+        SignalInterceptingInputStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public int read() throws IOException {
+            int b = super.read();
+            if (b >= 0) {
+                checkSignalByte(b);
+            }
+            return b;
+        }
+
+        @Override
+        public int read(byte[] buf, int off, int len) throws IOException {
+            int n = super.read(buf, off, len);
+            if (n > 0) {
+                checkSignalBytes(buf, off, n);
+            }
+            return n;
+        }
+
+        private void checkSignalByte(int b) {
+            Attributes attr = cachedAttributes;
+            if (!attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
+                raiseIfSignal(b, attr);
+            }
+        }
+
+        private void checkSignalBytes(byte[] buf, int off, int count) {
+            Attributes attr = cachedAttributes;
+            if (!attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
+                for (int i = 0; i < count; i++) {
+                    raiseIfSignal(buf[off + i] & 0xFF, attr);
+                }
+            }
+        }
+
+        private void raiseIfSignal(int b, Attributes attr) {
+            if (b == attr.getControlChar(Attributes.ControlChar.VINTR)) {
+                raise(Signal.INT);
+            } else if (b == attr.getControlChar(Attributes.ControlChar.VQUIT)) {
+                raise(Signal.QUIT);
+            } else if (b == attr.getControlChar(Attributes.ControlChar.VSUSP)) {
+                raise(Signal.TSTP);
+            } else if (b == attr.getControlChar(Attributes.ControlChar.VSTATUS)) {
+                raise(Signal.INFO);
+            }
+        }
     }
 }

--- a/terminal/src/test/java/org/jline/terminal/impl/SignalInterceptionTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/SignalInterceptionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.ControlChar;
+import org.jline.terminal.Attributes.LocalFlag;
+import org.jline.terminal.Terminal.Signal;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for software signal interception when ISIG is cleared (raw mode).
+ *
+ * <p>Since {@code AbstractUnixSysTerminal.SignalInterceptingInputStream} is tied
+ * to {@code FileDescriptor.in} and cannot be instantiated in a unit test, we test
+ * the equivalent behavior through {@link LineDisciplineTerminal} which has its own
+ * signal translation in {@code doProcessInputByte()}.
+ *
+ * <p>These tests verify the signal-raising contract that both implementations share:
+ * when ISIG is enabled, signal control characters trigger the corresponding signal.
+ */
+class SignalInterceptionTest {
+
+    @Test
+    void testVintrRaisesSignalInt() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "ansi", masterOutput, StandardCharsets.UTF_8)) {
+            // ISIG is on by default — signal bytes should be intercepted
+            Attributes attr = terminal.getAttributes();
+            assertTrue(attr.getLocalFlag(LocalFlag.ISIG));
+            int vintr = attr.getControlChar(ControlChar.VINTR);
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            // Write VINTR byte to the terminal's master input
+            terminal.processInputByte((byte) vintr);
+
+            assertEquals(Signal.INT, received.get());
+        }
+    }
+
+    @Test
+    void testVquitRaisesSignalQuit() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "ansi", masterOutput, StandardCharsets.UTF_8)) {
+            Attributes attr = terminal.getAttributes();
+            int vquit = attr.getControlChar(ControlChar.VQUIT);
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.QUIT, received::set);
+
+            terminal.processInputByte((byte) vquit);
+
+            assertEquals(Signal.QUIT, received.get());
+        }
+    }
+
+    @Test
+    void testVsuspRaisesSignalTstp() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "ansi", masterOutput, StandardCharsets.UTF_8)) {
+            Attributes attr = terminal.getAttributes();
+            int vsusp = attr.getControlChar(ControlChar.VSUSP);
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.TSTP, received::set);
+
+            terminal.processInputByte((byte) vsusp);
+
+            assertEquals(Signal.TSTP, received.get());
+        }
+    }
+
+    @Test
+    void testNoSignalWhenIsigDisabled() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "ansi", masterOutput, StandardCharsets.UTF_8)) {
+            // Disable ISIG — LineDisciplineTerminal should NOT intercept signal bytes
+            Attributes attr = terminal.getAttributes();
+            attr.setLocalFlag(LocalFlag.ISIG, false);
+            terminal.setAttributes(attr);
+
+            int vintr = attr.getControlChar(ControlChar.VINTR);
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            terminal.processInputByte((byte) vintr);
+
+            // LineDisciplineTerminal does NOT raise when ISIG is off
+            // (AbstractUnixSysTerminal.SignalInterceptingInputStream fills this gap
+            // for system terminals)
+            assertNull(received.get());
+        }
+    }
+
+    @Test
+    void testDisabledControlCharDoesNotRaise() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "ansi", masterOutput, StandardCharsets.UTF_8)) {
+            // Disable VINTR by setting it to -1
+            Attributes attr = terminal.getAttributes();
+            attr.setControlChar(ControlChar.VINTR, -1);
+            terminal.setAttributes(attr);
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            // Send Ctrl+C (0x03) — should NOT raise because VINTR is disabled
+            terminal.processInputByte((byte) 0x03);
+
+            assertNull(received.get());
+        }
+    }
+}


### PR DESCRIPTION
## Problem

PR #1912 cleared ISIG in `enterRawMode()` to align with POSIX `cfmakeraw(3)`. This means Ctrl+C now arrives as byte `0x03` instead of generating SIGINT via the kernel. The LineReader handles this through its INTERRUPT widget, but users calling `terminal.handle(Signal.INT, handler)` without LineReader no longer receive signals.

## Fix

Add a `SignalInterceptingInputStream` wrapper in `AbstractUnixSysTerminal` that intercepts signal control characters (VINTR, VQUIT, VSUSP) when ISIG is off and calls `raise()` for the corresponding signal. The byte is always passed through so that LineReader keymaps still see `0x03`.

### System Property

A new system property `org.jline.terminal.softwareSignals` controls this behavior:
- **`true`** (default): intercept signal bytes and raise signals in software — backward compatible
- **`false`**: pure native terminal behavior, no automatic signal raising

This default may change in a future major release (4.2/4.3) to favor native terminal behavior.

Fixes #1942.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new system property to control “software signal” handling for terminal input (`org.jline.terminal.softwareSignals`), enabled by default.
  * When enabled, software terminals can translate common raw-mode control characters (VINTR/VQUIT/VSUSP) into the corresponding signal events.
  * Signal translation occurs only when the terminal is not actively interpreting `ISIG`, and it follows attribute changes made after startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->