### PR TITLE
fix: disable Read File command in nano restricted mode

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -2515,6 +2515,10 @@ public class Nano implements Editor {
     }
 
     void read() {
+        if (restricted) {
+            setMessage("This function is disabled in restricted mode");
+            return;
+        }
         KeyMap<Operation> readKeyMap = new KeyMap<>();
         readKeyMap.setUnicode(Operation.INSERT);
         for (char i = 32; i < 256; i++) {

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -2777,7 +2777,9 @@ public class Nano implements Editor {
         if (!view) {
             s.put("^O", "WriteOut");
         }
-        s.put("^R", "Read File");
+        if (!restricted) {
+            s.put("^R", "Read File");
+        }
         s.put("^Y", "Prev Page");
         if (!view) {
             s.put("^K", "Cut Text");

--- a/builtins/src/test/java/org/jline/builtins/NanoTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NanoTest.java
@@ -10,14 +10,18 @@ package org.jline.builtins;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.jline.keymap.KeyMap;
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.InputFlag;
 import org.jline.terminal.Size;
 import org.jline.terminal.impl.LineDisciplineTerminal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class NanoTest {
@@ -41,6 +45,47 @@ class NanoTest {
                     Options.compile(Nano.usage()).parse(argv));
             assertNotNull(nano);
             nano.run();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void restrictedModeDoesNotReadArbitraryFiles() throws Exception {
+        Path root = Files.createTempDirectory("nano-restricted-root");
+        Path secret = Files.createTempFile("nano-restricted-secret", ".txt");
+        String marker = "SECRET_OUTSIDE_ROOT_a1b2c3d4";
+        Files.write(secret, marker.getBytes(StandardCharsets.UTF_8));
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            try (LineDisciplineTerminal terminal =
+                    new LineDisciplineTerminal("nano", "xterm", output, StandardCharsets.UTF_8)) {
+                terminal.setSize(Size.of(80, 25));
+                // Deliver Enter as a raw CR (nano runs in raw mode; avoid CR->NL translation)
+                Attributes attrs = terminal.getAttributes();
+                attrs.setInputFlag(InputFlag.ICRNL, false);
+                terminal.setAttributes(attrs);
+                // ^R (Read File), type an absolute path escaping the root, accept
+                terminal.processInputByte(KeyMap.ctrl('R').getBytes()[0]);
+                for (byte b : secret.toAbsolutePath().toString().getBytes(StandardCharsets.UTF_8)) {
+                    terminal.processInputByte(b);
+                }
+                terminal.processInputByte('\r');
+                // Quit both the (possibly opened) buffer and the original one, discarding changes
+                terminal.processInputByte(KeyMap.ctrl('X').getBytes()[0]);
+                terminal.processInputByte('n');
+                terminal.processInputByte(KeyMap.ctrl('X').getBytes()[0]);
+                terminal.processInputByte('n');
+                String[] argv = {"--ignorercfiles", "--restricted"};
+                Nano nano =
+                        new Nano(terminal, root, Options.compile(Nano.usage()).parse(argv));
+                nano.run();
+            }
+            assertFalse(
+                    output.toString(StandardCharsets.UTF_8).contains(marker),
+                    "restricted mode must not read files outside the specified one");
+        } finally {
+            Files.deleteIfExists(secret);
+            Files.deleteIfExists(root);
         }
     }
 }


### PR DESCRIPTION
Restricted mode (-R, rnano) already blocks writing to another file, but the Read File command (^R) was never gated:

    ^R  /etc/passwd  <Enter>

read() resolves the typed name with root.resolve(name) (an absolute argument is returned verbatim and .. is not collapsed) and opens it into a new buffer, so a user confined to editing one file can read any file the process can access. The same prompt also reaches the file-browser binding.

The fix gates read() on the restricted flag, reusing the message toggleSuspension already shows, so ^R is a no-op in restricted mode. read() is the only runtime action that opens a file the caller did not specify; the command-line open() path and the write/save path are untouched. The added test drives a restricted session that tries to read a file outside the root and asserts its contents never reach the buffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted mode now blocks the file-open/read flow and shows a clear “disabled in restricted mode” message.
  * Prevents reading arbitrary files while using the editor in restricted mode.
* **Tests**
  * Added coverage for restricted-mode behavior to verify sensitive file contents are not displayed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->