### PR TITLE
fix: clear thread interrupt flag after UserInterruptException (fixes #2039)

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -791,7 +791,6 @@ public class LineReaderImpl implements LineReader, Flushable {
             }
         } catch (IOError e) {
             if (e.getCause() instanceof InterruptedIOException) {
-                userInterrupt = true;
                 throw new UserInterruptException(buf.toString());
             } else {
                 throw e;

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -627,6 +627,7 @@ public class LineReaderImpl implements LineReader, Flushable {
         SignalHandler previousContHandler = null;
         Attributes originalAttributes = null;
         boolean dumb = isTerminalDumb();
+        boolean userInterrupt = false;
         try {
 
             this.maskingCallback = maskingCallback;
@@ -768,6 +769,7 @@ public class LineReaderImpl implements LineReader, Flushable {
                         case EOF:
                             throw new EndOfFileException();
                         case INTERRUPT:
+                            userInterrupt = true;
                             throw new UserInterruptException(buf.toString());
                     }
 
@@ -789,6 +791,7 @@ public class LineReaderImpl implements LineReader, Flushable {
             }
         } catch (IOError e) {
             if (e.getCause() instanceof InterruptedIOException) {
+                userInterrupt = true;
                 throw new UserInterruptException(buf.toString());
             } else {
                 throw e;
@@ -821,7 +824,7 @@ public class LineReaderImpl implements LineReader, Flushable {
             } finally {
                 lock.unlock();
                 startedReading.set(false);
-                if (interrupted.get()) {
+                if (interrupted.get() && !userInterrupt) {
                     Thread.currentThread().interrupt();
                 }
             }

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderInterruptTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderInterruptTest.java
@@ -83,7 +83,12 @@ class LineReaderInterruptTest {
                                 // Keep thread alive so PipedInputStream doesn't
                                 // raise "Write end dead".
                                 Thread.sleep(Long.MAX_VALUE);
-                            } catch (Exception ignored) {
+                            } catch (InterruptedException ok) {
+                                // Expected: sender.interrupt() in the finally block
+                                // terminates this thread after the test completes.
+                            } catch (Exception e) {
+                                // IOException from feeder.write — test will fail
+                                // on its own via the readLine() timeout.
                             }
                         },
                         "ctrl-c-sender");

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderInterruptTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderInterruptTest.java
@@ -42,6 +42,15 @@ class LineReaderInterruptTest {
      * Pressing Ctrl-C during readLine() should throw UserInterruptException
      * and leave the thread's interrupt flag clear so that a subsequent
      * readLine() call works without requiring Thread.interrupted() first.
+     *
+     * <p>This simulates the behaviour of {@code SignalInterceptingInputStream}
+     * used on native (FFM/JNI) terminals: it raises {@code Signal.INT} on the
+     * reader thread (which sets the interrupt flag via the LineReader's signal
+     * handler) and then passes 0x03 through so the INTERRUPT widget fires.
+     * With a plain {@code LineDisciplineTerminal} created via
+     * {@code TerminalBuilder.streams()}, ISIG is cleared in raw mode and the
+     * terminal does not raise the signal itself, so we call
+     * {@code terminal.raise(Signal.INT)} explicitly to exercise the same path.
      */
     @Test
     void interruptFlagClearedAfterUserInterrupt() throws Exception {
@@ -60,11 +69,15 @@ class LineReaderInterruptTest {
                         LineReaderBuilder.builder().terminal(terminal).build();
 
                 // Send Ctrl-C after a short delay to allow readLine() to
-                // enter raw mode and set up the INTERRUPT widget binding.
+                // enter raw mode and install the INT signal handler.
+                // Raise Signal.INT first (mimicking SignalInterceptingInputStream)
+                // so the handler sets the thread's interrupt flag, then write
+                // the 0x03 byte so the INTERRUPT widget fires.
                 Thread sender = new Thread(
                         () -> {
                             try {
                                 TimeUnit.MILLISECONDS.sleep(INPUT_DELAY_MS);
+                                terminal.raise(Terminal.Signal.INT);
                                 feeder.write(CTRL_C);
                                 feeder.flush();
                                 // Keep thread alive so PipedInputStream doesn't

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderInterruptTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderInterruptTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader.impl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.UserInterruptException;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Verifies that the thread interrupt flag is cleared after a
+ * {@link UserInterruptException} is thrown from {@link LineReader#readLine()}.
+ *
+ * @see <a href="https://github.com/jline/jline3/issues/2039">#2039</a>
+ */
+class LineReaderInterruptTest {
+
+    private static final byte CTRL_C = 0x03;
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+    private static final long INPUT_DELAY_MS = 200;
+
+    /**
+     * Pressing Ctrl-C during readLine() should throw UserInterruptException
+     * and leave the thread's interrupt flag clear so that a subsequent
+     * readLine() call works without requiring Thread.interrupted() first.
+     */
+    @Test
+    void interruptFlagClearedAfterUserInterrupt() throws Exception {
+        assertTimeoutPreemptively(TIMEOUT, () -> {
+            PipedInputStream in = new PipedInputStream();
+            PipedOutputStream feeder = new PipedOutputStream(in);
+
+            Terminal terminal = TerminalBuilder.builder()
+                    .type("ansi")
+                    .streams(in, new ByteArrayOutputStream())
+                    .build();
+            terminal.setSize(Size.of(80, 24));
+
+            try (terminal) {
+                LineReader reader =
+                        LineReaderBuilder.builder().terminal(terminal).build();
+
+                // Send Ctrl-C after a short delay to allow readLine() to
+                // enter raw mode and set up the INTERRUPT widget binding.
+                Thread sender = new Thread(
+                        () -> {
+                            try {
+                                TimeUnit.MILLISECONDS.sleep(INPUT_DELAY_MS);
+                                feeder.write(CTRL_C);
+                                feeder.flush();
+                                // Keep thread alive so PipedInputStream doesn't
+                                // raise "Write end dead".
+                                Thread.sleep(Long.MAX_VALUE);
+                            } catch (Exception ignored) {
+                            }
+                        },
+                        "ctrl-c-sender");
+                sender.setDaemon(true);
+                sender.start();
+
+                try {
+                    assertThrows(UserInterruptException.class, () -> reader.readLine());
+
+                    assertFalse(
+                            Thread.currentThread().isInterrupted(),
+                            "Thread interrupt flag should be clear after " + "UserInterruptException (see #2039)");
+                } finally {
+                    sender.interrupt();
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
When software signals are enabled, pressing Ctrl-C during `readLine()` leaves the thread's interrupt flag set after `UserInterruptException` is thrown. This means a subsequent call to `readLine()` fails unless `Thread.interrupted()` is called explicitly — a regression from 4.0.x behavior.

## Root Cause

With ISIG cleared in raw mode (commit a1a378e0), Ctrl-C arrives as byte 0x03 in the input stream. `SignalInterceptingInputStream` intercepts it and calls `terminal.raise(Signal.INT)`, which invokes the handler: `readLineThread.interrupt()`. Since this happens on the **same thread** right after the `read()` completed successfully, the interrupt flag is never consumed by a blocking I/O operation. The INTERRUPT widget then fires and `UserInterruptException` is thrown, but the finally block captures and unconditionally restores the interrupt flag — leaking it to the caller.

On 4.0.x, ISIG was not cleared so the kernel consumed Ctrl-C as SIGINT. The signal handler ran on a different thread and interrupted a blocking read, which consumed the flag via `InterruptedIOException`.

## Fix

Track whether `UserInterruptException` is being thrown and skip restoring the thread's interrupt flag in that case. The exception itself is the interrupt notification to the caller.

## Test Plan

- Added `LineReaderInterruptTest` that sends Ctrl-C during `readLine()` and asserts the thread's interrupt flag is clear after catching `UserInterruptException`
- All 211 reader module tests pass
- Full reactor build passes (builtins failures are pre-existing: font config in headless env, unrelated watch command test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ctrl-C handling in the line reader so user interrupts no longer leave the current thread in an interrupted state.
  * Reduced duplicate interruption signaling after a user-triggered interrupt, making interruption behavior more consistent.
* **Tests**
  * Added coverage to verify that a user interrupt exits input cleanly and clears the thread’s interrupt flag afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->