### PR TITLE
feat: add AIX support to FFM terminal provider (fixes #1984)

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -101,6 +101,7 @@ class CLibrary {
         private static final VarHandle c_cflag;
         private static final VarHandle c_lflag;
         private static final long c_cc_offset;
+        private static final int c_cc_used;
         private static final VarHandle c_ispeed;
         private static final VarHandle c_ospeed;
 
@@ -114,6 +115,7 @@ class CLibrary {
                         MemoryLayout.sequenceLayout(32, ValueLayout.JAVA_BYTE).withName("c_cc"),
                         ValueLayout.JAVA_LONG.withName("c_ispeed"),
                         ValueLayout.JAVA_LONG.withName("c_ospeed"));
+                c_cc_used = 20;
             } else if (OSUtils.IS_LINUX) {
                 LAYOUT = MemoryLayout.structLayout(
                         ValueLayout.JAVA_INT.withName("c_iflag"),
@@ -125,26 +127,40 @@ class CLibrary {
                         MemoryLayout.paddingLayout(3),
                         ValueLayout.JAVA_INT.withName("c_ispeed"),
                         ValueLayout.JAVA_INT.withName("c_ospeed"));
+                c_cc_used = 20;
+            } else if (OSUtils.IS_AIX) {
+                LAYOUT = MemoryLayout.structLayout(
+                        ValueLayout.JAVA_INT.withName("c_iflag"),
+                        ValueLayout.JAVA_INT.withName("c_oflag"),
+                        ValueLayout.JAVA_INT.withName("c_cflag"),
+                        ValueLayout.JAVA_INT.withName("c_lflag"),
+                        MemoryLayout.sequenceLayout(16, ValueLayout.JAVA_BYTE).withName("c_cc"));
+                c_cc_used = 16;
             } else {
                 throw new IllegalStateException("Unsupported system!");
             }
-            c_iflag = adjust2LinuxHandle(
+            c_iflag = adjustIntHandle(
                     FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("c_iflag")));
-            c_oflag = adjust2LinuxHandle(
+            c_oflag = adjustIntHandle(
                     FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("c_oflag")));
-            c_cflag = adjust2LinuxHandle(
+            c_cflag = adjustIntHandle(
                     FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("c_cflag")));
-            c_lflag = adjust2LinuxHandle(
+            c_lflag = adjustIntHandle(
                     FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("c_lflag")));
             c_cc_offset = LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("c_cc"));
-            c_ispeed = adjust2LinuxHandle(
-                    FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("c_ispeed")));
-            c_ospeed = adjust2LinuxHandle(
-                    FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("c_ospeed")));
+            if (OSUtils.IS_AIX) {
+                c_ispeed = null;
+                c_ospeed = null;
+            } else {
+                c_ispeed = adjustIntHandle(
+                        FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("c_ispeed")));
+                c_ospeed = adjustIntHandle(
+                        FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("c_ospeed")));
+            }
         }
 
-        private static VarHandle adjust2LinuxHandle(VarHandle v) {
-            if (OSUtils.IS_LINUX) {
+        private static VarHandle adjustIntHandle(VarHandle v) {
+            if (OSUtils.IS_LINUX || OSUtils.IS_AIX) {
                 MethodHandle id = MethodHandles.identity(int.class);
                 v = MethodHandles.filterValue(
                         v,
@@ -168,7 +184,7 @@ class CLibrary {
             c_oflag(data.oflag());
             c_cflag(data.cflag());
             c_lflag(data.lflag());
-            c_cc().copyFrom(MemorySegment.ofArray(data.cc()).asSlice(0, 20));
+            c_cc().copyFrom(MemorySegment.ofArray(data.cc()).asSlice(0, c_cc_used));
         }
 
         MemorySegment segment() {
@@ -208,23 +224,23 @@ class CLibrary {
         }
 
         MemorySegment c_cc() {
-            return seg.asSlice(c_cc_offset, 20);
+            return seg.asSlice(c_cc_offset, c_cc_used);
         }
 
         long c_ispeed() {
-            return (long) c_ispeed.get(seg);
+            return c_ispeed != null ? (long) c_ispeed.get(seg) : 0;
         }
 
         void c_ispeed(long f) {
-            c_ispeed.set(seg, f);
+            if (c_ispeed != null) c_ispeed.set(seg, f);
         }
 
         long c_ospeed() {
-            return (long) c_ospeed.get(seg);
+            return c_ospeed != null ? (long) c_ospeed.get(seg) : 0;
         }
 
         void c_ospeed(long f) {
-            c_ospeed.set(seg, f);
+            if (c_ospeed != null) c_ospeed.set(seg, f);
         }
 
         /**
@@ -302,6 +318,14 @@ class CLibrary {
                     } catch (Throwable t) {
                         suppressed.add(t);
                     }
+                }
+            }
+            if (openPtyAddr.isEmpty() && OSUtils.IS_AIX) {
+                try {
+                    System.loadLibrary("bsd");
+                    openPtyAddr = lookup.find("openpty");
+                } catch (Throwable t) {
+                    suppressed.add(t);
                 }
             }
             if (openPtyAddr.isEmpty() && OSUtils.IS_LINUX) {
@@ -495,6 +519,9 @@ class CLibrary {
             TIOCGWINSZ = 0x40087468;
             TIOCSWINSZ = 0x80087467;
         } else if (osName.startsWith("FreeBSD")) {
+            TIOCGWINSZ = 0x40087468;
+            TIOCSWINSZ = 0x80087467;
+        } else if (osName.contains("AIX")) {
             TIOCGWINSZ = 0x40087468;
             TIOCSWINSZ = 0x80087467;
         } else {

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -143,6 +143,22 @@ class FfmSignalHandler {
                         ValueLayout.JAVA_INT.withName(SA_FLAGS),
                         MemoryLayout.sequenceLayout(16, ValueLayout.JAVA_BYTE).withName(SA_MASK),
                         MemoryLayout.paddingLayout(4));
+            } else if (osName.contains("AIX")) {
+                sighup = 1;
+                sigint = 2;
+                sigquit = 3;
+                sigterm = 15;
+                sigtstp = 18;
+                sigcont = 19;
+                siginfo = -1;
+                sigwinch = 28;
+                saRestart = 0x0008;
+
+                layout = MemoryLayout.structLayout(
+                        ValueLayout.ADDRESS.withName(SA_HANDLER),
+                        MemoryLayout.sequenceLayout(8, ValueLayout.JAVA_BYTE).withName(SA_MASK),
+                        ValueLayout.JAVA_INT.withName(SA_FLAGS),
+                        MemoryLayout.paddingLayout(4));
             }
 
             if (layout != null) {

--- a/terminal/src/main/java/org/jline/terminal/impl/AixTermiosMapping.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AixTermiosMapping.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.util.EnumMap;
+
+import org.jline.terminal.Attributes.*;
+
+/**
+ * AIX-specific termios flag constants and control character indices.
+ *
+ * @see TermiosMapping
+ */
+@SuppressWarnings("java:S6548")
+public class AixTermiosMapping extends TermiosMapping {
+
+    /** Singleton instance. */
+    public static final AixTermiosMapping INSTANCE = new AixTermiosMapping();
+
+    private AixTermiosMapping() {
+        super(inputFlags(), outputFlags(), controlFlags(), localFlags(), controlChars());
+    }
+
+    private static EnumMap<InputFlag, Long> inputFlags() {
+        var map = new EnumMap<InputFlag, Long>(InputFlag.class);
+        map.put(InputFlag.IGNBRK, 0x0000001L);
+        map.put(InputFlag.BRKINT, 0x0000002L);
+        map.put(InputFlag.IGNPAR, 0x0000004L);
+        map.put(InputFlag.PARMRK, 0x0000008L);
+        map.put(InputFlag.INPCK, 0x0000010L);
+        map.put(InputFlag.ISTRIP, 0x0000020L);
+        map.put(InputFlag.INLCR, 0x0000040L);
+        map.put(InputFlag.IGNCR, 0x0000080L);
+        map.put(InputFlag.ICRNL, 0x0000100L);
+        map.put(InputFlag.IXON, 0x0000200L);
+        map.put(InputFlag.IXOFF, 0x0000400L);
+        map.put(InputFlag.IUCLC, 0x0000800L);
+        map.put(InputFlag.IXANY, 0x0001000L);
+        map.put(InputFlag.IMAXBEL, 0x0010000L);
+        return map;
+    }
+
+    private static EnumMap<OutputFlag, Long> outputFlags() {
+        var map = new EnumMap<OutputFlag, Long>(OutputFlag.class);
+        map.put(OutputFlag.OPOST, 0x0000001L);
+        map.put(OutputFlag.OLCUC, 0x0000002L);
+        map.put(OutputFlag.ONLCR, 0x0000004L);
+        map.put(OutputFlag.OCRNL, 0x0000008L);
+        map.put(OutputFlag.ONOCR, 0x0000010L);
+        map.put(OutputFlag.ONLRET, 0x0000020L);
+        map.put(OutputFlag.OFILL, 0x0000040L);
+        map.put(OutputFlag.OFDEL, 0x0000080L);
+        map.put(OutputFlag.CRDLY, 0x0000300L);
+        map.put(OutputFlag.TABDLY, 0x0000c00L);
+        map.put(OutputFlag.BSDLY, 0x0001000L);
+        map.put(OutputFlag.FFDLY, 0x0002000L);
+        map.put(OutputFlag.NLDLY, 0x0004000L);
+        map.put(OutputFlag.VTDLY, 0x0008000L);
+        return map;
+    }
+
+    private static EnumMap<ControlFlag, Long> controlFlags() {
+        var map = new EnumMap<ControlFlag, Long>(ControlFlag.class);
+        map.put(ControlFlag.CS5, 0x0000000L);
+        map.put(ControlFlag.CS6, 0x0000010L);
+        map.put(ControlFlag.CS7, 0x0000020L);
+        map.put(ControlFlag.CS8, 0x0000030L);
+        map.put(ControlFlag.CSTOPB, 0x0000040L);
+        map.put(ControlFlag.CREAD, 0x0000080L);
+        map.put(ControlFlag.PARENB, 0x0000100L);
+        map.put(ControlFlag.PARODD, 0x0000200L);
+        map.put(ControlFlag.HUPCL, 0x0000400L);
+        map.put(ControlFlag.CLOCAL, 0x0000800L);
+        return map;
+    }
+
+    private static EnumMap<LocalFlag, Long> localFlags() {
+        var map = new EnumMap<LocalFlag, Long>(LocalFlag.class);
+        map.put(LocalFlag.ISIG, 0x0000001L);
+        map.put(LocalFlag.ICANON, 0x0000002L);
+        map.put(LocalFlag.XCASE, 0x0000004L);
+        map.put(LocalFlag.ECHO, 0x0000008L);
+        map.put(LocalFlag.ECHOE, 0x0000010L);
+        map.put(LocalFlag.ECHOK, 0x0000020L);
+        map.put(LocalFlag.ECHONL, 0x0000040L);
+        map.put(LocalFlag.NOFLSH, 0x0000080L);
+        map.put(LocalFlag.TOSTOP, 0x0010000L);
+        map.put(LocalFlag.ECHOCTL, 0x0020000L);
+        map.put(LocalFlag.ECHOPRT, 0x0040000L);
+        map.put(LocalFlag.ECHOKE, 0x0080000L);
+        map.put(LocalFlag.FLUSHO, 0x0100000L);
+        map.put(LocalFlag.IEXTEN, 0x0200000L);
+        map.put(LocalFlag.PENDIN, 0x20000000L);
+        return map;
+    }
+
+    private static EnumMap<ControlChar, Integer> controlChars() {
+        var map = new EnumMap<ControlChar, Integer>(ControlChar.class);
+        map.put(ControlChar.VINTR, 0);
+        map.put(ControlChar.VQUIT, 1);
+        map.put(ControlChar.VERASE, 2);
+        map.put(ControlChar.VKILL, 3);
+        map.put(ControlChar.VEOF, 4);
+        map.put(ControlChar.VEOL, 5);
+        map.put(ControlChar.VEOL2, 6);
+        map.put(ControlChar.VMIN, 4); // shares index with VEOF
+        map.put(ControlChar.VTIME, 5); // shares index with VEOL
+        map.put(ControlChar.VSTART, 7);
+        map.put(ControlChar.VSTOP, 8);
+        map.put(ControlChar.VSUSP, 9);
+        map.put(ControlChar.VDSUSP, 10);
+        map.put(ControlChar.VREPRINT, 11);
+        map.put(ControlChar.VDISCARD, 12);
+        map.put(ControlChar.VWERASE, 13);
+        map.put(ControlChar.VLNEXT, 14);
+        return map;
+    }
+}

--- a/terminal/src/main/java/org/jline/terminal/impl/TermiosMapping.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/TermiosMapping.java
@@ -21,6 +21,7 @@ import org.jline.terminal.Attributes.*;
  * {@link #toTermios(Attributes)} and {@link #toAttributes(TermiosData)}, so subclasses
  * are pure data declarations with no conversion logic.</p>
  *
+ * @see AixTermiosMapping
  * @see LinuxTermiosMapping
  * @see OsXTermiosMapping
  * @see FreeBsdTermiosMapping
@@ -145,6 +146,8 @@ public abstract class TermiosMapping {
                 return SolarisTermiosMapping.INSTANCE;
             } else if (osName.startsWith("FreeBSD")) {
                 return FreeBsdTermiosMapping.INSTANCE;
+            } else if (osName.contains("AIX")) {
+                return AixTermiosMapping.INSTANCE;
             }
             throw new UnsupportedOperationException("Unsupported OS: " + osName);
         }


### PR DESCRIPTION
Adds IBM AIX as a supported platform for the FFM (Foreign Function & Memory) terminal provider, so JLine works natively on AIX with Java 22+ without falling back to the exec provider.

Changes:

- **CLibrary**: add AIX termios struct layout (4×int + 16-byte c_cc, no ispeed/ospeed fields), track per-platform c_cc size, rename `adjust2LinuxHandle` → `adjustIntHandle` since AIX also uses 32-bit ints, add AIX openpty lookup via libbsd, add AIX TIOCGWINSZ/TIOCSWINSZ ioctl constants
- **FfmSignalHandler**: add AIX signal numbers and sigaction struct layout (sa_handler, 8-byte sa_mask, sa_flags)
- **AixTermiosMapping**: new termios flag/control-char mapping class for AIX, following the existing per-platform pattern (Linux, macOS, FreeBSD, Solaris)
- **TermiosMapping**: register AixTermiosMapping in platform detection

Fixes #1984.