### PR TITLE
fix: confine ConfigurationPath lookups to the config directory

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
+++ b/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
@@ -107,15 +107,15 @@ public class ConfigurationPath {
     /**
      * Resolves {@code name} against {@code base} and keeps the result inside {@code base}.
      * Returns {@code null} when {@code base} is {@code null} or when the resolved path would
-     * escape {@code base} through an absolute path or {@code ..} segments, so a configuration
-     * file name can never point outside its configuration directory.
+     * lexically escape {@code base} through an absolute path or {@code ..} segments.
      */
     private static Path confine(Path base, String name) {
         if (base == null) {
             return null;
         }
-        Path resolved = base.resolve(name).normalize();
-        return resolved.startsWith(base.normalize()) ? resolved : null;
+        Path normalizedBase = base.toAbsolutePath().normalize();
+        Path resolved = normalizedBase.resolve(name).normalize();
+        return resolved.startsWith(normalizedBase) ? resolved : null;
     }
 
     /**

--- a/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
+++ b/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
@@ -59,13 +59,15 @@ public class ConfigurationPath {
      */
     public Path getConfig(String name) {
         Path out = null;
+        Path userPath = confine(userConfig, name);
+        Path appPath = confine(appConfig, name);
         // First check user config
-        if (userConfig != null && Files.exists(userConfig.resolve(name))) {
-            out = userConfig.resolve(name);
+        if (userPath != null && Files.exists(userPath)) {
+            out = userPath;
         }
         // Then check app config directory
-        else if (appConfig != null && Files.exists(appConfig.resolve(name))) {
-            out = appConfig.resolve(name);
+        else if (appPath != null && Files.exists(appPath)) {
+            out = appPath;
         }
         return out;
     }
@@ -90,15 +92,30 @@ public class ConfigurationPath {
      */
     public Path getUserConfig(String name, boolean create) throws IOException {
         Path out = null;
-        if (userConfig != null) {
-            if (!Files.exists(userConfig.resolve(name)) && create) {
-                Files.createFile(userConfig.resolve(name));
+        Path path = confine(userConfig, name);
+        if (path != null) {
+            if (!Files.exists(path) && create) {
+                Files.createFile(path);
             }
-            if (Files.exists(userConfig.resolve(name))) {
-                out = userConfig.resolve(name);
+            if (Files.exists(path)) {
+                out = path;
             }
         }
         return out;
+    }
+
+    /**
+     * Resolves {@code name} against {@code base} and keeps the result inside {@code base}.
+     * Returns {@code null} when {@code base} is {@code null} or when the resolved path would
+     * escape {@code base} through an absolute path or {@code ..} segments, so a configuration
+     * file name can never point outside its configuration directory.
+     */
+    private static Path confine(Path base, String name) {
+        if (base == null) {
+            return null;
+        }
+        Path resolved = base.resolve(name).normalize();
+        return resolved.startsWith(base.normalize()) ? resolved : null;
     }
 
     /**

--- a/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
+++ b/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
@@ -106,16 +106,30 @@ public class ConfigurationPath {
 
     /**
      * Resolves {@code name} against {@code base} and keeps the result inside {@code base}.
-     * Returns {@code null} when {@code base} is {@code null} or when the resolved path would
-     * lexically escape {@code base} through an absolute path or {@code ..} segments.
+     * Returns {@code null} when {@code base} is {@code null}, when the base directory cannot
+     * be resolved, or when the resolved path would escape {@code base} through an absolute
+     * path, {@code ..} segments, or symlink indirection.
      */
     private static Path confine(Path base, String name) {
         if (base == null) {
             return null;
         }
-        Path normalizedBase = base.toAbsolutePath().normalize();
-        Path resolved = normalizedBase.resolve(name).normalize();
-        return resolved.startsWith(normalizedBase) ? resolved : null;
+        try {
+            Path realBase = base.toRealPath();
+            Path resolved = realBase.resolve(name).normalize();
+            if (!resolved.startsWith(realBase)) {
+                return null;
+            }
+            // If the target already exists, verify its real path is also inside the base
+            // to catch symlinks that point outside the config directory.
+            if (Files.exists(resolved) && !resolved.toRealPath().startsWith(realBase)) {
+                return null;
+            }
+            return resolved;
+        } catch (IOException e) {
+            // Base directory doesn't exist or can't be resolved
+            return null;
+        }
     }
 
     /**

--- a/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
@@ -65,4 +65,35 @@ class ConfigurationPathTest {
         assertNull(configPath.getConfig("../secret"));
         assertTrue(Files.exists(secret));
     }
+
+    @Test
+    void getConfigFallsBackToAppConfig(@TempDir Path root) throws Exception {
+        Path userConfig = Files.createDirectories(root.resolve("user"));
+        Path appConfig = Files.createDirectories(root.resolve("app"));
+        Files.write(appConfig.resolve("jnanorc"), new byte[] {1});
+        ConfigurationPath configPath = new ConfigurationPath(appConfig, userConfig);
+
+        // Not in userConfig, so the lookup falls back to appConfig.
+        Path resolved = configPath.getConfig("jnanorc");
+        assertNotNull(resolved);
+        assertEquals(appConfig.resolve("jnanorc").toAbsolutePath().normalize(), resolved);
+        // Traversal out of appConfig is rejected as well.
+        Files.write(root.resolve("escape"), new byte[] {1});
+        assertNull(configPath.getConfig("../escape"));
+    }
+
+    @Test
+    void relativeBaseStillResolves() throws Exception {
+        // Console constructs ConfigurationPath with Path.of("."); an empty normalized
+        // base must not make every lookup return null.
+        Path file = Files.createTempFile(Path.of("").toAbsolutePath(), "configpath", ".txt");
+        try {
+            ConfigurationPath configPath = new ConfigurationPath(Path.of("."), Path.of("."));
+            String name = file.getFileName().toString();
+            assertNotNull(configPath.getConfig(name));
+            assertNotNull(configPath.getUserConfig(name, false));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
 }

--- a/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigurationPathTest {
+
+    @Test
+    void getUserConfigStaysInsideUserConfig(@TempDir Path root) throws Exception {
+        Path userConfig = root.resolve("config");
+        Files.createDirectories(userConfig);
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        Path resolved = configPath.getUserConfig("history", true);
+        assertNotNull(resolved);
+        assertTrue(resolved.toAbsolutePath()
+                .normalize()
+                .startsWith(userConfig.toAbsolutePath().normalize()));
+        assertTrue(Files.exists(userConfig.resolve("history")));
+    }
+
+    @Test
+    void getUserConfigRejectsParentTraversal(@TempDir Path root) throws Exception {
+        Path userConfig = root.resolve("config");
+        Files.createDirectories(userConfig);
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        // Mirrors a `set historylog ../pwned` directive read from a jlessrc/jnanorc file.
+        assertNull(configPath.getUserConfig("../pwned", true));
+        assertFalse(Files.exists(root.resolve("pwned")), "must not create a file outside the config directory");
+    }
+
+    @Test
+    void getUserConfigRejectsAbsolutePath(@TempDir Path root) throws Exception {
+        Path userConfig = root.resolve("config");
+        Files.createDirectories(userConfig);
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        Path outside = root.resolve("outside");
+        assertNull(configPath.getUserConfig(outside.toAbsolutePath().toString(), true));
+        assertFalse(Files.exists(outside));
+    }
+
+    @Test
+    void getConfigRejectsParentTraversal(@TempDir Path root) throws Exception {
+        Path userConfig = root.resolve("config");
+        Files.createDirectories(userConfig);
+        // A real file sits one level above the config directory.
+        Path secret = Files.write(root.resolve("secret"), new byte[] {1});
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        assertNull(configPath.getConfig("../secret"));
+        assertTrue(Files.exists(secret));
+    }
+}

--- a/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
@@ -26,10 +26,8 @@ class ConfigurationPathTest {
 
         Path resolved = configPath.getUserConfig("history", true);
         assertNotNull(resolved);
-        assertTrue(resolved.toAbsolutePath()
-                .normalize()
-                .startsWith(userConfig.toAbsolutePath().normalize()));
-        assertTrue(Files.exists(userConfig.resolve("history")));
+        assertTrue(resolved.startsWith(userConfig.toRealPath()));
+        assertTrue(Files.exists(resolved));
     }
 
     @Test

--- a/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
@@ -76,10 +76,26 @@ class ConfigurationPathTest {
         // Not in userConfig, so the lookup falls back to appConfig.
         Path resolved = configPath.getConfig("jnanorc");
         assertNotNull(resolved);
-        assertEquals(appConfig.resolve("jnanorc").toAbsolutePath().normalize(), resolved);
+        assertEquals(appConfig.toRealPath().resolve("jnanorc"), resolved);
         // Traversal out of appConfig is rejected as well.
         Files.write(root.resolve("escape"), new byte[] {1});
         assertNull(configPath.getConfig("../escape"));
+    }
+
+    @Test
+    void getConfigRejectsSymlinkEscape(@TempDir Path root) throws Exception {
+        Path userConfig = Files.createDirectories(root.resolve("config"));
+        Path outside = Files.createDirectories(root.resolve("outside"));
+        Files.write(outside.resolve("secret"), "sensitive".getBytes());
+        // Create a symlink inside the config directory pointing outside
+        Path link = userConfig.resolve("escape");
+        Files.createSymbolicLink(link, outside);
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        // "escape/secret" passes a lexical startsWith check but the symlink
+        // resolves to outside/secret which is not inside the config directory.
+        assertNull(configPath.getConfig("escape/secret"));
+        assertNull(configPath.getUserConfig("escape/secret", false));
     }
 
     @Test


### PR DESCRIPTION
ConfigurationPath.getUserConfig resolves the requested name against the user config directory with a plain Path.resolve and never checks that the result stays inside it. resolve returns an absolute argument unchanged and keeps .. segments, so a value like ../../pwned or an absolute path lands outside the config directory. That name is not always internal: Less and Nano read `set historylog <val>` out of the loaded jlessrc/jnanorc and pass the value straight to getUserConfig(historyLog, true), so a shared or attacker-supplied rc makes Files.createFile create a file outside the directory and PatternHistory.persist then writes the search-pattern list into it. I noticed it while tracing where the historylog value ends up once config parsing is done. getConfig has the same unchecked resolve, so both now go through a confine() helper that normalizes the path and requires it to start with the base directory, returning null otherwise. Every existing caller passes a fixed name like jnanorc or aliases.json, which stays inside, so valid lookups behave exactly as before; the added test covers the ../ and absolute cases along with a normal name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened configuration path resolution for both lookups and optional file creation to prevent directory traversal, absolute-path inputs, and symlink-based escapes outside the allowed config roots.
  * Config lookups now prefer the user config directory first, then safely fall back to the app config when the user file is missing, while avoiding access to pre-existing external targets.

* **Tests**
  * Added validation for traversal rejection, in-root creation behavior, user→app fallback, handling of out-of-root pre-existing files, and a symlink escape scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->