### PR TITLE
fix: use exclusive create for extracted native library temp files

### DIFF
--- a/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
+++ b/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
@@ -29,7 +29,6 @@ package org.jline.nativ;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,11 +36,13 @@ import java.io.OutputStream;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
 
 /**
  * Manages the loading of JLine's native libraries (*.dll, *.jnilib, *.so) according to the current
@@ -334,12 +335,13 @@ public class JLineNativeLoader {
         File extractedLckFile = new File(targetFolder, extractedLckFileName);
 
         try {
-            // Extract a native library file into the target directory
+            // Extract a native library file into the target directory.
+            // The target sits in the shared system temp directory, so open both
+            // files with CREATE_NEW: an existing path or a symlink planted there
+            // by another local user is refused instead of being followed.
             try (InputStream in = JLineNativeLoader.class.getResourceAsStream(nativeLibraryFilePath)) {
-                if (!extractedLckFile.exists()) {
-                    new FileOutputStream(extractedLckFile).close();
-                }
-                try (OutputStream out = new FileOutputStream(extractedLibFile)) {
+                newExclusiveStream(extractedLckFile).close();
+                try (OutputStream out = newExclusiveStream(extractedLibFile)) {
                     copy(in, out);
                 }
             } finally {
@@ -378,7 +380,17 @@ public class JLineNativeLoader {
     }
 
     private static String randomUUID() {
-        return Long.toHexString(new Random().nextLong());
+        return Long.toHexString(new SecureRandom().nextLong());
+    }
+
+    /**
+     * Opens an output stream that creates a brand new file, failing if the path already
+     * exists. {@code CREATE_NEW} maps to an exclusive create at the OS level, so a symlink
+     * or a regular file planted at the target path in the shared temp directory is rejected
+     * rather than followed.
+     */
+    static OutputStream newExclusiveStream(File file) throws IOException {
+        return Files.newOutputStream(file.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
     }
 
     private static void copy(InputStream in, OutputStream out) throws IOException {

--- a/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
+++ b/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
@@ -38,11 +38,11 @@ import java.lang.System.Logger.Level;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Manages the loading of JLine's native libraries (*.dll, *.jnilib, *.so) according to the current
@@ -380,7 +380,7 @@ public class JLineNativeLoader {
     }
 
     private static String randomUUID() {
-        return Long.toHexString(new SecureRandom().nextLong());
+        return Long.toHexString(ThreadLocalRandom.current().nextLong());
     }
 
     /**

--- a/native/src/test/java/org/jline/nativ/JLineNativeLoaderTest.java
+++ b/native/src/test/java/org/jline/nativ/JLineNativeLoaderTest.java
@@ -8,14 +8,41 @@
  */
 package org.jline.nativ;
 
+import java.io.File;
+import java.io.OutputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JLineNativeLoaderTest {
 
     @Test
     void testLoadLibrary() {
         assertDoesNotThrow(JLineNativeLoader::initialize);
+    }
+
+    @Test
+    void exclusiveStreamRefusesExistingTarget(@TempDir Path dir) throws Exception {
+        // A file already sitting at the target path stands in for a symlink an attacker
+        // planted in the shared temp directory: the open must fail instead of writing through it.
+        File planted = dir.resolve("jlinenative-planted").toFile();
+        assertTrue(planted.createNewFile());
+        assertThrows(
+                FileAlreadyExistsException.class,
+                () -> JLineNativeLoader.newExclusiveStream(planted).close());
+
+        // A fresh path is created normally.
+        File fresh = dir.resolve("jlinenative-fresh").toFile();
+        try (OutputStream out = JLineNativeLoader.newExclusiveStream(fresh)) {
+            out.write(new byte[] {1, 2, 3});
+        }
+        assertTrue(Files.isRegularFile(fresh.toPath()));
     }
 }


### PR DESCRIPTION
`JLineNativeLoader.extractAndLoadLibraryFile()` extracts the bundled native library into `java.io.tmpdir` (shared, world-writable) using `FileOutputStream`, which follows symlinks. A local attacker who can predict or race the filename could plant a symlink to overwrite an arbitrary file owned by the victim process.

Changes:

- Replace `FileOutputStream` with `Files.newOutputStream(..., CREATE_NEW, WRITE)` so the OS-level open uses `O_EXCL`, refusing to follow symlinks or overwrite existing files
- Replace `new Random()` with `ThreadLocalRandom.current()` for better name entropy without pulling in `SecureRandom` and its JCA provider graph
- Add tests verifying that an existing file at the target path is rejected with `FileAlreadyExistsException`