### PR TITLE
Add Terminal.getenv() for remote terminal environment support

### DIFF
--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
@@ -179,26 +179,25 @@ public class ShellFactoryImpl implements ShellFactory {
                             break;
                     }
                 }
+                Map<String, String> sshEnv = env.getEnv();
                 Terminal terminal = TerminalBuilder.builder()
                         .name("JLine SSH")
-                        .type(env.getEnv().get("TERM"))
+                        .type(sshEnv.get("TERM"))
                         .system(false)
                         .streams(in, out)
                         .attributes(attributes)
-                        .size(Size.of(
-                                Integer.parseInt(env.getEnv().get("COLUMNS")),
-                                Integer.parseInt(env.getEnv().get("LINES"))))
+                        .env(sshEnv::get)
+                        .size(Size.of(Integer.parseInt(sshEnv.get("COLUMNS")), Integer.parseInt(sshEnv.get("LINES"))))
                         .build();
                 env.addSignalListener(
                         (channel, signals) -> {
                             terminal.setSize(Size.of(
-                                    Integer.parseInt(env.getEnv().get("COLUMNS")),
-                                    Integer.parseInt(env.getEnv().get("LINES"))));
+                                    Integer.parseInt(sshEnv.get("COLUMNS")), Integer.parseInt(sshEnv.get("LINES"))));
                             terminal.raise(Terminal.Signal.WINCH);
                         },
                         Signal.WINCH);
 
-                shell.accept(new Ssh.ShellParams(env.getEnv(), session.getSession(), terminal, () -> destroy(session)));
+                shell.accept(new Ssh.ShellParams(sshEnv, session.getSession(), terminal, () -> destroy(session)));
             } catch (Throwable t) {
                 if (!closed) {
                     LOGGER.error("Error occured while executing shell", t);

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1462,7 +1462,7 @@ public interface Terminal extends Closeable, Flushable, Sized {
      *
      * @param name the name of the environment variable
      * @return the value of the variable, or {@code null} if it is not defined
-     * @see TerminalBuilder#env(java.util.function.Function)
+     * @see TerminalBuilder#env(java.util.function.UnaryOperator)
      */
     default String getenv(String name) {
         return System.getenv(name);

--- a/terminal/src/main/java/org/jline/terminal/Terminal.java
+++ b/terminal/src/main/java/org/jline/terminal/Terminal.java
@@ -1441,6 +1441,34 @@ public interface Terminal extends Closeable, Flushable, Sized {
     }
 
     /**
+     * Returns the value of the specified environment variable from the terminal's
+     * environment.
+     *
+     * <p>
+     * For local terminals this defaults to {@link System#getenv(String)}, which
+     * reads the JVM process's own environment. Remote terminal implementations
+     * (e.g., SSH) should override this method to return the remote client's
+     * environment variables instead, since terminal-related variables like
+     * {@code TERM}, {@code TERM_PROGRAM}, {@code COLORTERM}, etc. originate
+     * from the client side and are not present in the server JVM's environment.
+     * </p>
+     *
+     * <p>
+     * JLine's internal capability detection (true-color support, graphics protocol
+     * support, grapheme cluster mode, etc.) uses this method rather than calling
+     * {@link System#getenv(String)} directly, ensuring correct behavior across
+     * both local and remote terminals.
+     * </p>
+     *
+     * @param name the name of the environment variable
+     * @return the value of the variable, or {@code null} if it is not defined
+     * @see TerminalBuilder#env(java.util.function.Function)
+     */
+    default String getenv(String name) {
+        return System.getenv(name);
+    }
+
+    /**
      * Returns the color palette for this terminal.
      *
      * <p>

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -382,7 +382,7 @@ public final class TerminalBuilder {
     private Terminal.SignalHandler signalHandler = Terminal.SignalHandler.SIG_DFL;
     private boolean paused = false;
     private Boolean graphemeCluster;
-    private Function<String, String> env;
+    private UnaryOperator<String> env;
 
     private TerminalBuilder() {}
 
@@ -815,7 +815,7 @@ public final class TerminalBuilder {
      * @return this builder
      * @see Terminal#getenv(String)
      */
-    public TerminalBuilder env(Function<String, String> env) {
+    public TerminalBuilder env(UnaryOperator<String> env) {
         this.env = env;
         return this;
     }

--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -381,6 +382,7 @@ public final class TerminalBuilder {
     private Terminal.SignalHandler signalHandler = Terminal.SignalHandler.SIG_DFL;
     private boolean paused = false;
     private Boolean graphemeCluster;
+    private Function<String, String> env;
 
     private TerminalBuilder() {}
 
@@ -788,6 +790,37 @@ public final class TerminalBuilder {
     }
 
     /**
+     * Sets a custom environment variable provider for the terminal.
+     *
+     * <p>By default, terminals read environment variables from
+     * {@link System#getenv(String)}, which returns the JVM process's own
+     * environment. For remote terminals (e.g., SSH), the client's environment
+     * variables are different from the server JVM's. This method allows
+     * injecting the correct environment so that capability detection
+     * (true-color, graphics protocol, grapheme cluster mode, etc.) uses
+     * the remote client's values.</p>
+     *
+     * <p>Example — SSH server passing the client's environment:</p>
+     * <pre>
+     * Map&lt;String, String&gt; sshEnv = sshSession.getEnvironment();
+     * Terminal terminal = TerminalBuilder.builder()
+     *     .system(false)
+     *     .streams(in, out)
+     *     .env(sshEnv::get)
+     *     .build();
+     * </pre>
+     *
+     * @param env a function that returns the value of an environment variable
+     *            given its name, or {@code null} if not defined
+     * @return this builder
+     * @see Terminal#getenv(String)
+     */
+    public TerminalBuilder env(Function<String, String> env) {
+        this.env = env;
+        return this;
+    }
+
+    /**
      * Create and configure a Terminal instance according to this builder's settings.
      *
      * If a global terminal override has been set, that instance is returned instead of creating a new one.
@@ -808,6 +841,12 @@ public final class TerminalBuilder {
         if (terminal instanceof AbstractPosixTerminal) {
             Log.debug(() -> "Using pty "
                     + ((AbstractPosixTerminal) terminal).getPty().getClass().getSimpleName());
+        }
+        // Set custom environment provider if configured.
+        // This must happen before grapheme cluster probing, which reads
+        // env vars like TERM_PROGRAM to decide whether to send DECRQM.
+        if (this.env != null && terminal instanceof AbstractTerminal) {
+            ((AbstractTerminal) terminal).setEnv(this.env);
         }
         // Enable grapheme cluster mode if supported
         Boolean gc = this.graphemeCluster;
@@ -1051,7 +1090,7 @@ public final class TerminalBuilder {
         if (dumb == null) {
             // detect emacs using the env variable
             if (color == null) {
-                String emacs = System.getenv("INSIDE_EMACS");
+                String emacs = getEnvVar("INSIDE_EMACS");
                 if (emacs != null && emacs.contains("comint")) {
                     color = true;
                 }
@@ -1059,7 +1098,7 @@ public final class TerminalBuilder {
             // detect Intellij Idea
             if (color == null) {
                 // using the env variable on windows
-                String ideHome = System.getenv("IDE_HOME");
+                String ideHome = getEnvVar("IDE_HOME");
                 if (ideHome != null) {
                     color = true;
                 } else {
@@ -1071,7 +1110,7 @@ public final class TerminalBuilder {
                 }
             }
             if (color == null) {
-                color = systemStream != null && System.getenv("TERM") != null;
+                color = systemStream != null && getEnvVar("TERM") != null;
             }
         } else {
             if (color == null) {
@@ -1139,7 +1178,7 @@ public final class TerminalBuilder {
             type = System.getProperty(PROP_TYPE);
         }
         if (type == null) {
-            type = System.getenv("TERM");
+            type = getEnvVar("TERM");
         }
         return type;
     }
@@ -1296,6 +1335,14 @@ public final class TerminalBuilder {
             }
         }
         return null;
+    }
+
+    /**
+     * Reads an environment variable using the configured provider, or
+     * {@link System#getenv(String)} if none was set.
+     */
+    private String getEnvVar(String name) {
+        return env != null ? env.apply(name) : System.getenv(name);
     }
 
     private static String getParentProcessCommand() {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 
@@ -85,6 +86,7 @@ public abstract class AbstractTerminal implements TerminalExt {
     protected final Map<Capability, Integer> ints = new HashMap<>();
     protected final Map<Capability, String> strings = new HashMap<>();
     protected final ColorPalette palette;
+    protected Function<String, String> envProvider = System::getenv;
     protected Status status;
     protected Runnable onClose;
     protected MouseTracking currentMouseTracking = MouseTracking.Off;
@@ -144,6 +146,27 @@ public abstract class AbstractTerminal implements TerminalExt {
 
     public void setOnClose(Runnable onClose) {
         this.onClose = onClose;
+    }
+
+    @Override
+    public String getenv(String name) {
+        return envProvider.apply(name);
+    }
+
+    /**
+     * Sets the environment variable provider for this terminal and re-detects
+     * environment-dependent capabilities (e.g., true-color support).
+     *
+     * <p>This is called by {@link TerminalBuilder} when a custom environment
+     * has been configured, for example to inject the SSH client's environment
+     * into a remote terminal.</p>
+     *
+     * @param env a function that returns the value of an environment variable
+     *            given its name, or {@code null} if not defined
+     */
+    public void setEnv(Function<String, String> env) {
+        this.envProvider = Objects.requireNonNull(env);
+        detectTrueColorSupport();
     }
 
     public Status getStatus() {
@@ -323,7 +346,7 @@ public abstract class AbstractTerminal implements TerminalExt {
         if (maxColors != null && maxColors >= 0x7FFF) {
             return; // already true-color capable
         }
-        String colorterm = System.getenv("COLORTERM");
+        String colorterm = getenv("COLORTERM");
         if (colorterm != null) {
             colorterm = colorterm.toLowerCase(java.util.Locale.ROOT);
         }
@@ -515,7 +538,7 @@ public abstract class AbstractTerminal implements TerminalExt {
         // Terminal.app's CSI parser does not handle intermediate bytes correctly
         // and leaks the final byte 'p' of the DECRQM sequence as visible text.
         // Skip DECRQM but return NOT_SUPPORTED (not NO_RESPONSE) so the cursor probe runs.
-        String termProgram = System.getenv("TERM_PROGRAM");
+        String termProgram = getenv("TERM_PROGRAM");
         if ("Apple_Terminal".equals(termProgram)) {
             return ProbeResult.NOT_SUPPORTED;
         }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -20,9 +20,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
+import java.util.function.UnaryOperator;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Attributes.ControlChar;
@@ -86,7 +86,7 @@ public abstract class AbstractTerminal implements TerminalExt {
     protected final Map<Capability, Integer> ints = new HashMap<>();
     protected final Map<Capability, String> strings = new HashMap<>();
     protected final ColorPalette palette;
-    protected Function<String, String> envProvider = System::getenv;
+    protected UnaryOperator<String> envProvider = System::getenv;
     protected Status status;
     protected Runnable onClose;
     protected MouseTracking currentMouseTracking = MouseTracking.Off;
@@ -164,7 +164,7 @@ public abstract class AbstractTerminal implements TerminalExt {
      * @param env a function that returns the value of an environment variable
      *            given its name, or {@code null} if not defined
      */
-    public void setEnv(Function<String, String> env) {
+    public void setEnv(UnaryOperator<String> env) {
         this.envProvider = Objects.requireNonNull(env);
         detectTrueColorSupport();
     }

--- a/terminal/src/main/java/org/jline/terminal/impl/ITerm2Graphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ITerm2Graphics.java
@@ -73,24 +73,24 @@ public class ITerm2Graphics implements TerminalGraphics {
         }
 
         // Check for iTerm2
-        String termProgram = System.getenv("TERM_PROGRAM");
+        String termProgram = terminal.getenv("TERM_PROGRAM");
         if ("iTerm.app".equals(termProgram)) {
             return true;
         }
 
         // Check for iTerm2-specific environment variables
-        if (System.getenv("ITERM_SESSION_ID") != null) {
+        if (terminal.getenv("ITERM_SESSION_ID") != null) {
             return true;
         }
 
         // Check TERM_PROGRAM_VERSION for iTerm2
-        String termProgramVersion = System.getenv("TERM_PROGRAM_VERSION");
+        String termProgramVersion = terminal.getenv("TERM_PROGRAM_VERSION");
         if (termProgramVersion != null && "iTerm.app".equals(termProgram)) {
             return true;
         }
 
         // Check for LC_TERMINAL which iTerm2 sets
-        String lcTerminal = System.getenv("LC_TERMINAL");
+        String lcTerminal = terminal.getenv("LC_TERMINAL");
         if ("iTerm2".equals(lcTerminal)) {
             return true;
         }

--- a/terminal/src/main/java/org/jline/terminal/impl/KittyGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/KittyGraphics.java
@@ -75,7 +75,7 @@ public class KittyGraphics implements TerminalGraphics {
         }
 
         // Check TERM_PROGRAM environment variable
-        String termProgram = System.getenv("TERM_PROGRAM");
+        String termProgram = terminal.getenv("TERM_PROGRAM");
 
         // Check if this is Ghostty first - skip runtime detection to avoid hanging
         if ("com.mitchellh.ghostty".equals(termProgram) || "ghostty".equals(termProgram)) {
@@ -83,7 +83,7 @@ public class KittyGraphics implements TerminalGraphics {
         }
 
         // Check for Ghostty-specific environment variables
-        if (System.getenv("GHOSTTY_RESOURCES_DIR") != null) {
+        if (terminal.getenv("GHOSTTY_RESOURCES_DIR") != null) {
             return true;
         }
 
@@ -104,7 +104,7 @@ public class KittyGraphics implements TerminalGraphics {
 
         // Check for iTerm2 (supports Kitty graphics protocol since version 3.5.0)
         if ("iTerm.app".equals(termProgram)) {
-            String termProgramVersion = System.getenv("TERM_PROGRAM_VERSION");
+            String termProgramVersion = terminal.getenv("TERM_PROGRAM_VERSION");
             if (termProgramVersion != null) {
                 try {
                     String[] versionParts = termProgramVersion.split("\\.");
@@ -124,14 +124,14 @@ public class KittyGraphics implements TerminalGraphics {
         }
 
         // Check TERM environment variable
-        String term = System.getenv("TERM");
+        String term = terminal.getenv("TERM");
         if (term != null && term.contains("kitty")) {
             return true;
         }
 
         // Check for Kitty-specific capabilities
         // Kitty sets KITTY_WINDOW_ID when running
-        if (System.getenv("KITTY_WINDOW_ID") != null) {
+        if (terminal.getenv("KITTY_WINDOW_ID") != null) {
             return true;
         }
 

--- a/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/SixelGraphics.java
@@ -124,7 +124,7 @@ public class SixelGraphics implements TerminalGraphics {
         // This prevents hanging and response leakage
         // Note: We return null (not false) to allow fallback to static detection,
         // since the environment variable might not match the actual terminal type
-        String termProgram = System.getenv("TERM_PROGRAM");
+        String termProgram = terminal.getenv("TERM_PROGRAM");
         if ("com.mitchellh.ghostty".equals(termProgram)
                 || "ghostty".equals(termProgram)
                 || "kitty".equals(termProgram)
@@ -204,9 +204,9 @@ public class SixelGraphics implements TerminalGraphics {
         }
 
         // Check for environment variables that might indicate sixel support
-        String termEnv = System.getenv("TERM");
-        String termProgram = System.getenv("TERM_PROGRAM");
-        String termProgramVersion = System.getenv("TERM_PROGRAM_VERSION");
+        String termEnv = terminal.getenv("TERM");
+        String termProgram = terminal.getenv("TERM_PROGRAM");
+        String termProgramVersion = terminal.getenv("TERM_PROGRAM_VERSION");
 
         // Check for terminals that should use other protocols instead of Sixel
 


### PR DESCRIPTION
## Summary

When JLine runs a remote terminal through SSH, environment variables like `TERM_PROGRAM`, `COLORTERM`, `KITTY_WINDOW_ID` etc. come from the SSH client, not the server JVM's process environment. The scattered `System.getenv()` calls throughout JLine meant that graphics protocol detection, true-color detection, and grapheme cluster probing all got wrong answers for remote terminals.

This PR:

- Adds `Terminal.getenv(String)` as the canonical way to read terminal environment variables (defaults to `System.getenv()` for backward compatibility)
- Adds `TerminalBuilder.env(Function<String, String>)` to inject a custom environment provider
- Replaces `System.getenv()` with `terminal.getenv()` in all terminal capability detection code:
  - `AbstractTerminal` — true-color detection (`COLORTERM`) and Mode 2027 probing (`TERM_PROGRAM`)
  - `KittyGraphics` — `TERM_PROGRAM`, `GHOSTTY_RESOURCES_DIR`, `TERM_PROGRAM_VERSION`, `TERM`, `KITTY_WINDOW_ID`
  - `ITerm2Graphics` — `TERM_PROGRAM`, `ITERM_SESSION_ID`, `TERM_PROGRAM_VERSION`, `LC_TERMINAL`
  - `SixelGraphics` — `TERM`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`
  - `TerminalBuilder` — `TERM`, `INSIDE_EMACS`, `IDE_HOME`
- Wires the SSH session environment through `ShellFactoryImpl` via `.env(sshEnv::get)`

**Not changed** (correctly use `System.getenv()`):
- `OSUtils` — detects JVM platform (Cygwin, WSL, etc.), not terminal client
- `AnsiConsole` — static JVM environment detection
- `Diag` — diagnostic output showing JVM env

## Test plan

- [x] Full build compiles successfully
- [x] All terminal module tests pass (372 tests)
- [x] All reader, shell module tests pass
- [ ] Verify SSH terminal correctly detects remote client's graphics protocol support
- [ ] Verify `TerminalBuilder.env()` overrides env for capability detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal environment values can now be provided per terminal session, improving support for remote and custom terminal setups.

* **Bug Fixes**
  * Terminal capabilities such as true color, iTerm2, Kitty, Ghostty, and Sixel detection now use the active terminal’s environment instead of the process-wide environment.
  * Shell terminal sizing and resize handling now stay consistent with the connected SSH session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->