### PR TITLE
fix: remove unused WebTerminal /static/ handler (classpath disclosure)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/WebTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/WebTerminal.java
@@ -262,8 +262,6 @@ public class WebTerminal extends LineDisciplineTerminal {
 
                 if ("/".equals(path) || "/index.html".equals(path)) {
                     serveTerminalPage(exchange);
-                } else if (path.startsWith("/static/")) {
-                    serveStaticResource(exchange, path);
                 } else {
                     send404(exchange);
                 }
@@ -282,40 +280,6 @@ public class WebTerminal extends LineDisciplineTerminal {
             try (OutputStream os = exchange.getResponseBody()) {
                 os.write(response);
             }
-        }
-
-        private void serveStaticResource(HttpExchange exchange, String path) throws IOException {
-            String resourcePath = path.substring(8); // Remove "/static/"
-            try (InputStream is = getClass().getResourceAsStream("/" + resourcePath)) {
-                if (is == null) {
-                    send404(exchange);
-                    return;
-                }
-
-                String contentType = getContentType(resourcePath);
-                exchange.getResponseHeaders().set("Content-Type", contentType);
-
-                byte[] buffer = new byte[8192];
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                int bytesRead;
-                while ((bytesRead = is.read(buffer)) != -1) {
-                    baos.write(buffer, 0, bytesRead);
-                }
-
-                byte[] response = baos.toByteArray();
-                exchange.sendResponseHeaders(200, response.length);
-
-                try (OutputStream os = exchange.getResponseBody()) {
-                    os.write(response);
-                }
-            }
-        }
-
-        private String getContentType(String path) {
-            if (path.endsWith(".js")) return "application/javascript";
-            if (path.endsWith(".css")) return "text/css";
-            if (path.endsWith(".html")) return "text/html";
-            return "application/octet-stream";
         }
 
         private void send404(HttpExchange exchange) throws IOException {

--- a/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
+++ b/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
@@ -299,6 +299,26 @@ class WebTerminalIntegrationTest {
     }
 
     @Test
+    void testStaticHandlerDoesNotServeArbitraryClasspathResources() throws IOException {
+        // A bundled resource that exists on the classpath but is not a web asset.
+        assertEquals(404, getStatus("/static/org/jline/builtins/less-help.txt"));
+        // A compiled class on the classpath.
+        assertEquals(404, getStatus("/static/org/jline/builtins/WebTerminal.class"));
+        // Traversal back to the classpath root.
+        assertEquals(404, getStatus("/static/..%2f..%2forg/jline/builtins/less-help.txt"));
+    }
+
+    private int getStatus(String pathAndQuery) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + pathAndQuery).openConnection();
+        conn.setRequestMethod("GET");
+        try {
+            return conn.getResponseCode();
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    @Test
     void testMethodNotAllowed() throws IOException {
         // GET on /terminal should be 405
         HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + "/terminal").openConnection();


### PR DESCRIPTION
## Summary

Remove the unused `/static/` resource handler from `WebTerminal` to eliminate a classpath resource disclosure vulnerability.

### Problem

The `serveStaticResource()` method mapped `GET /static/<path>` directly to `getResourceAsStream("/" + path)`, allowing a remote client to read **any resource on the application classpath** — class files, configuration, bundled data.

### Solution

Since all CSS and JS are already embedded inline in `getTerminalHtml()` (the `/static/` handler was effectively dead code serving nothing), the cleanest fix is to **remove the handler entirely** rather than trying to confine it.

### Changes

- Remove the `/static/` routing branch from `TerminalHandler.handle()`
- Remove `serveStaticResource()` and `getContentType()` methods
- Add integration test verifying that `/static/` paths return 404