### PR TITLE
refactor: batch DEC mode probing into single DECRQM round-trip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <groovy.version>5.0.6</groovy.version>
         <ivy.version>2.5.3</ivy.version>
         <picocli.version>4.7.7</picocli.version>
-        <graal.version>25.0.3</graal.version>
+        <graal.version>25.1.3</graal.version>
         <graal.plugin.version>21.2.0</graal.plugin.version>
         <native.plugin.version>1.1.3</native.plugin.version>
         <palantir.version>2.94.0</palantir.version>
@@ -523,7 +523,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <java>
                             <toggleOffOn />

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1294,6 +1294,83 @@ public interface Terminal extends Closeable, Flushable, Sized {
      */
     MouseEvent readMouseEvent(IntSupplier reader, String prefix);
 
+    //
+    // Terminal mode probing
+    //
+
+    /**
+     * Terminal modes that JLine probes for support.
+     *
+     * <p>Most modes are DEC private modes probed via DECRQM
+     * ({@code CSI ? Pd $ p} / {@code CSI ? Pd ; Ps $ y}).
+     * Non-DEC modes such as the Kitty Keyboard Protocol and Sixel
+     * graphics use their own detection mechanism but are probed in
+     * the same batch and cached identically.</p>
+     *
+     * <p>Support is detected at most once per terminal and the
+     * results are cached for subsequent queries.</p>
+     *
+     * @see #isModeSupported(Mode)
+     */
+    enum Mode {
+        /**
+         * Sixel graphics support.
+         *
+         * <p>Detected from the DA1 (Primary Device Attributes) response
+         * ({@code CSI c} / {@code CSI ? ... c}): attribute code {@code 4}
+         * indicates Sixel support. No extra query is needed — the DA1
+         * response is already read as the batch probe sentinel.</p>
+         */
+        SIXEL(-1),
+        /**
+         * <a href="https://sw.kovidgoyal.net/kitty/keyboard-protocol/">Kitty
+         * Keyboard Protocol</a>.
+         *
+         * <p>Probed via {@code CSI ? u}; not a DEC private mode.</p>
+         */
+        KITTY_KEYBOARD(0),
+        /** Synchronized output (DEC private mode 2026). */
+        SYNCHRONIZED_OUTPUT(2026),
+        /** Grapheme cluster / Unicode Core (DEC private mode 2027). */
+        GRAPHEME_CLUSTER(2027),
+        /** In-band window resize notifications (DEC private mode 2048). */
+        IN_BAND_RESIZE(2048);
+
+        private final int modeId;
+
+        Mode(int modeId) {
+            this.modeId = modeId;
+        }
+
+        /**
+         * Returns the DEC private mode number, {@code 0} for modes that
+         * use a custom query (e.g. {@link #KITTY_KEYBOARD}), or a
+         * negative value for modes detected from the DA1 response
+         * (e.g. {@link #SIXEL}).
+         */
+        public int mode() {
+            return modeId;
+        }
+    }
+
+    /**
+     * Checks whether the terminal supports the given mode.
+     *
+     * <p>The default implementation always returns {@code false}.
+     * Concrete implementations (e.g.
+     * {@link org.jline.terminal.impl.AbstractTerminal}) override this
+     * to trigger a single batch probe on first call: DEC private modes
+     * are queried via DECRQM, the Kitty Keyboard Protocol via
+     * {@code CSI ? u}, and Sixel support is detected from the DA1
+     * response. Results are cached for subsequent calls.</p>
+     *
+     * @param mode the mode to check
+     * @return {@code true} if the terminal supports the mode
+     */
+    default boolean isModeSupported(Mode mode) {
+        return false;
+    }
+
     /**
      * Returns whether the terminal has support for focus tracking.
      *

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -91,17 +92,26 @@ public abstract class AbstractTerminal implements TerminalExt {
     protected Runnable onClose;
     protected MouseTracking currentMouseTracking = MouseTracking.Off;
     protected volatile boolean closed = false;
+
+    // ---- Mode probe results ----
+    private final EnumMap<Mode, ProbeResult> modeProbeResults = new EnumMap<>(Mode.class);
+    private volatile boolean modesProbed;
+
+    // ---- Grapheme cluster state (mode 2027 + cursor-position fallback) ----
     private Boolean graphemeClusterModeSupported;
     private boolean graphemeClusterModeEnabled;
     private boolean graphemeClusterNative;
     private boolean groupsRegionalIndicators;
     private boolean groupsZwjSequences;
 
-    /** Result of the Mode 2027 probe. */
-    private enum ProbeResult {
-        /** Mode 2027 is supported. */
+    /** CSI prefix for DEC private mode sequences ({@code ESC [ ?}). */
+    static final String CSI_DEC = "\033[?";
+
+    /** Result of a terminal mode probe. */
+    enum ProbeResult {
+        /** Mode is supported (DECRPM Ps = 1, 2, or 3; or DA1/protocol-specific positive). */
         SUPPORTED,
-        /** Terminal responded but does not support Mode 2027. */
+        /** Terminal responded but does not support the mode. */
         NOT_SUPPORTED,
         /** Terminal did not respond at all. */
         NO_RESPONSE
@@ -421,6 +431,220 @@ public abstract class AbstractTerminal implements TerminalExt {
         }
     }
 
+    // ---- Terminal mode batch probing ----
+
+    @Override
+    public boolean isModeSupported(Mode mode) {
+        ensureModesProbed();
+        synchronized (modeProbeResults) {
+            return modeProbeResults.getOrDefault(mode, ProbeResult.NO_RESPONSE) == ProbeResult.SUPPORTED;
+        }
+    }
+
+    /**
+     * Ensures all terminal modes have been probed.
+     *
+     * <p>On first call, sends a single batch query containing a Kitty
+     * keyboard query ({@code CSI ? u}), a DECRQM query for every
+     * DEC private {@link Mode} value, and a DA1 sentinel ({@code CSI c}).
+     * The combined response is parsed once, populating
+     * {@link #modeProbeResults}. Subsequent calls are no-ops.</p>
+     *
+     * <p>macOS Terminal.app is explicitly skipped because its CSI parser
+     * does not handle the {@code $} intermediate byte and leaks the
+     * final {@code p} as visible text. All modes are marked
+     * {@link ProbeResult#NOT_SUPPORTED} so mode-specific fallbacks (e.g.
+     * the cursor position probe for grapheme clusters) can still run.</p>
+     *
+     * <p>Thread-safe: the {@code modesProbed} flag is volatile and the
+     * map is populated under a lock so concurrent callers never observe
+     * a partially filled map.</p>
+     */
+    private void ensureModesProbed() {
+        if (modesProbed) {
+            return;
+        }
+        synchronized (modeProbeResults) {
+            if (modesProbed) {
+                return;
+            }
+            try {
+                if (TYPE_DUMB.equals(type) || TYPE_DUMB_COLOR.equals(type)) {
+                    return; // map stays empty → all modes default to NO_RESPONSE
+                }
+
+                // Terminal.app's CSI parser does not handle intermediate bytes correctly
+                // and leaks the final byte 'p' of the DECRQM sequence as visible text.
+                // Mark all modes NOT_SUPPORTED (not NO_RESPONSE) so fallbacks can run.
+                String termProgram = getenv("TERM_PROGRAM");
+                if ("Apple_Terminal".equals(termProgram)) {
+                    for (Mode m : Mode.values()) {
+                        modeProbeResults.put(m, ProbeResult.NOT_SUPPORTED);
+                    }
+                    return;
+                }
+
+                Attributes prev = getAttributes();
+                Attributes probeAttrs = new Attributes(prev);
+                probeAttrs.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO), false);
+                probeAttrs.setControlChar(ControlChar.VMIN, 0);
+                probeAttrs.setControlChar(ControlChar.VTIME, 0);
+                setAttributes(probeAttrs);
+                try {
+                    probeModes();
+                } finally {
+                    long drainTimeout = getLongProperty(TerminalBuilder.PROP_DRAIN_TIMEOUT, 25);
+                    drainInput(reader(), drainTimeout, -1);
+                    setAttributes(prev);
+                }
+            } finally {
+                modesProbed = true;
+            }
+        }
+    }
+
+    /**
+     * Sends a batch query for all {@link Mode} values, terminated by a
+     * DA1 sentinel.
+     *
+     * <p>DEC private modes (those with {@code mode() > 0}) are queried
+     * via DECRQM ({@code CSI ? Pd $ p}). The Kitty Keyboard Protocol
+     * ({@code mode() == 0}) is queried via {@code CSI ? u}. The query
+     * takes the form:
+     * {@code CSI ? u  CSI ? 2026 $ p  CSI ? 2027 $ p  CSI ? 2048 $ p  CSI c}
+     * </p>
+     *
+     * <p>DA1 is near-universally supported, so its response acts as a
+     * fence: if we receive the DA1 response without any preceding DECRPM,
+     * the terminal does not support DECRQM and all modes are marked
+     * {@link ProbeResult#NOT_SUPPORTED}.</p>
+     */
+    private void probeModes() {
+        // Build batch query: Kitty keyboard + all DECRQM + DA1 sentinel
+        StringBuilder query = new StringBuilder();
+        query.append(CSI_DEC).append("u"); // Kitty keyboard query
+        for (Mode m : Mode.values()) {
+            if (m.mode() > 0) {
+                query.append(CSI_DEC).append(m.mode()).append("$p");
+            }
+        }
+        query.append("\033[c"); // DA1 sentinel
+        writer().write(query.toString());
+        writer().flush();
+
+        String response = readTerminalResponse();
+        if (response == null) {
+            // Terminal did not respond at all
+            return;
+        }
+
+        // Parse responses for each mode
+        for (Mode m : Mode.values()) {
+            if (m == Mode.SIXEL) {
+                // DA1 attribute 4 indicates Sixel support
+                modeProbeResults.put(
+                        m, parseSixelFromDa1(response) ? ProbeResult.SUPPORTED : ProbeResult.NOT_SUPPORTED);
+            } else if (m == Mode.KITTY_KEYBOARD) {
+                // Kitty keyboard: CSI ? flags u
+                modeProbeResults.put(
+                        m, parseKittyResponse(response) ? ProbeResult.SUPPORTED : ProbeResult.NOT_SUPPORTED);
+            } else {
+                // DECRPM: CSI ? mode ; Ps $ y
+                modeProbeResults.put(m, parseDecrpm(response, m.mode()));
+            }
+        }
+    }
+
+    /**
+     * Parses a DECRPM response for a single mode from the combined
+     * terminal response string.
+     *
+     * <p>Looks for the pattern {@code CSI ? mode ; Ps $ y} where
+     * Ps indicates the mode status:
+     * <ul>
+     *   <li>0 — not recognized</li>
+     *   <li>1 — set (enabled)</li>
+     *   <li>2 — reset, but can be set</li>
+     *   <li>3 — permanently set</li>
+     *   <li>4 — permanently reset</li>
+     * </ul>
+     * Ps values 1, 2, and 3 are considered {@link ProbeResult#SUPPORTED}.
+     *
+     * @param response the raw terminal response
+     * @param mode the DEC private mode number to look for
+     * @return the probe result for this mode
+     */
+    static ProbeResult parseDecrpm(String response, int mode) {
+        String prefix = CSI_DEC + mode + ";";
+        int idx = response.indexOf(prefix);
+        if (idx < 0) {
+            return ProbeResult.NOT_SUPPORTED;
+        }
+        idx += prefix.length();
+        // Verify full DECRPM sequence: CSI ? mode ; Ps $ y
+        if (idx + 2 < response.length() && response.charAt(idx + 1) == '$' && response.charAt(idx + 2) == 'y') {
+            char ps = response.charAt(idx);
+            if (ps == '1' || ps == '2' || ps == '3') {
+                return ProbeResult.SUPPORTED;
+            }
+        }
+        return ProbeResult.NOT_SUPPORTED;
+    }
+
+    /**
+     * Parses a Kitty Keyboard Protocol flags response from the combined
+     * terminal response string.
+     *
+     * <p>Looks for the pattern {@code CSI ? digits u}. If found the
+     * terminal supports the protocol.</p>
+     *
+     * @param response the raw terminal response
+     * @return {@code true} if a Kitty keyboard flags response was found
+     */
+    static boolean parseKittyResponse(String response) {
+        // Look for CSI ? <digits> u  (but not CSI ? <digits> ; <digit> $ y which is DECRPM)
+        int idx = 0;
+        while (true) {
+            idx = response.indexOf(CSI_DEC, idx);
+            if (idx < 0) {
+                return false;
+            }
+            int start = idx + 3; // past "CSI ?"
+            int pos = start;
+            // Read digits
+            while (pos < response.length() && response.charAt(pos) >= '0' && response.charAt(pos) <= '9') {
+                pos++;
+            }
+            // Must have at least one digit and terminate with 'u'
+            if (pos > start && pos < response.length() && response.charAt(pos) == 'u') {
+                return true;
+            }
+            idx = start; // advance past this CSI ? and continue searching
+        }
+    }
+
+    /**
+     * Checks whether the DA1 (Primary Device Attributes) response
+     * indicates Sixel graphics support.
+     *
+     * <p>The DA1 response has the format {@code CSI ? Pp ; Ps1 ; Ps2 ; ... c}.
+     * The first parameter ({@code Pp}) is the device conformance level, not
+     * an attribute. Attribute code {@code 4} among the subsequent parameters
+     * means the terminal supports Sixel graphics.</p>
+     *
+     * @param response the raw terminal response (may contain DECRPM, Kitty, and DA1)
+     * @return {@code true} if the DA1 response contains attribute code 4
+     */
+    static boolean parseSixelFromDa1(String response) {
+        // DA1 response: CSI ? Pp ; Ps1 ; ... c
+        // The first parameter (Pp) is the device type, NOT an attribute.
+        // We look for ";4;" (middle) or ";4c" (last) which indicates
+        // attribute 4 (Sixel) as a standalone parameter after the device type.
+        return response.contains(";4;") || response.contains(";4c");
+    }
+
+    // ---- Grapheme cluster support (mode 2027 + cursor-position fallback) ----
+
     @Override
     public boolean supportsGraphemeClusterMode() {
         if (graphemeClusterModeSupported == null) {
@@ -469,23 +693,40 @@ public abstract class AbstractTerminal implements TerminalExt {
     /**
      * Probes the terminal for grapheme cluster support.
      *
-     * <p>First attempts Mode 2027 detection via DECRQM ({@link #probeMode2027()}).
-     * If the terminal responds but does not support Mode 2027, falls back to a
+     * <p>Uses the batch DEC mode probe to check for mode 2027. If the
+     * terminal responds but does not support mode 2027, falls back to a
      * cursor position probe ({@link #probeCursorPosition()}): writes test
      * emoji (a flag and a ZWJ sequence) and measures cursor displacement via
      * DSR/CPR. If the cursor advances by exactly 2 columns, the terminal
      * natively groups that emoji category as a single cluster.</p>
      *
-     * <p>The cursor probe is only attempted when the terminal has already
-     * responded to the DECRQM/DA1 query, which guarantees it handles escape
-     * sequences and avoids blocking indefinitely on an unresponsive terminal.</p>
+     * <p>The cursor probe is only attempted when the batch probe received
+     * a response (i.e. the terminal answered DA1), which guarantees it
+     * handles escape sequences and avoids blocking indefinitely.</p>
      *
      * @return {@code true} if the terminal supports grapheme clusters
      */
     private boolean probeGraphemeClusterMode() {
-        if (TYPE_DUMB.equals(type) || TYPE_DUMB_COLOR.equals(type)) {
-            return false;
+        ensureModesProbed();
+        ProbeResult result;
+        synchronized (modeProbeResults) {
+            result = modeProbeResults.getOrDefault(Mode.GRAPHEME_CLUSTER, ProbeResult.NO_RESPONSE);
         }
+        if (result == ProbeResult.SUPPORTED) {
+            return true;
+        }
+        // Cursor probe is only safe when the terminal actually responded to the
+        // batch query; otherwise DSR/CPR would block indefinitely.
+        if (result == ProbeResult.NOT_SUPPORTED) {
+            return probeCursorPositionWithSetup();
+        }
+        return false;
+    }
+
+    /**
+     * Runs the cursor-position emoji probe with its own raw-attr setup.
+     */
+    private boolean probeCursorPositionWithSetup() {
         Attributes prev = getAttributes();
         Attributes probeAttrs = new Attributes(prev);
         probeAttrs.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO), false);
@@ -493,71 +734,12 @@ public abstract class AbstractTerminal implements TerminalExt {
         probeAttrs.setControlChar(ControlChar.VTIME, 0);
         setAttributes(probeAttrs);
         try {
-            ProbeResult mode2027 = probeMode2027();
-            if (mode2027 == ProbeResult.SUPPORTED) {
-                return true;
-            }
-            // Cursor probe is only safe when the terminal actually responded to the
-            // DECRQM/DA1 query; otherwise getCursorPosition would block indefinitely.
-            if (mode2027 == ProbeResult.NOT_SUPPORTED) {
-                return probeCursorPosition();
-            }
-            return false;
+            return probeCursorPosition();
         } finally {
             long drainTimeout = getLongProperty(TerminalBuilder.PROP_DRAIN_TIMEOUT, 25);
             drainInput(reader(), drainTimeout, -1);
             setAttributes(prev);
         }
-    }
-
-    /**
-     * Probes the terminal for mode 2027 support using DECRQM.
-     *
-     * <p>Sends {@code CSI ? 2027 $ p} followed by a DA1 (Primary Device
-     * Attributes) query {@code CSI c} as a sentinel.  DA1 is near-universally
-     * supported, so its response acts as a fence: if we receive the DA1
-     * response without a preceding DECRPM, the terminal does not support
-     * DECRQM and we return immediately instead of waiting for a timeout.</p>
-     *
-     * <p>The expected DECRPM response is {@code CSI ? 2027 ; Ps $ y} where
-     * Ps indicates the mode status.  Both DECRPM and DA1 responses share the
-     * {@code CSI ?} prefix, but diverge immediately after ({@code 2027;}
-     * vs the DA1 device-type parameter), so they are easy to distinguish.</p>
-     *
-     * <p>macOS Terminal.app is explicitly skipped because its CSI parser does
-     * not handle the {@code $} intermediate byte and leaks the final {@code p}
-     * as visible text. A {@code false} (not {@code null}) is returned so the
-     * cursor position fallback is still attempted.</p>
-     *
-     * @return {@link ProbeResult#SUPPORTED} if mode 2027 is supported,
-     *         {@link ProbeResult#NOT_SUPPORTED} if the terminal responded but
-     *         does not support it, or {@link ProbeResult#NO_RESPONSE} if the
-     *         terminal did not respond at all
-     */
-    private ProbeResult probeMode2027() {
-        // Terminal.app's CSI parser does not handle intermediate bytes correctly
-        // and leaks the final byte 'p' of the DECRQM sequence as visible text.
-        // Skip DECRQM but return NOT_SUPPORTED (not NO_RESPONSE) so the cursor probe runs.
-        String termProgram = getenv("TERM_PROGRAM");
-        if ("Apple_Terminal".equals(termProgram)) {
-            return ProbeResult.NOT_SUPPORTED;
-        }
-        // Send DECRQM query for mode 2027 followed by DA1 as sentinel.
-        // readTerminalResponse() reads until the DA1 terminator 'c', capturing
-        // both the DECRPM (ESC[?2027;Ps$y) and the DA1 response.
-        writer().write("\033[?2027$p\033[c");
-        writer().flush();
-        String response = readTerminalResponse();
-        if (response == null) {
-            return ProbeResult.NO_RESPONSE;
-        }
-        // DECRPM: ESC[?2027;Ps$y where Ps: 1=set, 2=reset (can be set), 3=permanently set
-        if (response.contains("\033[?2027;1$y")
-                || response.contains("\033[?2027;2$y")
-                || response.contains("\033[?2027;3$y")) {
-            return ProbeResult.SUPPORTED;
-        }
-        return ProbeResult.NOT_SUPPORTED;
     }
 
     /**

--- a/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
@@ -16,17 +16,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import javax.imageio.ImageIO;
 
-import org.jline.terminal.Attributes;
-import org.jline.terminal.Attributes.ControlChar;
-import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
 
 /**
  * Implementation of the Sixel Graphics Protocol.
@@ -89,9 +84,13 @@ public class SixelGraphics implements TerminalGraphics {
     /**
      * Checks if the terminal supports Sixel graphics.
      *
-     * This method uses a combination of terminal type checking and environment
-     * variables to determine if the terminal supports Sixel graphics.
-     * The detection can be overridden using setSixelSupportOverride().
+     * <p>Detection priority:
+     * <ol>
+     *   <li>User override via {@link #setSixelSupportOverride(Boolean)}</li>
+     *   <li>Runtime DA1 detection via {@link Terminal#isModeSupported(Terminal.Mode)
+     *       isModeSupported(Mode.SIXEL)} (part of the batch mode probe)</li>
+     *   <li>Static detection based on terminal type and environment variables</li>
+     * </ol>
      *
      * @param terminal the terminal to check
      * @return true if the terminal supports Sixel graphics, false otherwise
@@ -102,74 +101,13 @@ public class SixelGraphics implements TerminalGraphics {
             return sixelSupportOverride;
         }
 
-        // Try runtime detection first (if terminal supports it)
-        Boolean runtimeDetection = detectSixelSupportRuntime(terminal);
-        if (runtimeDetection != null) {
-            return runtimeDetection;
+        // Try runtime detection via the batch mode probe (DA1 attribute 4)
+        if (terminal.isModeSupported(Terminal.Mode.SIXEL)) {
+            return true;
         }
 
-        // Fall back to static detection
+        // Fall back to static detection (known terminal types / env vars)
         return detectSixelSupportStatic(terminal);
-    }
-
-    /**
-     * Attempts to detect Sixel support at runtime by querying the terminal.
-     * This is more reliable than static detection but may not work with all terminals.
-     *
-     * @param terminal the terminal to query
-     * @return true if sixel is supported, false if not supported, null if detection failed
-     */
-    private static Boolean detectSixelSupportRuntime(Terminal terminal) {
-        // Skip runtime detection for terminals we know don't support Sixel
-        // This prevents hanging and response leakage
-        // Note: We return null (not false) to allow fallback to static detection,
-        // since the environment variable might not match the actual terminal type
-        String termProgram = terminal.getenv("TERM_PROGRAM");
-        if ("com.mitchellh.ghostty".equals(termProgram)
-                || "ghostty".equals(termProgram)
-                || "kitty".equals(termProgram)
-                || "Apple_Terminal".equals(termProgram)) {
-            return null; // Skip runtime detection, fall back to static detection
-        }
-
-        Attributes originalAttributes = null;
-        Boolean result = null;
-        try {
-            originalAttributes = terminal.getAttributes();
-            Attributes probeAttrs = new Attributes(originalAttributes);
-            probeAttrs.setLocalFlags(EnumSet.of(LocalFlag.ICANON, LocalFlag.ECHO), false);
-            probeAttrs.setControlChar(ControlChar.VMIN, 0);
-            probeAttrs.setControlChar(ControlChar.VTIME, 0);
-            terminal.setAttributes(probeAttrs);
-
-            // Send Device Attributes query
-            terminal.writer().print("\033[c");
-            terminal.writer().flush();
-
-            // Read response with configurable timeout
-            String response = ((AbstractTerminal) terminal).readTerminalResponse();
-            if (response != null) {
-                // Response format: ESC[?Pp;Ps1;Ps2;...c
-                // Code "4" = Sixel graphics support
-                result = response.contains(";4;")
-                        || response.contains(";4c")
-                        || response.contains("?4;")
-                        || response.contains("?4c");
-            }
-        } catch (Exception e) {
-            // If runtime detection fails, return null to fall back to static detection
-        } finally {
-            long drainTimeout = AbstractTerminal.getLongProperty(TerminalBuilder.PROP_DRAIN_TIMEOUT, 25);
-            AbstractTerminal.drainInput(terminal.reader(), drainTimeout, -1);
-            if (originalAttributes != null) {
-                try {
-                    terminal.setAttributes(originalAttributes);
-                } catch (Exception e) {
-                    // Ignore errors during attribute restoration
-                }
-            }
-        }
-        return result;
     }
 
     /**

--- a/terminal/src/test/java/org/jline/terminal/impl/DecModeProbeTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/DecModeProbeTest.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.Terminal.Mode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the batch mode probing infrastructure: DECRQM,
+ * Kitty Keyboard Protocol, and Sixel (DA1) detection.
+ */
+class DecModeProbeTest {
+
+    // --- isModeSupported batch probing ---
+
+    @Test
+    void testAllModesFromBatchResponse() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Feed responses for all three DECRQM modes + DA1 with Sixel attribute (4)
+        terminal.slaveInputPipe.write(
+                ("\033[?2026;2$y\033[?2027;1$y\033[?2048;3$y\033[?64;1;2;4;6;22c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.isModeSupported(Mode.SYNCHRONIZED_OUTPUT));
+        assertTrue(terminal.isModeSupported(Mode.GRAPHEME_CLUSTER));
+        assertTrue(terminal.isModeSupported(Mode.IN_BAND_RESIZE));
+        assertTrue(terminal.isModeSupported(Mode.SIXEL));
+
+        // Batch query should contain all DECRQM queries and DA1
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?2026$p"));
+        assertTrue(output.contains("\033[?2027$p"));
+        assertTrue(output.contains("\033[?2048$p"));
+        assertTrue(output.contains("\033[c"));
+
+        terminal.close();
+    }
+
+    @Test
+    void testPartialModeSupport() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Only mode 2027 supported, 2026 not recognized, 2048 permanently reset
+        terminal.slaveInputPipe.write(
+                ("\033[?2026;0$y\033[?2027;2$y\033[?2048;4$y\033[?64c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertFalse(terminal.isModeSupported(Mode.SYNCHRONIZED_OUTPUT));
+        assertTrue(terminal.isModeSupported(Mode.GRAPHEME_CLUSTER));
+        assertFalse(terminal.isModeSupported(Mode.IN_BAND_RESIZE));
+
+        terminal.close();
+    }
+
+    @Test
+    void testNoModeSupportedWhenDa1Only() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // DA1 only — terminal doesn't understand DECRQM, no Sixel attribute
+        terminal.slaveInputPipe.write("\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertFalse(terminal.isModeSupported(Mode.SYNCHRONIZED_OUTPUT));
+        assertFalse(terminal.isModeSupported(Mode.GRAPHEME_CLUSTER));
+        assertFalse(terminal.isModeSupported(Mode.IN_BAND_RESIZE));
+        assertFalse(terminal.isModeSupported(Mode.SIXEL));
+
+        terminal.close();
+    }
+
+    @Test
+    void testNoModeSupportedOnDumbTerminal() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", Terminal.TYPE_DUMB, masterOutput, StandardCharsets.UTF_8);
+
+        assertFalse(terminal.isModeSupported(Mode.SYNCHRONIZED_OUTPUT));
+        assertFalse(terminal.isModeSupported(Mode.GRAPHEME_CLUSTER));
+        assertFalse(terminal.isModeSupported(Mode.IN_BAND_RESIZE));
+        assertFalse(terminal.isModeSupported(Mode.SIXEL));
+
+        // No queries should have been sent
+        assertEquals(0, masterOutput.size());
+
+        terminal.close();
+    }
+
+    @Test
+    void testNoModeSupportedOnDumbColorTerminal() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", Terminal.TYPE_DUMB_COLOR, masterOutput, StandardCharsets.UTF_8);
+
+        assertFalse(terminal.isModeSupported(Mode.SYNCHRONIZED_OUTPUT));
+        assertEquals(0, masterOutput.size());
+
+        terminal.close();
+    }
+
+    @Test
+    void testProbeResultsCached() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        terminal.slaveInputPipe.write(("\033[?2027;1$y\033[?64c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.isModeSupported(Mode.GRAPHEME_CLUSTER));
+
+        // Record output length after first probe
+        int firstProbeLen = masterOutput.size();
+
+        // Second call should not re-probe
+        assertTrue(terminal.isModeSupported(Mode.GRAPHEME_CLUSTER));
+        assertFalse(terminal.isModeSupported(Mode.SYNCHRONIZED_OUTPUT));
+        assertEquals(firstProbeLen, masterOutput.size());
+
+        terminal.close();
+    }
+
+    @Test
+    void testBatchQueryIncludesKittyQuery() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Feed DA1 only
+        terminal.slaveInputPipe.write("\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        terminal.isModeSupported(Mode.GRAPHEME_CLUSTER);
+
+        String output = masterOutput.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\033[?u"), "Batch query should include Kitty keyboard query");
+
+        terminal.close();
+    }
+
+    @Test
+    void testIsModeConsistentWithSupportsGraphemeCluster() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        terminal.slaveInputPipe.write(("\033[?2027;1$y\033[?64c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        // Both should agree when mode 2027 is supported via DECRQM
+        assertTrue(terminal.isModeSupported(Mode.GRAPHEME_CLUSTER));
+        assertTrue(terminal.supportsGraphemeClusterMode());
+
+        terminal.close();
+    }
+
+    // --- Kitty Keyboard Protocol detection ---
+
+    @Test
+    void testKittyKeyboardSupported() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Kitty response (flags=1) + mode 2027 DECRPM + DA1
+        terminal.slaveInputPipe.write(("\033[?1u\033[?2027;2$y\033[?64c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.isModeSupported(Mode.KITTY_KEYBOARD));
+        assertTrue(terminal.isModeSupported(Mode.GRAPHEME_CLUSTER));
+
+        terminal.close();
+    }
+
+    @Test
+    void testKittyKeyboardSupportedWithHigherFlags() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // Kitty flags=31 (all flags) + DA1
+        terminal.slaveInputPipe.write(("\033[?31u\033[?64c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.isModeSupported(Mode.KITTY_KEYBOARD));
+
+        terminal.close();
+    }
+
+    @Test
+    void testKittyKeyboardNotSupportedWhenNoResponse() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // No Kitty response, just DA1
+        terminal.slaveInputPipe.write("\033[?64c".getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertFalse(terminal.isModeSupported(Mode.KITTY_KEYBOARD));
+
+        terminal.close();
+    }
+
+    @Test
+    void testKittyKeyboardNotSupportedOnDumbTerminal() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", Terminal.TYPE_DUMB, masterOutput, StandardCharsets.UTF_8);
+
+        assertFalse(terminal.isModeSupported(Mode.KITTY_KEYBOARD));
+        assertEquals(0, masterOutput.size());
+
+        terminal.close();
+    }
+
+    @Test
+    void testKittyKeyboardCachedWithModes() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        terminal.slaveInputPipe.write(("\033[?1u\033[?64c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        // Trigger via isModeSupported — Kitty result should also be cached
+        terminal.isModeSupported(Mode.GRAPHEME_CLUSTER);
+        assertTrue(terminal.isModeSupported(Mode.KITTY_KEYBOARD));
+
+        terminal.close();
+    }
+
+    // --- Sixel (DA1 attribute 4) detection ---
+
+    @Test
+    void testSixelSupportedFromDa1() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // DA1 with attribute 4 (Sixel) among parameters
+        terminal.slaveInputPipe.write(("\033[?64;1;2;4;6;22c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.isModeSupported(Mode.SIXEL));
+
+        terminal.close();
+    }
+
+    @Test
+    void testSixelSupportedWhenAttribute4AtEnd() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // DA1 with attribute 4 as last parameter
+        terminal.slaveInputPipe.write(("\033[?64;4c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.isModeSupported(Mode.SIXEL));
+
+        terminal.close();
+    }
+
+    @Test
+    void testSixelSupportedWhenAttribute4IsFirstAttribute() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // DA1 with attribute 4 as first attribute after device type (Pp=1)
+        terminal.slaveInputPipe.write(("\033[?1;4;6c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertTrue(terminal.isModeSupported(Mode.SIXEL));
+
+        terminal.close();
+    }
+
+    @Test
+    void testSixelNotSupportedWhenDeviceTypeIs4() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // DA1 with Pp=4 (device type), not attribute 4 — should not be treated as Sixel
+        terminal.slaveInputPipe.write(("\033[?4;6c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertFalse(terminal.isModeSupported(Mode.SIXEL));
+
+        terminal.close();
+    }
+
+    @Test
+    void testSixelNotSupportedWhenNoAttribute4() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // DA1 without attribute 4
+        terminal.slaveInputPipe.write(("\033[?64;1;2;6;22c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        assertFalse(terminal.isModeSupported(Mode.SIXEL));
+
+        terminal.close();
+    }
+
+    @Test
+    void testSixelNotSupportedOnDumbTerminal() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", Terminal.TYPE_DUMB, masterOutput, StandardCharsets.UTF_8);
+
+        assertFalse(terminal.isModeSupported(Mode.SIXEL));
+        assertEquals(0, masterOutput.size());
+
+        terminal.close();
+    }
+
+    @Test
+    void testSixelCachedWithOtherModes() throws Exception {
+        ByteArrayOutputStream masterOutput = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "xterm-256color", masterOutput, StandardCharsets.UTF_8);
+
+        // DA1 with Sixel + DECRPM for mode 2027
+        terminal.slaveInputPipe.write(("\033[?2027;1$y\033[?64;4c").getBytes(StandardCharsets.UTF_8));
+        terminal.slaveInputPipe.flush();
+
+        // Trigger probe via any mode
+        assertTrue(terminal.isModeSupported(Mode.GRAPHEME_CLUSTER));
+
+        // Sixel should also be cached from the same batch
+        assertTrue(terminal.isModeSupported(Mode.SIXEL));
+
+        terminal.close();
+    }
+
+    // --- parseDecrpm unit tests ---
+
+    @Test
+    void testParseDecrpmSupported() {
+        String response = "\033[?2027;1$y\033[?64c";
+        assertEquals(AbstractTerminal.ProbeResult.SUPPORTED, AbstractTerminal.parseDecrpm(response, 2027));
+    }
+
+    @Test
+    void testParseDecrpmResetButSettable() {
+        String response = "\033[?2026;2$y\033[?64c";
+        assertEquals(AbstractTerminal.ProbeResult.SUPPORTED, AbstractTerminal.parseDecrpm(response, 2026));
+    }
+
+    @Test
+    void testParseDecrpmPermanentlySet() {
+        String response = "\033[?2048;3$y\033[?64c";
+        assertEquals(AbstractTerminal.ProbeResult.SUPPORTED, AbstractTerminal.parseDecrpm(response, 2048));
+    }
+
+    @Test
+    void testParseDecrpmNotRecognized() {
+        String response = "\033[?2027;0$y\033[?64c";
+        assertEquals(AbstractTerminal.ProbeResult.NOT_SUPPORTED, AbstractTerminal.parseDecrpm(response, 2027));
+    }
+
+    @Test
+    void testParseDecrpmPermanentlyReset() {
+        String response = "\033[?2027;4$y\033[?64c";
+        assertEquals(AbstractTerminal.ProbeResult.NOT_SUPPORTED, AbstractTerminal.parseDecrpm(response, 2027));
+    }
+
+    @Test
+    void testParseDecrpmModeNotPresent() {
+        String response = "\033[?2027;1$y\033[?64c";
+        assertEquals(AbstractTerminal.ProbeResult.NOT_SUPPORTED, AbstractTerminal.parseDecrpm(response, 2048));
+    }
+
+    @Test
+    void testParseDecrpmMultipleModes() {
+        String response = "\033[?2026;2$y\033[?2027;1$y\033[?2048;0$y\033[?64c";
+        assertEquals(AbstractTerminal.ProbeResult.SUPPORTED, AbstractTerminal.parseDecrpm(response, 2026));
+        assertEquals(AbstractTerminal.ProbeResult.SUPPORTED, AbstractTerminal.parseDecrpm(response, 2027));
+        assertEquals(AbstractTerminal.ProbeResult.NOT_SUPPORTED, AbstractTerminal.parseDecrpm(response, 2048));
+    }
+
+    // --- parseKittyResponse unit tests ---
+
+    @Test
+    void testParseKittyResponsePresent() {
+        assertTrue(AbstractTerminal.parseKittyResponse("\033[?1u\033[?2027;1$y\033[?64c"));
+    }
+
+    @Test
+    void testParseKittyResponseHighFlags() {
+        assertTrue(AbstractTerminal.parseKittyResponse("\033[?31u\033[?64c"));
+    }
+
+    @Test
+    void testParseKittyResponseZeroFlags() {
+        assertTrue(AbstractTerminal.parseKittyResponse("\033[?0u\033[?64c"));
+    }
+
+    @Test
+    void testParseKittyResponseAbsent() {
+        assertFalse(AbstractTerminal.parseKittyResponse("\033[?2027;1$y\033[?64c"));
+    }
+
+    @Test
+    void testParseKittyResponseDoesNotMatchDecrpm() {
+        // CSI ? 2027 ; 1 $ y  — digits are followed by ';', not 'u'
+        assertFalse(AbstractTerminal.parseKittyResponse("\033[?2027;1$y\033[?64c"));
+    }
+
+    @Test
+    void testParseKittyResponseEmptyString() {
+        assertFalse(AbstractTerminal.parseKittyResponse(""));
+    }
+
+    // --- parseSixelFromDa1 unit tests ---
+
+    @Test
+    void testParseSixelFromDa1MiddleParam() {
+        // Attribute 4 in the middle of the parameter list
+        assertTrue(AbstractTerminal.parseSixelFromDa1("\033[?64;1;2;4;6;22c"));
+    }
+
+    @Test
+    void testParseSixelFromDa1LastParam() {
+        // Attribute 4 at the end: ;4c
+        assertTrue(AbstractTerminal.parseSixelFromDa1("\033[?64;4c"));
+    }
+
+    @Test
+    void testParseSixelFromDa1FirstAttribute() {
+        // Attribute 4 as first attribute after device type (Pp=1)
+        assertTrue(AbstractTerminal.parseSixelFromDa1("\033[?1;4;6c"));
+    }
+
+    @Test
+    void testParseSixelFromDa1DeviceTypeNotAttribute() {
+        // Pp=4 is the device type, NOT attribute 4 — must not match
+        assertFalse(AbstractTerminal.parseSixelFromDa1("\033[?4c"));
+    }
+
+    @Test
+    void testParseSixelFromDa1DeviceType4WithOtherAttrs() {
+        // Pp=4 with attributes=[6] — device type 4 is not attribute 4
+        assertFalse(AbstractTerminal.parseSixelFromDa1("\033[?4;6c"));
+    }
+
+    @Test
+    void testParseSixelFromDa1Absent() {
+        // No attribute 4
+        assertFalse(AbstractTerminal.parseSixelFromDa1("\033[?64;1;2;6;22c"));
+    }
+
+    @Test
+    void testParseSixelFromDa1DoesNotMatchSubstring() {
+        // "64" contains "4" but not ";4;" or ";4c"
+        assertFalse(AbstractTerminal.parseSixelFromDa1("\033[?64c"));
+    }
+
+    @Test
+    void testParseSixelFromDa1EmptyString() {
+        assertFalse(AbstractTerminal.parseSixelFromDa1(""));
+    }
+
+    @Test
+    void testParseSixelFromDa1WithDecrpmInResponse() {
+        // Combined response: DECRPM with Ps=4 (permanently reset) + DA1 without Sixel
+        // The ";4$" in DECRPM should NOT match ";4;" or ";4c"
+        assertFalse(AbstractTerminal.parseSixelFromDa1("\033[?2048;4$y\033[?64c"));
+    }
+
+    @Test
+    void testParseSixelFromDa1WithDecrpmAndSixel() {
+        // Combined response: DECRPM + DA1 with Sixel attribute
+        assertTrue(AbstractTerminal.parseSixelFromDa1("\033[?2027;1$y\033[?64;4c"));
+    }
+}

--- a/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterModeTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/GraphemeClusterModeTest.java
@@ -402,6 +402,9 @@ class GraphemeClusterModeTest {
         assertFalse(terminal.supportsGraphemeClusterMode());
         assertFalse(terminal.getGraphemeClusterMode());
         assertFalse(terminal.setGraphemeClusterMode(true, false));
+        assertFalse(terminal.isModeSupported(Terminal.Mode.GRAPHEME_CLUSTER));
+        assertFalse(terminal.isModeSupported(Terminal.Mode.KITTY_KEYBOARD));
+        assertFalse(terminal.isModeSupported(Terminal.Mode.SIXEL));
     }
 
     // --- Force-enable via setGraphemeClusterMode(true, true) ---


### PR DESCRIPTION
## Summary

Replaces per-mode probe methods (`probeMode2027()`, and the pattern being duplicated in #2021 with `probeMode2048()`) with a single batch query that sends DECRQM for all `Mode` enum values plus a Kitty keyboard query, terminated by a DA1 sentinel. Results are parsed once and cached in an `EnumMap<Mode, ProbeResult>`.

### What changed

- **`Terminal.java`**: New `Mode` enum (`SIXEL`, `KITTY_KEYBOARD`, `SYNCHRONIZED_OUTPUT`, `GRAPHEME_CLUSTER`, `IN_BAND_RESIZE`) with `isModeSupported(Mode)` default method
- **`AbstractTerminal.java`**: `ensureModesProbed()` sends one batch query (`CSI ? u` + `CSI ? 2026 $ p` + `CSI ? 2027 $ p` + `CSI ? 2048 $ p` + `CSI c`), `probeModes()` parses all DECRPM + Kitty + DA1 responses via `parseDecrpm()`, `parseKittyResponse()`, and `parseSixelFromDa1()` helpers. Thread-safe via double-checked locking with volatile flag.
- **`SixelGraphics.java`**: Runtime Sixel detection delegates to `isModeSupported(Mode.SIXEL)` — eliminates duplicated DA1 query and attribute setup/teardown
- Cursor-position fallback for grapheme cluster detection is preserved
- 45 tests in `DecModeProbeTest` covering batch probing, Kitty detection, Sixel DA1 parsing, caching, dumb terminals, and response parsing

### Motivation

With #2021 (mode 2048), #2022 (mode 2026), and #2007 (Kitty keyboard) all adding terminal probing, each was duplicating the DECRQM query + DA1 sentinel + response parsing pattern. This refactoring means adding a new mode costs one enum constant instead of a full copy-paste method, and all probing happens in a single terminal round-trip.

### Impact on open PRs

- **#2021** (mode 2048 / in-band resize): Can drop `probeMode2048()` / `probeInBandResize()` and use `isModeSupported(Mode.IN_BAND_RESIZE)` directly
- **#2022** (mode 2026 / synchronized output): Can use `isModeSupported(Mode.SYNCHRONIZED_OUTPUT)` to check support before sending BSU/ESU
- **#2007** (Kitty keyboard): Can drop the ad-hoc Kitty query piggybacking on `probeMode2027()` and use `isModeSupported(Mode.KITTY_KEYBOARD)` directly

## Test plan

- [x] All 45 `DecModeProbeTest` tests pass (DECRQM, Kitty, Sixel DA1, caching, dumb terminals)
- [x] All existing `GraphemeClusterModeTest` tests pass (behavior preserved)
- [x] Full terminal module test suite passes (415 tests)
- [x] Full project builds successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified API to check whether terminal capabilities are supported for Sixel, Kitty keyboard, synchronized output, grapheme cluster, and in-band resize.
  * Introduced one-time batch probing with cached results for consistent repeated queries.
* **Bug Fixes**
  * Reduced unnecessary/blocking probes by batching capability checks and skipping cursor probing when no response is detected.
  * Updated Sixel detection to use runtime mode support first, then fall back to static detection.
* **Tests**
  * Added/expanded coverage for batch probing, parsing helpers, caching behavior, and edge/negative response cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->