### PR TITLE
fix: guard against null lines and null rules in syntax highlighting (fixes #2040)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -1364,7 +1364,10 @@ public class Less {
         if (highlight) {
             syntaxHighlighter.reset();
             for (int i = Math.max(0, inputLine - height); i < inputLine; i++) {
-                syntaxHighlighter.highlight(getLine(i));
+                AttributedString prevLine = getLine(i);
+                if (prevLine != null) {
+                    syntaxHighlighter.highlight(prevLine);
+                }
             }
         }
         for (int terminalLine = 0; terminalLine < height - 1; terminalLine++) {

--- a/builtins/src/main/java/org/jline/builtins/SyntaxHighlighter.java
+++ b/builtins/src/main/java/org/jline/builtins/SyntaxHighlighter.java
@@ -383,7 +383,7 @@ public class SyntaxHighlighter {
             AttributedString line, List<HighlightRule> rules, CharSequence startWith, CharSequence continueAs) {
         AttributedStringBuilder asb = new AttributedStringBuilder();
         asb.append(line);
-        if (rules.isEmpty()) {
+        if (rules == null || rules.isEmpty()) {
             return asb;
         }
         int startId = ruleStartId;

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -204,6 +204,29 @@ class LessTest {
         }
     }
 
+    /**
+     * Reproduces the NPE described in GitHub issue #2040: when firstLineToDisplay is
+     * beyond the available content (e.g. after scrolling past EOF in a
+     * SequenceInputStream), the pre-highlighting loop in display() called
+     * syntaxHighlighter.highlight(getLine(i)) with a null line, causing an NPE in
+     * SyntaxHighlighter.splitAndHighlight().
+     */
+    @Test
+    @Timeout(5)
+    void displayDoesNotThrowWhenFirstLineToDisplayExceedsContent() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = newDisplayableLess(terminal);
+            // Provide a short source (3 lines) but set the display position past it
+            less.reader = new BufferedReader(new StringReader("line1\nline2\nline3\n"));
+            less.firstLineToDisplay = 10;
+
+            // Before the fix, this threw NullPointerException in
+            // SyntaxHighlighter.splitAndHighlight because getLine() returned null
+            less.display(false);
+        }
+    }
+
     @Test
     @Timeout(5)
     void displayHandlesEmptyDefaultPromptWithoutError() throws IOException {

--- a/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterTest.java
@@ -11,6 +11,7 @@ package org.jline.builtins;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,8 +19,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jline.utils.AttributedString;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,6 +30,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class SyntaxHighlighterTest {
+
+    /**
+     * Verifies that highlight(AttributedString) does not throw when given a null-safe
+     * empty highlighter (no nanorc rules). Relates to GitHub issue #2040.
+     */
+    @Test
+    void highlightWithNoRulesDoesNotThrow() {
+        SyntaxHighlighter highlighter = SyntaxHighlighter.build(new ArrayList<>(), null, "none");
+        AttributedString result = highlighter.highlight(new AttributedString("some text"));
+        Assertions.assertNotNull(result);
+    }
 
     private static String fixRegexesOld(String line) {
         return line.replaceAll("\\\\<", "\\\\b")

--- a/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterTest.java
+++ b/builtins/src/test/java/org/jline/builtins/SyntaxHighlighterTest.java
@@ -32,13 +32,23 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 class SyntaxHighlighterTest {
 
     /**
-     * Verifies that highlight(AttributedString) does not throw when given a null-safe
-     * empty highlighter (no nanorc rules). Relates to GitHub issue #2040.
+     * Exercises the null-rules path fixed for GitHub issue #2040: when the parser
+     * emits a token whose name has no corresponding entry in the rules map,
+     * {@code rules.get(t.getName())} returns {@code null}. Before the fix this
+     * caused an NPE inside {@code _highlight()}; now it should return gracefully.
      */
     @Test
-    void highlightWithNoRulesDoesNotThrow() {
+    void highlightWithMissingTokenRulesDoesNotThrow() {
         SyntaxHighlighter highlighter = SyntaxHighlighter.build(new ArrayList<>(), null, "none");
-        AttributedString result = highlighter.highlight(new AttributedString("some text"));
+        // Configure a parser that recognises line comments starting with "//"
+        // under a token name that has NO matching entry in the rules map.
+        SyntaxHighlighter.Parser parser = new SyntaxHighlighter.Parser();
+        parser.setLineCommentDelimiters("$UNMAPPED_TOKEN", new String[] {"//"});
+        highlighter.setParser(parser);
+
+        // The input contains "//", so the parser will produce a token with name
+        // "$UNMAPPED_TOKEN".  rules.get("$UNMAPPED_TOKEN") returns null.
+        AttributedString result = highlighter.highlight(new AttributedString("code // comment"));
         Assertions.assertNotNull(result);
     }
 


### PR DESCRIPTION
## Summary

Fixes #2040 — NullPointerException in `SyntaxHighlighter.splitAndHighlight` when using `Less` with `SequenceInputStream`.

The bug has two null-safety gaps:

1. **`Less.display()`**: the pre-highlighting loop passes `getLine(i)` directly to `syntaxHighlighter.highlight()` without a null check. When `firstLineToDisplay` exceeds the number of available lines (e.g. after scrolling past EOF in a finite `SequenceInputStream`), `getLine()` returns `null`, which propagates to `splitAndHighlight()` and causes `null.columnSplitLength()` → NPE.

2. **`SyntaxHighlighter._highlight()`**: `rules.get(t.getName())` can return `null` when the parser identifies a token (block comment, line comment, balanced delimiter) for which no highlight rules exist. The `null` list is then used as `rules.isEmpty()` → NPE.

### Changes
- **`Less.java`**: added null check for `getLine(i)` in the pre-highlighting loop
- **`SyntaxHighlighter.java`**: added null-safe check `rules == null || rules.isEmpty()` in `_highlight()`
- **`LessTest.java`**: test that `display()` does not throw when `firstLineToDisplay` exceeds content length
- **`SyntaxHighlighterTest.java`**: test that `highlight()` works with a rule-less highlighter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when paging/scrolling past the end of available content.
  * Improved syntax highlighting resilience by safely handling missing or absent highlighting rules.
* **Tests**
  * Added regression tests covering out-of-range first-line display and missing token rule scenarios to prevent future crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->