### PR TITLE
fix: add compiled groovy classes to javadoc classpath

### DIFF
--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -58,6 +58,19 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalDependencies>
+                        <additionalDependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <version>${project.version}</version>
+                        </additionalDependency>
+                    </additionalDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <showWarnings>true</showWarnings>


### PR DESCRIPTION
The javadoc plugin could not resolve `org.jline.groovy` classes (`ObjectInspector`, `Utils`) because they are compiled from `.groovy` sources by gmavenplus and are not on the javadoc classpath. This caused 3 errors during the release build javadoc generation.

Fix: add the module's own artifact as an `additionalDependency` in the javadoc plugin configuration for the groovy module, so the compiled Groovy classes are available on the classpath during javadoc generation.

This was observed during the 4.2.0 release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->