### PR TITLE
fix: override bulk write in NonCloseableOutputStream to avoid byte-at-a-time writes

### DIFF
--- a/terminal/src/main/java/org/jline/utils/NonCloseableOutputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonCloseableOutputStream.java
@@ -24,6 +24,11 @@ public class NonCloseableOutputStream extends FilterOutputStream {
     }
 
     @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+    }
+
+    @Override
     public void close() throws IOException {
         flush();
     }


### PR DESCRIPTION
## Summary

- Fixes #1943 — significant performance regression (flickering) between 4.0.0 and 4.1.3
- `NonCloseableOutputStream` extends `FilterOutputStream`, whose `write(byte[], int, int)` calls `write(int)` in a loop — turning every buffered flush into hundreds of individual write syscalls
- Override `write(byte[], int, int)` to delegate directly to the underlying stream's bulk write

## Root cause

PR #1911 wrapped the system output stream in `NonCloseableOutputStream` (a `FilterOutputStream` subclass) to prevent closing shared file descriptors. However, `FilterOutputStream.write(byte[], int, int)` is intentionally implemented as a byte-at-a-time loop (to support transforming subclasses). For a pass-through wrapper this is pure overhead — each `terminal.flush()` that used to be a single write syscall became hundreds of individual byte writes, causing the terminal to render partial frames.

## Test plan

- [x] Bisected the regression to commit 0ac019ab (#1911)
- [x] Verified fix eliminates flickering using the [reproducer project](https://github.com/jline/jline3/issues/1943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced internal stream handling for bulk write operations to improve reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->