### PR TITLE
feat: support in-band window resize notifications (mode 2048)

### DIFF
--- a/reader/src/main/java/org/jline/reader/LineReader.java
+++ b/reader/src/main/java/org/jline/reader/LineReader.java
@@ -271,6 +271,7 @@ public interface LineReader {
     String MOUSE = "mouse";
     String FOCUS_IN = "terminal-focus-in";
     String FOCUS_OUT = "terminal-focus-out";
+    String TERMINAL_RESIZE = "terminal-resize";
 
     String BEGIN_PASTE = "begin-paste";
 

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -133,6 +133,7 @@ public class LineReaderImpl implements LineReader, Flushable {
 
     public static final String FOCUS_IN_SEQ = "\033[I";
     public static final String FOCUS_OUT_SEQ = "\033[O";
+    public static final String RESIZE_SEQ = "\033[48;";
     public static final int DEFAULT_MAX_REPEAT_COUNT = 9999;
 
     /**
@@ -4204,6 +4205,7 @@ public class LineReaderImpl implements LineReader, Flushable {
         addBuiltinWidget(widgets, BEGIN_PASTE, this::beginPaste);
         addBuiltinWidget(widgets, FOCUS_IN, this::focusIn);
         addBuiltinWidget(widgets, FOCUS_OUT, this::focusOut);
+        addBuiltinWidget(widgets, TERMINAL_RESIZE, this::terminalResize);
         return widgets;
     }
 
@@ -6473,6 +6475,71 @@ public class LineReaderImpl implements LineReader, Flushable {
     }
 
     /**
+     * Handles an in-band window resize report (mode 2048).
+     *
+     * <p>The binding reader has already consumed the {@code CSI 48 ;}
+     * prefix.  This method reads the remaining parameters
+     * ({@code rows ; cols [ ; pixelHeight ; pixelWidth ]}) up to the
+     * final byte {@code t}, updates the terminal size, and raises
+     * {@link Terminal.Signal#WINCH}.</p>
+     *
+     * @return {@code true} always
+     */
+    public boolean terminalResize() {
+        String params = readResizeParams();
+        if (params != null) {
+            applyResizeParams(params);
+        }
+        return true;
+    }
+
+    /**
+     * Reads resize parameters from the input until the final {@code t} byte.
+     *
+     * @return the parameter string (e.g. {@code "24;80"}), or {@code null}
+     *         if the sequence is malformed or too long
+     */
+    private String readResizeParams() {
+        StringBuilder sb = new StringBuilder();
+        int c;
+        while ((c = bindingReader.readCharacter()) >= 0) {
+            if (c == 't') {
+                return sb.toString();
+            }
+            if ((c >= '0' && c <= '9') || c == ';') {
+                sb.append((char) c);
+                if (sb.length() > 50) {
+                    return null; // Too long — discard
+                }
+            } else {
+                return null; // Invalid character — discard
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parses {@code rows;cols[;pixelHeight;pixelWidth]} and applies
+     * the new terminal size, raising {@link Terminal.Signal#WINCH}.
+     */
+    private void applyResizeParams(String params) {
+        String[] parts = params.split(";", -1);
+        if (parts.length < 2) {
+            return;
+        }
+        try {
+            int rows = Integer.parseInt(parts[0]);
+            int cols = Integer.parseInt(parts[1]);
+            if (rows > 0 && cols > 0) {
+                terminal.setSize(Size.of(cols, rows));
+                terminal.raise(Terminal.Signal.WINCH);
+            }
+        } catch (NumberFormatException e) {
+            // Ignore malformed resize reports
+        }
+    }
+
+    /**
      * Clean the used display
      * @return <code>true</code>
      */
@@ -6948,6 +7015,7 @@ public class LineReaderImpl implements LineReader, Flushable {
         bind(map, BEGIN_PASTE, BRACKETED_PASTE_BEGIN);
         bind(map, FOCUS_IN, FOCUS_IN_SEQ);
         bind(map, FOCUS_OUT, FOCUS_OUT_SEQ);
+        bind(map, TERMINAL_RESIZE, RESIZE_SEQ);
     }
 
     /**

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -6501,18 +6501,21 @@ public class LineReaderImpl implements LineReader, Flushable {
      */
     private String readResizeParams() {
         StringBuilder sb = new StringBuilder();
+        boolean discard = false;
         int c;
         while ((c = bindingReader.readCharacter()) >= 0) {
             if (c == 't') {
-                return sb.toString();
+                return discard ? null : sb.toString();
             }
-            if ((c >= '0' && c <= '9') || c == ';') {
-                sb.append((char) c);
-                if (sb.length() > 50) {
-                    return null; // Too long — discard
+            if (!discard) {
+                if ((c >= '0' && c <= '9') || c == ';') {
+                    sb.append((char) c);
+                    if (sb.length() > 50) {
+                        discard = true; // Too long — drain to 't' then discard
+                    }
+                } else {
+                    discard = true; // Invalid character — drain to 't' then discard
                 }
-            } else {
-                return null; // Invalid character — discard
             }
         }
         return null;

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -133,6 +133,7 @@ public class LineReaderImpl implements LineReader, Flushable {
 
     public static final String FOCUS_IN_SEQ = "\033[I";
     public static final String FOCUS_OUT_SEQ = "\033[O";
+    public static final String RESIZE_SEQ = "\033[48;";
     public static final int DEFAULT_MAX_REPEAT_COUNT = 9999;
 
     /**
@@ -4206,6 +4207,7 @@ public class LineReaderImpl implements LineReader, Flushable {
         addBuiltinWidget(widgets, BEGIN_PASTE, this::beginPaste);
         addBuiltinWidget(widgets, FOCUS_IN, this::focusIn);
         addBuiltinWidget(widgets, FOCUS_OUT, this::focusOut);
+        addBuiltinWidget(widgets, TERMINAL_RESIZE, this::terminalResize);
         return widgets;
     }
 
@@ -6495,6 +6497,71 @@ public class LineReaderImpl implements LineReader, Flushable {
     }
 
     /**
+     * Handles an in-band window resize report (mode 2048).
+     *
+     * <p>The binding reader has already consumed the {@code CSI 48 ;}
+     * prefix.  This method reads the remaining parameters
+     * ({@code rows ; cols [ ; pixelHeight ; pixelWidth ]}) up to the
+     * final byte {@code t}, updates the terminal size, and raises
+     * {@link Terminal.Signal#WINCH}.</p>
+     *
+     * @return {@code true} always
+     */
+    public boolean terminalResize() {
+        String params = readResizeParams();
+        if (params != null) {
+            applyResizeParams(params);
+        }
+        return true;
+    }
+
+    /**
+     * Reads resize parameters from the input until the final {@code t} byte.
+     *
+     * @return the parameter string (e.g. {@code "24;80"}), or {@code null}
+     *         if the sequence is malformed or too long
+     */
+    private String readResizeParams() {
+        StringBuilder sb = new StringBuilder();
+        int c;
+        while ((c = bindingReader.readCharacter()) >= 0) {
+            if (c == 't') {
+                return sb.toString();
+            }
+            if ((c >= '0' && c <= '9') || c == ';') {
+                sb.append((char) c);
+                if (sb.length() > 50) {
+                    return null; // Too long — discard
+                }
+            } else {
+                return null; // Invalid character — discard
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parses {@code rows;cols[;pixelHeight;pixelWidth]} and applies
+     * the new terminal size, raising {@link Terminal.Signal#WINCH}.
+     */
+    private void applyResizeParams(String params) {
+        String[] parts = params.split(";", -1);
+        if (parts.length < 2) {
+            return;
+        }
+        try {
+            int rows = Integer.parseInt(parts[0]);
+            int cols = Integer.parseInt(parts[1]);
+            if (rows > 0 && cols > 0) {
+                terminal.setSize(Size.of(cols, rows));
+                terminal.raise(Terminal.Signal.WINCH);
+            }
+        } catch (NumberFormatException e) {
+            // Ignore malformed resize reports
+        }
+    }
+
+    /**
      * Clean the used display
      * @return <code>true</code>
      */
@@ -6970,6 +7037,7 @@ public class LineReaderImpl implements LineReader, Flushable {
         bind(map, BEGIN_PASTE, BRACKETED_PASTE_BEGIN);
         bind(map, FOCUS_IN, FOCUS_IN_SEQ);
         bind(map, FOCUS_OUT, FOCUS_OUT_SEQ);
+        bind(map, TERMINAL_RESIZE, RESIZE_SEQ);
     }
 
     /**

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -6523,18 +6523,21 @@ public class LineReaderImpl implements LineReader, Flushable {
      */
     private String readResizeParams() {
         StringBuilder sb = new StringBuilder();
+        boolean discard = false;
         int c;
         while ((c = bindingReader.readCharacter()) >= 0) {
             if (c == 't') {
-                return sb.toString();
+                return discard ? null : sb.toString();
             }
-            if ((c >= '0' && c <= '9') || c == ';') {
-                sb.append((char) c);
-                if (sb.length() > 50) {
-                    return null; // Too long — discard
+            if (!discard) {
+                if ((c >= '0' && c <= '9') || c == ';') {
+                    sb.append((char) c);
+                    if (sb.length() > 50) {
+                        discard = true; // Too long — drain to 't' then discard
+                    }
+                } else {
+                    discard = true; // Invalid character — drain to 't' then discard
                 }
-            } else {
-                return null; // Invalid character — discard
             }
         }
         return null;

--- a/reader/src/test/java/org/jline/reader/impl/InBandResizeWidgetTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/InBandResizeWidgetTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader.impl;
+
+import org.jline.terminal.Size;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for the {@code terminal-resize} widget that parses
+ * in-band resize reports ({@code CSI 48 ; rows ; cols [; pixelH ; pixelW] t})
+ * and updates the terminal size.
+ */
+class InBandResizeWidgetTest extends ReaderTestSupport {
+
+    @Test
+    void resizeSequenceUpdatesSizeAndCompletesLine() {
+        // CSI 48;30;100;0;0t followed by "ok" + Enter
+        assertLine("ok", new TestBuffer("\033[48;30;100;0;0tok\n"));
+        assertEquals(Size.of(100, 30), terminal.getSize());
+    }
+
+    @Test
+    void resizeSequenceWithRowsAndColsOnly() {
+        assertLine("hi", new TestBuffer("\033[48;50;120thi\n"));
+        assertEquals(Size.of(120, 50), terminal.getSize());
+    }
+
+    @Test
+    void malformedResizeSequenceDoesNotCrash() {
+        // Invalid character 'x' in the sequence — should be drained to 't' and discarded
+        assertLine("ab", new TestBuffer("\033[48;10x30;80tab\n"));
+        // Size should remain unchanged (160x80 from setUp)
+        assertEquals(Size.of(160, 80), terminal.getSize());
+    }
+
+    @Test
+    void tooLongResizeSequenceIsDrained() {
+        // Build a sequence with > 50 chars of parameters
+        StringBuilder sb = new StringBuilder("\033[48;");
+        for (int i = 0; i < 60; i++) {
+            sb.append('1');
+        }
+        sb.append("tcd\n");
+        assertLine("cd", new TestBuffer(sb.toString()));
+        // Size should remain unchanged
+        assertEquals(Size.of(160, 80), terminal.getSize());
+    }
+
+    @Test
+    void multipleResizeSequencesApplyLast() {
+        // Two resize sequences: first 30x100, then 40x200
+        assertLine("z", new TestBuffer("\033[48;30;100;0;0t\033[48;40;200;0;0tz\n"));
+        assertEquals(Size.of(200, 40), terminal.getSize());
+    }
+}

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1458,6 +1458,58 @@ public interface Terminal extends Closeable, Flushable, Sized {
     boolean trackFocus(boolean tracking);
 
     /**
+     * Returns whether the terminal supports in-band window resize notifications
+     * (DEC private mode 2048).
+     *
+     * <p>
+     * Mode 2048 places resize events into the terminal's data stream as
+     * {@code CSI 48 ; rows ; cols ; pixelHeight ; pixelWidth t} reports,
+     * eliminating the race conditions inherent in SIGWINCH-based resize
+     * detection.  It is especially useful over SSH/Telnet transports where
+     * SIGWINCH does not propagate reliably.
+     * </p>
+     *
+     * <p>
+     * Support detection uses the batch DEC mode probe via
+     * {@link #isModeSupported(Mode) isModeSupported(Mode.IN_BAND_RESIZE)}.
+     * The probe is never sent to dumb terminals.
+     * </p>
+     *
+     * @return {@code true} if the terminal supports mode 2048
+     * @see #trackInBandResize(boolean)
+     */
+    default boolean hasInBandResizeSupport() {
+        return false;
+    }
+
+    /**
+     * Enables or disables in-band window resize notification mode
+     * (DEC private mode 2048).
+     *
+     * <p>
+     * When enabled, the terminal sends {@code CSI 48 ; rows ; cols ; pixelHeight ; pixelWidth t}
+     * reports through the input stream whenever the window size changes.
+     * An initial report is sent immediately when the mode is first enabled.
+     * </p>
+     *
+     * <p>
+     * Applications using {@link org.jline.reader.LineReader} do not need to
+     * parse the reports manually — the reader's built-in
+     * {@code terminal-resize} widget handles them automatically, updating
+     * the terminal size and raising {@link Signal#WINCH}.
+     * </p>
+     *
+     * @param tracking {@code true} to enable in-band resize notifications,
+     *                 {@code false} to disable them
+     * @return {@code true} if the operation succeeded, {@code false} if the
+     *         terminal does not support mode 2048
+     * @see #hasInBandResizeSupport()
+     */
+    default boolean trackInBandResize(boolean tracking) {
+        return false;
+    }
+
+    /**
      * Returns whether the terminal supports mode 2027 (grapheme cluster / Unicode Core).
      *
      * <p>

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1477,9 +1477,10 @@ public interface Terminal extends Closeable, Flushable, Sized {
      *
      * @return {@code true} if the terminal supports mode 2048
      * @see #trackInBandResize(boolean)
+     * @since 3.30.0
      */
     default boolean hasInBandResizeSupport() {
-        return false;
+        return isModeSupported(Mode.IN_BAND_RESIZE);
     }
 
     /**
@@ -1501,9 +1502,11 @@ public interface Terminal extends Closeable, Flushable, Sized {
      *
      * @param tracking {@code true} to enable in-band resize notifications,
      *                 {@code false} to disable them
-     * @return {@code true} if the operation succeeded, {@code false} if the
-     *         terminal does not support mode 2048
+     * @return when enabling, {@code true} if the terminal supports mode 2048
+     *         and the mode was activated, {@code false} otherwise;
+     *         when disabling, always {@code true} (idempotent)
      * @see #hasInBandResizeSupport()
+     * @since 3.30.0
      */
     default boolean trackInBandResize(boolean tracking) {
         return false;

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1569,6 +1569,58 @@ public interface Terminal extends Closeable, Flushable, Sized {
     }
 
     /**
+     * Returns whether the terminal supports in-band window resize notifications
+     * (DEC private mode 2048).
+     *
+     * <p>
+     * Mode 2048 places resize events into the terminal's data stream as
+     * {@code CSI 48 ; rows ; cols ; pixelHeight ; pixelWidth t} reports,
+     * eliminating the race conditions inherent in SIGWINCH-based resize
+     * detection.  It is especially useful over SSH/Telnet transports where
+     * SIGWINCH does not propagate reliably.
+     * </p>
+     *
+     * <p>
+     * Support detection uses the batch DEC mode probe via
+     * {@link #isModeSupported(Mode) isModeSupported(Mode.IN_BAND_RESIZE)}.
+     * The probe is never sent to dumb terminals.
+     * </p>
+     *
+     * @return {@code true} if the terminal supports mode 2048
+     * @see #trackInBandResize(boolean)
+     */
+    default boolean hasInBandResizeSupport() {
+        return false;
+    }
+
+    /**
+     * Enables or disables in-band window resize notification mode
+     * (DEC private mode 2048).
+     *
+     * <p>
+     * When enabled, the terminal sends {@code CSI 48 ; rows ; cols ; pixelHeight ; pixelWidth t}
+     * reports through the input stream whenever the window size changes.
+     * An initial report is sent immediately when the mode is first enabled.
+     * </p>
+     *
+     * <p>
+     * Applications using {@link org.jline.reader.LineReader} do not need to
+     * parse the reports manually — the reader's built-in
+     * {@code terminal-resize} widget handles them automatically, updating
+     * the terminal size and raising {@link Signal#WINCH}.
+     * </p>
+     *
+     * @param tracking {@code true} to enable in-band resize notifications,
+     *                 {@code false} to disable them
+     * @return {@code true} if the operation succeeded, {@code false} if the
+     *         terminal does not support mode 2048
+     * @see #hasInBandResizeSupport()
+     */
+    default boolean trackInBandResize(boolean tracking) {
+        return false;
+    }
+
+    /**
      * Returns whether the terminal supports mode 2027 (grapheme cluster / Unicode Core).
      *
      * <p>

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1588,9 +1588,10 @@ public interface Terminal extends Closeable, Flushable, Sized {
      *
      * @return {@code true} if the terminal supports mode 2048
      * @see #trackInBandResize(boolean)
+     * @since 3.30.0
      */
     default boolean hasInBandResizeSupport() {
-        return false;
+        return isModeSupported(Mode.IN_BAND_RESIZE);
     }
 
     /**
@@ -1612,9 +1613,11 @@ public interface Terminal extends Closeable, Flushable, Sized {
      *
      * @param tracking {@code true} to enable in-band resize notifications,
      *                 {@code false} to disable them
-     * @return {@code true} if the operation succeeded, {@code false} if the
-     *         terminal does not support mode 2048
+     * @return when enabling, {@code true} if the terminal supports mode 2048
+     *         and the mode was activated, {@code false} otherwise;
+     *         when disabling, always {@code true} (idempotent)
      * @see #hasInBandResizeSupport()
+     * @since 3.30.0
      */
     default boolean trackInBandResize(boolean tracking) {
         return false;

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -103,6 +103,7 @@ public abstract class AbstractTerminal implements TerminalExt {
     private boolean graphemeClusterNative;
     private boolean groupsRegionalIndicators;
     private boolean groupsZwjSequences;
+    private boolean inBandResizeEnabled;
 
     /** CSI prefix for DEC private mode sequences ({@code ESC [ ?}). */
     static final String CSI_DEC = "\033[?";
@@ -219,6 +220,9 @@ public abstract class AbstractTerminal implements TerminalExt {
     }
 
     protected void doClose() throws IOException {
+        if (inBandResizeEnabled) {
+            trackInBandResize(false);
+        }
         if (graphemeClusterModeEnabled) {
             setGraphemeClusterMode(false, false);
         }
@@ -643,6 +647,33 @@ public abstract class AbstractTerminal implements TerminalExt {
         return response.contains(";4;") || response.contains(";4c");
     }
 
+    // ---- In-band resize support (mode 2048) ----
+
+    @Override
+    public boolean hasInBandResizeSupport() {
+        return isModeSupported(Mode.IN_BAND_RESIZE);
+    }
+
+    @Override
+    public boolean trackInBandResize(boolean tracking) {
+        if (tracking) {
+            if (hasInBandResizeSupport()) {
+                writer().write("\033[?2048h");
+                writer().flush();
+                inBandResizeEnabled = true;
+                return true;
+            }
+            return false;
+        } else {
+            if (inBandResizeEnabled) {
+                writer().write("\033[?2048l");
+                writer().flush();
+                inBandResizeEnabled = false;
+            }
+            return true;
+        }
+    }
+
     // ---- Grapheme cluster support (mode 2027 + cursor-position fallback) ----
 
     @Override
@@ -754,7 +785,7 @@ public abstract class AbstractTerminal implements TerminalExt {
      * only group regional indicators (flags). Two probes detect this.</p>
      *
      * <p>This method must only be called when the terminal is known to
-     * respond to escape sequences (i.e., after {@link #probeMode2027()}
+     * respond to escape sequences (i.e., after the batch mode probe
      * received a response), because DSR/CPR blocks until a response
      * arrives.</p>
      *

--- a/terminal/src/test/java/org/jline/terminal/impl/InBandResizeTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/InBandResizeTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.function.IntConsumer;
+import java.util.function.IntSupplier;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Cursor;
+import org.jline.terminal.MouseEvent;
+import org.jline.terminal.Size;
+import org.jline.terminal.Sized;
+import org.jline.terminal.Terminal;
+import org.jline.utils.ColorPalette;
+import org.jline.utils.InfoCmp.Capability;
+import org.jline.utils.NonBlockingReader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for in-band window resize support (mode 2048) via the
+ * {@link Terminal#hasInBandResizeSupport()} and
+ * {@link Terminal#trackInBandResize(boolean)} API.
+ *
+ * <p>Low-level DECRPM parsing and batch probe mechanics are covered
+ * by {@link DecModeProbeTest}; this class focuses on the higher-level
+ * enable/disable/close lifecycle.</p>
+ */
+class InBandResizeTest {
+
+    @Test
+    void testSupportedWhenBatchProbeFindsMode2048() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Feed DECRPM response for mode 2048 (Ps=2 → recognized, reset) + DA1
+        terminal.slaveInputPipe.write("\033[?2048;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.hasInBandResizeSupport());
+
+        terminal.close();
+    }
+
+    @Test
+    void testNotSupportedOnDumbTerminal() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", Terminal.TYPE_DUMB, masterOutput, StandardCharsets.UTF_8);
+
+        assertFalse(terminal.hasInBandResizeSupport());
+        // No query should have been sent
+        assertEquals(0, masterOutput.size());
+
+        terminal.close();
+    }
+
+    @Test
+    void testNotSupportedWhenNoResponse() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        assertFalse(terminal.hasInBandResizeSupport());
+
+        // Batch query and DA1 sentinel should have been sent
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?2048$p"));
+        assertTrue(output.contains("\033[c"));
+
+        terminal.close();
+    }
+
+    @Test
+    void testTrackInBandResizeEnable() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        terminal.slaveInputPipe.write("\033[?2048;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.trackInBandResize(true));
+
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?2048h"));
+
+        terminal.close();
+    }
+
+    @Test
+    void testTrackInBandResizeDisable() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        terminal.slaveInputPipe.write("\033[?2048;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.trackInBandResize(true));
+        assertTrue(terminal.trackInBandResize(false));
+
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?2048h"));
+        assertTrue(output.contains("\033[?2048l"));
+
+        terminal.close();
+    }
+
+    @Test
+    void testTrackInBandResizeReturnsFalseWhenNotSupported() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", Terminal.TYPE_DUMB, masterOutput, StandardCharsets.UTF_8);
+
+        assertFalse(terminal.trackInBandResize(true));
+
+        terminal.close();
+    }
+
+    @Test
+    void testModeDisabledOnClose() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        terminal.slaveInputPipe.write("\033[?2048;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.trackInBandResize(true));
+
+        // Close should disable the mode
+        terminal.close();
+
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?2048h"));
+        assertTrue(output.contains("\033[?2048l"));
+    }
+
+    @Test
+    void testModeNotDisabledOnCloseIfNeverEnabled() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        terminal.slaveInputPipe.write("\033[?2048;2$y\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.hasInBandResizeSupport());
+
+        terminal.close();
+
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?2048$p"));
+        assertFalse(output.contains("\033[?2048h"));
+        assertFalse(output.contains("\033[?2048l"));
+    }
+
+    @Test
+    void testDefaultInterfaceMethodsReturnFalse() {
+        Terminal terminal = new Terminal() {
+            public String getName() {
+                return "test";
+            }
+
+            public SignalHandler handle(Signal signal, SignalHandler handler) {
+                return null;
+            }
+
+            public void raise(Signal signal) {
+                // no-op for stub
+            }
+
+            public NonBlockingReader reader() {
+                return null;
+            }
+
+            public PrintWriter writer() {
+                return null;
+            }
+
+            public Charset encoding() {
+                return StandardCharsets.UTF_8;
+            }
+
+            public InputStream input() {
+                return null;
+            }
+
+            public OutputStream output() {
+                return null;
+            }
+
+            public boolean canPauseResume() {
+                return false;
+            }
+
+            public void pause() {
+                // no-op for stub
+            }
+
+            public void pause(boolean wait) {
+                // no-op for stub
+            }
+
+            public void resume() {
+                // no-op for stub
+            }
+
+            public boolean paused() {
+                return false;
+            }
+
+            public Attributes enterRawMode() {
+                return null;
+            }
+
+            public boolean echo() {
+                return false;
+            }
+
+            public boolean echo(boolean echo) {
+                return false;
+            }
+
+            public Attributes getAttributes() {
+                return null;
+            }
+
+            public void setAttributes(Attributes attr) {
+                // no-op for stub
+            }
+
+            public Size getSize() {
+                return Size.of(80, 24);
+            }
+
+            public void setSize(Sized size) {
+                // no-op for stub
+            }
+
+            public void flush() {
+                // no-op for stub
+            }
+
+            public String getType() {
+                return "test";
+            }
+
+            public boolean puts(Capability capability, Object... params) {
+                return false;
+            }
+
+            public boolean getBooleanCapability(Capability capability) {
+                return false;
+            }
+
+            public Integer getNumericCapability(Capability capability) {
+                return null;
+            }
+
+            public String getStringCapability(Capability capability) {
+                return null;
+            }
+
+            public Cursor getCursorPosition(IntConsumer discarded) {
+                return null;
+            }
+
+            public boolean hasMouseSupport() {
+                return false;
+            }
+
+            public boolean trackMouse(MouseTracking tracking) {
+                return false;
+            }
+
+            public MouseTracking getCurrentMouseTracking() {
+                return MouseTracking.Off;
+            }
+
+            public MouseEvent readMouseEvent() {
+                return null;
+            }
+
+            public MouseEvent readMouseEvent(IntSupplier reader) {
+                return null;
+            }
+
+            public MouseEvent readMouseEvent(String prefix) {
+                return null;
+            }
+
+            public MouseEvent readMouseEvent(IntSupplier reader, String prefix) {
+                return null;
+            }
+
+            public boolean hasFocusSupport() {
+                return false;
+            }
+
+            public boolean trackFocus(boolean tracking) {
+                return false;
+            }
+
+            public ColorPalette getPalette() {
+                return null;
+            }
+
+            public void close() {
+                // no-op for stub
+            }
+        };
+
+        assertFalse(terminal.hasInBandResizeSupport());
+        assertFalse(terminal.trackInBandResize(true));
+    }
+}


### PR DESCRIPTION
## Summary

Add support for [DEC private mode 2048](https://gist.github.com/rockorager/e695fb2924d36b2bcf1fff4a3704bd83) — in-band window resize notifications. Fixes #2009.

### Changes

- **Terminal API** (`Terminal.java`): Added `hasInBandResizeSupport()` and `trackInBandResize(boolean)` following the existing `hasFocusSupport()` / `trackFocus()` pattern
- **DECRQM probing** (`AbstractTerminal.java`): Lazy probe for mode 2048 support using the same DECRQM + DA1 sentinel strategy as mode 2027
- **Input parsing** (`LineReaderImpl.java`): New `terminal-resize` widget bound to `CSI 48 ;` that reads rows/cols/pixel parameters until final byte `t`, updates terminal size, and raises `WINCH`
- **Lifecycle**: Mode is automatically disabled when the terminal is closed
- **Remote terminals**: Mode 2048 works transparently over SSH/Telnet — escape sequences flow through the data stream, so no remote module changes are needed

### Sequences

| Action | Sequence |
|--------|----------|
| Enable | `CSI ? 2048 h` |
| Disable | `CSI ? 2048 l` |
| Query (DECRQM) | `CSI ? 2048 $ p` |
| Report (terminal → app) | `CSI 48 ; rows ; cols ; pixelHeight ; pixelWidth t` |

### Usage

```java
Terminal terminal = TerminalBuilder.terminal();

if (terminal.hasInBandResizeSupport()) {
    terminal.trackInBandResize(true);
    // Resize reports are now delivered in-band as CSI 48 t
    // LineReader handles them automatically via the terminal-resize widget
}
```

## Test plan

- [x] DECRPM probing: set (Ps=1), reset (Ps=2), permanently set (Ps=3) → supported
- [x] DECRPM probing: not recognized (Ps=0), permanently reset (Ps=4) → not supported
- [x] Dumb/dumb-color terminals → not supported, no probe sent
- [x] No DECRPM response (DA1 only) → not supported
- [x] No response at all → not supported
- [x] Probe result is cached
- [x] Enable/disable sends correct escape sequences
- [x] Mode disabled on terminal close
- [x] Default interface methods return false
- [x] All existing terminal tests pass (388 tests)
- [x] All existing reader tests pass (210 tests)
- [x] Full reactor build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-band terminal resize reporting for compatible terminals.
  * Added support checks and controls for enabling or disabling resize tracking.
  * Terminal resize events now update dimensions and trigger resize notifications automatically.

* **Bug Fixes**
  * Ensured resize tracking is disabled when a terminal session closes.
  * Improved handling of malformed resize reports.
  * Reduced the default delay for ambiguous key bindings.
  * Improved control-character display and interrupt cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->