### PR TITLE
fix: only read local jar: archives in PosixCommands getSources

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -1990,13 +1990,12 @@ public class PosixCommands {
             return Stream.of(new StdInSource(context.in()));
         } else if (arg.startsWith("jar:")) {
             // Handle JAR URLs - don't resolve them against the current directory.
-            // Only file-backed jars are read here; a jar: URL whose nested scheme is
-            // http/https/ftp would make these local file-reading commands fetch an
-            // arbitrary URL, so anything but a local jar falls through to path handling.
+            // Only archives backed by a local file are read here; anything else falls
+            // through to normal path handling.
             try {
                 URL url = new URL(arg);
                 URL jarFileUrl = ((JarURLConnection) url.openConnection()).getJarFileURL();
-                if ("file".equalsIgnoreCase(jarFileUrl.getProtocol())) {
+                if (isLocalJarFile(jarFileUrl)) {
                     return Stream.of(new URLSource(url, arg));
                 }
             } catch (IOException e) {
@@ -2004,6 +2003,22 @@ public class PosixCommands {
             }
         }
         return maybeExpandGlob(context, arg).map(path -> new PathSource(path, path.toString()));
+    }
+
+    /**
+     * Tests whether the archive a {@code jar:} URL wraps lives on the local file system.
+     *
+     * <p>A nested {@code http}, {@code https} or {@code ftp} URL would turn the file-reading
+     * commands into an arbitrary-URL fetcher. A {@code file:} URL carrying an authority is no
+     * safer: {@code file://host/x.jar} is retrieved over FTP by the JDK's file protocol handler,
+     * and resolves to a UNC path on Windows. Only an empty or local authority reads from disk.
+     */
+    static boolean isLocalJarFile(URL jarFileUrl) {
+        if (!"file".equalsIgnoreCase(jarFileUrl.getProtocol())) {
+            return false;
+        }
+        String host = jarFileUrl.getHost();
+        return host == null || host.isEmpty() || "localhost".equalsIgnoreCase(host);
     }
 
     private static Stream<Path> maybeExpandGlob(Context context, String pattern) {

--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -9,7 +9,7 @@
 package org.jline.builtins;
 
 import java.io.*;
-import java.net.MalformedURLException;
+import java.net.JarURLConnection;
 import java.net.URL;
 import java.nio.file.*;
 import java.nio.file.attribute.FileTime;
@@ -1989,11 +1989,17 @@ public class PosixCommands {
         if ("-".equals(arg)) {
             return Stream.of(new StdInSource(context.in()));
         } else if (arg.startsWith("jar:")) {
-            // Handle JAR URLs - don't resolve them against current directory
+            // Handle JAR URLs - don't resolve them against the current directory.
+            // Only file-backed jars are read here; a jar: URL whose nested scheme is
+            // http/https/ftp would make these local file-reading commands fetch an
+            // arbitrary URL, so anything but a local jar falls through to path handling.
             try {
                 URL url = new URL(arg);
-                return Stream.of(new URLSource(url, arg));
-            } catch (MalformedURLException e) {
+                URL jarFileUrl = ((JarURLConnection) url.openConnection()).getJarFileURL();
+                if ("file".equalsIgnoreCase(jarFileUrl.getProtocol())) {
+                    return Stream.of(new URLSource(url, arg));
+                }
+            } catch (IOException e) {
                 // Fall through to normal path handling
             }
         }

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsSsrfTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsSsrfTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.DumbTerminal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the file-reading POSIX commands only accept local (file-backed)
+ * {@code jar:} sources and never fetch a nested network URL such as
+ * {@code jar:http://host/x.jar!/entry}.
+ */
+class PosixCommandsSsrfTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Terminal terminal;
+    private PosixCommands.Context context;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        Map<String, Object> vars = new HashMap<>();
+        terminal = new DumbTerminal(in, out);
+        context = new PosixCommands.Context(
+                in, new PrintStream(out), new PrintStream(new ByteArrayOutputStream()), tempDir, terminal, vars::get);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (terminal != null) {
+            terminal.close();
+        }
+    }
+
+    @Test
+    void catDoesNotFetchNestedHttpJarUrl() throws Exception {
+        CountDownLatch connected = new CountDownLatch(1);
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            server.setSoTimeout(3000);
+            Thread accepter = new Thread(() -> {
+                try (Socket s = server.accept()) {
+                    connected.countDown();
+                    // Reply with an empty 404 and close so the client never blocks.
+                    s.getOutputStream()
+                            .write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                                    .getBytes());
+                    s.getOutputStream().flush();
+                } catch (Exception ignore) {
+                    // timeout: no connection was made
+                }
+            });
+            accepter.setDaemon(true);
+            accepter.start();
+
+            String url = "jar:http://127.0.0.1:" + server.getLocalPort() + "/x.jar!/entry";
+            Thread run = new Thread(() -> {
+                try {
+                    PosixCommands.cat(context, new String[] {"cat", url});
+                } catch (Exception ignore) {
+                    // a rejected jar: URL is read as a bogus local path and fails; that is fine
+                }
+            });
+            run.setDaemon(true);
+            run.start();
+            run.join(5000);
+
+            assertFalse(
+                    connected.await(500, TimeUnit.MILLISECONDS),
+                    "cat must not open a network connection for a jar:http URL argument");
+        }
+    }
+
+    @Test
+    void catStillReadsLocalFileJar() throws Exception {
+        Path jar = tempDir.resolve("local.jar");
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jar))) {
+            jos.putNextEntry(new JarEntry("entry.txt"));
+            jos.write("hello-from-jar".getBytes());
+            jos.closeEntry();
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PosixCommands.Context ctx = new PosixCommands.Context(
+                new ByteArrayInputStream(new byte[0]),
+                new PrintStream(out),
+                new PrintStream(new ByteArrayOutputStream()),
+                tempDir,
+                terminal,
+                new HashMap<String, Object>()::get);
+
+        String url = "jar:" + jar.toUri() + "!/entry.txt";
+        PosixCommands.cat(ctx, new String[] {"cat", url});
+
+        assertTrue(out.toString().contains("hello-from-jar"), "cat should still read entries from a local file jar");
+    }
+}

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsSsrfTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsSsrfTest.java
@@ -15,6 +15,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -46,9 +47,15 @@ class PosixCommandsSsrfTest {
 
     private Terminal terminal;
     private PosixCommands.Context context;
+    private boolean jarCachingDefault;
 
     @BeforeEach
     void setUp() throws Exception {
+        // The jar protocol handler caches the open JarFile by default; the cached handle
+        // outlives the read and keeps the jar locked on Windows, so @TempDir cleanup fails.
+        // With caching off, closing the entry stream closes the jar file as well.
+        jarCachingDefault = URLConnection.getDefaultUseCaches("jar");
+        URLConnection.setDefaultUseCaches("jar", false);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
         Map<String, Object> vars = new HashMap<>();
@@ -59,6 +66,7 @@ class PosixCommandsSsrfTest {
 
     @AfterEach
     void tearDown() throws Exception {
+        URLConnection.setDefaultUseCaches("jar", jarCachingDefault);
         if (terminal != null) {
             terminal.close();
         }

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsSsrfTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsSsrfTest.java
@@ -14,6 +14,7 @@ import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -95,10 +96,29 @@ class PosixCommandsSsrfTest {
             run.start();
             run.join(5000);
 
+            assertFalse(run.isAlive(), "cat must not block on a jar:http URL argument");
             assertFalse(
                     connected.await(500, TimeUnit.MILLISECONDS),
                     "cat must not open a network connection for a jar:http URL argument");
         }
+    }
+
+    @Test
+    void onlyFileBackedJarsAreReadAsUrlSources() throws Exception {
+        // An empty or local authority is what the JDK's file handler reads from disk.
+        assertTrue(PosixCommands.isLocalJarFile(new URL("file:/tmp/x.jar")));
+        assertTrue(PosixCommands.isLocalJarFile(new URL("file:///tmp/x.jar")));
+        assertTrue(PosixCommands.isLocalJarFile(new URL("file://localhost/tmp/x.jar")));
+
+        // A file: URL with a remote authority is fetched over FTP by the file handler,
+        // and resolves to a UNC path on Windows, so it must not be read as a URL source.
+        assertFalse(PosixCommands.isLocalJarFile(new URL("file://169.254.169.254/x.jar")));
+        assertFalse(PosixCommands.isLocalJarFile(new URL("file://attacker.example.com/share/x.jar")));
+
+        // Nested network schemes stay rejected.
+        assertFalse(PosixCommands.isLocalJarFile(new URL("http://169.254.169.254/x.jar")));
+        assertFalse(PosixCommands.isLocalJarFile(new URL("https://169.254.169.254/x.jar")));
+        assertFalse(PosixCommands.isLocalJarFile(new URL("ftp://169.254.169.254/x.jar")));
     }
 
     @Test


### PR DESCRIPTION
The file-reading builtins (cat, less, head, tail, grep, nl) resolve a `jar:`
argument straight to a network fetch:

    getSources() -> new URL("jar:http://169.254.169.254/...!/x")
                 -> URLSource.read() -> url.openStream()

The `jar:` scheme wraps its nested URL, so `jar:http:`/`jar:https:`/`jar:ftp:`
turns these local file readers into an arbitrary-URL fetcher run by the server
process, reachable when the builtins are exposed to a client over
remote-telnet/ssh. The only valid `jar:` input here is a local
`jar:file:...!/entry` archive, so getSources now checks the jar's backing URL
and lets anything that is not `file:` fall through to normal path handling.

Added a regression test that points `cat` at a `jar:http://127.0.0.1:<port>/...`
argument and asserts no socket is opened, while a `jar:file:` archive is still
read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `jar:` URL handling for POSIX file-reading commands to avoid incorrect source resolution.
  * Strengthened protections against nested `jar:` URLs that could lead to unintended remote access or blocking.
  * Local `jar:file:` locations continue to be read correctly, including specific entry content.
* **Tests**
  * Added JUnit 5 coverage for nested `jar:` SSRF behavior in POSIX `cat`, including remote-blocking prevention and local jar-entry reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->