### PR TITLE
fix: validate terminal type before passing to infocmp

### DIFF
--- a/terminal/src/main/java/org/jline/utils/InfoCmp.java
+++ b/terminal/src/main/java/org/jline/utils/InfoCmp.java
@@ -602,7 +602,12 @@ public final class InfoCmp {
     public static String getInfoCmp(String terminal) throws IOException, InterruptedException {
         IOException error = new IOException("Unable to retrieve infocmp for " + terminal);
         String caps = getLoadedInfoCmp(terminal);
-        if (caps == null) {
+        // The terminal type may come from an untrusted, remote source (the TTYPE negotiated by a
+        // telnet client, or the TERM env sent by an ssh client). infocmp parses it as a command
+        // argument, so a value like "-1" or "-A/some/dir" is taken as an option (CWE-88). Only run
+        // infocmp for names within the terminfo alias character set; the pure map lookups above and
+        // below are unaffected.
+        if (caps == null && isValidTerminalName(terminal)) {
             try {
                 Process p = new ProcessBuilder(OSUtils.INFOCMP_COMMAND, "-x", terminal).start();
                 caps = ExecHelper.waitAndCapture(p);
@@ -615,7 +620,7 @@ public final class InfoCmp {
                 error.addSuppressed(e);
             }
         }
-        if (caps == null) {
+        if (caps == null && isValidTerminalName(terminal)) {
             try {
                 Process p = new ProcessBuilder(OSUtils.INFOCMP_COMMAND, terminal).start();
                 caps = ExecHelper.waitAndCapture(p);
@@ -637,6 +642,32 @@ public final class InfoCmp {
             }
         }
         return caps;
+    }
+
+    /**
+     * Tests whether a terminal type is safe to pass to the external {@code infocmp} command.
+     * Terminfo entry names are limited to alphanumerics and {@code - _ . +}, and never start with
+     * {@code -}. Rejecting anything else keeps an untrusted type from being interpreted as an
+     * infocmp option or otherwise altering the command.
+     */
+    static boolean isValidTerminalName(String terminal) {
+        if (terminal == null || terminal.isEmpty() || terminal.charAt(0) == '-') {
+            return false;
+        }
+        for (int i = 0; i < terminal.length(); i++) {
+            char c = terminal.charAt(i);
+            boolean ok = (c >= 'a' && c <= 'z')
+                    || (c >= 'A' && c <= 'Z')
+                    || (c >= '0' && c <= '9')
+                    || c == '-'
+                    || c == '_'
+                    || c == '.'
+                    || c == '+';
+            if (!ok) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static void parseInfoCmp(

--- a/terminal/src/main/java/org/jline/utils/InfoCmp.java
+++ b/terminal/src/main/java/org/jline/utils/InfoCmp.java
@@ -644,6 +644,8 @@ public final class InfoCmp {
         return caps;
     }
 
+    private static final Pattern VALID_TERMINAL_NAME = Pattern.compile("[A-Za-z0-9_.+][A-Za-z0-9_.+\\-]*");
+
     /**
      * Tests whether a terminal type is safe to pass to the external {@code infocmp} command.
      * Terminfo entry names are limited to alphanumerics and {@code - _ . +}, and never start with
@@ -651,23 +653,7 @@ public final class InfoCmp {
      * infocmp option or otherwise altering the command.
      */
     static boolean isValidTerminalName(String terminal) {
-        if (terminal == null || terminal.isEmpty() || terminal.charAt(0) == '-') {
-            return false;
-        }
-        for (int i = 0; i < terminal.length(); i++) {
-            char c = terminal.charAt(i);
-            boolean ok = (c >= 'a' && c <= 'z')
-                    || (c >= 'A' && c <= 'Z')
-                    || (c >= '0' && c <= '9')
-                    || c == '-'
-                    || c == '_'
-                    || c == '.'
-                    || c == '+';
-            if (!ok) {
-                return false;
-            }
-        }
-        return true;
+        return terminal != null && VALID_TERMINAL_NAME.matcher(terminal).matches();
     }
 
     public static void parseInfoCmp(

--- a/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
+++ b/terminal/src/test/java/org/jline/utils/InfoCmpTest.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -109,5 +111,27 @@ class InfoCmpTest {
         allCaps.forEach((capsName) -> assertNotNull(
                 InfoCmp.getLoadedInfoCmp(capsName),
                 String.format("%s.caps was not registered in InfoCmp class", capsName)));
+    }
+
+    @Test
+    void testValidTerminalName() {
+        for (String name : new String[] {
+            "xterm", "xterm-256color", "screen.xterm-256color", "rxvt-unicode-256color", "vt100", "Eterm", "dumb"
+        }) {
+            assertTrue(InfoCmp.isValidTerminalName(name), name);
+        }
+        for (String name : new String[] {"-1", "-A/tmp/evil", "xterm; id", "foo bar", "../xterm", "a/b", "", null}) {
+            assertFalse(InfoCmp.isValidTerminalName(name), String.valueOf(name));
+        }
+    }
+
+    @Test
+    void testGetInfoCmpRejectsOptionLikeType() throws Exception {
+        // A type from an untrusted client that looks like an infocmp option must not be run as one;
+        // getInfoCmp falls through to the (absent) default and reports failure instead of executing.
+        assertThrows(IOException.class, () -> InfoCmp.getInfoCmp("-1"));
+        assertThrows(IOException.class, () -> InfoCmp.getInfoCmp("-A/tmp/evil"));
+        // A registered type still resolves from the bundled defaults.
+        assertNotNull(InfoCmp.getInfoCmp("dumb"));
     }
 }


### PR DESCRIPTION
`infocmp -x -1` on a server whose `$TERM=xterm`:

    #	Reconstructed via infocmp from file: /usr/share/terminfo/78/xterm
    xterm|xterm terminal emulator (X Window System), ...
    exit=0

`InfoCmp.getInfoCmp(terminal)` runs `infocmp` with the terminal type as an argument. That type is remote-controlled: `remote-telnet` negotiates it via TTYPE (`ConnectionData.getNegotiatedTerminalType`) and `remote-ssh` reads it from the client `TERM` env in `ShellFactoryImpl`, both flowing through `TerminalBuilder.type()` -> `AbstractTerminal.parseInfoCmp()` -> `getInfoCmp()`. Since `infocmp` parses it as a command argument, a value beginning with `-` is taken as an option (CWE-88): `-1` makes the call succeed and dump the server's own terminal instead of failing on an unknown name, and `-A<dir>` redirects the terminfo search directory.

The guard validates the type against the terminfo alias character set (alphanumerics plus `- _ . +`, no leading `-`) before spawning `infocmp`; anything else skips the exec and falls back to the bundled defaults. The map lookups around it are untouched, so known types resolve exactly as before.

`InfoCmpTest.testGetInfoCmpRejectsOptionLikeType` fails on the pre-patch tree (the `-1` type executes and returns caps) and passes after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal handling by validating terminal names before looking up capabilities.
  * Prevented malformed or option-like terminal values from being passed into external terminal queries, reducing unexpected failures.
  * More robust fallback behavior now avoids unsafe terminal inputs, improving reliability when terminal detection is imperfect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->