### PR TITLE
fix: add synchronized to fillInStackTrace override (S3551)

### DIFF
--- a/shell/src/main/java/org/jline/shell/ExitShellException.java
+++ b/shell/src/main/java/org/jline/shell/ExitShellException.java
@@ -43,7 +43,7 @@ public class ExitShellException extends RuntimeException {
     }
 
     @Override
-    public Throwable fillInStackTrace() {
+    public synchronized Throwable fillInStackTrace() {
         return this;
     }
 }


### PR DESCRIPTION
## Summary

- Add `synchronized` modifier to `ExitShellException.fillInStackTrace()` to match the parent `Throwable.fillInStackTrace()` contract.

Fixes SonarCloud S3551 which is causing the Quality Gate to fail on master (C Reliability Rating on New Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell exit handling to be more reliable under concurrent use, reducing the chance of unexpected behavior when leaving the shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->