### PR TITLE
fix: warn on insecure permissions when history file created concurrently

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -435,13 +435,15 @@ public class DefaultHistory implements History {
                     PosixFilePermissions.asFileAttribute(
                             EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)));
         } catch (FileAlreadyExistsException e) {
-            // created concurrently between the check and the call
+            // created concurrently between the check and the call — warn if the
+            // other creator left the file group/world readable
+            warnIfAccessibleByOthers(path);
         } catch (UnsupportedOperationException e) {
             // non-POSIX filesystem (e.g. Windows): fall back to default creation
             try {
                 Files.createFile(path);
             } catch (FileAlreadyExistsException ignore) {
-                // created concurrently
+                // created concurrently (no POSIX perms to warn about)
             }
         }
     }


### PR DESCRIPTION
When `Files.createFile()` races with another process and throws `FileAlreadyExistsException`, the catch block was silently ignoring it without calling `warnIfAccessibleByOthers()`. This means a concurrently-created history file with group/world-readable permissions would skip the security warning entirely.

Now the POSIX `FileAlreadyExistsException` path calls `warnIfAccessibleByOthers(path)` so the user is notified if the file was created with insecure permissions. The non-POSIX fallback path is left as-is since there are no POSIX permissions to check.

Follow-up to #1986.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history-file handling when the file already exists, so users are now warned if it may be accessible by other users.
  * Updated the fallback path to keep behavior consistent when secure file permissions aren’t supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->