### PR TITLE
test: add LineReader EOF tests for different terminal providers (#1961)

### DIFF
--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class LineReaderEofTest {
+
+    @Test
+    @Timeout(10)
+    void eofWithExecProvider() throws Exception {
+        checkEof(TerminalBuilder.PROP_PROVIDER_EXEC);
+    }
+
+    @Test
+    @Timeout(10)
+    void eofWithDefaultProvider() throws Exception {
+        checkEof(null);
+    }
+
+    private void checkEof(String providerType) throws Exception {
+        String savedProviders = System.getProperty(TerminalBuilder.PROP_PROVIDERS);
+        try {
+            if (providerType != null) {
+                System.setProperty(TerminalBuilder.PROP_PROVIDERS, providerType);
+            }
+
+            PipedInputStream in = new PipedInputStream();
+            PipedOutputStream outIn = new PipedOutputStream(in);
+            outIn.write("hello\n".getBytes(StandardCharsets.UTF_8));
+            ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+
+            Terminal terminal;
+            try {
+                terminal = TerminalBuilder.builder().streams(in, out).build();
+            } catch (Exception e) {
+                assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
+                return;
+            }
+
+            try (terminal) {
+                LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
+                assertEquals("hello", lr.readLine());
+                outIn.close();
+                Thread.sleep(200);
+                assertThrows(EndOfFileException.class, () -> lr.readLine());
+            }
+        } finally {
+            if (savedProviders != null) {
+                System.setProperty(TerminalBuilder.PROP_PROVIDERS, savedProviders);
+            } else {
+                System.clearProperty(TerminalBuilder.PROP_PROVIDERS);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add integration tests for EOF propagation through the full LineReader stack, complementing the low-level PtyInputStreamTest added in #1963.

Tests exercise TerminalBuilder.streams() → LineReader.readLine() with:
- **exec** provider (ExternalTerminal with real PTY via fork/exec)
- **default** provider (whatever the environment provides)

Each test writes data to a pipe, reads one line, closes the pipe, and verifies that a subsequent readLine() throws EndOfFileException.

Follow-up to #1963, as suggested in #1961.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for EOF (End of File) handling in the line reader to ensure proper exception behavior when input stream is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->