### PR TITLE
fix: check NewObject() return in JNI newFileDescriptor/newRedirectPipe (fixes #2046)

### DIFF
--- a/native/src/main/native/jlinenative.c
+++ b/native/src/main/native/jlinenative.c
@@ -24,14 +24,17 @@ JNIEXPORT jobject JNICALL JLineLibrary_NATIVE(newFileDescriptor)(JNIEnv *env, jc
     class_fdesc = (*env)->FindClass(env, "java/io/FileDescriptor");
     if (class_fdesc == NULL) return NULL;
 
-    // construct a new FileDescriptor
-    const_fdesc = (*env)->GetMethodID(env, class_fdesc, "<init>", "()V");
-    if (const_fdesc == NULL) return NULL;
-    ret = (*env)->NewObject(env, class_fdesc, const_fdesc);
-
-    // poke the "fd" field with the file descriptor
+    // resolve field and constructor before allocating
     field_fd = (*env)->GetFieldID(env, class_fdesc, "fd", "I");
     if (field_fd == NULL) return NULL;
+    const_fdesc = (*env)->GetMethodID(env, class_fdesc, "<init>", "()V");
+    if (const_fdesc == NULL) return NULL;
+
+    // construct a new FileDescriptor
+    ret = (*env)->NewObject(env, class_fdesc, const_fdesc);
+    if (ret == NULL) return NULL;
+
+    // poke the "fd" field with the file descriptor
     (*env)->SetIntField(env, ret, field_fd, fd);
 
     // and return it
@@ -48,14 +51,17 @@ JNIEXPORT jobject JNICALL JLineLibrary_NATIVE(newRedirectPipe)(JNIEnv *env, jcla
     class_rpi = (*env)->FindClass(env, "java/lang/ProcessBuilder$RedirectPipeImpl");
     if (class_rpi == NULL) return NULL;
 
-    // construct a new RedirectPipeImpl
-    const_rpi = (*env)->GetMethodID(env, class_rpi, "<init>", "()V");
-    if (const_rpi == NULL) return NULL;
-    ret = (*env)->NewObject(env, class_rpi, const_rpi);
-
-    // poke the "fd" field with the file descriptor
+    // resolve field and constructor before allocating
     field_fd = (*env)->GetFieldID(env, class_rpi, "fd", "Ljava/io/FileDescriptor;");
     if (field_fd == NULL) return NULL;
+    const_rpi = (*env)->GetMethodID(env, class_rpi, "<init>", "()V");
+    if (const_rpi == NULL) return NULL;
+
+    // construct a new RedirectPipeImpl
+    ret = (*env)->NewObject(env, class_rpi, const_rpi);
+    if (ret == NULL) return NULL;
+
+    // poke the "fd" field with the file descriptor
     (*env)->SetObjectField(env, ret, field_fd, fd);
 
     // and return it


### PR DESCRIPTION
## Summary

Adds missing NULL checks after `NewObject()` calls in the JNI functions
`newFileDescriptor()` and `newRedirectPipe()` in `jlinenative.c`.

If `NewObject()` returns NULL (e.g. due to `OutOfMemoryError`), execution
previously continued into `SetIntField()`/`SetObjectField()` with a NULL
object reference — undefined behavior per JNI that typically crashes the VM.

### Changes

- **Add NULL check after `NewObject()`** in both `newFileDescriptor()` and
  `newRedirectPipe()`, returning NULL to preserve the pending exception.
- **Reorder `GetFieldID()` before `NewObject()`** so that metadata resolution
  happens before allocation. This avoids a JNI metadata lookup while an
  exception is already pending, and skips the allocation entirely if field
  resolution itself fails.

Fixes #2046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native file descriptor handling when creating redirected or file-backed streams, reducing the chance of construction failures in affected environments.
  * Kept existing error handling behavior intact while making object creation more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->