### PR TITLE
feat: allow customizing the default prompt in Less pager

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -86,6 +86,7 @@ public class Less {
     public boolean noInit;
     protected List<Integer> tabs = Collections.singletonList(4);
     protected String syntaxName;
+    protected String defaultPrompt;
     private String historyLog = null;
 
     protected final Terminal terminal;
@@ -142,6 +143,7 @@ public class Less {
             "  -I --IGNORE-CASE             Search ignores all case",
             "  -x --tabs=N[,...]            Set tab stops",
             "  -N --LINE-NUMBERS            Display line number for each line",
+            "  -P --prompt=string           Set the default prompt string",
             "  -Y --syntax=name             The name of the syntax highlighting to use.",
             "     --no-init                 Disable terminal initialization",
             "     --no-keypad               Disable keypad handling",
@@ -210,6 +212,9 @@ public class Less {
             }
             if (opts.isSet("tabs")) {
                 doTabs(opts.get("tabs"));
+            }
+            if (opts.isSet("prompt")) {
+                defaultPrompt = opts.get("prompt");
             }
             if (opts.isSet("syntax")) {
                 syntaxName = opts.get("syntax");
@@ -305,6 +310,19 @@ public class Less {
     // to be removed
     public Less tabs(List<Integer> tabs) {
         this.tabs = tabs;
+        return this;
+    }
+
+    /**
+     * Sets a custom default prompt string displayed at the bottom of the screen
+     * when no message is active. If not set, the default {@code ":"} is shown.
+     * The prompt is rendered with inverse video style.
+     *
+     * @param prompt the prompt string to display
+     * @return this {@code Less} instance for chaining
+     */
+    public Less defaultPrompt(String prompt) {
+        this.defaultPrompt = prompt;
         return this;
     }
 
@@ -1422,6 +1440,10 @@ public class Less {
             msg.style(AttributedStyle.INVERSE.inverseOff());
         } else if (displayPattern != null) {
             msg.append("&");
+        } else if (defaultPrompt != null) {
+            msg.style(AttributedStyle.INVERSE);
+            msg.append(defaultPrompt);
+            msg.style(AttributedStyle.INVERSE.inverseOff());
         } else {
             msg.append(":");
         }

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import org.jline.terminal.Size;
 import org.jline.terminal.impl.LineDisciplineTerminal;
@@ -33,6 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * feature added to {@link Less}.
  */
 class LessTest {
+
+    private static final Pattern ANSI_ESCAPE = Pattern.compile("\033\\[[0-9;]*[A-Za-z]");
+
+    /** Strip ANSI escape sequences to get plain visible text. */
+    private static String stripAnsi(String s) {
+        return ANSI_ESCAPE.matcher(s).replaceAll("");
+    }
 
     private LineDisciplineTerminal newTerminal(ByteArrayOutputStream output) throws IOException {
         LineDisciplineTerminal terminal = new LineDisciplineTerminal("less", "xterm", output, StandardCharsets.UTF_8);
@@ -153,8 +161,10 @@ class LessTest {
 
             less.display(false);
 
-            String rendered = output.toString(StandardCharsets.UTF_8);
-            assertTrue(rendered.contains(":"), "Expected the default ':' prompt to be rendered");
+            // Strip ANSI escape sequences so we match the actual visible ':' prompt
+            // rather than a stray colon inside an escape sequence.
+            String plainText = stripAnsi(output.toString(StandardCharsets.UTF_8));
+            assertTrue(plainText.contains(":"), "Expected the default ':' prompt in the visible output");
         }
     }
 
@@ -207,6 +217,10 @@ class LessTest {
             boolean fitsOneScreen = less.display(false);
 
             assertFalse(fitsOneScreen);
+            // Verify that the empty prompt does not fall back to the ':' default.
+            // With an empty source and empty prompt, ':' should not appear in the visible output.
+            String plainText = stripAnsi(output.toString(StandardCharsets.UTF_8));
+            assertFalse(plainText.contains(":"), "Empty defaultPrompt should not fall back to the ':' default");
         }
     }
 }

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -139,7 +139,8 @@ class LessTest {
             less.display(false);
 
             String rendered = output.toString(StandardCharsets.UTF_8);
-            assertTrue(rendered.contains("CUSTOM-PROMPT>"), "Expected the rendered output to contain the custom prompt");
+            assertTrue(
+                    rendered.contains("CUSTOM-PROMPT>"), "Expected the rendered output to contain the custom prompt");
         }
     }
 

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.jline.terminal.Size;
+import org.jline.terminal.impl.LineDisciplineTerminal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the {@code -P}/{@code --prompt} option and the {@link Less#defaultPrompt(String)}
+ * feature added to {@link Less}.
+ */
+class LessTest {
+
+    private LineDisciplineTerminal newTerminal(ByteArrayOutputStream output) throws IOException {
+        LineDisciplineTerminal terminal = new LineDisciplineTerminal("less", "xterm", output, StandardCharsets.UTF_8);
+        terminal.setSize(Size.of(80, 24));
+        return terminal;
+    }
+
+    /**
+     * Builds a {@link Less} instance with the minimal internal state required to safely
+     * invoke the package-private {@code display(boolean)} method directly, without going
+     * through the full {@code run()}/{@code openSource()} machinery (which requires a real
+     * file/source and an interactive read loop).
+     */
+    private Less newDisplayableLess(LineDisciplineTerminal terminal) {
+        Less less = new Less(terminal, Path.of("."));
+        less.size = terminal.getSize();
+        // Avoid touching the (null) reader field's owning BufferedReader by providing an
+        // empty source, so getLine() cleanly reports EOF instead of throwing an NPE.
+        less.reader = new BufferedReader(new StringReader(""));
+        // "highlight" defaults to true and is exercised unconditionally by display(), so a
+        // real (but file-less) SyntaxHighlighter instance is required to avoid an NPE.
+        less.syntaxHighlighter = SyntaxHighlighter.build(new ArrayList<>(), null, "none");
+        return less;
+    }
+
+    @Test
+    void usageIncludesPromptOption() {
+        String[] usage = Less.usage();
+        assertTrue(
+                Arrays.stream(usage).anyMatch(line -> line.contains("--prompt=string")),
+                "usage() should document the -P/--prompt option");
+    }
+
+    @Test
+    void constructorParsesShortPromptOption() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Options opts = Options.compile(Less.usage()).parse(new String[] {"-P", "my-prompt"});
+            Less less = new Less(terminal, Path.of("."), opts);
+            assertEquals("my-prompt", less.defaultPrompt);
+        }
+    }
+
+    @Test
+    void constructorParsesLongPromptOption() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Options opts = Options.compile(Less.usage()).parse(new String[] {"--prompt=custom>"});
+            Less less = new Less(terminal, Path.of("."), opts);
+            assertEquals("custom>", less.defaultPrompt);
+        }
+    }
+
+    @Test
+    void constructorWithoutPromptOptionLeavesDefaultPromptNull() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Options opts = Options.compile(Less.usage()).parse(new String[] {});
+            Less less = new Less(terminal, Path.of("."), opts);
+            assertNull(less.defaultPrompt);
+        }
+    }
+
+    @Test
+    void constructorWithNullOptionsLeavesDefaultPromptNull() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = new Less(terminal, Path.of("."));
+            assertNull(less.defaultPrompt);
+        }
+    }
+
+    @Test
+    void defaultPromptSetterUpdatesFieldAndReturnsSameInstance() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = new Less(terminal, Path.of("."));
+            Less returned = less.defaultPrompt("some-prompt");
+            assertSame(less, returned, "defaultPrompt() should return 'this' for chaining");
+            assertEquals("some-prompt", less.defaultPrompt);
+        }
+    }
+
+    @Test
+    void defaultPromptSetterOverridesConstructorOption() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Options opts = Options.compile(Less.usage()).parse(new String[] {"-P", "from-option"});
+            Less less = new Less(terminal, Path.of("."), opts);
+            assertEquals("from-option", less.defaultPrompt);
+            less.defaultPrompt("from-setter");
+            assertEquals("from-setter", less.defaultPrompt);
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void displayRendersDefaultPromptWhenSet() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = newDisplayableLess(terminal);
+            less.defaultPrompt("CUSTOM-PROMPT>");
+
+            less.display(false);
+
+            String rendered = output.toString(StandardCharsets.UTF_8);
+            assertTrue(rendered.contains("CUSTOM-PROMPT>"), "Expected the rendered output to contain the custom prompt");
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void displayFallsBackToColonWhenNoPromptSet() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = newDisplayableLess(terminal);
+
+            less.display(false);
+
+            String rendered = output.toString(StandardCharsets.UTF_8);
+            assertTrue(rendered.contains(":"), "Expected the default ':' prompt to be rendered");
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void displayMessageTakesPrecedenceOverDefaultPrompt() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = newDisplayableLess(terminal);
+            less.defaultPrompt("CUSTOM-PROMPT>");
+            less.message = "Some status message";
+
+            less.display(false);
+
+            String rendered = output.toString(StandardCharsets.UTF_8);
+            assertTrue(rendered.contains("Some status message"));
+            assertFalse(
+                    rendered.contains("CUSTOM-PROMPT>"), "An active message should take precedence over defaultPrompt");
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void displayPatternTakesPrecedenceOverDefaultPrompt() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = newDisplayableLess(terminal);
+            less.defaultPrompt("CUSTOM-PROMPT>");
+            less.displayPattern = "foo";
+
+            less.display(false);
+
+            String rendered = output.toString(StandardCharsets.UTF_8);
+            assertFalse(
+                    rendered.contains("CUSTOM-PROMPT>"),
+                    "An active displayPattern should take precedence over defaultPrompt");
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void displayHandlesEmptyDefaultPromptWithoutError() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = newDisplayableLess(terminal);
+            less.defaultPrompt("");
+
+            // An empty (but non-null) prompt is still "set", so it must be handled without
+            // throwing and without falling back to the ":" default rendering path.
+            boolean fitsOneScreen = less.display(false);
+
+            assertFalse(fitsOneScreen);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2033

## Summary

Adds support for customizing the default prompt (status line) in the `Less` pager:

- Adds a `defaultPrompt` field with a fluent setter (`Less.defaultPrompt(String)`), allowing applications to replace the hardcoded `:` with a custom string (e.g., `'q' to Quit, <Space> for more, 'h' for Help`).
- Adds the `-P` / `--prompt=string` command-line option to set the default prompt from the shell.
- The custom prompt is rendered with inverse video style, consistent with how other messages are displayed.
- Fully backward-compatible: users who do not set a `defaultPrompt` see no change.

## Test plan

- [x] Build succeeds (`./mvx mvn install -DskipTests`)
- [x] Spotless formatting passes
- [x] Existing tests pass (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable default prompt for the pager, including `-P` / `--prompt=string` support.
  * Added a fluent option to set the default prompt; it appears when no other status text is active.
* **Bug Fixes**
  * Improved prompt rendering precedence, including correct behavior when a display pattern is set or when an empty prompt is provided.
* **Tests**
  * Added coverage for the new prompt option, chaining behavior, rendering precedence, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->