### PR TITLE
fix: guard regex matching against catastrophic backtracking (ReDoS)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Commands.java
+++ b/builtins/src/main/java/org/jline/builtins/Commands.java
@@ -44,6 +44,7 @@ import org.jline.reader.Widget;
 import org.jline.terminal.Terminal;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
+import org.jline.utils.SafeRegex;
 import org.jline.utils.StyleResolver;
 
 import static org.jline.builtins.SyntaxHighlighter.*;
@@ -361,16 +362,7 @@ public class Commands {
 
         Pattern pattern = null;
         if (opt.isSet("m") && opt.args().size() > argId) {
-            StringBuilder sb = new StringBuilder();
-            char prev = '0';
-            for (char c : opt.args().get(argId++).toCharArray()) {
-                if (c == '*' && prev != '\\' && prev != '.') {
-                    sb.append('.');
-                }
-                sb.append(c);
-                prev = c;
-            }
-            pattern = Pattern.compile(sb.toString(), Pattern.DOTALL);
+            pattern = SafeRegex.compileGlob(opt.args().get(argId++), Pattern.DOTALL);
         }
         boolean reverse = opt.isSet("r") || (opt.isSet("s") && opt.args().size() <= argId);
         int firstId = opt.args().size() > argId
@@ -400,7 +392,7 @@ public class Commands {
         while (iter.hasNext() && listed < tot) {
             History.Entry entry = iter.next();
             listed++;
-            if (pattern != null && !pattern.matcher(entry.line()).matches()) {
+            if (pattern != null && !SafeRegex.matches(pattern, entry.line())) {
                 continue;
             }
             if (execute.isExecute()) {

--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -41,6 +41,7 @@ import org.jline.utils.AttributedStyle;
 import org.jline.utils.Display;
 import org.jline.utils.InfoCmp.Capability;
 import org.jline.utils.NonBlockingReader;
+import org.jline.utils.SafeRegex;
 import org.jline.utils.Status;
 
 import static org.jline.builtins.SyntaxHighlighter.*;
@@ -1103,7 +1104,7 @@ public class Less {
                     break;
                 } else if (!toBeDisplayed(line, dpCompiled)) {
                     continue;
-                } else if (compiled.matcher(line).find()) {
+                } else if (SafeRegex.find(compiled, line)) {
                     display.clear();
                     firstLineToDisplay = lineNumber;
                     offsetInLine = 0;
@@ -1143,7 +1144,7 @@ public class Less {
                     break;
                 } else if (!toBeDisplayed(line, dpCompiled)) {
                     continue;
-                } else if (compiled.matcher(line).find()) {
+                } else if (SafeRegex.find(compiled, line)) {
                     display.clear();
                     firstLineToDisplay = lineNumber;
                     offsetInLine = 0;
@@ -1317,10 +1318,7 @@ public class Less {
     }
 
     private boolean toBeDisplayed(AttributedString curLine, Pattern dpCompiled) {
-        return curLine == null
-                || dpCompiled == null
-                || sourceIdx == 0
-                || dpCompiled.matcher(curLine).find();
+        return curLine == null || dpCompiled == null || sourceIdx == 0 || SafeRegex.find(dpCompiled, curLine);
     }
 
     synchronized boolean display(boolean oneScreen) throws IOException {

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -1343,7 +1343,7 @@ public class Nano implements Editor {
             try {
                 while (m.find()) {
                     res.add(m.start());
-                    matchedLength = m.group(0).length();
+                    matchedLength = m.end() - m.start();
                 }
             } catch (RegexTimeoutException e) {
                 // Return whatever matches were found before timeout

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -49,6 +49,8 @@ import org.jline.terminal.Terminal.SignalHandler;
 import org.jline.terminal.impl.MouseSupport;
 import org.jline.utils.*;
 import org.jline.utils.InfoCmp.Capability;
+import org.jline.utils.RegexTimeoutException;
+import org.jline.utils.SafeRegex;
 import org.jline.utils.Status;
 import org.mozilla.universalchardet.UniversalDetector;
 
@@ -1336,11 +1338,15 @@ public class Nano implements Editor {
                     searchTerm,
                     (searchCaseSensitive ? 0 : Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE)
                             | (searchRegexp ? 0 : Pattern.LITERAL));
-            Matcher m = pat.matcher(text);
+            Matcher m = SafeRegex.matcher(pat, text);
             List<Integer> res = new ArrayList<>();
-            while (m.find()) {
-                res.add(m.start());
-                matchedLength = m.group(0).length();
+            try {
+                while (m.find()) {
+                    res.add(m.start());
+                    matchedLength = m.group(0).length();
+                }
+            } catch (RegexTimeoutException e) {
+                // Return whatever matches were found before timeout
             }
             return res;
         }

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -1334,6 +1334,7 @@ public class Nano implements Editor {
         }
 
         private List<Integer> doSearch(String text) {
+            matchedLength = 0;
             Pattern pat = Pattern.compile(
                     searchTerm,
                     (searchCaseSensitive ? 0 : Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE)

--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -49,6 +49,8 @@ import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.InfoCmp.Capability;
 import org.jline.utils.OSUtils;
+import org.jline.utils.RegexTimeoutException;
+import org.jline.utils.SafeRegex;
 import org.jline.utils.StyleResolver;
 
 /**
@@ -1414,10 +1416,9 @@ public class PosixCommands {
         if (opt.isSet("word-regexp")) {
             regexp = "\\b" + regexp + "\\b";
         }
-        if (opt.isSet("line-regexp")) {
+        boolean lineRegexp = opt.isSet("line-regexp");
+        if (lineRegexp) {
             regexp = "^" + regexp + "$";
-        } else {
-            regexp = ".*" + regexp + ".*";
         }
         Pattern p;
         Pattern p2;
@@ -1485,7 +1486,7 @@ public class PosixCommands {
                     int lineno = 1;
                     int lineMatch = 0;
                     while ((line = r.readLine()) != null) {
-                        boolean matches = p.matcher(line).matches();
+                        boolean matches = lineRegexp ? SafeRegex.matches(p, line) : SafeRegex.find(p, line);
                         if (invert) {
                             matches = !matches;
                         }
@@ -1514,15 +1515,19 @@ public class PosixCommands {
                                     sbl.append(":");
                                 }
                                 if (colored) {
-                                    Matcher matcher2 = p2.matcher(line);
+                                    Matcher matcher2 = SafeRegex.matcher(p2, line);
                                     int cur = 0;
-                                    while (matcher2.find()) {
-                                        applyStyle(sbl, colors, "se");
-                                        sbl.append(line, cur, matcher2.start());
-                                        applyStyle(sbl, colors, "ms");
-                                        sbl.append(line, matcher2.start(), matcher2.end());
-                                        applyStyle(sbl, colors, "se");
-                                        cur = matcher2.end();
+                                    try {
+                                        while (matcher2.find()) {
+                                            applyStyle(sbl, colors, "se");
+                                            sbl.append(line, cur, matcher2.start());
+                                            applyStyle(sbl, colors, "ms");
+                                            sbl.append(line, matcher2.start(), matcher2.end());
+                                            applyStyle(sbl, colors, "se");
+                                            cur = matcher2.end();
+                                        }
+                                    } catch (RegexTimeoutException e) {
+                                        // Append remaining text without highlighting
                                     }
                                     sbl.append(line, cur, line.length());
                                 } else {

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -48,6 +48,8 @@ import org.jline.utils.Curses;
 import org.jline.utils.Display;
 import org.jline.utils.InfoCmp.Capability;
 import org.jline.utils.Log;
+import org.jline.utils.RegexTimeoutException;
+import org.jline.utils.SafeRegex;
 import org.jline.utils.Status;
 import org.jline.utils.StyleResolver;
 import org.jline.utils.WCWidth;
@@ -3119,9 +3121,13 @@ public class LineReaderImpl implements LineReader, Flushable {
 
     private List<Pair<Integer, Integer>> matches(Pattern p, String line, int index) {
         List<Pair<Integer, Integer>> starts = new ArrayList<>();
-        Matcher m = p.matcher(line);
-        while (m.find()) {
-            starts.add(new Pair<>(index, m.start()));
+        Matcher m = SafeRegex.matcher(p, line);
+        try {
+            while (m.find()) {
+                starts.add(new Pair<>(index, m.start()));
+            }
+        } catch (RegexTimeoutException e) {
+            // Return whatever matches were found before timeout
         }
         return starts;
     }
@@ -4393,21 +4399,13 @@ public class LineReaderImpl implements LineReader, Flushable {
             return "";
         }
         History history = getHistory();
-        StringBuilder sb = new StringBuilder();
-        for (char c : buffer.replace("\\", "\\\\").toCharArray()) {
-            if (c == '(' || c == ')' || c == '[' || c == ']' || c == '{' || c == '}' || c == '^' || c == '*' || c == '$'
-                    || c == '.' || c == '?' || c == '+' || c == '|' || c == '<' || c == '>' || c == '!' || c == '-') {
-                sb.append('\\');
-            }
-            sb.append(c);
-        }
-        Pattern pattern = Pattern.compile(sb.toString() + ".*", Pattern.DOTALL);
+        Pattern pattern = Pattern.compile(Pattern.quote(buffer) + ".*", Pattern.DOTALL);
         Iterator<History.Entry> iter = history.reverseIterator(history.last());
         String suggestion = "";
         int tot = 0;
         while (iter.hasNext()) {
             History.Entry entry = iter.next();
-            Matcher matcher = pattern.matcher(entry.line());
+            Matcher matcher = SafeRegex.matcher(pattern, entry.line());
             if (matcher.matches()) {
                 suggestion = entry.line().substring(buffer.length());
                 break;

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4405,11 +4405,16 @@ public class LineReaderImpl implements LineReader, Flushable {
         int tot = 0;
         while (iter.hasNext()) {
             History.Entry entry = iter.next();
-            Matcher matcher = SafeRegex.matcher(pattern, entry.line());
-            if (matcher.matches()) {
-                suggestion = entry.line().substring(buffer.length());
-                break;
-            } else if (tot > 200) {
+            try {
+                Matcher matcher = SafeRegex.matcher(pattern, entry.line());
+                if (matcher.matches()) {
+                    suggestion = entry.line().substring(buffer.length());
+                    break;
+                }
+            } catch (RegexTimeoutException e) {
+                // Treat timeout as non-match, continue searching
+            }
+            if (tot > 200) {
                 break;
             }
             tot++;

--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -19,10 +19,12 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import org.jline.reader.History;
 import org.jline.reader.LineReader;
 import org.jline.utils.Log;
+import org.jline.utils.SafeRegex;
 
 import static org.jline.reader.LineReader.HISTORY_IGNORE;
 import static org.jline.reader.impl.ReaderUtils.*;
@@ -670,21 +672,25 @@ public class DefaultHistory implements History {
         if (patterns == null || patterns.isEmpty()) {
             return false;
         }
+        // HISTORY_IGNORE uses a glob-like syntax where '*' matches any string,
+        // ':' separates alternatives, and '\' escapes the next character.
+        // All other characters must match literally — regex metacharacters
+        // are quoted to prevent ReDoS via catastrophic backtracking.
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < patterns.length(); i++) {
             char ch = patterns.charAt(i);
-            if (ch == '\\') {
+            if (ch == '\\' && i + 1 < patterns.length()) {
                 ch = patterns.charAt(++i);
-                sb.append(ch);
+                sb.append(Pattern.quote(String.valueOf(ch)));
             } else if (ch == ':') {
                 sb.append('|');
             } else if (ch == '*') {
-                sb.append('.').append('*');
+                sb.append(".*");
             } else {
-                sb.append(ch);
+                sb.append(Pattern.quote(String.valueOf(ch)));
             }
         }
-        return line.matches(sb.toString());
+        return SafeRegex.matches(Pattern.compile(sb.toString()), line);
     }
 
     /**

--- a/terminal/src/main/java/org/jline/utils/AttributedString.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedString.java
@@ -445,16 +445,25 @@ public class AttributedString extends AttributedCharSequence {
      * @return a new AttributedString with the specified style applied to matching regions
      */
     public AttributedString styleMatches(Pattern pattern, AttributedStyle style) {
-        Matcher matcher = pattern.matcher(this);
-        boolean result = matcher.find();
+        Matcher matcher = SafeRegex.matcher(pattern, this);
+        boolean result;
+        try {
+            result = matcher.find();
+        } catch (RegexTimeoutException e) {
+            return this;
+        }
         if (result) {
             long[] newstyle = this.style.clone();
-            do {
-                for (int i = matcher.start(); i < matcher.end(); i++) {
-                    newstyle[this.start + i] = (newstyle[this.start + i] & ~style.getMask()) | style.getStyle();
-                }
-                result = matcher.find();
-            } while (result);
+            try {
+                do {
+                    for (int i = matcher.start(); i < matcher.end(); i++) {
+                        newstyle[this.start + i] = (newstyle[this.start + i] & ~style.getMask()) | style.getStyle();
+                    }
+                    result = matcher.find();
+                } while (result);
+            } catch (RegexTimeoutException e) {
+                // Apply whatever matches we found so far
+            }
             return new AttributedString(buffer, newstyle, start, end);
         }
         return this;

--- a/terminal/src/main/java/org/jline/utils/RegexTimeoutException.java
+++ b/terminal/src/main/java/org/jline/utils/RegexTimeoutException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+/**
+ * Thrown when a regular expression match exceeds its time budget.
+ *
+ * <p>This is an unchecked exception because it is thrown from within
+ * {@link CharSequence#charAt(int)}, which the {@code java.util.regex}
+ * engine calls during matching. Callers that use
+ * {@link SafeRegex#matcher(java.util.regex.Pattern, CharSequence)}
+ * directly should catch this exception; the convenience methods
+ * {@link SafeRegex#matches} and {@link SafeRegex#find} catch it
+ * internally and return {@code false}.</p>
+ */
+public class RegexTimeoutException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public RegexTimeoutException() {
+        super("Regular expression matching timed out");
+    }
+
+    public RegexTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/terminal/src/main/java/org/jline/utils/SafeRegex.java
+++ b/terminal/src/main/java/org/jline/utils/SafeRegex.java
@@ -29,7 +29,10 @@ import java.util.regex.Pattern;
  *       match groups), use {@link #matcher} and catch
  *       {@link RegexTimeoutException} yourself.</li>
  *   <li>For glob-style patterns (only {@code *} is special), use
- *       {@link #compileGlob} to get a safe {@link Pattern}.</li>
+ *       {@link #compileGlob} to compile a {@link Pattern} that properly
+ *       escapes literal characters. Note: {@code compileGlob} only builds
+ *       the pattern; to get timeout protection, pass the result through
+ *       {@link #matcher}, {@link #matches}, or {@link #find}.</li>
  * </ul>
  */
 public final class SafeRegex {
@@ -59,11 +62,13 @@ public final class SafeRegex {
 
     /**
      * Create a {@link Matcher} that will throw {@link RegexTimeoutException}
-     * if matching exceeds the given timeout.
+     * if matching exceeds the given timeout.  The timeout starts on the
+     * first {@code charAt} call (i.e. when matching actually begins), not
+     * when the {@link Matcher} is created.
      */
     public static Matcher matcher(Pattern pattern, CharSequence input, long timeoutMs) {
-        long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
-        return pattern.matcher(new TimeoutCharSequence(input, deadlineNanos));
+        long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        return pattern.matcher(new TimeoutCharSequence(input, timeoutNanos));
     }
 
     // ---- convenience boolean methods ---------------------------------------
@@ -154,22 +159,43 @@ public final class SafeRegex {
      * it considers during matching.  During catastrophic backtracking the
      * call count explodes; we check {@link System#nanoTime()} every
      * {@value #CHECK_INTERVAL} calls and throw if the deadline has passed.</p>
+     *
+     * <p>The deadline is lazily initialised on the first {@code charAt}
+     * check so the timeout measures actual matching time, not the gap
+     * between {@link Matcher} creation and first use.  Instances created
+     * via {@link #subSequence} share the same deadline array, so the
+     * timeout covers the entire matching operation.</p>
      */
     private static final class TimeoutCharSequence implements CharSequence {
 
         private final CharSequence inner;
-        private final long deadlineNanos;
+        private final long timeoutNanos;
+        /** Shared across {@link #subSequence} calls; element 0 holds the deadline (0 = not yet started). */
+        private final long[] sharedDeadline;
+
         private int calls;
 
-        TimeoutCharSequence(CharSequence inner, long deadlineNanos) {
+        TimeoutCharSequence(CharSequence inner, long timeoutNanos) {
             this.inner = inner;
-            this.deadlineNanos = deadlineNanos;
+            this.timeoutNanos = timeoutNanos;
+            this.sharedDeadline = new long[1];
+        }
+
+        private TimeoutCharSequence(CharSequence inner, long timeoutNanos, long[] sharedDeadline) {
+            this.inner = inner;
+            this.timeoutNanos = timeoutNanos;
+            this.sharedDeadline = sharedDeadline;
         }
 
         @Override
         public char charAt(int index) {
-            if (++calls % CHECK_INTERVAL == 0 && System.nanoTime() > deadlineNanos) {
-                throw new RegexTimeoutException();
+            if (++calls % CHECK_INTERVAL == 0) {
+                long now = System.nanoTime();
+                if (sharedDeadline[0] == 0) {
+                    sharedDeadline[0] = now + timeoutNanos;
+                } else if (now > sharedDeadline[0]) {
+                    throw new RegexTimeoutException();
+                }
             }
             return inner.charAt(index);
         }
@@ -181,7 +207,7 @@ public final class SafeRegex {
 
         @Override
         public CharSequence subSequence(int start, int end) {
-            return new TimeoutCharSequence(inner.subSequence(start, end), deadlineNanos);
+            return new TimeoutCharSequence(inner.subSequence(start, end), timeoutNanos, sharedDeadline);
         }
 
         @Override

--- a/terminal/src/main/java/org/jline/utils/SafeRegex.java
+++ b/terminal/src/main/java/org/jline/utils/SafeRegex.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Regex utilities that guard against catastrophic backtracking (ReDoS).
+ *
+ * <p>Java's {@code java.util.regex} engine uses backtracking, so patterns with
+ * nested quantifiers (e.g. {@code (a+)+b}) can take exponential time on
+ * non-matching input. This class wraps input in a {@link CharSequence} that
+ * enforces a wall-clock deadline, throwing {@link RegexTimeoutException} if
+ * matching takes too long.</p>
+ *
+ * <p>Usage:</p>
+ * <ul>
+ *   <li>For simple boolean checks, use {@link #matches} or {@link #find} —
+ *       they catch timeouts and return {@code false}.</li>
+ *   <li>When you need the {@link Matcher} (e.g. for a find loop or to read
+ *       match groups), use {@link #matcher} and catch
+ *       {@link RegexTimeoutException} yourself.</li>
+ *   <li>For glob-style patterns (only {@code *} is special), use
+ *       {@link #compileGlob} to get a safe {@link Pattern}.</li>
+ * </ul>
+ */
+public final class SafeRegex {
+
+    /** Default timeout for regex matching operations. */
+    private static final long DEFAULT_TIMEOUT_MS = 1500;
+
+    /**
+     * How often (in {@code charAt} calls) the deadline is checked.
+     * Checking every call would add measurable overhead; checking every
+     * 1024 calls keeps the cost negligible while still catching runaway
+     * backtracking within milliseconds on typical input.
+     */
+    private static final int CHECK_INTERVAL = 1024;
+
+    private SafeRegex() {}
+
+    // ---- matcher factory ---------------------------------------------------
+
+    /**
+     * Create a {@link Matcher} that will throw {@link RegexTimeoutException}
+     * if matching exceeds the default timeout.
+     */
+    public static Matcher matcher(Pattern pattern, CharSequence input) {
+        return matcher(pattern, input, DEFAULT_TIMEOUT_MS);
+    }
+
+    /**
+     * Create a {@link Matcher} that will throw {@link RegexTimeoutException}
+     * if matching exceeds the given timeout.
+     */
+    public static Matcher matcher(Pattern pattern, CharSequence input, long timeoutMs) {
+        return pattern.matcher(new TimeoutCharSequence(input, timeoutMs));
+    }
+
+    // ---- convenience boolean methods ---------------------------------------
+
+    /**
+     * Test whether the pattern matches the entire input, with timeout
+     * protection. Returns {@code false} on timeout.
+     */
+    public static boolean matches(Pattern pattern, CharSequence input) {
+        try {
+            return matcher(pattern, input).matches();
+        } catch (RegexTimeoutException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Test whether the pattern is found anywhere in the input, with timeout
+     * protection. Returns {@code false} on timeout.
+     */
+    public static boolean find(Pattern pattern, CharSequence input) {
+        try {
+            return matcher(pattern, input).find();
+        } catch (RegexTimeoutException e) {
+            return false;
+        }
+    }
+
+    // ---- glob compilation --------------------------------------------------
+
+    /**
+     * Compile a glob-style pattern into a {@link Pattern}.
+     *
+     * <p>Only {@code *} (match any string) and {@code \} (escape) are
+     * special; every other character is regex-quoted so it matches
+     * literally. This is suitable for user-facing wildcard syntax where
+     * full regex power is not intended.</p>
+     *
+     * @param globPattern the glob pattern (e.g. {@code "foo*bar"})
+     * @return a compiled regex pattern
+     */
+    public static Pattern compileGlob(String globPattern) {
+        return compileGlob(globPattern, 0);
+    }
+
+    /**
+     * Compile a glob-style pattern into a {@link Pattern} with the given
+     * regex flags.
+     *
+     * @param globPattern the glob pattern
+     * @param flags       regex flags (e.g. {@link Pattern#DOTALL})
+     * @return a compiled regex pattern
+     */
+    public static Pattern compileGlob(String globPattern, int flags) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < globPattern.length(); i++) {
+            char ch = globPattern.charAt(i);
+            if (ch == '\\' && i + 1 < globPattern.length()) {
+                appendQuoted(sb, globPattern.charAt(++i));
+            } else if (ch == '*') {
+                sb.append(".*");
+            } else {
+                appendQuoted(sb, ch);
+            }
+        }
+        return Pattern.compile(sb.toString(), flags);
+    }
+
+    // ---- internal ----------------------------------------------------------
+
+    private static void appendQuoted(StringBuilder sb, char ch) {
+        // Quote individual regex metacharacters inline rather than using
+        // Pattern.quote() (\Q...\E) to keep the generated regex readable.
+        if ("\\^$.|?*+()[]{}".indexOf(ch) >= 0) {
+            sb.append('\\');
+        }
+        sb.append(ch);
+    }
+
+    /**
+     * A {@link CharSequence} wrapper that enforces a wall-clock deadline.
+     *
+     * <p>The Java regex engine calls {@link #charAt(int)} for every position
+     * it considers during matching.  During catastrophic backtracking the
+     * call count explodes; we check {@link System#nanoTime()} every
+     * {@value #CHECK_INTERVAL} calls and throw if the deadline has passed.</p>
+     */
+    private static final class TimeoutCharSequence implements CharSequence {
+
+        private final CharSequence inner;
+        private final long deadlineNanos;
+        private int calls;
+
+        TimeoutCharSequence(CharSequence inner, long timeoutMs) {
+            this.inner = inner;
+            this.deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        }
+
+        /** Private constructor that shares an existing deadline (for {@link #subSequence}). */
+        private TimeoutCharSequence(CharSequence inner, long deadlineNanos, boolean ignored) {
+            this.inner = inner;
+            this.deadlineNanos = deadlineNanos;
+        }
+
+        @Override
+        public char charAt(int index) {
+            if (++calls % CHECK_INTERVAL == 0 && System.nanoTime() > deadlineNanos) {
+                throw new RegexTimeoutException();
+            }
+            return inner.charAt(index);
+        }
+
+        @Override
+        public int length() {
+            return inner.length();
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return new TimeoutCharSequence(inner.subSequence(start, end), deadlineNanos, true);
+        }
+
+        @Override
+        public String toString() {
+            return inner.toString();
+        }
+    }
+}

--- a/terminal/src/main/java/org/jline/utils/SafeRegex.java
+++ b/terminal/src/main/java/org/jline/utils/SafeRegex.java
@@ -62,9 +62,9 @@ public final class SafeRegex {
 
     /**
      * Create a {@link Matcher} that will throw {@link RegexTimeoutException}
-     * if matching exceeds the given timeout.  The timeout starts on the
-     * first {@code charAt} call (i.e. when matching actually begins), not
-     * when the {@link Matcher} is created.
+     * if matching exceeds the given timeout.  The timeout starts lazily on
+     * the first deadline check during matching (not when the {@link Matcher}
+     * is created), so it measures actual matching time.
      */
     public static Matcher matcher(Pattern pattern, CharSequence input, long timeoutMs) {
         long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMs);

--- a/terminal/src/main/java/org/jline/utils/SafeRegex.java
+++ b/terminal/src/main/java/org/jline/utils/SafeRegex.java
@@ -62,7 +62,8 @@ public final class SafeRegex {
      * if matching exceeds the given timeout.
      */
     public static Matcher matcher(Pattern pattern, CharSequence input, long timeoutMs) {
-        return pattern.matcher(new TimeoutCharSequence(input, timeoutMs));
+        long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        return pattern.matcher(new TimeoutCharSequence(input, deadlineNanos));
     }
 
     // ---- convenience boolean methods ---------------------------------------
@@ -118,14 +119,18 @@ public final class SafeRegex {
      */
     public static Pattern compileGlob(String globPattern, int flags) {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < globPattern.length(); i++) {
+        int i = 0;
+        while (i < globPattern.length()) {
             char ch = globPattern.charAt(i);
             if (ch == '\\' && i + 1 < globPattern.length()) {
-                appendQuoted(sb, globPattern.charAt(++i));
+                appendQuoted(sb, globPattern.charAt(i + 1));
+                i += 2;
             } else if (ch == '*') {
                 sb.append(".*");
+                i++;
             } else {
                 appendQuoted(sb, ch);
+                i++;
             }
         }
         return Pattern.compile(sb.toString(), flags);
@@ -156,13 +161,7 @@ public final class SafeRegex {
         private final long deadlineNanos;
         private int calls;
 
-        TimeoutCharSequence(CharSequence inner, long timeoutMs) {
-            this.inner = inner;
-            this.deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
-        }
-
-        /** Private constructor that shares an existing deadline (for {@link #subSequence}). */
-        private TimeoutCharSequence(CharSequence inner, long deadlineNanos, boolean ignored) {
+        TimeoutCharSequence(CharSequence inner, long deadlineNanos) {
             this.inner = inner;
             this.deadlineNanos = deadlineNanos;
         }
@@ -182,7 +181,7 @@ public final class SafeRegex {
 
         @Override
         public CharSequence subSequence(int start, int end) {
-            return new TimeoutCharSequence(inner.subSequence(start, end), deadlineNanos, true);
+            return new TimeoutCharSequence(inner.subSequence(start, end), deadlineNanos);
         }
 
         @Override


### PR DESCRIPTION
## Summary

- Adds `SafeRegex` utility class in the `terminal` module that wraps regex input in a `TimeoutCharSequence` to enforce a wall-clock deadline during matching, preventing denial-of-service via patterns with catastrophic backtracking (e.g. `(a+)+b`).
- Fixes 8 locations across `terminal`, `reader`, and `builtins` modules where user-controlled input was compiled/matched as a Java regex without validation.
- Removes the unsafe `.*` pattern wrapping in the built-in `grep` command, using `Matcher.find()` instead.
- Properly quotes regex metacharacters in `HISTORY_IGNORE` glob patterns and the history `-m` flag.
- Replaces incomplete manual regex escaping in `matchPreviousCommand()` with `Pattern.quote()`.

Addresses: GHSA-r2xf-8xr9-62gw, GHSA-2v9w-34q6-wpqx, GHSA-ph9c-7hw9-vhhw, GHSA-5q95-hrpc-m3w3 and additional unreported locations.

## Approach

Rather than adding a dependency on RE2/J, the fix uses a `TimeoutCharSequence` wrapper that checks `System.nanoTime()` every 1024 `charAt()` calls during regex matching. When the JDK regex engine backtracks catastrophically, the call count explodes and the deadline is hit within milliseconds. No extra threads or thread interruption needed.

## Fixed locations

| Module | File | Issue |
|--------|------|-------|
| terminal | `AttributedString.styleMatches()` | Search highlight rendering |
| builtins | `Less.java` | Search and display-filter matching |
| builtins | `Nano.java` | Regex search mode |
| builtins | `PosixCommands.java` (grep) | `.*` wrapping amplified backtracking |
| builtins | `Commands.java` (history -m) | Unescaped glob pattern |
| reader | `DefaultHistory.matchPatterns()` | HISTORY_IGNORE glob injection |
| reader | `LineReaderImpl.matches()` | Ctrl-R/Ctrl-S history search |
| reader | `LineReaderImpl.matchPreviousCommand()` | Incomplete manual regex escaping |

## Test plan

- [x] `./mvx mvn install -DskipTests` — full build passes
- [x] `./mvx mvn test -pl terminal` — 372 tests pass
- [x] `./mvx mvn test -pl reader` — 210 tests pass
- [x] `./mvx mvn test -pl builtins` — 1026 tests pass (23 pre-existing SwingTerminal/Fontconfig errors in headless env)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safer pattern matching for history search, autosuggestions, and text highlighting, including improved glob (`*`) handling in relevant commands.

* **Bug Fixes**
  * Reduced freezes and excessive slowdowns caused by complex regular expressions by adding timeout-aware matching.
  * Regex highlighting and match evaluation now fail gracefully on timeouts (including continued scanning where applicable), keeping the interface responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->