### PR TITLE
fix: propagate EOF in PtyInputStream to avoid infinite loop

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
 
 import org.jline.nativ.JLineLibrary;
 import org.jline.nativ.JLineNativeLoader;
@@ -146,8 +147,9 @@ public abstract class AbstractPty implements Pty {
                 return r;
             } else {
                 setNonBlocking();
-                long start = System.currentTimeMillis();
+                long start = System.nanoTime();
                 while (true) {
+                    long readStart = System.nanoTime();
                     int r = in.read();
                     if (r >= 0) {
                         if (isPeek) {
@@ -155,9 +157,16 @@ public abstract class AbstractPty implements Pty {
                         }
                         return r;
                     }
+                    // r == -1: could be real EOF or VMIN=0/VTIME=1 timeout on a real PTY.
+                    // With VTIME=1 (100ms), a timeout takes ~100ms to return -1.
+                    // Real EOF (pipe closed, PTY slave closed) returns -1 instantly.
+                    long readElapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - readStart);
+                    if (readElapsed < 50) {
+                        return -1;
+                    }
                     checkInterrupted();
-                    long cur = System.currentTimeMillis();
-                    if (timeout > 0 && cur - start > timeout) {
+                    long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+                    if (timeout > 0 && elapsed > timeout) {
                         return NonBlockingInputStream.READ_EXPIRED;
                     }
                 }

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Size;
+import org.jline.terminal.Sized;
+import org.jline.utils.NonBlockingInputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.jline.terminal.TerminalBuilder.PROP_NON_BLOCKING_READS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PtyInputStreamTest {
+
+    private String savedNonBlockingReads;
+
+    @BeforeEach
+    void setUp() {
+        savedNonBlockingReads = System.getProperty(PROP_NON_BLOCKING_READS);
+        System.setProperty(PROP_NON_BLOCKING_READS, "true");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedNonBlockingReads != null) {
+            System.setProperty(PROP_NON_BLOCKING_READS, savedNonBlockingReads);
+        } else {
+            System.clearProperty(PROP_NON_BLOCKING_READS);
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void eofPropagation() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
+
+        AbstractPty pty = new AbstractPty(null, null) {
+            @Override
+            protected void doSetAttr(Attributes attr) {}
+
+            @Override
+            protected InputStream doGetSlaveInput() {
+                return pipedIn;
+            }
+
+            @Override
+            public InputStream getMasterInput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getMasterOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getSlaveOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Attributes getAttr() {
+                return new Attributes();
+            }
+
+            @Override
+            public Size getSize() {
+                return Size.of(80, 24);
+            }
+
+            @Override
+            public void setSize(Sized size) {}
+
+            @Override
+            public void close() {}
+        };
+
+        InputStream slaveInput = pty.getSlaveInput();
+        assertTrue(slaveInput instanceof NonBlockingInputStream);
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        pipedOut.write('A');
+        pipedOut.close();
+
+        int ch = nbis.read(1000);
+        assertEquals('A', ch);
+
+        // Without the fix, PtyInputStream loops until timeout and returns READ_EXPIRED (-2).
+        // With the fix, it detects instant EOF and returns -1.
+        int eof = nbis.read(1000);
+        assertEquals(-1, eof, "Expected EOF (-1) after pipe closed");
+    }
+}


### PR DESCRIPTION
## Problem

`PtyInputStream.read()` loops indefinitely when the underlying input stream returns -1 (EOF). The loop only exits for `r >= 0` or timeout expiry — but in blocking mode (`timeout == 0`), EOF falls through and retries forever.

This causes JLine to hang when reading from a non-interactive source (pipe, file) after input is exhausted.

Fixes #1961.

## Why It Regressed in 3.30.8

The bug has always existed in `PtyInputStream`, but was never triggered for custom streams before 3.30.8. The change:

- **Before 3.30.8:** `isNativeAccessEnabled()` falsely returned `false` on some JDK 21 builds (e.g. 21.0.10), preventing the JNI provider from loading. `TerminalBuilder.streams(in, out)` fell back to `ExecTerminalProvider` → `ExternalTerminal`, which has its own read loop and does NOT use `PtyInputStream`.
- **3.30.8 (#1689):** Fixed the native access check to skip JDK < 24. Now the JNI provider loads correctly → `JniTerminalProvider.newTerminal()` opens a real PTY and creates a `PosixPtyTerminal` even for custom streams. The `PipedInputStream` now goes through `PtyInputStream`, hitting the infinite loop on EOF.

## Root Cause

`PtyInputStream.setNonBlocking()` sets VMIN=0, VTIME=1 on the PTY for polling. With these settings, a real PTY returns 0 bytes after ~100ms of inactivity, which `FileInputStream` maps to -1. This is a timeout, not EOF. But for pipes/`PipedInputStream`, -1 always means real EOF — and it returns instantly.

So -1 is ambiguous: PTY timeout vs real EOF.

## Fix

Measure how long `in.read()` took to return -1:
- **< 50ms** → returned too fast to be a VTIME timeout → **real EOF**, propagate -1
- **≥ 50ms** → consistent with VTIME=1 (100ms) timeout → continue polling

Uses `System.nanoTime()` (monotonic clock) for all timing to avoid sensitivity to system clock adjustments.

## Test

Added `PtyInputStreamTest.eofPropagation` that directly exercises the `NonBlockingInputStream` returned by `AbstractPty.getSlaveInput()` with a `PipedInputStream`. After closing the pipe, verifies that `read(1000)` returns -1 (EOF) instead of -2 (READ_EXPIRED). The test fails without the fix and passes with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PTY input handling to properly distinguish between real end-of-file and timeout conditions, improving terminal reliability.

* **Tests**
  * Added test coverage for EOF propagation in pseudo-terminal input streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->