### PR TITLE
fix: warn on insecure permissions when history file created concurrently

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
+++ b/reader/src/main/java/org/jline/reader/impl/history/DefaultHistory.java
@@ -431,13 +431,15 @@ public class DefaultHistory implements History {
                     PosixFilePermissions.asFileAttribute(
                             EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)));
         } catch (FileAlreadyExistsException e) {
-            // created concurrently between the check and the call
+            // created concurrently between the check and the call — warn if the
+            // other creator left the file group/world readable
+            warnIfAccessibleByOthers(path);
         } catch (UnsupportedOperationException e) {
             // non-POSIX filesystem (e.g. Windows): fall back to default creation
             try {
                 Files.createFile(path);
             } catch (FileAlreadyExistsException ignore) {
-                // created concurrently
+                // created concurrently (no POSIX perms to warn about)
             }
         }
     }


### PR DESCRIPTION
Cherry-pick of #2013 to 4.0.x.

When `Files.createFile()` races with another process and throws `FileAlreadyExistsException`, call `warnIfAccessibleByOthers()` so a concurrently-created file with group/world-readable permissions does not silently skip the security warning.