### PR TITLE
feat: change default of softwareSignals to false and deprecate

### DIFF
--- a/demo/src/main/java/org/jline/demo/examples/RawModeExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/RawModeExample.java
@@ -46,21 +46,21 @@ public class RawModeExample {
             NonBlockingReader reader = terminal.reader();
 
             // Read characters until 'q' or the interrupt character is pressed
-            while (true) {
+            boolean running = true;
+            while (running) {
                 int c = reader.read(100);
-                if (c != -1) {
-                    if (c == intrChar) {
-                        terminal.writer().println("Interrupt received (Ctrl+C) — exiting.");
-                        terminal.writer().flush();
-                        break;
-                    }
-
+                if (c == -1) {
+                    continue;
+                }
+                if (c == intrChar) {
+                    terminal.writer().println("Interrupt received (Ctrl+C) — exiting.");
+                    terminal.writer().flush();
+                    running = false;
+                } else if (c == 'q' || c == 'Q') {
+                    running = false;
+                } else {
                     terminal.writer().println("Read: " + (char) c + " (ASCII: " + c + ")");
                     terminal.writer().flush();
-
-                    if (c == 'q' || c == 'Q') {
-                        break;
-                    }
                 }
             }
 

--- a/demo/src/main/java/org/jline/demo/examples/RawModeExample.java
+++ b/demo/src/main/java/org/jline/demo/examples/RawModeExample.java
@@ -11,12 +11,18 @@ package org.jline.demo.examples;
 import java.io.IOException;
 
 import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.ControlChar;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.NonBlockingReader;
 
 /**
  * Example demonstrating raw mode in JLine.
+ *
+ * <p>In raw mode, ISIG is cleared so the kernel no longer translates control
+ * characters into signals.  If your application needs to react to Ctrl+C
+ * (interrupt), read the VINTR byte from the terminal attributes and handle it
+ * in your own input loop as shown below.</p>
  */
 public class RawModeExample {
 
@@ -26,18 +32,29 @@ public class RawModeExample {
             // Save original terminal attributes
             Attributes originalAttributes = terminal.getAttributes();
 
-            // Enter raw mode
-            Attributes rawAttributes = terminal.enterRawMode();
+            // Retrieve the interrupt character (typically 0x03 / Ctrl+C)
+            // *before* entering raw mode, so we can handle it ourselves.
+            int intrChar = originalAttributes.getControlChar(ControlChar.VINTR);
 
-            terminal.writer().println("Terminal is in raw mode. Press keys (q to quit):");
+            // Enter raw mode — ISIG is cleared, so the terminal will no longer
+            // raise signals for control characters; they arrive as raw bytes.
+            terminal.enterRawMode();
+
+            terminal.writer().println("Terminal is in raw mode. Press keys (Ctrl+C or q to quit):");
             terminal.writer().flush();
 
             NonBlockingReader reader = terminal.reader();
 
-            // Read characters until 'q' is pressed
+            // Read characters until 'q' or the interrupt character is pressed
             while (true) {
                 int c = reader.read(100);
                 if (c != -1) {
+                    if (c == intrChar) {
+                        terminal.writer().println("Interrupt received (Ctrl+C) — exiting.");
+                        terminal.writer().flush();
+                        break;
+                    }
+
                     terminal.writer().println("Read: " + (char) c + " (ASCII: " + c + ")");
                     terminal.writer().flush();
 

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -187,9 +187,18 @@ public final class TerminalBuilder {
      * no automatic signal translation occurs — the application must handle raw bytes itself.
      * <p>
      * Applications that relied on {@code terminal.handle(Signal.INT, ...)} in raw mode
-     * should either set {@code -Dorg.jline.terminal.softwareSignals=true} explicitly,
-     * switch to LineReader's INTERRUPT widget, or handle byte {@code 0x03} (Ctrl+C)
-     * in their own input processing loop.
+     * should migrate to one of the following approaches:
+     * <ul>
+     *   <li>Set {@code -Dorg.jline.terminal.softwareSignals=true} explicitly to restore the
+     *       old behavior temporarily.</li>
+     *   <li>Use LineReader's INTERRUPT widget — Ctrl+C throws
+     *       {@link org.jline.reader.UserInterruptException} from {@code readLine()}
+     *       (see {@code SimpleLineReadingExample}).</li>
+     *   <li>In a raw-mode input loop, read the VINTR character from the terminal
+     *       attributes via {@link Terminal#getAttributes()} and
+     *       {@link Attributes.ControlChar#VINTR}, then handle that byte directly
+     *       (see {@code RawModeExample}).</li>
+     * </ul>
      *
      * @since 4.1.4
      * @deprecated This property is scheduled for removal in a future release.

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -197,7 +197,7 @@ public final class TerminalBuilder {
      *             applications should use the LineReader INTERRUPT widget or handle
      *             raw bytes directly.
      */
-    @Deprecated
+    @Deprecated(since = "4.4.0", forRemoval = true)
     @SuppressWarnings("java:S1133") // Intentional deprecation; removal planned for a future major version
     public static final String PROP_SOFTWARE_SIGNALS = "org.jline.terminal.softwareSignals";
 

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -178,18 +178,27 @@ public final class TerminalBuilder {
 
     public static final String PROP_NON_BLOCKING_READS = "org.jline.terminal.pty.nonBlockingReads";
     /**
-     * When {@code true} (the default), system terminals intercept signal control characters
+     * When {@code true}, system terminals intercept signal control characters
      * (VINTR, VQUIT, VSUSP) in software and raise the corresponding {@link Terminal.Signal}
      * when ISIG is cleared (raw mode). This restores {@code terminal.handle(Signal.INT, ...)}
      * behavior that was lost when {@code enterRawMode()} started clearing ISIG.
      * <p>
-     * Set to {@code false} for pure native terminal behavior where no automatic signal
-     * translation occurs — the application must handle raw bytes itself.
+     * Set to {@code false} (the default since 4.4.0) for pure native terminal behavior where
+     * no automatic signal translation occurs — the application must handle raw bytes itself.
      * <p>
-     * The default may change to {@code false} in a future release (4.2 or later).
+     * Applications that relied on {@code terminal.handle(Signal.INT, ...)} in raw mode
+     * should either set {@code -Dorg.jline.terminal.softwareSignals=true} explicitly,
+     * switch to LineReader's INTERRUPT widget, or handle byte {@code 0x03} (Ctrl+C)
+     * in their own input processing loop.
      *
      * @since 4.1.4
+     * @deprecated This property is scheduled for removal in a future release.
+     *             In pure native mode, signal byte interception should not be needed;
+     *             applications should use the LineReader INTERRUPT widget or handle
+     *             raw bytes directly.
      */
+    @Deprecated
+    @SuppressWarnings("java:S1133") // Intentional deprecation; removal planned for a future major version
     public static final String PROP_SOFTWARE_SIGNALS = "org.jline.terminal.softwareSignals";
 
     public static final String PROP_COLOR_DISTANCE = "org.jline.utils.colorDistance";

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -79,7 +79,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
     private volatile Attributes cachedAttributes;
     private final Task closer;
 
-    @SuppressWarnings({"this-escape", "squid:S107"})
+    @SuppressWarnings({"this-escape", "squid:S107", "deprecation"})
     protected AbstractUnixSysTerminal(
             TerminalProvider provider,
             SystemStream systemStream,
@@ -97,7 +97,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
         this.systemStream = systemStream;
         this.originalAttributes = originalAttributes;
         this.nativeSignals = nativeSignals;
-        boolean softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "true"));
+        boolean softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "false"));
 
         InputStream stdin = new NonCloseableInputStream(new FileInputStream(FileDescriptor.in));
         this.input = NonBlocking.nonBlocking(

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -79,7 +79,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
     private volatile Attributes cachedAttributes;
     private final Task closer;
 
-    @SuppressWarnings({"this-escape", "squid:S107", "deprecation"})
+    @SuppressWarnings({"this-escape", "squid:S107", "removal"})
     protected AbstractUnixSysTerminal(
             TerminalProvider provider,
             SystemStream systemStream,

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -136,7 +136,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
      *                        default native handlers will be registered
      * @throws IOException if the PTY streams or terminal I/O cannot be initialized
      */
-    @SuppressWarnings({"this-escape", "squid:S107", "deprecation"})
+    @SuppressWarnings({"this-escape", "squid:S107", "removal"})
     public PosixSysTerminal(
             TerminalProvider provider,
             String name,

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixSysTerminal.java
@@ -136,7 +136,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
      *                        default native handlers will be registered
      * @throws IOException if the PTY streams or terminal I/O cannot be initialized
      */
-    @SuppressWarnings({"this-escape", "squid:S107"})
+    @SuppressWarnings({"this-escape", "squid:S107", "deprecation"})
     public PosixSysTerminal(
             TerminalProvider provider,
             String name,
@@ -152,7 +152,7 @@ public class PosixSysTerminal extends AbstractPosixTerminal {
         this.provider = provider;
         this.nativeSignals = nativeSignals;
         this.cachedAttributes = new Attributes(this.originalAttributes);
-        boolean softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "true"));
+        boolean softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "false"));
         InputStream slaveInput = pty.getSlaveInput();
         this.input = NonBlocking.nonBlocking(
                 getName(),

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@SuppressWarnings("deprecation") // Tests intentionally exercise the deprecated PROP_SOFTWARE_SIGNALS property
+@SuppressWarnings("removal") // Tests intentionally exercise the deprecated-for-removal PROP_SOFTWARE_SIGNALS property
 class PosixSysTerminalTest {
 
     @Test

--- a/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PosixSysTerminalTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("deprecation") // Tests intentionally exercise the deprecated PROP_SOFTWARE_SIGNALS property
 class PosixSysTerminalTest {
 
     @Test
@@ -255,6 +256,44 @@ class PosixSysTerminalTest {
             assertTrue(terminal.nativeHandlers.isEmpty());
             terminal.handle(Signal.INT, s -> {});
             assertTrue(terminal.nativeHandlers.isEmpty());
+        }
+    }
+
+    @Test
+    void testDefaultSoftwareSignalsDisabled() throws Exception {
+        // Verify that when the property is not set, software signal interception is off (default false)
+        String prev = System.getProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS);
+        try {
+            System.clearProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS);
+
+            Attributes attr = new Attributes();
+            attr.setControlChar(ControlChar.VINTR, 3);
+
+            Pty pty = EasyMock.createNiceMock(Pty.class);
+            EasyMock.expect(pty.getAttr()).andReturn(attr).anyTimes();
+            EasyMock.expect(pty.getSlaveInput())
+                    .andReturn(new ByteArrayInputStream(new byte[] {0x03}))
+                    .anyTimes();
+            EasyMock.expect(pty.getSlaveOutput())
+                    .andReturn(new ByteArrayOutputStream())
+                    .anyTimes();
+            EasyMock.replay(pty);
+            try (PosixSysTerminal terminal =
+                    new PosixSysTerminal("name", "ansi", pty, null, false, SignalHandler.SIG_DFL)) {
+                AtomicReference<Signal> received = new AtomicReference<>();
+                terminal.handle(Signal.INT, received::set);
+
+                int b = terminal.input().read();
+                assertEquals(0x03, b);
+                // With the default (softwareSignals=false), no signal should be raised
+                assertNull(received.get());
+            }
+        } finally {
+            if (prev == null) {
+                System.clearProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS);
+            } else {
+                System.setProperty(TerminalBuilder.PROP_SOFTWARE_SIGNALS, prev);
+            }
         }
     }
 }


### PR DESCRIPTION
Fix #1960

Changes the default of `org.jline.terminal.softwareSignals` from `true` to `false` and deprecates the property for eventual removal.

### Changes

- **Default changed**: `PROP_SOFTWARE_SIGNALS` now defaults to `false` in both `AbstractUnixSysTerminal` and `PosixSysTerminal`.

- **Property deprecated**: `PROP_SOFTWARE_SIGNALS` is marked `@Deprecated(since = "4.4.0", forRemoval = true)` with Javadoc explaining the migration paths.

- **Test added**: `testDefaultSoftwareSignalsDisabled` verifies that when the property is unset, no software signal interception occurs (the VINTR byte is delivered without raising `Signal.INT`).

- **RawModeExample updated**: demonstrates how to handle Ctrl+C in a raw-mode input loop by reading the VINTR character from terminal attributes via `getControlChar(ControlChar.VINTR)`.

### Migration

Applications that relied on `terminal.handle(Signal.INT, ...)` in raw mode should migrate to one of:

1. **Set the property explicitly** — `-Dorg.jline.terminal.softwareSignals=true` restores the old behavior temporarily.
2. **LineReader's INTERRUPT widget** — Ctrl+C throws `UserInterruptException` from `readLine()` (see [`SimpleLineReadingExample`](demo/src/main/java/org/jline/demo/examples/SimpleLineReadingExample.java)).
3. **Handle the VINTR byte directly** — read the interrupt character from terminal attributes and handle it in your own input loop (see [`RawModeExample`](demo/src/main/java/org/jline/demo/examples/RawModeExample.java)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the default behavior of software signal interception so it remains disabled when the related property is unset.
  * Updated raw-mode interrupt expectations so Ctrl+C (VINTR) is handled explicitly by applications.
* **New Features**
  * Enhanced the raw-mode example to detect Ctrl+C and exit cleanly.
* **Tests**
  * Added coverage to confirm the default software-signal behavior is disabled when the property is not set.
* **Documentation**
  * Refreshed Javadoc to clarify defaults and provide raw-mode migration guidance.
* **Deprecations**
  * Marked the software-signal property as deprecated for removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->