### PR TITLE
fix: create persisted history file with owner-only permissions

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -9,10 +9,13 @@
 package org.jline.reader.impl.history;
 
 import java.io.*;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.*;
@@ -391,6 +394,7 @@ public class DefaultHistory implements History {
             if (!Files.exists(parent)) {
                 Files.createDirectories(parent);
             }
+            createWithOwnerOnlyPermissions(path.toAbsolutePath());
             // Append new items to the history file
             try (BufferedWriter writer = Files.newBufferedWriter(
                     path.toAbsolutePath(),
@@ -410,6 +414,33 @@ public class DefaultHistory implements History {
             }
         }
         setLastLoaded(path, items.size());
+    }
+
+    /**
+     * Creates the history file restricted to the owner when it does not exist yet.
+     * History lines can contain secrets typed on the command line, so the file
+     * must not be left group/world readable as the umask default (0644) would.
+     * On non-POSIX filesystems the file is created with the platform default.
+     */
+    private static void createWithOwnerOnlyPermissions(Path path) throws IOException {
+        if (Files.exists(path)) {
+            return;
+        }
+        try {
+            Files.createFile(
+                    path,
+                    PosixFilePermissions.asFileAttribute(
+                            EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)));
+        } catch (FileAlreadyExistsException e) {
+            // created concurrently between the check and the call
+        } catch (UnsupportedOperationException e) {
+            // non-POSIX filesystem (e.g. Windows): fall back to default creation
+            try {
+                Files.createFile(path);
+            } catch (FileAlreadyExistsException ignore) {
+                // created concurrently
+            }
+        }
     }
 
     /**

--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -395,12 +395,12 @@ public class DefaultHistory implements History {
                 Files.createDirectories(parent);
             }
             createWithOwnerOnlyPermissions(path.toAbsolutePath());
-            // Append new items to the history file
+            // Append new items to the history file. createWithOwnerOnlyPermissions guarantees the
+            // file exists, so CREATE is intentionally omitted: should the file be removed in the
+            // narrow window before this open, fail with NoSuchFileException rather than silently
+            // re-creating it with umask-default (group/world readable) permissions.
             try (BufferedWriter writer = Files.newBufferedWriter(
-                    path.toAbsolutePath(),
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.APPEND,
-                    StandardOpenOption.CREATE)) {
+                    path.toAbsolutePath(), StandardOpenOption.WRITE, StandardOpenOption.APPEND)) {
                 for (Entry entry : items.subList(from, items.size())) {
                     if (isPersistable(entry)) {
                         writer.append(format(entry));
@@ -424,6 +424,9 @@ public class DefaultHistory implements History {
      */
     private static void createWithOwnerOnlyPermissions(Path path) throws IOException {
         if (Files.exists(path)) {
+            // A pre-existing file (e.g. created by an older JLine without this fix) keeps its
+            // current permissions; we don't silently tighten it, but warn so the user can.
+            warnIfAccessibleByOthers(path);
             return;
         }
         try {
@@ -440,6 +443,31 @@ public class DefaultHistory implements History {
             } catch (FileAlreadyExistsException ignore) {
                 // created concurrently
             }
+        }
+    }
+
+    private static final Set<Path> WARNED_INSECURE_PERMS = Collections.synchronizedSet(new HashSet<>());
+
+    private static final Set<PosixFilePermission> NON_OWNER_PERMS = EnumSet.of(
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.GROUP_WRITE,
+            PosixFilePermission.GROUP_EXECUTE,
+            PosixFilePermission.OTHERS_READ,
+            PosixFilePermission.OTHERS_WRITE,
+            PosixFilePermission.OTHERS_EXECUTE);
+
+    /**
+     * Warns, at most once per path, when an existing history file is accessible by users other
+     * than the owner. The file's permissions are left untouched so as not to surprise the user.
+     */
+    private static void warnIfAccessibleByOthers(Path path) {
+        try {
+            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(path);
+            if (perms.stream().anyMatch(NON_OWNER_PERMS::contains) && WARNED_INSECURE_PERMS.add(path)) {
+                Log.warn("History file ", path, " is accessible by other users; consider 'chmod 600'");
+            }
+        } catch (UnsupportedOperationException | IOException e) {
+            // non-POSIX filesystem or attributes unavailable: nothing to warn about
         }
     }
 

--- a/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
@@ -9,10 +9,15 @@
 package org.jline.reader.impl.history;
 
 import java.io.IOException;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.stream.IntStream;
@@ -21,6 +26,7 @@ import org.jline.reader.LineReader;
 import org.jline.reader.impl.ReaderTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -120,6 +126,30 @@ class HistoryPersistenceTest extends ReaderTestSupport {
 
         Assertions.assertDoesNotThrow(history::load);
         Assertions.assertEquals(5, history.size());
+    }
+
+    @Test
+    void testHistoryFilePermissions() throws Exception {
+        Path dir = Files.createTempDirectory("jline-hist-perm");
+        Path testPath = dir.resolve("history");
+        try {
+            FileStore store = Files.getFileStore(dir);
+            Assumptions.assumeTrue(store.supportsFileAttributeView(PosixFileAttributeView.class));
+
+            reader.setVariable(LineReader.HISTORY_FILE, testPath);
+            DefaultHistory history = new DefaultHistory(reader);
+            history.add("password=hunter2");
+            history.save();
+
+            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(testPath);
+            assertEquals(
+                    EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+                    perms,
+                    "newly created history file must not be group/world readable");
+        } finally {
+            Files.deleteIfExists(testPath);
+            Files.deleteIfExists(dir);
+        }
     }
 
     @Test


### PR DESCRIPTION
`DefaultHistory.internalWrite()` previously opened the history file with `StandardOpenOption.CREATE` and no file attributes, so a freshly created file inherited the umask default (typically `rw-r--r--`). Since the history routinely holds secrets typed inline (passwords, tokens, API keys), any local user could read them.

Changes:

- Pre-create the history file with POSIX `0600` permissions (`OWNER_READ | OWNER_WRITE`) before opening it for append
- Fall back to platform-default creation on non-POSIX filesystems (e.g. Windows)
- Warn (once per path, via `System.Logger`) when an existing history file has group/world permissions, without silently tightening them
- Omit `CREATE` from the append open so that if the file is removed between pre-creation and the open, a `NoSuchFileException` is raised rather than silently re-creating with insecure permissions
- Add a test that verifies the file permissions on POSIX systems (skipped on non-POSIX)