### PR TITLE
fix: backport telnet DoS mitigations (GHSA-47qp, GHSA-2r2c) to 4.0.x

### DIFF
--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
@@ -279,6 +279,7 @@ public class TelnetIO {
     protected static final int NE_IN_END = -3;
     protected static final int NE_VAR_NAME_MAXLENGTH = 50;
     protected static final int NE_VAR_VALUE_MAXLENGTH = 1000;
+    protected static final int NE_VAR_COUNT_MAX = 100;
     /**
      * Unused
      */
@@ -296,6 +297,8 @@ public class TelnetIO {
     private static final int SMALLEST_BELIEVABLE_HEIGHT = 6;
     private static final int DEFAULT_WIDTH = 80;
     private static final int DEFAULT_HEIGHT = 25;
+    private static final int LARGEST_BELIEVABLE_WIDTH = 500;
+    private static final int LARGEST_BELIEVABLE_HEIGHT = 500;
     private Connection connection; // a reference to the connection this instance works for
     private ConnectionData connectionData; // holds all important information of the connection
     private DataOutputStream out; // the byte oriented outputstream
@@ -596,10 +599,10 @@ public class TelnetIO {
      * @param height Integer that represents the Window height in chars
      */
     private void setTerminalGeometry(int width, int height) {
-        if (width < SMALLEST_BELIEVABLE_WIDTH) {
+        if (width < SMALLEST_BELIEVABLE_WIDTH || width > LARGEST_BELIEVABLE_WIDTH) {
             width = DEFAULT_WIDTH;
         }
-        if (height < SMALLEST_BELIEVABLE_HEIGHT) {
+        if (height < SMALLEST_BELIEVABLE_HEIGHT || height > LARGEST_BELIEVABLE_HEIGHT) {
             height = DEFAULT_HEIGHT;
         }
         // DEBUG: write("[New Window Size " + window_width + "x" + window_height + "]");
@@ -1143,6 +1146,7 @@ public class TelnetIO {
                 LOG.log(Level.FINE, "readNEVariables()::INVALID VARIABLE");
                 return;
             }
+            int varCount = 0;
             boolean cont = true;
             if (i == NE_VAR || i == NE_USERVAR) {
                 do {
@@ -1155,6 +1159,11 @@ public class TelnetIO {
                             return;
                         case NE_VAR_DEFINED:
                             LOG.log(Level.FINE, "readNEVariables()::NE_VAR_DEFINED");
+                            if (++varCount > NE_VAR_COUNT_MAX) {
+                                LOG.log(Level.WARNING, "readNEVariables()::TOO_MANY_VARS (>" + NE_VAR_COUNT_MAX + ")");
+                                skipToSE();
+                                return;
+                            }
                             String str = sbuf.toString();
                             sbuf.delete(0, sbuf.length());
                             switch (readNEVariableValue(sbuf)) {


### PR DESCRIPTION
## Summary

Backport of two high-severity telnet security fixes from 4.2.1 to the 4.0.x branch:

- **GHSA-47qp-hqvx-6r3f** — `readNEVariables()` did not limit the number of environment variables a client could inject via the Telnet NEW-ENVIRON option. An unauthenticated attacker could exhaust JVM heap memory (~3 MB of traffic → 512 MB heap). Fix: add `NE_VAR_COUNT_MAX = 100` and abort the subnegotiation with `skipToSE()` when exceeded.

- **GHSA-2r2c-cx56-8933** — `setTerminalGeometry()` only enforced lower bounds on client-supplied terminal dimensions. An attacker could send NAWS with 65535×65535 and alternate values to trigger continuous expensive rendering. Fix: add `LARGEST_BELIEVABLE_WIDTH/HEIGHT = 500` upper bounds, clamping to defaults (80×25) when exceeded.

Both fixes are isolated to `TelnetIO.java` in the `remote-telnet` module with no API changes.