### PR TITLE
fix: add software signal interception to PosixSysTerminal (fixes #1982)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -11,7 +11,6 @@ package org.jline.terminal.impl;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -101,8 +100,11 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
         boolean softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "true"));
 
         InputStream stdin = new NonCloseableInputStream(new FileInputStream(FileDescriptor.in));
-        this.input =
-                NonBlocking.nonBlocking(getName(), softwareSignals ? new SignalInterceptingInputStream(stdin) : stdin);
+        this.input = NonBlocking.nonBlocking(
+                getName(),
+                softwareSignals
+                        ? new SignalInterceptingInputStream(stdin, () -> cachedAttributes, this::raise)
+                        : stdin);
         cachedAttributes = new Attributes(originalAttributes);
         FileDescriptor outFd;
         if (systemStream == SystemStream.Output) {
@@ -293,65 +295,5 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
             size = null;
         }
         return getKind() + "[" + "name='" + name + '\'' + ", type='" + type + '\'' + ", size='" + size + '\'' + ']';
-    }
-
-    /**
-     * Wraps the raw stdin to intercept signal control characters when ISIG is cleared
-     * (raw mode). Unlike {@link LineDisciplineTerminal#doProcessInputByte} which
-     * <em>consumes</em> signal bytes (they never reach the reader), this wrapper
-     * <em>passes them through</em> — the byte is returned to the caller after raising
-     * the signal. This is intentional: in raw mode the LineReader's INTERRUPT widget
-     * also needs to see {@code 0x03} via its keymap binding.
-     */
-    private class SignalInterceptingInputStream extends FilterInputStream {
-        SignalInterceptingInputStream(InputStream in) {
-            super(in);
-        }
-
-        @Override
-        public int read() throws IOException {
-            int b = super.read();
-            if (b >= 0) {
-                checkSignalByte(b);
-            }
-            return b;
-        }
-
-        @Override
-        public int read(byte[] buf, int off, int len) throws IOException {
-            int n = super.read(buf, off, len);
-            if (n > 0) {
-                checkSignalBytes(buf, off, n);
-            }
-            return n;
-        }
-
-        private void checkSignalByte(int b) {
-            Attributes attr = cachedAttributes;
-            if (!attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
-                raiseIfSignal(b, attr);
-            }
-        }
-
-        private void checkSignalBytes(byte[] buf, int off, int count) {
-            Attributes attr = cachedAttributes;
-            if (!attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
-                for (int i = 0; i < count; i++) {
-                    raiseIfSignal(buf[off + i] & 0xFF, attr);
-                }
-            }
-        }
-
-        private void raiseIfSignal(int b, Attributes attr) {
-            if (b == attr.getControlChar(Attributes.ControlChar.VINTR)) {
-                raise(Signal.INT);
-            } else if (b == attr.getControlChar(Attributes.ControlChar.VQUIT)) {
-                raise(Signal.QUIT);
-            } else if (b == attr.getControlChar(Attributes.ControlChar.VSUSP)) {
-                raise(Signal.TSTP);
-            } else if (b == attr.getControlChar(Attributes.ControlChar.VSTATUS)) {
-                raise(Signal.INFO);
-            }
-        }
     }
 }

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -8,7 +8,6 @@
  */
 package org.jline.terminal.impl;
 
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -71,6 +70,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
     protected final PrintWriter writer;
     protected final Map<Signal, Object> nativeHandlers = new HashMap<>();
     protected final Task closer;
+    private final boolean nativeSignals;
     private volatile Attributes cachedAttributes;
 
     /**
@@ -150,11 +150,15 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
             throws IOException {
         super(name, type, pty, encoding, inputEncoding, outputEncoding, signalHandler);
         this.provider = provider;
-        this.cachedAttributes = this.originalAttributes;
+        this.nativeSignals = nativeSignals;
+        this.cachedAttributes = new Attributes(this.originalAttributes);
         boolean softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "true"));
         InputStream slaveInput = pty.getSlaveInput();
         this.input = NonBlocking.nonBlocking(
-                getName(), softwareSignals ? new SignalInterceptingInputStream(slaveInput) : slaveInput);
+                getName(),
+                softwareSignals
+                        ? new SignalInterceptingInputStream(slaveInput, () -> cachedAttributes, this::raise)
+                        : slaveInput);
         this.output = new FastBufferedOutputStream(pty.getSlaveOutput());
         this.reader = NonBlocking.nonBlocking(getName(), input, inputEncoding());
         this.writer = new PrintWriter(new OutputStreamWriter(output, outputEncoding()));
@@ -185,11 +189,19 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
     @Override
     public SignalHandler handle(Signal signal, SignalHandler handler) {
         SignalHandler prev = super.handle(signal, handler);
-        if (prev != handler) {
+        if (nativeSignals && prev != handler) {
+            Object previousNative = nativeHandlers.remove(signal);
+            if (previousNative != null) {
+                doUnregisterSignal(signal.name(), previousNative);
+            }
+            Object nativeHandler;
             if (handler == SignalHandler.SIG_DFL) {
-                doRegisterDefaultSignal(signal.name());
+                nativeHandler = doRegisterDefaultSignal(signal.name());
             } else {
-                doRegisterSignal(signal.name(), () -> raise(signal));
+                nativeHandler = doRegisterSignal(signal.name(), () -> raise(signal));
+            }
+            if (nativeHandler != null) {
+                nativeHandlers.put(signal, nativeHandler);
             }
         }
         return prev;
@@ -302,64 +314,5 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         }
         super.doClose();
         reader.close();
-    }
-
-    /**
-     * Wraps the PTY slave input to intercept signal control characters when ISIG is cleared
-     * (raw mode). The byte is passed through after raising the signal so that the LineReader's
-     * INTERRUPT widget can also see it via its keymap binding.
-     *
-     * @see AbstractUnixSysTerminal — same pattern for direct-fd terminals
-     */
-    private class SignalInterceptingInputStream extends FilterInputStream {
-        SignalInterceptingInputStream(InputStream in) {
-            super(in);
-        }
-
-        @Override
-        public int read() throws IOException {
-            int b = super.read();
-            if (b >= 0) {
-                checkSignalByte(b);
-            }
-            return b;
-        }
-
-        @Override
-        public int read(byte[] buf, int off, int len) throws IOException {
-            int n = super.read(buf, off, len);
-            if (n > 0) {
-                checkSignalBytes(buf, off, n);
-            }
-            return n;
-        }
-
-        private void checkSignalByte(int b) {
-            Attributes attr = cachedAttributes;
-            if (attr != null && !attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
-                raiseIfSignal(b, attr);
-            }
-        }
-
-        private void checkSignalBytes(byte[] buf, int off, int count) {
-            Attributes attr = cachedAttributes;
-            if (attr != null && !attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
-                for (int i = 0; i < count; i++) {
-                    raiseIfSignal(buf[off + i] & 0xFF, attr);
-                }
-            }
-        }
-
-        private void raiseIfSignal(int b, Attributes attr) {
-            if (b == attr.getControlChar(Attributes.ControlChar.VINTR)) {
-                raise(Signal.INT);
-            } else if (b == attr.getControlChar(Attributes.ControlChar.VQUIT)) {
-                raise(Signal.QUIT);
-            } else if (b == attr.getControlChar(Attributes.ControlChar.VSUSP)) {
-                raise(Signal.TSTP);
-            } else if (b == attr.getControlChar(Attributes.ControlChar.VSTATUS)) {
-                raise(Signal.INFO);
-            }
-        }
     }
 }

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -14,8 +14,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.spi.Pty;
@@ -68,7 +68,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
     protected final OutputStream output;
     protected final NonBlockingReader reader;
     protected final PrintWriter writer;
-    protected final Map<Signal, Object> nativeHandlers = new HashMap<>();
+    protected final Map<Signal, Object> nativeHandlers = new ConcurrentHashMap<>();
     protected final Task closer;
     private final boolean nativeSignals;
     private volatile Attributes cachedAttributes;
@@ -165,10 +165,14 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         parseInfoCmp();
         if (nativeSignals) {
             for (final Signal signal : Signal.values()) {
+                Object nativeHandler;
                 if (signalHandler == SignalHandler.SIG_DFL) {
-                    nativeHandlers.put(signal, doRegisterDefaultSignal(signal.name()));
+                    nativeHandler = doRegisterDefaultSignal(signal.name());
                 } else {
-                    nativeHandlers.put(signal, doRegisterSignal(signal.name(), () -> raise(signal)));
+                    nativeHandler = doRegisterSignal(signal.name(), () -> raise(signal));
+                }
+                if (nativeHandler != null) {
+                    nativeHandlers.put(signal, nativeHandler);
                 }
             }
         }
@@ -309,10 +313,20 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
     protected void doClose() throws IOException {
         writer.flush();
         ShutdownHooks.remove(closer);
-        for (Map.Entry<Signal, Object> entry : nativeHandlers.entrySet()) {
-            doUnregisterSignal(entry.getKey().name(), entry.getValue());
+        try {
+            for (Map.Entry<Signal, Object> entry : nativeHandlers.entrySet()) {
+                try {
+                    doUnregisterSignal(entry.getKey().name(), entry.getValue());
+                } catch (Exception ignore) {
+                    // best-effort cleanup during close
+                }
+            }
+        } finally {
+            try {
+                super.doClose();
+            } finally {
+                reader.close();
+            }
         }
-        super.doClose();
-        reader.close();
     }
 }

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -8,6 +8,7 @@
  */
 package org.jline.terminal.impl;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -17,6 +18,7 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jline.terminal.Attributes;
 import org.jline.terminal.spi.Pty;
 import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.FastBufferedOutputStream;
@@ -27,6 +29,8 @@ import org.jline.utils.OSUtils;
 import org.jline.utils.ShutdownHooks;
 import org.jline.utils.ShutdownHooks.Task;
 import org.jline.utils.Signals;
+
+import static org.jline.terminal.TerminalBuilder.PROP_SOFTWARE_SIGNALS;
 
 /**
  * Terminal implementation for POSIX systems using system streams.
@@ -67,6 +71,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
     protected final PrintWriter writer;
     protected final Map<Signal, Object> nativeHandlers = new HashMap<>();
     protected final Task closer;
+    private volatile Attributes cachedAttributes;
 
     /**
      * Creates a POSIX system terminal backed by the provided PTY, using the same charset for input
@@ -145,7 +150,11 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
             throws IOException {
         super(name, type, pty, encoding, inputEncoding, outputEncoding, signalHandler);
         this.provider = provider;
-        this.input = NonBlocking.nonBlocking(getName(), pty.getSlaveInput());
+        this.cachedAttributes = this.originalAttributes;
+        boolean softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "true"));
+        InputStream slaveInput = pty.getSlaveInput();
+        this.input = NonBlocking.nonBlocking(
+                getName(), softwareSignals ? new SignalInterceptingInputStream(slaveInput) : slaveInput);
         this.output = new FastBufferedOutputStream(pty.getSlaveOutput());
         this.reader = NonBlocking.nonBlocking(getName(), input, inputEncoding());
         this.writer = new PrintWriter(new OutputStreamWriter(output, outputEncoding()));
@@ -222,6 +231,19 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         }
     }
 
+    @Override
+    public Attributes getAttributes() {
+        Attributes attr = super.getAttributes();
+        cachedAttributes = attr;
+        return attr;
+    }
+
+    @Override
+    public void setAttributes(Attributes attr) {
+        super.setAttributes(attr);
+        cachedAttributes = new Attributes(attr);
+    }
+
     /**
      * Determine if grapheme cluster mode is supported for this terminal.
      *
@@ -280,5 +302,64 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         }
         super.doClose();
         reader.close();
+    }
+
+    /**
+     * Wraps the PTY slave input to intercept signal control characters when ISIG is cleared
+     * (raw mode). The byte is passed through after raising the signal so that the LineReader's
+     * INTERRUPT widget can also see it via its keymap binding.
+     *
+     * @see AbstractUnixSysTerminal — same pattern for direct-fd terminals
+     */
+    private class SignalInterceptingInputStream extends FilterInputStream {
+        SignalInterceptingInputStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public int read() throws IOException {
+            int b = super.read();
+            if (b >= 0) {
+                checkSignalByte(b);
+            }
+            return b;
+        }
+
+        @Override
+        public int read(byte[] buf, int off, int len) throws IOException {
+            int n = super.read(buf, off, len);
+            if (n > 0) {
+                checkSignalBytes(buf, off, n);
+            }
+            return n;
+        }
+
+        private void checkSignalByte(int b) {
+            Attributes attr = cachedAttributes;
+            if (attr != null && !attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
+                raiseIfSignal(b, attr);
+            }
+        }
+
+        private void checkSignalBytes(byte[] buf, int off, int count) {
+            Attributes attr = cachedAttributes;
+            if (attr != null && !attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
+                for (int i = 0; i < count; i++) {
+                    raiseIfSignal(buf[off + i] & 0xFF, attr);
+                }
+            }
+        }
+
+        private void raiseIfSignal(int b, Attributes attr) {
+            if (b == attr.getControlChar(Attributes.ControlChar.VINTR)) {
+                raise(Signal.INT);
+            } else if (b == attr.getControlChar(Attributes.ControlChar.VQUIT)) {
+                raise(Signal.QUIT);
+            } else if (b == attr.getControlChar(Attributes.ControlChar.VSUSP)) {
+                raise(Signal.TSTP);
+            } else if (b == attr.getControlChar(Attributes.ControlChar.VSTATUS)) {
+                raise(Signal.INFO);
+            }
+        }
     }
 }

--- a/terminal/src/main/java/org/jline/terminal/impl/SignalInterceptingInputStream.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/SignalInterceptingInputStream.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Terminal.Signal;
+
+/**
+ * Wraps an input stream to intercept signal control characters when ISIG is cleared
+ * (raw mode). The byte is passed through after raising the signal so that the
+ * LineReader's INTERRUPT widget can also see it via its keymap binding.
+ *
+ * <p>Used by both {@link AbstractUnixSysTerminal} (direct-fd terminals) and
+ * {@link PosixSysTerminal} (PTY-based fallback terminals).</p>
+ */
+class SignalInterceptingInputStream extends FilterInputStream {
+
+    private final Supplier<Attributes> attributesSupplier;
+    private final Consumer<Signal> signalRaiser;
+
+    SignalInterceptingInputStream(
+            InputStream in, Supplier<Attributes> attributesSupplier, Consumer<Signal> signalRaiser) {
+        super(in);
+        this.attributesSupplier = attributesSupplier;
+        this.signalRaiser = signalRaiser;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int b = super.read();
+        if (b >= 0) {
+            checkSignalByte(b);
+        }
+        return b;
+    }
+
+    @Override
+    public int read(byte[] buf, int off, int len) throws IOException {
+        int n = super.read(buf, off, len);
+        if (n > 0) {
+            checkSignalBytes(buf, off, n);
+        }
+        return n;
+    }
+
+    private void checkSignalByte(int b) {
+        Attributes attr = attributesSupplier.get();
+        if (attr != null && !attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
+            raiseIfSignal(b, attr);
+        }
+    }
+
+    private void checkSignalBytes(byte[] buf, int off, int count) {
+        Attributes attr = attributesSupplier.get();
+        if (attr != null && !attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
+            for (int i = 0; i < count; i++) {
+                raiseIfSignal(buf[off + i] & 0xFF, attr);
+            }
+        }
+    }
+
+    private void raiseIfSignal(int b, Attributes attr) {
+        if (b == attr.getControlChar(Attributes.ControlChar.VINTR)) {
+            signalRaiser.accept(Signal.INT);
+        } else if (b == attr.getControlChar(Attributes.ControlChar.VQUIT)) {
+            signalRaiser.accept(Signal.QUIT);
+        } else if (b == attr.getControlChar(Attributes.ControlChar.VSUSP)) {
+            signalRaiser.accept(Signal.TSTP);
+        } else if (b == attr.getControlChar(Attributes.ControlChar.VSTATUS)) {
+            signalRaiser.accept(Signal.INFO);
+        }
+    }
+}

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -19,6 +19,7 @@ import org.jline.terminal.Attributes.ControlChar;
 import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Terminal.Signal;
 import org.jline.terminal.Terminal.SignalHandler;
+import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.spi.Pty;
 import org.junit.jupiter.api.Test;
 
@@ -123,58 +124,80 @@ class PosixSysTerminalTest {
 
     @Test
     void testSignalInterceptionWhenIsigCleared() throws Exception {
-        Attributes attr = new Attributes();
-        attr.setControlChar(ControlChar.VINTR, 3);
-        attr.setControlChar(ControlChar.VQUIT, 28);
-        attr.setControlChar(ControlChar.VSUSP, 26);
+        String prev = System.getProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS);
+        try {
+            System.setProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS, "true");
 
-        Pty pty = EasyMock.createNiceMock(Pty.class);
-        EasyMock.expect(pty.getAttr()).andReturn(attr).anyTimes();
-        EasyMock.expect(pty.getSlaveInput())
-                .andReturn(new ByteArrayInputStream(new byte[] {0x03}))
-                .anyTimes();
-        EasyMock.expect(pty.getSlaveOutput())
-                .andReturn(new ByteArrayOutputStream())
-                .anyTimes();
-        EasyMock.replay(pty);
-        try (PosixSysTerminal terminal =
-                new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
-            // ISIG is off by default in a new Attributes — signal interception should be active
-            AtomicReference<Signal> received = new AtomicReference<>();
-            terminal.handle(Signal.INT, received::set);
+            Attributes attr = new Attributes();
+            attr.setControlChar(ControlChar.VINTR, 3);
+            attr.setControlChar(ControlChar.VQUIT, 28);
+            attr.setControlChar(ControlChar.VSUSP, 26);
 
-            int b = terminal.input().read();
-            assertEquals(0x03, b);
-            assertEquals(Signal.INT, received.get());
+            Pty pty = EasyMock.createNiceMock(Pty.class);
+            EasyMock.expect(pty.getAttr()).andReturn(attr).anyTimes();
+            EasyMock.expect(pty.getSlaveInput())
+                    .andReturn(new ByteArrayInputStream(new byte[] {0x03}))
+                    .anyTimes();
+            EasyMock.expect(pty.getSlaveOutput())
+                    .andReturn(new ByteArrayOutputStream())
+                    .anyTimes();
+            EasyMock.replay(pty);
+            try (PosixSysTerminal terminal =
+                    new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
+                // ISIG is off by default in a new Attributes — signal interception should be active
+                AtomicReference<Signal> received = new AtomicReference<>();
+                terminal.handle(Signal.INT, received::set);
+
+                int b = terminal.input().read();
+                assertEquals(0x03, b);
+                assertEquals(Signal.INT, received.get());
+            }
+        } finally {
+            if (prev == null) {
+                System.clearProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS);
+            } else {
+                System.setProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS, prev);
+            }
         }
     }
 
     @Test
     void testNoSignalInterceptionWhenIsigSet() throws Exception {
-        Attributes attr = new Attributes();
-        attr.setControlChar(ControlChar.VINTR, 3);
-        attr.setLocalFlag(LocalFlag.ISIG, true);
+        String prev = System.getProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS);
+        try {
+            System.setProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS, "true");
 
-        Pty pty = EasyMock.createNiceMock(Pty.class);
-        EasyMock.expect(pty.getAttr()).andReturn(attr).anyTimes();
-        EasyMock.expect(pty.getSlaveInput())
-                .andReturn(new ByteArrayInputStream(new byte[] {0x03}))
-                .anyTimes();
-        EasyMock.expect(pty.getSlaveOutput())
-                .andReturn(new ByteArrayOutputStream())
-                .anyTimes();
-        EasyMock.replay(pty);
-        try (PosixSysTerminal terminal =
-                new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
-            // Set ISIG so the software interceptor should NOT fire
-            terminal.setAttributes(attr);
+            Attributes attr = new Attributes();
+            attr.setControlChar(ControlChar.VINTR, 3);
+            attr.setLocalFlag(LocalFlag.ISIG, true);
 
-            AtomicReference<Signal> received = new AtomicReference<>();
-            terminal.handle(Signal.INT, received::set);
+            Pty pty = EasyMock.createNiceMock(Pty.class);
+            EasyMock.expect(pty.getAttr()).andReturn(attr).anyTimes();
+            EasyMock.expect(pty.getSlaveInput())
+                    .andReturn(new ByteArrayInputStream(new byte[] {0x03}))
+                    .anyTimes();
+            EasyMock.expect(pty.getSlaveOutput())
+                    .andReturn(new ByteArrayOutputStream())
+                    .anyTimes();
+            EasyMock.replay(pty);
+            try (PosixSysTerminal terminal =
+                    new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
+                // Set ISIG so the software interceptor should NOT fire
+                terminal.setAttributes(attr);
 
-            int b = terminal.input().read();
-            assertEquals(0x03, b);
-            assertNull(received.get());
+                AtomicReference<Signal> received = new AtomicReference<>();
+                terminal.handle(Signal.INT, received::set);
+
+                int b = terminal.input().read();
+                assertEquals(0x03, b);
+                assertNull(received.get());
+            }
+        } finally {
+            if (prev == null) {
+                System.clearProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS);
+            } else {
+                System.setProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS, prev);
+            }
         }
     }
 

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -24,6 +24,7 @@ import org.jline.terminal.spi.Pty;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -41,7 +42,7 @@ class PosixSysTerminalTest {
                 .anyTimes();
         EasyMock.replay(pty);
         try (PosixSysTerminal terminal = new PosixSysTerminal("name", "ansi", pty, null, true, SignalHandler.SIG_DFL)) {
-            assertEquals(Signal.values().length, terminal.nativeHandlers.size());
+            assertFalse(terminal.nativeHandlers.isEmpty());
         }
     }
 
@@ -57,7 +58,7 @@ class PosixSysTerminalTest {
                 .anyTimes();
         EasyMock.replay(pty);
         try (PosixSysTerminal terminal = new PosixSysTerminal("name", "ansi", pty, null, true, SignalHandler.SIG_IGN)) {
-            assertEquals(Signal.values().length, terminal.nativeHandlers.size());
+            assertFalse(terminal.nativeHandlers.isEmpty());
         }
     }
 
@@ -73,11 +74,12 @@ class PosixSysTerminalTest {
                 .anyTimes();
         EasyMock.replay(pty);
         try (PosixSysTerminal terminal = new PosixSysTerminal("name", "ansi", pty, null, true, SignalHandler.SIG_DFL)) {
-            assertEquals(Signal.values().length, terminal.nativeHandlers.size());
+            int initialSize = terminal.nativeHandlers.size();
+            assertFalse(terminal.nativeHandlers.isEmpty());
             SignalHandler prev = terminal.handle(Signal.INT, s -> {});
-            assertEquals(Signal.values().length, terminal.nativeHandlers.size());
+            assertEquals(initialSize, terminal.nativeHandlers.size());
             terminal.handle(Signal.INT, prev);
-            assertEquals(Signal.values().length, terminal.nativeHandlers.size());
+            assertEquals(initialSize, terminal.nativeHandlers.size());
         }
     }
 
@@ -185,6 +187,42 @@ class PosixSysTerminalTest {
                 // Set ISIG so the software interceptor should NOT fire
                 terminal.setAttributes(attr);
 
+                AtomicReference<Signal> received = new AtomicReference<>();
+                terminal.handle(Signal.INT, received::set);
+
+                int b = terminal.input().read();
+                assertEquals(0x03, b);
+                assertNull(received.get());
+            }
+        } finally {
+            if (prev == null) {
+                System.clearProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS);
+            } else {
+                System.setProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS, prev);
+            }
+        }
+    }
+
+    @Test
+    void testNoSignalInterceptionWhenSoftwareSignalsDisabled() throws Exception {
+        String prev = System.getProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS);
+        try {
+            System.setProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS, "false");
+
+            Attributes attr = new Attributes();
+            attr.setControlChar(ControlChar.VINTR, 3);
+
+            Pty pty = EasyMock.createNiceMock(Pty.class);
+            EasyMock.expect(pty.getAttr()).andReturn(attr).anyTimes();
+            EasyMock.expect(pty.getSlaveInput())
+                    .andReturn(new ByteArrayInputStream(new byte[] {0x03}))
+                    .anyTimes();
+            EasyMock.expect(pty.getSlaveOutput())
+                    .andReturn(new ByteArrayOutputStream())
+                    .anyTimes();
+            EasyMock.replay(pty);
+            try (PosixSysTerminal terminal =
+                    new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
                 AtomicReference<Signal> received = new AtomicReference<>();
                 terminal.handle(Signal.INT, received::set);
 

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -10,17 +10,20 @@ package org.jline.terminal.impl;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Attributes.ControlChar;
+import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Terminal.Signal;
 import org.jline.terminal.Terminal.SignalHandler;
 import org.jline.terminal.spi.Pty;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PosixSysTerminalTest {
@@ -114,6 +117,82 @@ class PosixSysTerminalTest {
         EasyMock.replay(pty);
         try (PosixSysTerminal terminal =
                 new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
+            assertTrue(terminal.nativeHandlers.isEmpty());
+        }
+    }
+
+    @Test
+    void testSignalInterceptionWhenIsigCleared() throws Exception {
+        Attributes attr = new Attributes();
+        attr.setControlChar(ControlChar.VINTR, 3);
+        attr.setControlChar(ControlChar.VQUIT, 28);
+        attr.setControlChar(ControlChar.VSUSP, 26);
+
+        Pty pty = EasyMock.createNiceMock(Pty.class);
+        EasyMock.expect(pty.getAttr()).andReturn(attr).anyTimes();
+        EasyMock.expect(pty.getSlaveInput())
+                .andReturn(new ByteArrayInputStream(new byte[] {0x03}))
+                .anyTimes();
+        EasyMock.expect(pty.getSlaveOutput())
+                .andReturn(new ByteArrayOutputStream())
+                .anyTimes();
+        EasyMock.replay(pty);
+        try (PosixSysTerminal terminal =
+                new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
+            // ISIG is off by default in a new Attributes — signal interception should be active
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            int b = terminal.input().read();
+            assertEquals(0x03, b);
+            assertEquals(Signal.INT, received.get());
+        }
+    }
+
+    @Test
+    void testNoSignalInterceptionWhenIsigSet() throws Exception {
+        Attributes attr = new Attributes();
+        attr.setControlChar(ControlChar.VINTR, 3);
+        attr.setLocalFlag(LocalFlag.ISIG, true);
+
+        Pty pty = EasyMock.createNiceMock(Pty.class);
+        EasyMock.expect(pty.getAttr()).andReturn(attr).anyTimes();
+        EasyMock.expect(pty.getSlaveInput())
+                .andReturn(new ByteArrayInputStream(new byte[] {0x03}))
+                .anyTimes();
+        EasyMock.expect(pty.getSlaveOutput())
+                .andReturn(new ByteArrayOutputStream())
+                .anyTimes();
+        EasyMock.replay(pty);
+        try (PosixSysTerminal terminal =
+                new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
+            // Set ISIG so the software interceptor should NOT fire
+            terminal.setAttributes(attr);
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            int b = terminal.input().read();
+            assertEquals(0x03, b);
+            assertNull(received.get());
+        }
+    }
+
+    @Test
+    void testHandleDoesNotRegisterWhenNativeSignalsDisabled() throws Exception {
+        Pty pty = EasyMock.createNiceMock(Pty.class);
+        EasyMock.expect(pty.getAttr()).andReturn(new Attributes()).anyTimes();
+        EasyMock.expect(pty.getSlaveInput())
+                .andReturn(new ByteArrayInputStream(new byte[0]))
+                .anyTimes();
+        EasyMock.expect(pty.getSlaveOutput())
+                .andReturn(new ByteArrayOutputStream())
+                .anyTimes();
+        EasyMock.replay(pty);
+        try (PosixSysTerminal terminal =
+                new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
+            assertTrue(terminal.nativeHandlers.isEmpty());
+            terminal.handle(Signal.INT, s -> {});
             assertTrue(terminal.nativeHandlers.isEmpty());
         }
     }


### PR DESCRIPTION
Extends the `SignalInterceptingInputStream` (introduced in #1942 for FFM/JNI terminals) to also cover `PosixSysTerminal`, the PTY-based fallback provider. Without this, `terminal.handle(Signal.INT, ...)` had no effect on the fallback terminal when ISIG was cleared (raw mode).

Changes:

- Extract `SignalInterceptingInputStream` into its own top-level package-private class shared by both `AbstractUnixSysTerminal` and `PosixSysTerminal`
- Cache terminal attributes via `getAttributes()`/`setAttributes()` overrides to avoid per-byte PTY ioctl calls
- Guard `handle()` so it only registers/unregisters native signal handlers when `nativeSignals` is enabled
- Use `ConcurrentHashMap` for `nativeHandlers` for thread safety
- Wrap `doClose()` cleanup in try-finally to ensure the reader is always closed

Fixes #1982.