### PR TITLE
fix: use ConcurrentHashMap for InfoCmp capability caches

### DIFF
--- a/terminal/src/main/java/org/jline/utils/InfoCmp.java
+++ b/terminal/src/main/java/org/jline/utils/InfoCmp.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -58,8 +59,8 @@ import java.util.stream.Collectors;
  */
 public final class InfoCmp {
 
-    private static final Map<String, Object> CAPS_DEFAULT = new HashMap<>();
-    private static final Map<String, Object> CAPS_LOADED = new HashMap<>();
+    private static final Map<String, Object> CAPS_DEFAULT = new ConcurrentHashMap<>();
+    private static final Map<String, Object> CAPS_LOADED = new ConcurrentHashMap<>();
 
     private InfoCmp() {}
 

--- a/terminal/src/test/java/org/jline/utils/InfoCmpConcurrencyTest.java
+++ b/terminal/src/test/java/org/jline/utils/InfoCmpConcurrencyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The infocmp capability caches are shared static state populated once per terminal
+ * construction (via {@link InfoCmp#getInfoCmp(String)}), so a process that builds
+ * terminals on several threads at once writes them concurrently. This exercises that
+ * access pattern: on a plain {@code HashMap} concurrent puts drop entries or throw
+ * during a table resize.
+ */
+public class InfoCmpConcurrencyTest {
+
+    @Test
+    public void testConcurrentLoadedCapsAccess() throws Exception {
+        int threads = Math.max(8, Runtime.getRuntime().availableProcessors() * 2);
+        int perThread = 4000;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CopyOnWriteArrayList<Throwable> errors = new CopyOnWriteArrayList<>();
+
+        for (int t = 0; t < threads; t++) {
+            final int tid = t;
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < perThread; i++) {
+                        String key = "concurrency-test-" + tid + "-" + i;
+                        InfoCmp.setLoadedInfoCmp(key, key);
+                        InfoCmp.getLoadedInfoCmp("concurrency-test-" + tid + "-" + (i / 2));
+                    }
+                } catch (Throwable e) {
+                    errors.add(e);
+                }
+            });
+        }
+
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(60, TimeUnit.SECONDS), "workers did not finish in time");
+
+        assertEquals(java.util.Collections.emptyList(), errors, "concurrent cache access threw");
+        for (int t = 0; t < threads; t++) {
+            for (int i = 0; i < perThread; i++) {
+                String key = "concurrency-test-" + t + "-" + i;
+                assertEquals(key, InfoCmp.getLoadedInfoCmp(key), "cache lost entry " + key);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stress-testing concurrent terminal creation:

    org.opentest4j.AssertionFailedError: cache lost entry concurrency-test-0-29 ==> expected: <concurrency-test-0-29> but was: <null>

`CAPS_LOADED` and `CAPS_DEFAULT` are plain `HashMap`s. `getInfoCmp()` populates `CAPS_LOADED` through `setLoadedInfoCmp()` once per terminal construction (`AbstractTerminal.parseInfoCmp`), so building terminals of different types on several threads issues concurrent `put()` into the same map. The concurrent structural modification drops entries, and a `get()` racing a resize can return null for a key that was inserted.

Switch both caches to `ConcurrentHashMap`, matching the `CopyOnWriteArrayList` already used for the shared graphics-protocol registry. The added test fails reliably on the `HashMap` and passes after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when terminal capability data is accessed from multiple threads.
  * Reduced the risk of intermittent cache-related errors during concurrent use.

* **Tests**
  * Added a concurrency stress test to verify terminal capability caching remains consistent under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->