### PR TITLE
fix: backport security hardening to jline-3.x (#1986, #1995)

### DIFF
--- a/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
+++ b/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
@@ -29,17 +29,18 @@ package org.jline.nativ;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -327,12 +328,13 @@ public class JLineNativeLoader {
         File extractedLckFile = new File(targetFolder, extractedLckFileName);
 
         try {
-            // Extract a native library file into the target directory
+            // Extract a native library file into the target directory.
+            // The target sits in the shared system temp directory, so open both
+            // files with CREATE_NEW: an existing path or a symlink planted there
+            // by another local user is refused instead of being followed.
             try (InputStream in = JLineNativeLoader.class.getResourceAsStream(nativeLibraryFilePath)) {
-                if (!extractedLckFile.exists()) {
-                    new FileOutputStream(extractedLckFile).close();
-                }
-                try (OutputStream out = new FileOutputStream(extractedLibFile)) {
+                newExclusiveStream(extractedLckFile).close();
+                try (OutputStream out = newExclusiveStream(extractedLibFile)) {
                     copy(in, out);
                 }
             } finally {
@@ -371,7 +373,17 @@ public class JLineNativeLoader {
     }
 
     private static String randomUUID() {
-        return Long.toHexString(new Random().nextLong());
+        return Long.toHexString(ThreadLocalRandom.current().nextLong());
+    }
+
+    /**
+     * Opens an output stream that creates a brand new file, failing if the path already
+     * exists. {@code CREATE_NEW} maps to an exclusive create at the OS level, so a symlink
+     * or a regular file planted at the target path in the shared temp directory is rejected
+     * rather than followed.
+     */
+    static OutputStream newExclusiveStream(File file) throws IOException {
+        return Files.newOutputStream(file.toPath(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
     }
 
     private static void copy(InputStream in, OutputStream out) throws IOException {

--- a/native/src/test/java/org/jline/nativ/JLineNativeLoaderTest.java
+++ b/native/src/test/java/org/jline/nativ/JLineNativeLoaderTest.java
@@ -8,12 +8,40 @@
  */
 package org.jline.nativ;
 
+import java.io.File;
+import java.io.OutputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JLineNativeLoaderTest {
 
     @Test
     public void testLoadLibrary() {
         JLineNativeLoader.initialize();
+    }
+
+    @Test
+    void exclusiveStreamRefusesExistingTarget(@TempDir Path dir) throws Exception {
+        // A file already sitting at the target path stands in for a symlink an attacker
+        // planted in the shared temp directory: the open must fail instead of writing through it.
+        File planted = dir.resolve("jlinenative-planted").toFile();
+        assertTrue(planted.createNewFile());
+        assertThrows(
+                FileAlreadyExistsException.class,
+                () -> JLineNativeLoader.newExclusiveStream(planted).close());
+
+        // A fresh path is created normally.
+        File fresh = dir.resolve("jlinenative-fresh").toFile();
+        try (OutputStream out = JLineNativeLoader.newExclusiveStream(fresh)) {
+            out.write(new byte[] {1, 2, 3});
+        }
+        assertTrue(Files.isRegularFile(fresh.toPath()));
     }
 }

--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -10,6 +10,8 @@ package org.jline.reader.impl.history;
 
 import java.io.*;
 import java.nio.file.*;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.*;
@@ -388,12 +390,13 @@ public class DefaultHistory implements History {
             if (!Files.exists(parent)) {
                 Files.createDirectories(parent);
             }
-            // Append new items to the history file
+            createWithOwnerOnlyPermissions(path.toAbsolutePath());
+            // Append new items to the history file. createWithOwnerOnlyPermissions guarantees the
+            // file exists, so CREATE is intentionally omitted: should the file be removed in the
+            // narrow window before this open, fail with NoSuchFileException rather than silently
+            // re-creating it with umask-default (group/world readable) permissions.
             try (BufferedWriter writer = Files.newBufferedWriter(
-                    path.toAbsolutePath(),
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.APPEND,
-                    StandardOpenOption.CREATE)) {
+                    path.toAbsolutePath(), StandardOpenOption.WRITE, StandardOpenOption.APPEND)) {
                 for (Entry entry : items.subList(from, items.size())) {
                     if (isPersistable(entry)) {
                         writer.append(format(entry));
@@ -407,6 +410,61 @@ public class DefaultHistory implements History {
             }
         }
         setLastLoaded(path, items.size());
+    }
+
+    /**
+     * Creates the history file restricted to the owner when it does not exist yet.
+     * History lines can contain secrets typed on the command line, so the file
+     * must not be left group/world readable as the umask default (0644) would.
+     * On non-POSIX filesystems the file is created with the platform default.
+     */
+    private static void createWithOwnerOnlyPermissions(Path path) throws IOException {
+        if (Files.exists(path)) {
+            // A pre-existing file (e.g. created by an older JLine without this fix) keeps its
+            // current permissions; we don't silently tighten it, but warn so the user can.
+            warnIfAccessibleByOthers(path);
+            return;
+        }
+        try {
+            Files.createFile(
+                    path,
+                    PosixFilePermissions.asFileAttribute(
+                            EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)));
+        } catch (FileAlreadyExistsException e) {
+            // created concurrently between the check and the call
+        } catch (UnsupportedOperationException e) {
+            // non-POSIX filesystem (e.g. Windows): fall back to default creation
+            try {
+                Files.createFile(path);
+            } catch (FileAlreadyExistsException ignore) {
+                // created concurrently
+            }
+        }
+    }
+
+    private static final Set<Path> WARNED_INSECURE_PERMS = Collections.synchronizedSet(new HashSet<>());
+
+    private static final Set<PosixFilePermission> NON_OWNER_PERMS = EnumSet.of(
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.GROUP_WRITE,
+            PosixFilePermission.GROUP_EXECUTE,
+            PosixFilePermission.OTHERS_READ,
+            PosixFilePermission.OTHERS_WRITE,
+            PosixFilePermission.OTHERS_EXECUTE);
+
+    /**
+     * Warns, at most once per path, when an existing history file is accessible by users other
+     * than the owner. The file's permissions are left untouched so as not to surprise the user.
+     */
+    private static void warnIfAccessibleByOthers(Path path) {
+        try {
+            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(path);
+            if (perms.stream().anyMatch(NON_OWNER_PERMS::contains) && WARNED_INSECURE_PERMS.add(path)) {
+                Log.warn("History file ", path, " is accessible by other users; consider 'chmod 600'");
+            }
+        } catch (UnsupportedOperationException | IOException e) {
+            // non-POSIX filesystem or attributes unavailable: nothing to warn about
+        }
     }
 
     /**

--- a/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/history/HistoryPersistenceTest.java
@@ -9,10 +9,16 @@
 package org.jline.reader.impl.history;
 
 import java.io.IOException;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.stream.IntStream;
@@ -21,6 +27,7 @@ import org.jline.reader.LineReader;
 import org.jline.reader.impl.ReaderTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -116,6 +123,30 @@ public class HistoryPersistenceTest extends ReaderTestSupport {
 
         Assertions.assertDoesNotThrow(history::load);
         Assertions.assertEquals(5, history.size());
+    }
+
+    @Test
+    public void testHistoryFilePermissions() throws Exception {
+        Path dir = Files.createTempDirectory("jline-hist-perm");
+        Path testPath = dir.resolve("history");
+        try {
+            FileStore store = Files.getFileStore(dir);
+            Assumptions.assumeTrue(store.supportsFileAttributeView(PosixFileAttributeView.class));
+
+            reader.setVariable(LineReader.HISTORY_FILE, testPath);
+            DefaultHistory history = new DefaultHistory(reader);
+            history.add("password=hunter2");
+            history.save();
+
+            Set<PosixFilePermission> perms = Files.getPosixFilePermissions(testPath);
+            assertEquals(
+                    EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+                    perms,
+                    "newly created history file must not be group/world readable");
+        } finally {
+            Files.deleteIfExists(testPath);
+            Files.deleteIfExists(dir);
+        }
     }
 
     @Test


### PR DESCRIPTION
Backport of two security hardening fixes to the 3.x maintenance branch:

**History file permissions (CWE-732, #1986)**
- Create persisted history files with POSIX 0600 (owner-only read/write) instead of inheriting the process umask
- Prevents other users on a shared system from reading potentially sensitive command history
- Gracefully degrades on non-POSIX filesystems (Windows, unusual mounts)

**Native library temp file extraction (CWE-59/CWE-367, #1995)**  
- Use `Files.newOutputStream(CREATE_NEW, WRITE)` (O_EXCL) instead of `FileOutputStream` when extracting native libraries to temp directories
- Prevents symlink-following attacks (TOCTOU) in shared temp directories
- Replace `new Random()` with `ThreadLocalRandom` for less predictable temp file names

Cherry-picked from master commits 062647bb and bc80e3de with conflict resolution for 3.x import style (wildcard imports, `java.util.logging`).