### PR TITLE
fix: eliminate Display flicker on windows-vtp and high-FPS updates

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -452,307 +452,318 @@ public class Display implements Sized {
         if (fullScreen) {
             rawEsc(SYNC_START);
         }
+        try {
 
-        if (reset) {
-            puts(Capability.clear_screen);
-            puts(Capability.cursor_address, 0, 0);
-            oldLines.clear();
-            cursorPos = 0;
-            reset = false;
-        }
+            if (reset) {
+                puts(Capability.clear_screen);
+                puts(Capability.cursor_address, 0, 0);
+                oldLines.clear();
+                cursorPos = 0;
+                reset = false;
+            }
 
-        // If dumb display, get rid of ansi sequences now
-        if (cols == null || cols < 8) {
-            List<AttributedString> stripped = new ArrayList<>(newLines.size());
-            for (int idx = 0; idx < newLines.size(); idx++) {
-                stripped.add(new AttributedString(newLines.get(idx).toString()));
+            // If dumb display, get rid of ansi sequences now
+            if (cols == null || cols < 8) {
+                List<AttributedString> stripped = new ArrayList<>(newLines.size());
+                for (int idx = 0; idx < newLines.size(); idx++) {
+                    stripped.add(new AttributedString(newLines.get(idx).toString()));
+                }
+                newLines = stripped;
             }
-            newLines = stripped;
-        }
 
-        // Detect scrolling
-        if (scrollOptimization
-                && (fullScreen || newLines.size() >= rows)
-                && newLines.size() == oldLines.size()
-                && canScroll) {
-            int nbHeaders = 0;
-            int nbFooters = 0;
-            // Find common headers and footers
-            int l = newLines.size();
-            while (nbHeaders < l && Objects.equals(newLines.get(nbHeaders), oldLines.get(nbHeaders))) {
-                nbHeaders++;
-            }
-            while (nbFooters < l - nbHeaders - 1
-                    && Objects.equals(
-                            newLines.get(newLines.size() - nbFooters - 1),
-                            oldLines.get(oldLines.size() - nbFooters - 1))) {
-                nbFooters++;
-            }
-            int fromIndex = nbHeaders;
-            int toIndex = newLines.size() - nbFooters;
-            longestCommon(newLines, fromIndex, toIndex, oldLines, fromIndex, toIndex);
-            if (lcsResult[2] > 0) {
-                int s1 = lcsResult[0];
-                int s2 = lcsResult[1];
-                int sl = lcsResult[2];
-                if (sl > 1 && s1 < s2) {
-                    moveVisualCursorTo((nbHeaders + s1) * columns1);
-                    int nb = s2 - s1;
-                    deleteLines(nb);
-                    for (int i = 0; i < nb; i++) {
-                        oldLines.remove(nbHeaders + s1);
-                    }
-                    if (nbFooters > 0) {
-                        moveVisualCursorTo((nbHeaders + s1 + sl) * columns1);
-                        insertLines(nb);
-                        for (int i = 0; i < nb; i++) {
-                            oldLines.add(nbHeaders + s1 + sl, AttributedString.EMPTY);
-                        }
-                    }
-                } else if (sl > 1 && s1 > s2) {
-                    int nb = s1 - s2;
-                    if (nbFooters > 0) {
-                        moveVisualCursorTo((nbHeaders + s2 + sl) * columns1);
+            // Detect scrolling
+            if (scrollOptimization
+                    && (fullScreen || newLines.size() >= rows)
+                    && newLines.size() == oldLines.size()
+                    && canScroll) {
+                int nbHeaders = 0;
+                int nbFooters = 0;
+                // Find common headers and footers
+                int l = newLines.size();
+                while (nbHeaders < l && Objects.equals(newLines.get(nbHeaders), oldLines.get(nbHeaders))) {
+                    nbHeaders++;
+                }
+                while (nbFooters < l - nbHeaders - 1
+                        && Objects.equals(
+                                newLines.get(newLines.size() - nbFooters - 1),
+                                oldLines.get(oldLines.size() - nbFooters - 1))) {
+                    nbFooters++;
+                }
+                int fromIndex = nbHeaders;
+                int toIndex = newLines.size() - nbFooters;
+                longestCommon(newLines, fromIndex, toIndex, oldLines, fromIndex, toIndex);
+                if (lcsResult[2] > 0) {
+                    int s1 = lcsResult[0];
+                    int s2 = lcsResult[1];
+                    int sl = lcsResult[2];
+                    if (sl > 1 && s1 < s2) {
+                        moveVisualCursorTo((nbHeaders + s1) * columns1);
+                        int nb = s2 - s1;
                         deleteLines(nb);
                         for (int i = 0; i < nb; i++) {
-                            oldLines.remove(nbHeaders + s2 + sl);
+                            oldLines.remove(nbHeaders + s1);
                         }
-                    }
-                    moveVisualCursorTo((nbHeaders + s2) * columns1);
-                    insertLines(nb);
-                    for (int i = 0; i < nb; i++) {
-                        oldLines.add(nbHeaders + s2, AttributedString.EMPTY);
+                        if (nbFooters > 0) {
+                            moveVisualCursorTo((nbHeaders + s1 + sl) * columns1);
+                            insertLines(nb);
+                            for (int i = 0; i < nb; i++) {
+                                oldLines.add(nbHeaders + s1 + sl, AttributedString.EMPTY);
+                            }
+                        }
+                    } else if (sl > 1 && s1 > s2) {
+                        int nb = s1 - s2;
+                        if (nbFooters > 0) {
+                            moveVisualCursorTo((nbHeaders + s2 + sl) * columns1);
+                            deleteLines(nb);
+                            for (int i = 0; i < nb; i++) {
+                                oldLines.remove(nbHeaders + s2 + sl);
+                            }
+                        }
+                        moveVisualCursorTo((nbHeaders + s2) * columns1);
+                        insertLines(nb);
+                        for (int i = 0; i < nb; i++) {
+                            oldLines.add(nbHeaders + s2, AttributedString.EMPTY);
+                        }
                     }
                 }
             }
-        }
 
-        int lineIndex = 0;
-        int currentPos = 0;
-        int numLines = Math.min(rows, Math.max(oldLines.size(), newLines.size()));
-        boolean wrapNeeded = false;
-        while (lineIndex < numLines) {
-            AttributedString oldLine = lineIndex < oldLines.size() ? oldLines.get(lineIndex) : AttributedString.EMPTY;
-            AttributedString newLine = lineIndex < newLines.size() ? newLines.get(lineIndex) : AttributedString.EMPTY;
-            currentPos = lineIndex * columns1;
-            int curCol = currentPos;
-            // Track effective ranges instead of creating substrings
-            int oStart = 0;
-            int oEnd = oldLine.length();
-            int nStart = 0;
-            int nEnd = newLine.length();
-            boolean oldNL = oEnd > 0 && oldLine.charAt(oEnd - 1) == '\n';
-            boolean newNL = nEnd > 0 && newLine.charAt(nEnd - 1) == '\n';
-            if (oldNL) {
-                oEnd--;
-            }
-            if (newNL) {
-                nEnd--;
-            }
-            if (wrapNeeded && lineIndex == (cursorPos + 1) / columns1 && lineIndex < newLines.size()) {
-                // move from right margin to next line's left margin
-                cursorPos++;
-                if (nEnd - nStart == 0 || newLine.isHidden(nStart)) {
-                    // go to next line column zero
-                    if (hasCursorAddress) {
-                        puts(Capability.cursor_address, lineIndex, 0);
-                    } else {
-                        ensureDefaultAnsiStyle();
-                        rawPrint(' ');
-                        puts(Capability.cursor_left);
-                    }
-                } else {
-                    // go to next line column one
-                    rawPrint(newLine, nStart, nStart + 1);
-                    cursorPos += newLine.columnLength(
-                            terminal, graphemeBreakIterator, graphemeCharIterator, nStart, nStart + 1); // normally 1
-                    nStart++;
-                    if (oEnd - oStart > 0) {
-                        oStart++;
-                    }
-                    currentPos = cursorPos;
+            int lineIndex = 0;
+            int currentPos = 0;
+            int numLines = Math.min(rows, Math.max(oldLines.size(), newLines.size()));
+            boolean wrapNeeded = false;
+            while (lineIndex < numLines) {
+                AttributedString oldLine =
+                        lineIndex < oldLines.size() ? oldLines.get(lineIndex) : AttributedString.EMPTY;
+                AttributedString newLine =
+                        lineIndex < newLines.size() ? newLines.get(lineIndex) : AttributedString.EMPTY;
+                currentPos = lineIndex * columns1;
+                int curCol = currentPos;
+                // Track effective ranges instead of creating substrings
+                int oStart = 0;
+                int oEnd = oldLine.length();
+                int nStart = 0;
+                int nEnd = newLine.length();
+                boolean oldNL = oEnd > 0 && oldLine.charAt(oEnd - 1) == '\n';
+                boolean newNL = nEnd > 0 && newLine.charAt(nEnd - 1) == '\n';
+                if (oldNL) {
+                    oEnd--;
                 }
-            }
-            int oLen = oEnd - oStart;
-            int nLen = nEnd - nStart;
-            // When grapheme cluster mode is active, the terminal may retroactively
-            // combine or uncombine characters as ZWJ and other combining code points
-            // are added incrementally. This invalidates cursor position tracking
-            // based on char-level diffs. Force a full line repaint in this case.
-            if (terminal.getGraphemeClusterMode() && !equalsRange(oldLine, oStart, oEnd, newLine, nStart, nEnd)) {
-                cursorPos = moveVisualCursorTo(currentPos);
-                ensureDefaultAnsiStyle();
-                if (!puts(Capability.clr_eol)) {
-                    int oldLen =
-                            oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, oStart, oEnd);
-                    if (oldLen > 0) {
-                        rawPrint(' ', oldLen);
-                        cursorPos += oldLen;
-                        cursorPos = moveVisualCursorTo(currentPos);
-                    }
+                if (newNL) {
+                    nEnd--;
                 }
-                rawPrint(newLine, nStart, nEnd);
-                cursorPos += newLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, nStart, nEnd);
-                currentPos = cursorPos;
-                lineIndex++;
-                boolean newWrap2 = !newNL && lineIndex < newLines.size();
-                if (targetCursorPos + 1 == lineIndex * columns1 && (newWrap2 || !delayLineWrap)) targetCursorPos++;
-                wrapNeeded = newWrap2;
-                continue;
-            }
-            // Inline diff: compute common prefix/suffix lengths without allocation
-            DiffHelper.diff(oldLine, oStart, oEnd, newLine, nStart, nEnd, diffResult);
-            int cs = diffResult[0]; // common prefix length
-            int ce = diffResult[1]; // common suffix length
-            boolean hasInsert = nLen > cs + ce;
-            boolean hasDelete = oLen > cs + ce;
-            boolean hasEqSuffix = ce > 0;
-            boolean ident = true;
-            boolean cleared = false;
-            // EQUAL prefix
-            if (cs > 0) {
-                currentPos += oldLine.columnLength(
-                        terminal, graphemeBreakIterator, graphemeCharIterator, oStart, oStart + cs);
-            }
-            // INSERT
-            if (hasInsert) {
-                int iStart = nStart + cs;
-                int iEnd = nEnd - ce;
-                int insertWidth =
-                        newLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, iStart, iEnd);
-                boolean insertHandled = false;
-                // Optimization: if followed by EQUAL suffix (no DELETE), try insertChars
-                if (hasEqSuffix && !hasDelete) {
-                    cursorPos = moveVisualCursorTo(currentPos);
-                    ensureDefaultAnsiStyle();
-                    if (insertChars(insertWidth)) {
-                        rawPrint(newLine, iStart, iEnd);
-                        cursorPos += insertWidth;
-                        currentPos = cursorPos;
-                        insertHandled = true;
-                    }
-                }
-                // Optimization: if followed by DELETE with same width, overwrite
-                if (!insertHandled && hasDelete) {
-                    int dStart = oStart + cs;
-                    int dEnd = oEnd - ce;
-                    int deleteWidth =
-                            oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, dStart, dEnd);
-                    if (insertWidth == deleteWidth) {
-                        moveVisualCursorTo(currentPos);
-                        if (canSkipIntraLine && (iEnd - iStart) == (dEnd - dStart)) {
-                            emitOverwriteWithSkips(newLine, iStart, iEnd, oldLine, dStart);
-                        } else {
-                            rawPrint(newLine, iStart, iEnd);
-                            cursorPos += insertWidth;
-                        }
-                        currentPos = cursorPos;
-                        hasDelete = false; // skip DELETE processing
-                        insertHandled = true;
-                    }
-                }
-                // Default: just print
-                if (!insertHandled) {
-                    moveVisualCursorTo(currentPos);
-                    rawPrint(newLine, iStart, iEnd);
-                    cursorPos += insertWidth;
-                    currentPos = cursorPos;
-                    ident = false;
-                }
-            }
-            // DELETE
-            if (hasDelete && !cleared && currentPos - curCol < columns) {
-                int dStart = oStart + cs;
-                int dEnd = oEnd - ce;
-                int deleteWidth =
-                        oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, dStart, dEnd);
-                boolean deleteHandled = false;
-                // Optimization: if followed by EQUAL suffix, try deleteChars
-                if (hasEqSuffix) {
-                    int suffixWidth = oldLine.columnLength(
-                            terminal, graphemeBreakIterator, graphemeCharIterator, oEnd - ce, oEnd);
-                    if ((currentPos - curCol) + suffixWidth < columns) {
-                        moveVisualCursorTo(currentPos);
-                        ensureDefaultAnsiStyle();
-                        if (deleteChars(deleteWidth)) {
-                            deleteHandled = true;
-                        }
-                    }
-                }
-                if (!deleteHandled) {
-                    int oldColLen =
-                            oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, oStart, oEnd);
-                    int newColLen =
-                            newLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, nStart, nEnd);
-                    int nb = Math.max(oldColLen, newColLen) - (currentPos - curCol);
-                    moveVisualCursorTo(currentPos);
-                    ensureDefaultAnsiStyle();
-                    if (!puts(Capability.clr_eol)) {
-                        rawPrint(' ', nb);
-                        cursorPos += nb;
-                    }
-                    cleared = true;
-                    ident = false;
-                }
-            }
-            // EQUAL suffix
-            if (hasEqSuffix) {
-                int suffixWidth =
-                        oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, oEnd - ce, oEnd);
-                if (!ident) {
-                    cursorPos = moveVisualCursorTo(currentPos);
-                    rawPrint(newLine, nEnd - ce, nEnd);
-                    cursorPos += suffixWidth;
-                    currentPos = cursorPos;
-                } else {
-                    currentPos += suffixWidth;
-                }
-            }
-            lineIndex++;
-            boolean newWrap = !newNL && lineIndex < newLines.size();
-            if (targetCursorPos + 1 == lineIndex * columns1 && (newWrap || !delayLineWrap)) targetCursorPos++;
-            boolean atRight = (cursorPos - curCol) % columns1 == columns;
-            wrapNeeded = false;
-            if (this.delayedWrapAtEol) {
-                boolean oldWrap = !oldNL && lineIndex < oldLines.size();
-                if (newWrap != oldWrap && !(oldWrap && cleared)) {
-                    moveVisualCursorTo(lineIndex * columns1 - 1, newLines);
-                    if (newWrap) wrapNeeded = true;
-                    else {
-                        ensureDefaultAnsiStyle();
-                        puts(Capability.clr_eol);
-                    }
-                }
-            } else if (atRight) {
-                if (this.wrapAtEol) {
-                    if (!fullScreen || (fullScreen && lineIndex < numLines)) {
+                if (wrapNeeded && lineIndex == (cursorPos + 1) / columns1 && lineIndex < newLines.size()) {
+                    // move from right margin to next line's left margin
+                    cursorPos++;
+                    if (nEnd - nStart == 0 || newLine.isHidden(nStart)) {
+                        // go to next line column zero
                         if (hasCursorAddress) {
                             puts(Capability.cursor_address, lineIndex, 0);
-                            cursorPos = lineIndex * columns1;
                         } else {
                             ensureDefaultAnsiStyle();
                             rawPrint(' ');
                             puts(Capability.cursor_left);
-                            cursorPos++;
+                        }
+                    } else {
+                        // go to next line column one
+                        rawPrint(newLine, nStart, nStart + 1);
+                        cursorPos += newLine.columnLength(
+                                terminal,
+                                graphemeBreakIterator,
+                                graphemeCharIterator,
+                                nStart,
+                                nStart + 1); // normally 1
+                        nStart++;
+                        if (oEnd - oStart > 0) {
+                            oStart++;
+                        }
+                        currentPos = cursorPos;
+                    }
+                }
+                int oLen = oEnd - oStart;
+                int nLen = nEnd - nStart;
+                // When grapheme cluster mode is active, the terminal may retroactively
+                // combine or uncombine characters as ZWJ and other combining code points
+                // are added incrementally. This invalidates cursor position tracking
+                // based on char-level diffs. Force a full line repaint in this case.
+                if (terminal.getGraphemeClusterMode() && !equalsRange(oldLine, oStart, oEnd, newLine, nStart, nEnd)) {
+                    cursorPos = moveVisualCursorTo(currentPos);
+                    ensureDefaultAnsiStyle();
+                    if (!puts(Capability.clr_eol)) {
+                        int oldLen = oldLine.columnLength(
+                                terminal, graphemeBreakIterator, graphemeCharIterator, oStart, oEnd);
+                        if (oldLen > 0) {
+                            rawPrint(' ', oldLen);
+                            cursorPos += oldLen;
+                            cursorPos = moveVisualCursorTo(currentPos);
                         }
                     }
-                } else {
-                    puts(Capability.carriage_return); // CR / not newline.
-                    cursorPos = curCol;
+                    rawPrint(newLine, nStart, nEnd);
+                    cursorPos +=
+                            newLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, nStart, nEnd);
+                    currentPos = cursorPos;
+                    lineIndex++;
+                    boolean newWrap2 = !newNL && lineIndex < newLines.size();
+                    if (targetCursorPos + 1 == lineIndex * columns1 && (newWrap2 || !delayLineWrap)) targetCursorPos++;
+                    wrapNeeded = newWrap2;
+                    continue;
                 }
-                currentPos = cursorPos;
+                // Inline diff: compute common prefix/suffix lengths without allocation
+                DiffHelper.diff(oldLine, oStart, oEnd, newLine, nStart, nEnd, diffResult);
+                int cs = diffResult[0]; // common prefix length
+                int ce = diffResult[1]; // common suffix length
+                boolean hasInsert = nLen > cs + ce;
+                boolean hasDelete = oLen > cs + ce;
+                boolean hasEqSuffix = ce > 0;
+                boolean ident = true;
+                boolean cleared = false;
+                // EQUAL prefix
+                if (cs > 0) {
+                    currentPos += oldLine.columnLength(
+                            terminal, graphemeBreakIterator, graphemeCharIterator, oStart, oStart + cs);
+                }
+                // INSERT
+                if (hasInsert) {
+                    int iStart = nStart + cs;
+                    int iEnd = nEnd - ce;
+                    int insertWidth =
+                            newLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, iStart, iEnd);
+                    boolean insertHandled = false;
+                    // Optimization: if followed by EQUAL suffix (no DELETE), try insertChars
+                    if (hasEqSuffix && !hasDelete) {
+                        cursorPos = moveVisualCursorTo(currentPos);
+                        ensureDefaultAnsiStyle();
+                        if (insertChars(insertWidth)) {
+                            rawPrint(newLine, iStart, iEnd);
+                            cursorPos += insertWidth;
+                            currentPos = cursorPos;
+                            insertHandled = true;
+                        }
+                    }
+                    // Optimization: if followed by DELETE with same width, overwrite
+                    if (!insertHandled && hasDelete) {
+                        int dStart = oStart + cs;
+                        int dEnd = oEnd - ce;
+                        int deleteWidth = oldLine.columnLength(
+                                terminal, graphemeBreakIterator, graphemeCharIterator, dStart, dEnd);
+                        if (insertWidth == deleteWidth) {
+                            moveVisualCursorTo(currentPos);
+                            if (canSkipIntraLine && (iEnd - iStart) == (dEnd - dStart)) {
+                                emitOverwriteWithSkips(newLine, iStart, iEnd, oldLine, dStart);
+                            } else {
+                                rawPrint(newLine, iStart, iEnd);
+                                cursorPos += insertWidth;
+                            }
+                            currentPos = cursorPos;
+                            hasDelete = false; // skip DELETE processing
+                            insertHandled = true;
+                        }
+                    }
+                    // Default: just print
+                    if (!insertHandled) {
+                        moveVisualCursorTo(currentPos);
+                        rawPrint(newLine, iStart, iEnd);
+                        cursorPos += insertWidth;
+                        currentPos = cursorPos;
+                        ident = false;
+                    }
+                }
+                // DELETE
+                if (hasDelete && !cleared && currentPos - curCol < columns) {
+                    int dStart = oStart + cs;
+                    int dEnd = oEnd - ce;
+                    int deleteWidth =
+                            oldLine.columnLength(terminal, graphemeBreakIterator, graphemeCharIterator, dStart, dEnd);
+                    boolean deleteHandled = false;
+                    // Optimization: if followed by EQUAL suffix, try deleteChars
+                    if (hasEqSuffix) {
+                        int suffixWidth = oldLine.columnLength(
+                                terminal, graphemeBreakIterator, graphemeCharIterator, oEnd - ce, oEnd);
+                        if ((currentPos - curCol) + suffixWidth < columns) {
+                            moveVisualCursorTo(currentPos);
+                            ensureDefaultAnsiStyle();
+                            if (deleteChars(deleteWidth)) {
+                                deleteHandled = true;
+                            }
+                        }
+                    }
+                    if (!deleteHandled) {
+                        int oldColLen = oldLine.columnLength(
+                                terminal, graphemeBreakIterator, graphemeCharIterator, oStart, oEnd);
+                        int newColLen = newLine.columnLength(
+                                terminal, graphemeBreakIterator, graphemeCharIterator, nStart, nEnd);
+                        int nb = Math.max(oldColLen, newColLen) - (currentPos - curCol);
+                        moveVisualCursorTo(currentPos);
+                        ensureDefaultAnsiStyle();
+                        if (!puts(Capability.clr_eol)) {
+                            rawPrint(' ', nb);
+                            cursorPos += nb;
+                        }
+                        cleared = true;
+                        ident = false;
+                    }
+                }
+                // EQUAL suffix
+                if (hasEqSuffix) {
+                    int suffixWidth = oldLine.columnLength(
+                            terminal, graphemeBreakIterator, graphemeCharIterator, oEnd - ce, oEnd);
+                    if (!ident) {
+                        cursorPos = moveVisualCursorTo(currentPos);
+                        rawPrint(newLine, nEnd - ce, nEnd);
+                        cursorPos += suffixWidth;
+                        currentPos = cursorPos;
+                    } else {
+                        currentPos += suffixWidth;
+                    }
+                }
+                lineIndex++;
+                boolean newWrap = !newNL && lineIndex < newLines.size();
+                if (targetCursorPos + 1 == lineIndex * columns1 && (newWrap || !delayLineWrap)) targetCursorPos++;
+                boolean atRight = (cursorPos - curCol) % columns1 == columns;
+                wrapNeeded = false;
+                if (this.delayedWrapAtEol) {
+                    boolean oldWrap = !oldNL && lineIndex < oldLines.size();
+                    if (newWrap != oldWrap && !(oldWrap && cleared)) {
+                        moveVisualCursorTo(lineIndex * columns1 - 1, newLines);
+                        if (newWrap) wrapNeeded = true;
+                        else {
+                            ensureDefaultAnsiStyle();
+                            puts(Capability.clr_eol);
+                        }
+                    }
+                } else if (atRight) {
+                    if (this.wrapAtEol) {
+                        if (!fullScreen || (fullScreen && lineIndex < numLines)) {
+                            if (hasCursorAddress) {
+                                puts(Capability.cursor_address, lineIndex, 0);
+                                cursorPos = lineIndex * columns1;
+                            } else {
+                                ensureDefaultAnsiStyle();
+                                rawPrint(' ');
+                                puts(Capability.cursor_left);
+                                cursorPos++;
+                            }
+                        }
+                    } else {
+                        puts(Capability.carriage_return); // CR / not newline.
+                        cursorPos = curCol;
+                    }
+                    currentPos = cursorPos;
+                }
             }
-        }
-        if (cursorPos != targetCursorPos) {
-            moveVisualCursorTo(targetCursorPos < 0 ? currentPos : targetCursorPos, newLines);
-        }
-        oldLines.clear();
-        oldLines.addAll(newLines);
-        ensureDefaultAnsiStyle();
+            if (cursorPos != targetCursorPos) {
+                moveVisualCursorTo(targetCursorPos < 0 ? currentPos : targetCursorPos, newLines);
+            }
+            oldLines.clear();
+            oldLines.addAll(newLines);
+            ensureDefaultAnsiStyle();
 
-        // End synchronized update (mode 2026): the terminal renders all buffered output now.
-        if (fullScreen) {
-            rawEsc(SYNC_END);
+        } finally {
+            // End synchronized update (mode 2026): the terminal renders all buffered output now.
+            // In a finally block so the terminal never stays in synchronized-output mode on error.
+            if (fullScreen) {
+                rawEsc(SYNC_END);
+            }
         }
 
         if (useByteMode && byteBuilder.length() > 0) {

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -648,10 +648,15 @@ public class Display implements Sized {
             } else if (atRight) {
                 if (this.wrapAtEol) {
                     if (!fullScreen || (fullScreen && lineIndex < numLines)) {
-                        ensureDefaultAnsiStyle();
-                        rawPrint(' ');
-                        puts(Capability.cursor_left);
-                        cursorPos++;
+                        if (hasCursorAddress) {
+                            puts(Capability.cursor_address, lineIndex, 0);
+                            cursorPos = lineIndex * columns1;
+                        } else {
+                            ensureDefaultAnsiStyle();
+                            rawPrint(' ');
+                            puts(Capability.cursor_left);
+                            cursorPos++;
+                        }
                     }
                 } else {
                     puts(Capability.carriage_return); // CR / not newline.

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -120,6 +120,14 @@ public class Display implements Sized {
     private final boolean hasCursorAddress;
     private final boolean canSkipIntraLine;
 
+    // Synchronized output (mode 2026) escape sequences.
+    // BSU tells the terminal to buffer all output until ESU, then render atomically.
+    // Terminals that do not support mode 2026 silently ignore these sequences.
+    private static final String SYNC_START = "\033[?2026h";
+    private static final String SYNC_END = "\033[?2026l";
+
+    private boolean scrollOptimization = true;
+
     /*
      * Minimum number of unchanged characters within a changed region that justifies
      * a cursor-movement skip instead of re-emitting them.  A CUF escape (\e[nC)
@@ -181,6 +189,36 @@ public class Display implements Sized {
      */
     public void setDelayLineWrap(boolean v) {
         delayLineWrap = v;
+    }
+
+    /**
+     * Returns whether the scroll optimization is enabled.
+     * When enabled, the display uses terminal insert/delete line capabilities to
+     * scroll content efficiently instead of redrawing all changed lines.
+     *
+     * @return {@code true} if scroll optimization is enabled (the default)
+     */
+    public boolean scrollOptimization() {
+        return scrollOptimization;
+    }
+
+    /**
+     * Enable or disable the scroll optimization.
+     * <p>
+     * When enabled (the default), the display detects content shifts between frames
+     * and uses terminal insert/delete line capabilities to scroll content efficiently.
+     * This reduces the number of characters written but may cause visible flicker on
+     * terminals that render intermediate states (e.g. during high-FPS full-screen updates).
+     * </p>
+     * <p>
+     * Disabling the scroll optimization forces full per-line diff updates, which produces
+     * more output bytes but avoids flicker from insert/delete line intermediate states.
+     * </p>
+     *
+     * @param v {@code true} to enable scroll optimization, {@code false} to disable it
+     */
+    public void setScrollOptimization(boolean v) {
+        scrollOptimization = v;
     }
 
     /**
@@ -382,6 +420,14 @@ public class Display implements Sized {
             ansiColorState[1] = 0;
         }
 
+        // Begin synchronized update (mode 2026): tell the terminal to buffer all
+        // output until the matching ESU at the end, then render everything atomically.
+        // This prevents visible intermediate states from scroll optimization
+        // (insertLines/deleteLines) that otherwise cause flicker.
+        if (fullScreen) {
+            rawEsc(SYNC_START);
+        }
+
         if (reset) {
             puts(Capability.clear_screen);
             puts(Capability.cursor_address, 0, 0);
@@ -400,7 +446,10 @@ public class Display implements Sized {
         }
 
         // Detect scrolling
-        if ((fullScreen || newLines.size() >= rows) && newLines.size() == oldLines.size() && canScroll) {
+        if (scrollOptimization
+                && (fullScreen || newLines.size() >= rows)
+                && newLines.size() == oldLines.size()
+                && canScroll) {
             int nbHeaders = 0;
             int nbFooters = 0;
             // Find common headers and footers
@@ -480,9 +529,13 @@ public class Display implements Sized {
                 cursorPos++;
                 if (nEnd - nStart == 0 || newLine.isHidden(nStart)) {
                     // go to next line column zero
-                    ensureDefaultAnsiStyle();
-                    rawPrint(' ');
-                    puts(Capability.cursor_left);
+                    if (hasCursorAddress) {
+                        puts(Capability.cursor_address, lineIndex, 0);
+                    } else {
+                        ensureDefaultAnsiStyle();
+                        rawPrint(' ');
+                        puts(Capability.cursor_left);
+                    }
                 } else {
                     // go to next line column one
                     rawPrint(newLine, nStart, nStart + 1);
@@ -671,6 +724,11 @@ public class Display implements Sized {
         oldLines.clear();
         oldLines.addAll(newLines);
         ensureDefaultAnsiStyle();
+
+        // End synchronized update (mode 2026): the terminal renders all buffered output now.
+        if (fullScreen) {
+            rawEsc(SYNC_END);
+        }
 
         if (useByteMode && byteBuilder.length() > 0) {
             // Flush any pending writer data, then write accumulated bytes
@@ -1007,6 +1065,18 @@ public class Display implements Sized {
         } else {
             // Non-byte-mode path: fall back to subSequence (rare path for non-UTF-8 terminals)
             str.subSequence(start, end).print(terminal);
+        }
+    }
+
+    /**
+     * Write an ASCII escape sequence to the terminal output, bypassing cursor
+     * tracking and style state. Used for non-capability sequences like mode 2026.
+     */
+    private void rawEsc(String seq) {
+        if (useByteMode) {
+            byteBuilder.appendAscii(seq);
+        } else {
+            terminal.writer().write(seq);
         }
     }
 

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -82,7 +82,7 @@ public class Display implements Sized {
 
     protected final Terminal terminal;
     protected final boolean fullScreen;
-    protected final List<AttributedString> oldLines = new ArrayList<>();
+    private final List<AttributedString> oldLines = new ArrayList<>();
     protected int cursorPos;
     protected int columns;
     protected int columns1; // columns+1
@@ -339,6 +339,31 @@ public class Display implements Sized {
     @Override
     public int getRows() {
         return rows;
+    }
+
+    /**
+     * Returns the number of previously rendered lines stored in this display.
+     * Package-private: used by {@link Status} to determine cleanup needs.
+     */
+    int oldLinesSize() {
+        return oldLines.size();
+    }
+
+    /**
+     * Returns the previously rendered lines.
+     * Package-private: used by tests to verify reflow behavior.
+     */
+    List<AttributedString> oldLines() {
+        return oldLines;
+    }
+
+    /**
+     * Removes the first {@code count} entries from the previously rendered lines.
+     * Package-private: used by {@link Status} to sync its internal state after
+     * clearing stale status lines from the screen.
+     */
+    void removeFirstOldLines(int count) {
+        oldLines.subList(0, count).clear();
     }
 
     /**

--- a/terminal/src/main/java/org/jline/utils/ScreenTerminal.java
+++ b/terminal/src/main/java/org/jline/utils/ScreenTerminal.java
@@ -78,6 +78,7 @@ public class ScreenTerminal implements Sized {
 
     private int columns;
     private int rows;
+    private boolean eatNewlineGlitch;
     private long attr;
     private boolean eol;
     private int cx;
@@ -146,8 +147,23 @@ public class ScreenTerminal implements Sized {
      * @param rows the number of character rows for the terminal
      */
     public ScreenTerminal(int columns, int rows) {
+        this(columns, rows, true);
+    }
+
+    /**
+     * Creates a ScreenTerminal with the specified size and wrap behavior.
+     *
+     * @param columns the number of character columns for the terminal
+     * @param rows the number of character rows for the terminal
+     * @param eatNewlineGlitch when {@code true}, the cursor stays at the last column
+     *        after writing a character there (delayed wrap / xenl behavior, like xterm).
+     *        When {@code false}, writing at the last column immediately wraps the cursor
+     *        to column 0 of the next line (like windows-vtp).
+     */
+    public ScreenTerminal(int columns, int rows, boolean eatNewlineGlitch) {
         this.columns = columns;
         this.rows = rows;
+        this.eatNewlineGlitch = eatNewlineGlitch;
         this.tab_stops = new ArrayList<>();
         reset_hard();
     }
@@ -507,6 +523,15 @@ public class ScreenTerminal implements Sized {
         }
 
         cursor_right(charWidth);
+
+        // On terminals without eat_newline_glitch (e.g. windows-vtp), writing at the
+        // last column wraps the cursor to the next line immediately, rather than
+        // deferring the wrap to the next character write.
+        if (!eatNewlineGlitch && eol && vt100_mode_autowrap) {
+            eol = false;
+            ctrl_CR();
+            ctrl_LF();
+        }
     }
 
     //

--- a/terminal/src/main/java/org/jline/utils/Status.java
+++ b/terminal/src/main/java/org/jline/utils/Status.java
@@ -250,8 +250,6 @@ public class Status {
             lines.set(i, str);
         }
 
-        List<AttributedString> oldLines = this.display.oldLines;
-
         int newScrollRegion = display.rows - 1 - lines.size();
         // Update the scroll region if needed.
         // Note that settings the scroll region usually moves the cursor, so we need to get ready for that.
@@ -278,17 +276,18 @@ public class Status {
         // if the display has more lines, we need to add empty ones to make sure they will be erased
         List<AttributedString> toDraw = new ArrayList<>(lines);
         int nbToDraw = toDraw.size();
-        int nbOldLines = oldLines.size();
+        int nbOldLines = display.oldLinesSize();
         if (nbOldLines > nbToDraw) {
+            int excess = nbOldLines - nbToDraw;
             terminal.puts(Capability.save_cursor);
             terminal.puts(Capability.cursor_address, display.rows - nbOldLines, 0);
-            for (int i = 0; i < nbOldLines - nbToDraw; i++) {
+            for (int i = 0; i < excess; i++) {
                 terminal.puts(Capability.clr_eol);
-                if (i < nbOldLines - nbToDraw - 1) {
+                if (i < excess - 1) {
                     terminal.puts(Capability.cursor_down);
                 }
-                oldLines.remove(0);
             }
+            display.removeFirstOldLines(excess);
             terminal.puts(Capability.restore_cursor);
         }
         // update display

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -399,10 +399,12 @@ class DisplayTest {
             display.update(frame1, 0);
             terminal.flush();
 
-            // Frame 2: row 0 unchanged (still wraps), row 1 now has content
+            // Frame 2: row 0 unchanged (still wraps), row 1 stays empty so the
+            // delayed-wrap path must use CUP to move past it, row 2 changes to
+            // force output.
             terminal.startCapture();
             List<AttributedString> frame2 = new ArrayList<>(frame1);
-            frame2.set(1, new AttributedString("hello"));
+            frame2.set(2, new AttributedString("hello"));
             display.update(frame2, 0);
             terminal.flush();
 
@@ -410,24 +412,24 @@ class DisplayTest {
             String output = new String(captured, StandardCharsets.UTF_8);
 
             // Row 0 was unchanged so cursor stays at right margin with delayed wrap.
-            // wrapNeeded triggers: since row 1 has content (starts with 'h'),
-            // the Display emits the first char to wrap. There should be no
+            // wrapNeeded triggers: since row 1 is empty, Display must use CUP
+            // (cursor_address) to move to the next line. There should be no
             // space+cursor_left sequence.
             assertFalse(
                     output.contains(" \033[D"),
-                    "Should use CUP or rawPrint for delayed wrap, not space+cursor_left, output: "
+                    "Should use CUP for delayed wrap over empty line, not space+cursor_left, output: "
                             + output.replace("\033", "\\e"));
 
-            // Verify screen: row 0 = AAAAAAAAAA, row 1 = hello(spaces)
+            // Verify screen: row 0 = AAAAAAAAAA, row 2 = hello(spaces)
             long[] screen = terminal.dump();
             for (int c = 0; c < cols; c++) {
                 assertEquals('A', (char) screen[0 * cols + c], "Row 0 col " + c);
             }
-            assertEquals('h', (char) screen[1 * cols + 0]);
-            assertEquals('e', (char) screen[1 * cols + 1]);
-            assertEquals('l', (char) screen[1 * cols + 2]);
-            assertEquals('l', (char) screen[1 * cols + 3]);
-            assertEquals('o', (char) screen[1 * cols + 4]);
+            assertEquals('h', (char) screen[2 * cols + 0]);
+            assertEquals('e', (char) screen[2 * cols + 1]);
+            assertEquals('l', (char) screen[2 * cols + 2]);
+            assertEquals('l', (char) screen[2 * cols + 3]);
+            assertEquals('o', (char) screen[2 * cols + 4]);
         }
     }
 

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -97,7 +97,7 @@ class DisplayTest {
             terminal.resizeScreen(newCols, rows);
             display.resize(terminal);
 
-            assertEquals(expectedLines, display.oldLines);
+            assertEquals(expectedLines, display.oldLines());
             assertEquals(expectedCursor, display.cursorPos);
         }
     }
@@ -768,6 +768,300 @@ class DisplayTest {
             assertFalse(display.scrollOptimization(), "Should be disabled after set");
             display.setScrollOptimization(true);
             assertTrue(display.scrollOptimization(), "Should be enabled after re-enable");
+        }
+    }
+
+    // ====================================================================
+    // Resize reflow edge case tests
+    // ====================================================================
+
+    @Test
+    void resizeEmptyDisplay() throws IOException {
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, 80, 10)) {
+            Display display = new Display(terminal, false);
+            display.resize(Size.of(80, 10));
+
+            // Resize without any prior update — oldLines is empty, but columnSplitLength
+            // always produces at least one entry (an empty string)
+            terminal.resizeScreen(40, 10);
+            display.resize(terminal);
+
+            assertTrue(display.oldLines().size() <= 1);
+            assertEquals(0, display.cursorPos);
+        }
+    }
+
+    @Test
+    void resizeCursorAtOrigin() throws IOException {
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, 80, 10)) {
+            Display display = new Display(terminal, false);
+            display.resize(Size.of(80, 10));
+
+            List<AttributedString> lines = new ArrayList<>();
+            lines.add(new AttributedString("hello world\n"));
+            lines.add(new AttributedString("second line\n"));
+            display.update(lines, 0); // cursor at position 0
+
+            terminal.resizeScreen(40, 10);
+            display.resize(terminal);
+
+            assertEquals(0, display.cursorPos);
+        }
+    }
+
+    @Test
+    void resizeAggressiveNarrow() throws IOException {
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, 80, 10)) {
+            Display display = new Display(terminal, false);
+            display.resize(Size.of(80, 10));
+
+            // "hello world" is 11 chars, will need multiple lines at width 3
+            AttributedString rendered = new AttributedString("hello world\nsecond\n");
+            List<AttributedString> oldLines = rendered.columnSplitLength(terminal, 80, true, display.delayLineWrap());
+            int cursor = Size.of(80, 10)
+                    .cursorPos(
+                            oldLines.size() - 1,
+                            oldLines.get(oldLines.size() - 1).columnLength(terminal));
+            display.update(oldLines, cursor);
+
+            // Resize to 3 columns — content will reflow significantly
+            terminal.resizeScreen(3, 10);
+            display.resize(terminal);
+
+            List<AttributedString> expected = rendered.columnSplitLength(terminal, 3, true, display.delayLineWrap());
+            assertEquals(expected, display.oldLines());
+        }
+    }
+
+    @Test
+    void resizePreservesHardNewlines() throws IOException {
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, 40, 10)) {
+            Display display = new Display(terminal, false);
+            display.resize(Size.of(40, 10));
+
+            // Content with multiple hard newlines including empty lines
+            AttributedString rendered = new AttributedString("line1\n\n\nline4\n");
+            List<AttributedString> lines = rendered.columnSplitLength(terminal, 40, true, display.delayLineWrap());
+            int cursor = Size.of(40, 10)
+                    .cursorPos(lines.size() - 1, lines.get(lines.size() - 1).columnLength(terminal));
+            display.update(lines, cursor);
+
+            terminal.resizeScreen(20, 10);
+            display.resize(terminal);
+
+            List<AttributedString> expected = rendered.columnSplitLength(terminal, 20, true, display.delayLineWrap());
+            assertEquals(expected, display.oldLines());
+        }
+    }
+
+    @Test
+    void resizeLineExactlyAtColumnWidth() throws IOException {
+        int cols = 10;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, 10)) {
+            Display display = new Display(terminal, false);
+            display.resize(Size.of(cols, 10));
+
+            // Exactly 10 chars + newline, then another line
+            AttributedString rendered = new AttributedString("1234567890\nabcde\n");
+            List<AttributedString> lines = rendered.columnSplitLength(terminal, cols, true, display.delayLineWrap());
+            int cursor = Size.of(cols, 10)
+                    .cursorPos(lines.size() - 1, lines.get(lines.size() - 1).columnLength(terminal));
+            display.update(lines, cursor);
+
+            // Resize to 5 columns — the 10-char line wraps into two 5-char lines
+            terminal.resizeScreen(5, 10);
+            display.resize(terminal);
+
+            List<AttributedString> expected = rendered.columnSplitLength(terminal, 5, true, display.delayLineWrap());
+            assertEquals(expected, display.oldLines());
+            int expectedCursor = Size.of(5, 10)
+                    .cursorPos(
+                            expected.size() - 1,
+                            expected.get(expected.size() - 1).columnLength(terminal));
+            assertEquals(expectedCursor, display.cursorPos);
+        }
+    }
+
+    @Test
+    void resizeGrowingColumns() throws IOException {
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, 20, 10)) {
+            Display display = new Display(terminal, false);
+            display.resize(Size.of(20, 10));
+
+            // Content that wraps at 20 cols but fits in 40
+            AttributedString rendered = new AttributedString("this is a longer line of text\n");
+            List<AttributedString> lines = rendered.columnSplitLength(terminal, 20, true, display.delayLineWrap());
+            int cursor = Size.of(20, 10)
+                    .cursorPos(lines.size() - 1, lines.get(lines.size() - 1).columnLength(terminal));
+            display.update(lines, cursor);
+
+            // Grow to 40 columns — content should unwrap
+            terminal.resizeScreen(40, 10);
+            display.resize(terminal);
+
+            List<AttributedString> expected = rendered.columnSplitLength(terminal, 40, true, display.delayLineWrap());
+            assertEquals(expected, display.oldLines());
+        }
+    }
+
+    // ====================================================================
+    // Wide character (CJK) wrap tests
+    // ====================================================================
+
+    @Test
+    void wideCharacterAtWrapBoundary() throws IOException {
+        int cols = 5;
+        int rows = 4;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+
+            // CJK character (U+4E16 '世') takes 2 columns.
+            // At col 4 of a 5-wide terminal, a 2-col char doesn't fit and should wrap.
+            // "abcd世e" = a(1) b(1) c(1) d(1) 世(2) e(1) = 7 columns
+            List<AttributedString> frame = new ArrayList<>();
+            frame.add(new AttributedString("abcd世e\n"));
+            frame.add(new AttributedString("test\n"));
+            display.update(frame, 0);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            // Row 0: "abcd " (wide char doesn't fit, so padding space or just abcd)
+            // The exact behavior depends on columnSplitLength, but the screen
+            // should not be corrupted
+            assertEquals('a', (char) screen[0 * cols + 0]);
+            assertEquals('b', (char) screen[0 * cols + 1]);
+            assertEquals('c', (char) screen[0 * cols + 2]);
+            assertEquals('d', (char) screen[0 * cols + 3]);
+        }
+    }
+
+    @Test
+    void wideCharacterFullWidthRow() throws IOException {
+        int cols = 6;
+        int rows = 3;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+
+            // 3 CJK chars = 6 columns = exactly full width
+            List<AttributedString> frame = new ArrayList<>();
+            frame.add(new AttributedString("世界你\n")); // 2+2+2 = 6 cols
+            frame.add(new AttributedString("hello\n"));
+            display.update(frame, 0);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            assertEquals('h', (char) screen[1 * cols + 0]);
+            assertEquals('e', (char) screen[1 * cols + 1]);
+        }
+    }
+
+    // ====================================================================
+    // Attribute/style preservation at wrap boundary tests
+    // ====================================================================
+
+    @Test
+    void stylePreservedAcrossWrapBoundary() throws IOException {
+        int cols = 10;
+        int rows = 4;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+
+            // Full-width styled line followed by a styled line
+            AttributedStringBuilder sb1 = new AttributedStringBuilder();
+            sb1.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
+            for (int i = 0; i < cols; i++) sb1.append('R');
+            // No \n = wraps to next line
+
+            AttributedStringBuilder sb2 = new AttributedStringBuilder();
+            sb2.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN));
+            for (int i = 0; i < cols; i++) sb2.append('G');
+            sb2.append('\n');
+
+            List<AttributedString> frame1 = new ArrayList<>();
+            frame1.add(sb1.toAttributedString());
+            frame1.add(sb2.toAttributedString());
+            display.update(frame1, 0);
+            terminal.flush();
+
+            // Verify screen characters are correct
+            long[] screen = terminal.dump();
+            for (int c = 0; c < cols; c++) {
+                assertEquals('R', (char) screen[0 * cols + c], "Row 0 col " + c);
+                assertEquals('G', (char) screen[1 * cols + c], "Row 1 col " + c);
+            }
+
+            // Now update: change only the second line's content
+            terminal.startCapture();
+            AttributedStringBuilder sb3 = new AttributedStringBuilder();
+            sb3.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE));
+            for (int i = 0; i < cols; i++) sb3.append('B');
+            sb3.append('\n');
+
+            List<AttributedString> frame2 = new ArrayList<>();
+            frame2.add(sb1.toAttributedString()); // unchanged
+            frame2.add(sb3.toAttributedString()); // changed
+            display.update(frame2, 0);
+            terminal.flush();
+
+            byte[] captured = terminal.stopCapture();
+            String output = new String(captured, StandardCharsets.UTF_8);
+
+            // First line is unchanged — its styled content should NOT be re-emitted
+            assertFalse(
+                    output.contains("RRRR"),
+                    "Unchanged styled line should not be re-emitted, output: " + output.replace("\033", "\\e"));
+
+            // Verify final screen state
+            screen = terminal.dump();
+            for (int c = 0; c < cols; c++) {
+                assertEquals('R', (char) screen[0 * cols + c], "Row 0 col " + c + " should still be R");
+                assertEquals('B', (char) screen[1 * cols + c], "Row 1 col " + c + " should be B");
+            }
+        }
+    }
+
+    // ====================================================================
+    // Inline display wrap tests
+    // ====================================================================
+
+    @Test
+    void inlineDisplayMultipleLines() throws IOException {
+        int cols = 10;
+        int rows = 5;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+
+            Display display = new Display(terminal, false); // inline mode
+            display.resize(Size.of(cols, rows));
+
+            List<AttributedString> frame1 = new ArrayList<>();
+            frame1.add(new AttributedString("line1\n"));
+            frame1.add(new AttributedString("line2\n"));
+            display.update(frame1, 0);
+            terminal.flush();
+
+            // Update with different content
+            List<AttributedString> frame2 = new ArrayList<>();
+            frame2.add(new AttributedString("AAAA\n"));
+            frame2.add(new AttributedString("BBBB\n"));
+            display.update(frame2, 0);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            assertEquals('A', (char) screen[0 * cols + 0]);
+            assertEquals('B', (char) screen[1 * cols + 0]);
         }
     }
 

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -472,12 +472,9 @@ class DisplayTest {
             byte[] capturedOn = terminal.stopCapture();
             String outputOn = new String(capturedOn, StandardCharsets.UTF_8);
 
-            // insert_line for xterm is \e[L or \e[<n>L
-            boolean hasInsertLine = outputOn.contains("\033[L") || outputOn.matches("(?s).*\\\\e\\[\\d+L.*");
-            // Also check for the CSI IL parm form
-            boolean hasInsertLineParm = outputOn.contains("\033[1L") || outputOn.contains("\033[L");
+            // insert_line for xterm is \e[L (single) or \e[<n>L (parametric)
             assertTrue(
-                    hasInsertLine || hasInsertLineParm,
+                    outputOn.contains("\033[L") || outputOn.matches("(?s).*\033\\[\\d+L.*"),
                     "Scroll optimization ON should emit insert_line, output: " + outputOn.replace("\033", "\\e"));
 
             // Reset display and redo with scroll optimization OFF

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -198,6 +198,114 @@ class DisplayTest {
         }
     }
 
+    @Test
+    void fallingBlockPreservesLeftBorderXterm() throws IOException {
+        fallingBlockPreservesLeftBorder("xterm");
+    }
+
+    @Test
+    void fallingBlockPreservesLeftBorderWindowsVtp() throws IOException {
+        fallingBlockPreservesLeftBorder("windows-vtp");
+    }
+
+    void fallingBlockPreservesLeftBorder(String termType) throws IOException {
+        int rows = 20;
+        int cols = 20;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", termType, StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+
+            AttributedStyle borderStyle = AttributedStyle.DEFAULT.foreground(96, 96, 96);
+            AttributedStyle greenStyle = AttributedStyle.DEFAULT.foreground(0, 205, 0);
+            AttributedStyle orangeStyle = AttributedStyle.DEFAULT.foreground(205, 102, 0);
+
+            // Green block pattern (S-shape tetromino):
+            // row 0: .GG
+            // row 1: GG.
+            // row 2: ...
+            int[][] greenBlock = {{-1, 1, 1}, {1, 1, -1}, {-1, -1, -1}};
+
+            // Orange block pattern:
+            // row 0: ..O
+            // row 1: OOO
+            // row 2: ...
+            int[][] orangeBlock = {{-1, -1, 2}, {2, 2, 2}, {-1, -1, -1}};
+
+            int orangeCol = 10;
+            int orangeRow = 10;
+
+            for (int activeBlockRow = 0; activeBlockRow < rows - 3; activeBlockRow++) {
+                List<AttributedString> lines = new ArrayList<>();
+                for (int y = 0; y < rows; y++) {
+                    AttributedStringBuilder sb = new AttributedStringBuilder(cols);
+                    for (int x = 0; x < cols; x++) {
+                        // Check green block
+                        int blockType = -1;
+                        int gy = y - activeBlockRow;
+                        int gx = x - 4; // xPos = 4
+                        if (gy >= 0 && gy < 3 && gx >= 0 && gx < 3) {
+                            blockType = greenBlock[gy][gx];
+                        }
+                        // Check orange block
+                        if (blockType < 0) {
+                            int oy = y - orangeRow;
+                            int ox = x - orangeCol;
+                            if (oy >= 0 && oy < 3 && ox >= 0 && ox < 3) {
+                                blockType = orangeBlock[oy][ox];
+                            }
+                        }
+                        // Draw
+                        if (x == 0) {
+                            sb.style(borderStyle);
+                            sb.append('█'); // █
+                        } else if (blockType == 1) {
+                            sb.style(greenStyle);
+                            sb.append('█');
+                        } else if (blockType == 2) {
+                            sb.style(orangeStyle);
+                            sb.append('█');
+                        } else {
+                            sb.style(AttributedStyle.DEFAULT);
+                            sb.append(' ');
+                        }
+                    }
+                    lines.add(sb.toAttributedString());
+                }
+                display.update(lines, 0);
+                terminal.flush();
+
+                // Verify the left border is intact on every row
+                long[] screen = terminal.dump();
+                StringBuilder failures = new StringBuilder();
+                for (int y = 0; y < rows; y++) {
+                    char ch = (char) screen[y * cols]; // column 0 of each row
+                    if (ch != '█') {
+                        failures.append("Row ")
+                                .append(y)
+                                .append(": '")
+                                .append(ch)
+                                .append("' ");
+                    }
+                }
+                if (failures.length() > 0) {
+                    // Dump full screen for debugging
+                    StringBuilder screenDump = new StringBuilder();
+                    screenDump.append("\nFrame ").append(activeBlockRow).append(" screen:\n");
+                    for (int y = 0; y < rows; y++) {
+                        for (int x = 0; x < cols; x++) {
+                            screenDump.append((char) screen[y * cols + x]);
+                        }
+                        screenDump.append("|\n");
+                    }
+                    fail("Left border corruption at frame " + activeBlockRow + ": " + failures + screenDump);
+                }
+            }
+        }
+    }
+
     public static void main(String[] args) throws InterruptedException, IOException {
 
         try (Terminal terminal = TerminalBuilder.builder().build()) {

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -209,8 +209,13 @@ class DisplayTest {
     }
 
     void fallingBlockPreservesLeftBorder(String termType) throws IOException {
-        int rows = 20;
+        int contentRows = 20;
         int cols = 20;
+        // On non-xenl terminals (e.g. windows-vtp), writing the bottom-right corner
+        // character causes the screen to scroll.  Add an extra terminal row so the
+        // content never reaches the bottom-right corner.
+        boolean xenl = "xterm".equals(termType);
+        int rows = xenl ? contentRows : contentRows + 1;
         try (VirtualTerminal terminal = new VirtualTerminal("test", termType, StandardCharsets.UTF_8, cols, rows)) {
             terminal.enterRawMode();
             terminal.puts(enter_ca_mode);
@@ -237,9 +242,9 @@ class DisplayTest {
             int orangeCol = 10;
             int orangeRow = 10;
 
-            for (int activeBlockRow = 0; activeBlockRow < rows - 3; activeBlockRow++) {
+            for (int activeBlockRow = 0; activeBlockRow < contentRows - 3; activeBlockRow++) {
                 List<AttributedString> lines = new ArrayList<>();
-                for (int y = 0; y < rows; y++) {
+                for (int y = 0; y < contentRows; y++) {
                     AttributedStringBuilder sb = new AttributedStringBuilder(cols);
                     for (int x = 0; x < cols; x++) {
                         // Check green block
@@ -277,10 +282,10 @@ class DisplayTest {
                 display.update(lines, 0);
                 terminal.flush();
 
-                // Verify the left border is intact on every row
+                // Verify the left border is intact on every content row
                 long[] screen = terminal.dump();
                 StringBuilder failures = new StringBuilder();
-                for (int y = 0; y < rows; y++) {
+                for (int y = 0; y < contentRows; y++) {
                     char ch = (char) screen[y * cols]; // column 0 of each row
                     if (ch != '█') {
                         failures.append("Row ")
@@ -294,7 +299,7 @@ class DisplayTest {
                     // Dump full screen for debugging
                     StringBuilder screenDump = new StringBuilder();
                     screenDump.append("\nFrame ").append(activeBlockRow).append(" screen:\n");
-                    for (int y = 0; y < rows; y++) {
+                    for (int y = 0; y < contentRows; y++) {
                         for (int x = 0; x < cols; x++) {
                             screenDump.append((char) screen[y * cols + x]);
                         }
@@ -303,6 +308,466 @@ class DisplayTest {
                     fail("Left border corruption at frame " + activeBlockRow + ": " + failures + screenDump);
                 }
             }
+        }
+    }
+
+    // ====================================================================
+    // Wrap handling tests: verify CUP is used instead of rawPrint(' ')
+    // ====================================================================
+
+    /**
+     * On windows-vtp (am but no xenl), when the cursor is at the right margin
+     * and the next line starts with non-empty content, the wrapAtEol path should
+     * use CUP to move to the next line instead of emitting a visible space.
+     * Verifies both: no space+cursor_left in the output AND correct screen state.
+     */
+    @Test
+    void wrapAtEolUsesCupOnWindowsVtp() throws IOException {
+        int contentRows = 3;
+        int cols = 10;
+        // On non-xenl terminals, writing the bottom-right corner scrolls the screen.
+        // Add an extra terminal row so the content never hits the bottom-right corner.
+        int termRows = contentRows + 1;
+        try (VirtualTerminal terminal =
+                new VirtualTerminal("test", "windows-vtp", StandardCharsets.UTF_8, cols, termRows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, termRows));
+
+            // Frame 1: fill content rows (no trailing \n = wrap)
+            List<AttributedString> frame1 = new ArrayList<>();
+            for (int r = 0; r < contentRows; r++) {
+                StringBuilder sb = new StringBuilder();
+                for (int c = 0; c < cols; c++) sb.append((char) ('A' + r));
+                frame1.add(new AttributedString(sb.toString()));
+            }
+            display.update(frame1, 0);
+            terminal.flush();
+
+            // Frame 2: change row 1 so it triggers a diff after wrap-at-eol from row 0
+            terminal.startCapture();
+            List<AttributedString> frame2 = new ArrayList<>(frame1);
+            StringBuilder sb = new StringBuilder();
+            for (int c = 0; c < cols; c++) sb.append('X');
+            frame2.set(1, new AttributedString(sb.toString()));
+            display.update(frame2, 0);
+            terminal.flush();
+
+            byte[] captured = terminal.stopCapture();
+            String output = new String(captured, StandardCharsets.UTF_8);
+
+            // Verify: output must NOT contain a bare space followed by cursor_left (\e[D)
+            assertFalse(
+                    output.contains(" \033[D"),
+                    "Should use CUP instead of space+cursor_left, but found it in: " + output.replace("\033", "\\e"));
+
+            // Verify screen state: row 0 = AAAAAAAAAA, row 1 = XXXXXXXXXX
+            long[] screen = terminal.dump();
+            for (int c = 0; c < cols; c++) {
+                assertEquals('A', (char) screen[0 * cols + c], "Row 0 col " + c);
+                assertEquals('X', (char) screen[1 * cols + c], "Row 1 col " + c);
+            }
+        }
+    }
+
+    /**
+     * On xterm (am + xenl), the wrapNeeded path handles delayed wrap.
+     * When the next line is empty, the fix should use CUP (since xterm has
+     * cursor_address) instead of rawPrint(' ') + cursor_left.
+     */
+    @Test
+    void wrapNeededUsesCupOnXterm() throws IOException {
+        int rows = 4;
+        int cols = 10;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+
+            // Frame 1: fill row 0 full-width (no trailing \n = wraps), rows 1-3 empty
+            List<AttributedString> frame1 = new ArrayList<>();
+            StringBuilder full = new StringBuilder();
+            for (int c = 0; c < cols; c++) full.append('A');
+            frame1.add(new AttributedString(full.toString())); // wraps
+            for (int r = 1; r < rows; r++) {
+                frame1.add(new AttributedString(""));
+            }
+            display.update(frame1, 0);
+            terminal.flush();
+
+            // Frame 2: row 0 unchanged (still wraps), row 1 now has content
+            terminal.startCapture();
+            List<AttributedString> frame2 = new ArrayList<>(frame1);
+            frame2.set(1, new AttributedString("hello"));
+            display.update(frame2, 0);
+            terminal.flush();
+
+            byte[] captured = terminal.stopCapture();
+            String output = new String(captured, StandardCharsets.UTF_8);
+
+            // Row 0 was unchanged so cursor stays at right margin with delayed wrap.
+            // wrapNeeded triggers: since row 1 has content (starts with 'h'),
+            // the Display emits the first char to wrap. There should be no
+            // space+cursor_left sequence.
+            assertFalse(
+                    output.contains(" \033[D"),
+                    "Should use CUP or rawPrint for delayed wrap, not space+cursor_left, output: "
+                            + output.replace("\033", "\\e"));
+
+            // Verify screen: row 0 = AAAAAAAAAA, row 1 = hello(spaces)
+            long[] screen = terminal.dump();
+            for (int c = 0; c < cols; c++) {
+                assertEquals('A', (char) screen[0 * cols + c], "Row 0 col " + c);
+            }
+            assertEquals('h', (char) screen[1 * cols + 0]);
+            assertEquals('e', (char) screen[1 * cols + 1]);
+            assertEquals('l', (char) screen[1 * cols + 2]);
+            assertEquals('l', (char) screen[1 * cols + 3]);
+            assertEquals('o', (char) screen[1 * cols + 4]);
+        }
+    }
+
+    // ====================================================================
+    // Scroll optimization toggle tests
+    // ====================================================================
+
+    /**
+     * When scroll optimization is enabled (default), content shifts should produce
+     * insert_line/delete_line sequences. When disabled, they should not.
+     */
+    @Test
+    void scrollOptimizationToggle() throws IOException {
+        int rows = 6;
+        int cols = 20;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+
+            // Frame 1: rows with numbers
+            List<AttributedString> frame1 = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                frame1.add(new AttributedString("Line " + (r + 1)));
+            }
+            display.update(frame1, 0);
+            terminal.flush();
+
+            // Frame 2: shift all content down by 1 (insert at top, remove last)
+            List<AttributedString> frame2 = new ArrayList<>();
+            frame2.add(new AttributedString("Line 0")); // new line at top
+            for (int r = 0; r < rows - 1; r++) {
+                frame2.add(frame1.get(r)); // shifted down
+            }
+
+            // Test with scroll optimization ON (default)
+            terminal.startCapture();
+            display.update(frame2, 0);
+            terminal.flush();
+            byte[] capturedOn = terminal.stopCapture();
+            String outputOn = new String(capturedOn, StandardCharsets.UTF_8);
+
+            // insert_line for xterm is \e[L or \e[<n>L
+            boolean hasInsertLine = outputOn.contains("\033[L") || outputOn.matches("(?s).*\\\\e\\[\\d+L.*");
+            // Also check for the CSI IL parm form
+            boolean hasInsertLineParm = outputOn.contains("\033[1L") || outputOn.contains("\033[L");
+            assertTrue(
+                    hasInsertLine || hasInsertLineParm,
+                    "Scroll optimization ON should emit insert_line, output: " + outputOn.replace("\033", "\\e"));
+
+            // Reset display and redo with scroll optimization OFF
+            display.clear();
+            display.update(frame1, 0);
+            terminal.flush();
+
+            display.setScrollOptimization(false);
+            terminal.startCapture();
+            display.update(frame2, 0);
+            terminal.flush();
+            byte[] capturedOff = terminal.stopCapture();
+            String outputOff = new String(capturedOff, StandardCharsets.UTF_8);
+
+            assertFalse(
+                    outputOff.contains("\033[L") || outputOff.contains("\033[M"),
+                    "Scroll optimization OFF should NOT emit insert/delete line, output: "
+                            + outputOff.replace("\033", "\\e"));
+
+            // Both should produce the same screen state
+            long[] screen = terminal.dump();
+            assertEquals('L', (char) screen[0 * cols + 0]);
+            assertEquals('0', (char) screen[0 * cols + 5]);
+            assertEquals('L', (char) screen[1 * cols + 0]);
+            assertEquals('1', (char) screen[1 * cols + 5]);
+        }
+    }
+
+    // ====================================================================
+    // Synchronized output (mode 2026) tests
+    // ====================================================================
+
+    /**
+     * Full-screen updates should be wrapped in BSU/ESU (mode 2026) brackets.
+     * BSU = \e[?2026h, ESU = \e[?2026l
+     */
+    @Test
+    void syncOutputBracketsFullScreen() throws IOException {
+        int rows = 3;
+        int cols = 10;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+
+            // Initial frame
+            List<AttributedString> frame1 = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                frame1.add(new AttributedString("row" + r));
+            }
+            display.update(frame1, 0);
+            terminal.flush();
+
+            // Second frame — capture its output
+            terminal.startCapture();
+            List<AttributedString> frame2 = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                frame2.add(new AttributedString("ROW" + r));
+            }
+            display.update(frame2, 0);
+            terminal.flush();
+
+            byte[] captured = terminal.stopCapture();
+            String output = new String(captured, StandardCharsets.UTF_8);
+
+            // Must start with BSU and end with ESU (possibly followed by flush bytes)
+            assertTrue(
+                    output.contains("\033[?2026h"),
+                    "Full-screen update should contain BSU (\\e[?2026h), output: " + output.replace("\033", "\\e"));
+            assertTrue(
+                    output.contains("\033[?2026l"),
+                    "Full-screen update should contain ESU (\\e[?2026l), output: " + output.replace("\033", "\\e"));
+
+            // BSU must come before ESU
+            int bsuPos = output.indexOf("\033[?2026h");
+            int esuPos = output.indexOf("\033[?2026l");
+            assertTrue(bsuPos < esuPos, "BSU must come before ESU");
+        }
+    }
+
+    /**
+     * Non-full-screen (inline) Display should NOT emit mode 2026 sequences.
+     */
+    @Test
+    void syncOutputNotEmittedForInlineDisplay() throws IOException {
+        int rows = 3;
+        int cols = 10;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+
+            Display display = new Display(terminal, false); // inline mode
+            display.resize(Size.of(cols, rows));
+
+            List<AttributedString> frame1 = new ArrayList<>();
+            frame1.add(new AttributedString("hello"));
+            display.update(frame1, 0);
+            terminal.flush();
+
+            terminal.startCapture();
+            List<AttributedString> frame2 = new ArrayList<>();
+            frame2.add(new AttributedString("world"));
+            display.update(frame2, 0);
+            terminal.flush();
+
+            byte[] captured = terminal.stopCapture();
+            String output = new String(captured, StandardCharsets.UTF_8);
+
+            assertFalse(
+                    output.contains("\033[?2026"),
+                    "Inline display should NOT emit mode 2026 sequences, output: " + output.replace("\033", "\\e"));
+        }
+    }
+
+    // ====================================================================
+    // Screen state validation tests for both terminal types
+    // ====================================================================
+
+    /**
+     * Verify that an unchanged full-width line is NOT re-emitted.
+     * The output for the second frame should not contain the unchanged line's content.
+     */
+    @Test
+    void unchangedFullWidthLineNotReEmitted() throws IOException {
+        int rows = 3;
+        int cols = 15;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+
+            List<AttributedString> frame1 = new ArrayList<>();
+            frame1.add(new AttributedString("UNCHANGED_LINE\n"));
+            frame1.add(new AttributedString("old_text\n"));
+            frame1.add(new AttributedString("footer\n"));
+            display.update(frame1, 0);
+            terminal.flush();
+
+            terminal.startCapture();
+            List<AttributedString> frame2 = new ArrayList<>();
+            frame2.add(new AttributedString("UNCHANGED_LINE\n"));
+            frame2.add(new AttributedString("new_text\n"));
+            frame2.add(new AttributedString("footer\n"));
+            display.update(frame2, 0);
+            terminal.flush();
+
+            byte[] captured = terminal.stopCapture();
+            String output = new String(captured, StandardCharsets.UTF_8);
+
+            // The word "UNCHANGED" should NOT appear in the diff output
+            assertFalse(
+                    output.contains("UNCHANGED"),
+                    "Unchanged line should not be re-emitted, output: " + output.replace("\033", "\\e"));
+
+            // The changed portion should appear in the output.
+            // The diff engine may skip a common suffix (e.g. "_text"), but the
+            // changed prefix "new" (vs "old") must be emitted.
+            assertTrue(
+                    output.contains("new"),
+                    "Changed content should appear in output, output: " + output.replace("\033", "\\e"));
+
+            // Also verify "UNCHANGED" and "footer" are NOT in the output
+            assertFalse(
+                    output.contains("footer"),
+                    "Unchanged footer should not be re-emitted, output: " + output.replace("\033", "\\e"));
+
+            // Verify screen state
+            long[] screen = terminal.dump();
+            assertEquals('U', (char) screen[0 * cols + 0]); // row 0 unchanged
+            assertEquals('n', (char) screen[1 * cols + 0]); // row 1 updated
+            assertEquals('f', (char) screen[2 * cols + 0]); // row 2 unchanged
+        }
+    }
+
+    /**
+     * Verify that windows-vtp (no xenl) correctly renders a full-screen update
+     * where every row is full-width (no newline). The ScreenTerminal's immediate
+     * wrap behavior should produce correct screen content.
+     */
+    @Test
+    void fullWidthRowsWindowsVtp() throws IOException {
+        int contentRows = 3;
+        int cols = 5;
+        // Extra terminal row to avoid bottom-right corner scroll on non-xenl terminal.
+        int termRows = contentRows + 1;
+        try (VirtualTerminal terminal =
+                new VirtualTerminal("test", "windows-vtp", StandardCharsets.UTF_8, cols, termRows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, termRows));
+
+            // All content rows full-width, no trailing newline
+            List<AttributedString> frame = new ArrayList<>();
+            frame.add(new AttributedString("AAAAA"));
+            frame.add(new AttributedString("BBBBB"));
+            frame.add(new AttributedString("CCCCC"));
+            display.update(frame, 0);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            for (int c = 0; c < cols; c++) {
+                assertEquals('A', (char) screen[0 * cols + c], "Row 0 col " + c);
+                assertEquals('B', (char) screen[1 * cols + c], "Row 1 col " + c);
+                assertEquals('C', (char) screen[2 * cols + c], "Row 2 col " + c);
+            }
+        }
+    }
+
+    /**
+     * When blocks are adjacent (content shift of only 1 line with LCS < 2),
+     * the scroll optimization should not trigger even if enabled.
+     * This is the natural behavior of the LCS algorithm — verify the screen
+     * stays correct.
+     */
+    @Test
+    void singleRowShiftNoScroll() throws IOException {
+        int rows = 6;
+        int cols = 10;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.resize(Size.of(cols, rows));
+
+            // Frame 1: single unique row at position 2 (1-row "block")
+            List<AttributedString> frame1 = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                if (r == 2) {
+                    frame1.add(new AttributedString("##########"));
+                } else {
+                    frame1.add(new AttributedString(".........."));
+                }
+            }
+            display.update(frame1, 0);
+            terminal.flush();
+
+            // Frame 2: that single row shifted down by 1 to position 3
+            List<AttributedString> frame2 = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                if (r == 3) {
+                    frame2.add(new AttributedString("##########"));
+                } else {
+                    frame2.add(new AttributedString(".........."));
+                }
+            }
+
+            terminal.startCapture();
+            display.update(frame2, 0);
+            terminal.flush();
+            byte[] captured = terminal.stopCapture();
+            String output = new String(captured, StandardCharsets.UTF_8);
+
+            // Verify screen state is correct
+            long[] screen = terminal.dump();
+            for (int r = 0; r < rows; r++) {
+                char expected = (r == 3) ? '#' : '.';
+                assertEquals(expected, (char) screen[r * cols + 0], "Row " + r + " col 0");
+                assertEquals(expected, (char) screen[r * cols + 5], "Row " + r + " col 5");
+            }
+
+            // With only 1 common line shifted (the '##' row), LCS finds sl=1.
+            // The scroll optimization requires sl > 1 (at least 2 common lines),
+            // so no insert/delete line should be emitted.
+            assertFalse(
+                    output.contains("\033[L") || output.contains("\033[M"),
+                    "Single-row shift (sl=1) should not trigger scroll, output: " + output.replace("\033", "\\e"));
+        }
+    }
+
+    /**
+     * Verify the scroll optimization getter/setter API.
+     */
+    @Test
+    void scrollOptimizationGetterSetter() throws IOException {
+        int rows = 3;
+        int cols = 10;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            Display display = new Display(terminal, true);
+            // Default should be true
+            assertTrue(display.scrollOptimization(), "Default should be enabled");
+            display.setScrollOptimization(false);
+            assertFalse(display.scrollOptimization(), "Should be disabled after set");
+            display.setScrollOptimization(true);
+            assertTrue(display.scrollOptimization(), "Should be enabled after re-enable");
         }
     }
 

--- a/terminal/src/test/java/org/jline/utils/VirtualTerminal.java
+++ b/terminal/src/test/java/org/jline/utils/VirtualTerminal.java
@@ -28,7 +28,8 @@ public class VirtualTerminal extends LineDisciplineTerminal {
     public VirtualTerminal(String name, String type, Charset encoding, int cols, int rows) throws IOException {
         super(name, type, new SpyDelegateOutputStream(), encoding);
         setSize(Size.of(cols, rows));
-        virtual = new ScreenTerminal(cols, rows);
+        boolean xenl = getBooleanCapability(InfoCmp.Capability.eat_newline_glitch);
+        virtual = new ScreenTerminal(cols, rows, xenl);
         OutputStream feedbackOutput = new OutputStream() {
             @Override
             public void write(int b) throws IOException {


### PR DESCRIPTION
## Summary

Supersedes #1988 with a comprehensive fix for the flicker and block corruption issues reported in #1983.

**Root cause analysis**: PR #1988's CUP fix for the `wrapAtEol` path was correct but insufficient. The remaining flicker comes from the scroll optimization (`insertLines`/`deleteLines`) creating visible intermediate states during high-FPS full-screen updates. The "block corruption" regression reported after applying #1988 was caused by the CUP fix no longer writing a space at column 0 that previously forced adjacent lines to be redrawn, inadvertently masking the scroll optimization's flicker.

**Changes**:
- **CUP in `wrapNeeded` path**: Use `cursor_address` (when available) instead of `rawPrint(' ')` + `cursor_left` in the delayed-wrap path, matching the existing `wrapAtEol` fix
- **Synchronized output (mode 2026)**: Wrap full-screen `Display.update()` in BSU (`\e[?2026h`) / ESU (`\e[?2026l`) brackets so terminals that support it render atomically — eliminates flicker from any intermediate states. Terminals that don't support mode 2026 silently ignore these sequences
- **Scroll optimization toggle**: New `scrollOptimization()` / `setScrollOptimization(boolean)` API allowing applications to disable the insert/delete line optimization when it causes flicker (e.g. high-FPS game-like rendering)
- **ScreenTerminal xenl support**: Teach `ScreenTerminal` about `eat_newline_glitch` (xenl) so it correctly models both xterm-style (delayed wrap) and windows-vtp-style (immediate wrap) behavior. `VirtualTerminal` now derives xenl from terminal capabilities
- **Comprehensive tests**: 8 new test methods validating both escape sequences emitted AND screen state for xterm and windows-vtp terminal types

## Test plan
- [x] `wrapAtEolUsesCupOnWindowsVtp` — verifies CUP is used instead of space+cursor_left on windows-vtp
- [x] `wrapNeededUsesCupOnXterm` — verifies CUP is used for delayed wrap on xterm
- [x] `scrollOptimizationToggle` — verifies insert/delete line appears when ON, absent when OFF
- [x] `syncOutputBracketsFullScreen` — verifies BSU/ESU wrap full-screen updates
- [x] `syncOutputNotEmittedForInlineDisplay` — verifies no mode 2026 for inline display
- [x] `unchangedFullWidthLineNotReEmitted` — verifies diff skips unchanged lines
- [x] `fullWidthRowsWindowsVtp` — verifies correct screen state with full-width rows on non-xenl terminal
- [x] `singleRowShiftNoScroll` — verifies single-row shift (LCS=1) does not trigger scroll
- [x] `scrollOptimizationGetterSetter` — verifies the API
- [x] `fallingBlockPreservesLeftBorder` for both xterm and windows-vtp
- [x] All 350 terminal module tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal rendering reliability, including smoother full-screen updates and better support for terminals that handle wrapping differently.
  * Added an option to control scroll-based screen updates for more predictable behavior across terminal types.

* **Bug Fixes**
  * Fixed status line clearing so leftover lines are removed more cleanly.
  * Improved cursor placement and wrap handling to reduce visible artifacts when text reaches the edge of the screen.
  * Better support for wide characters, resizing, and repeated screen refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->