### PR TITLE
fix: drain buffered data before signaling EOF in NonBlockingPumpInputStream

### DIFF
--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -59,79 +59,63 @@ class LineReaderEofTest {
     }
 
     private void checkPipedInput(String providerType) throws Exception {
-        String savedProviders = System.getProperty(TerminalBuilder.PROP_PROVIDERS);
+        // Simulate piped input: all data written and stream closed before terminal reads
+        ByteArrayInputStream in = new ByteArrayInputStream("command1\ncommand2\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+
+        TerminalBuilder builder = TerminalBuilder.builder().streams(in, out);
+        if (providerType != null) {
+            builder.providers(providerType);
+        }
+
+        Terminal terminal;
         try {
-            if (providerType != null) {
-                System.setProperty(TerminalBuilder.PROP_PROVIDERS, providerType);
+            terminal = builder.build();
+        } catch (Exception e) {
+            assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
+            return;
+        }
+
+        try (terminal) {
+            // Wait for the pump thread to consume all piped input.
+            // Poll available bytes instead of Thread.sleep() to avoid brittle timing.
+            long deadline = System.nanoTime() + 5_000_000_000L;
+            while (terminal.input().available() == 0 && System.nanoTime() < deadline) {
+                Thread.onSpinWait();
             }
 
-            // Simulate piped input: all data written and stream closed before terminal reads
-            ByteArrayInputStream in = new ByteArrayInputStream("command1\ncommand2\n".getBytes(StandardCharsets.UTF_8));
-            ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-
-            Terminal terminal;
-            try {
-                terminal = TerminalBuilder.builder().streams(in, out).build();
-            } catch (Exception e) {
-                assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
-                return;
-            }
-
-            try (terminal) {
-                // Wait for the pump thread to consume all piped input.
-                // Poll available bytes instead of Thread.sleep() to avoid brittle timing.
-                long deadline = System.nanoTime() + 5_000_000_000L;
-                while (terminal.input().available() == 0 && System.nanoTime() < deadline) {
-                    Thread.onSpinWait();
-                }
-
-                LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
-                assertEquals("command1", lr.readLine());
-                assertEquals("command2", lr.readLine());
-                assertThrows(EndOfFileException.class, () -> lr.readLine());
-            }
-        } finally {
-            if (savedProviders != null) {
-                System.setProperty(TerminalBuilder.PROP_PROVIDERS, savedProviders);
-            } else {
-                System.clearProperty(TerminalBuilder.PROP_PROVIDERS);
-            }
+            LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
+            assertEquals("command1", lr.readLine());
+            assertEquals("command2", lr.readLine());
+            assertThrows(EndOfFileException.class, () -> lr.readLine());
         }
     }
 
     private void checkEof(String providerType) throws Exception {
-        String savedProviders = System.getProperty(TerminalBuilder.PROP_PROVIDERS);
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write("hello\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+
+        TerminalBuilder builder = TerminalBuilder.builder().streams(in, out);
+        if (providerType != null) {
+            builder.providers(providerType);
+        }
+
+        Terminal terminal;
         try {
-            if (providerType != null) {
-                System.setProperty(TerminalBuilder.PROP_PROVIDERS, providerType);
-            }
+            terminal = builder.build();
+        } catch (Exception e) {
+            assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
+            return;
+        }
 
-            PipedInputStream in = new PipedInputStream();
-            PipedOutputStream outIn = new PipedOutputStream(in);
-            outIn.write("hello\n".getBytes(StandardCharsets.UTF_8));
-            ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-
-            Terminal terminal;
-            try {
-                terminal = TerminalBuilder.builder().streams(in, out).build();
-            } catch (Exception e) {
-                assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
-                return;
-            }
-
-            try (terminal) {
-                LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
-                assertEquals("hello", lr.readLine());
-                outIn.close();
-                Thread.sleep(200);
-                assertThrows(EndOfFileException.class, () -> lr.readLine());
-            }
-        } finally {
-            if (savedProviders != null) {
-                System.setProperty(TerminalBuilder.PROP_PROVIDERS, savedProviders);
-            } else {
-                System.clearProperty(TerminalBuilder.PROP_PROVIDERS);
-            }
+        try (terminal) {
+            LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
+            assertEquals("hello", lr.readLine());
+            outIn.close();
+            // readLine() will block until the pump detects the closed pipe and signals EOF
+            assertThrows(EndOfFileException.class, () -> lr.readLine());
         }
     }
 }

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -78,8 +78,12 @@ class LineReaderEofTest {
             }
 
             try (terminal) {
-                // Give the pump thread time to read all input and reach EOF
-                Thread.sleep(500);
+                // Wait for the pump thread to consume all piped input.
+                // Poll available bytes instead of Thread.sleep() to avoid brittle timing.
+                long deadline = System.nanoTime() + 5_000_000_000L;
+                while (terminal.input().available() == 0 && System.nanoTime() < deadline) {
+                    Thread.onSpinWait();
+                }
 
                 LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
                 assertEquals("command1", lr.readLine());

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -10,9 +10,12 @@ package org.jline.reader.impl;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
@@ -24,6 +27,7 @@ import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class LineReaderEofTest {
@@ -59,8 +63,20 @@ class LineReaderEofTest {
     }
 
     private void checkPipedInput(String providerType) throws Exception {
-        // Simulate piped input: all data written and stream closed before terminal reads
-        ByteArrayInputStream in = new ByteArrayInputStream("command1\ncommand2\n".getBytes(StandardCharsets.UTF_8));
+        // Simulate piped input: all data written and stream closed before terminal reads.
+        // The CountDownLatch fires when the pump's read() returns -1, which is after
+        // all processInputBytes() calls — so all data is already in the buffer.
+        CountDownLatch inputEof = new CountDownLatch(1);
+        InputStream in = new ByteArrayInputStream("command1\ncommand2\n".getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public int read(byte[] b, int off, int len) {
+                int result = super.read(b, off, len);
+                if (result == -1) {
+                    inputEof.countDown();
+                }
+                return result;
+            }
+        };
         ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
 
         TerminalBuilder builder = TerminalBuilder.builder().streams(in, out);
@@ -72,17 +88,17 @@ class LineReaderEofTest {
         try {
             terminal = builder.build();
         } catch (Exception e) {
+            if (providerType == null) {
+                throw e;
+            }
             assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
             return;
         }
 
         try (terminal) {
-            // Wait for the pump thread to consume all piped input.
-            // Poll available bytes instead of Thread.sleep() to avoid brittle timing.
-            long deadline = System.nanoTime() + 5_000_000_000L;
-            while (terminal.input().available() == 0 && System.nanoTime() < deadline) {
-                Thread.onSpinWait();
-            }
+            // Wait for the pump thread to observe EOF on the input stream,
+            // guaranteeing all data has been written to the terminal's buffer.
+            assertTrue(inputEof.await(5, TimeUnit.SECONDS), "Pump did not reach EOF within timeout");
 
             LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
             assertEquals("command1", lr.readLine());
@@ -106,6 +122,9 @@ class LineReaderEofTest {
         try {
             terminal = builder.build();
         } catch (Exception e) {
+            if (providerType == null) {
+                throw e;
+            }
             assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
             return;
         }

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -8,6 +8,7 @@
  */
 package org.jline.reader.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -37,6 +38,61 @@ class LineReaderEofTest {
     @Timeout(10)
     void eofWithDefaultProvider() throws Exception {
         checkEof(null);
+    }
+
+    /**
+     * Tests that piped input is correctly read even when the input stream
+     * is already at EOF before readLine() is called. This simulates the
+     * scenario of {@code printf 'cmd1\ncmd2\n' | ssh host}.
+     * See https://github.com/jline/jline3/issues/2054
+     */
+    @Test
+    @Timeout(10)
+    void pipedInputReadBeforeEof() throws Exception {
+        checkPipedInput(null);
+    }
+
+    @Test
+    @Timeout(10)
+    void pipedInputReadBeforeEofWithExecProvider() throws Exception {
+        checkPipedInput(TerminalBuilder.PROP_PROVIDER_EXEC);
+    }
+
+    private void checkPipedInput(String providerType) throws Exception {
+        String savedProviders = System.getProperty(TerminalBuilder.PROP_PROVIDERS);
+        try {
+            if (providerType != null) {
+                System.setProperty(TerminalBuilder.PROP_PROVIDERS, providerType);
+            }
+
+            // Simulate piped input: all data written and stream closed before terminal reads
+            ByteArrayInputStream in = new ByteArrayInputStream("command1\ncommand2\n".getBytes(StandardCharsets.UTF_8));
+            ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+
+            Terminal terminal;
+            try {
+                terminal = TerminalBuilder.builder().streams(in, out).build();
+            } catch (Exception e) {
+                assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
+                return;
+            }
+
+            try (terminal) {
+                // Give the pump thread time to read all input and reach EOF
+                Thread.sleep(500);
+
+                LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
+                assertEquals("command1", lr.readLine());
+                assertEquals("command2", lr.readLine());
+                assertThrows(EndOfFileException.class, () -> lr.readLine());
+            }
+        } finally {
+            if (savedProviders != null) {
+                System.setProperty(TerminalBuilder.PROP_PROVIDERS, savedProviders);
+            } else {
+                System.clearProperty(TerminalBuilder.PROP_PROVIDERS);
+            }
+        }
     }
 
     private void checkEof(String providerType) throws Exception {

--- a/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
@@ -319,7 +319,7 @@ public class ExternalTerminal extends LineDisciplineTerminal {
             }
         }
         try {
-            slaveInput.close();
+            slaveInputPipe.close();
         } catch (IOException e) {
             // ignore
         }

--- a/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
@@ -312,7 +312,13 @@ public class ExternalTerminal extends LineDisciplineTerminal {
                 }
             }
         } catch (IOException e) {
-            processIOException(e);
+            // If the terminal is being shut down (doClose set the closed flag),
+            // the exception is expected and should not be propagated to readers.
+            // This avoids storing a ClosedException that would be rethrown by
+            // checkIoException() and bypass the configured close mode (e.g., warn).
+            if (!closed.get()) {
+                processIOException(e);
+            }
         } finally {
             synchronized (lock) {
                 pumpThread = null;

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
@@ -56,7 +56,13 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
                 throw new InterruptedIOException();
             }
         }
-        return buffer.hasRemaining() ? 0 : (closed || writerClosed) ? EOF : READ_EXPIRED;
+        if (buffer.hasRemaining()) {
+            return 0;
+        } else if (closed || writerClosed) {
+            return EOF;
+        } else {
+            return READ_EXPIRED;
+        }
     }
 
     private static boolean rewind(ByteBuffer buffer, ByteBuffer other) {

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
@@ -23,6 +23,7 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
 
     private final OutputStream output;
 
+    private boolean writerClosed;
     private IOException ioException;
 
     public NonBlockingPumpInputStream() {
@@ -44,7 +45,7 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
 
     private int wait(ByteBuffer buffer, long timeout) throws IOException {
         Timeout t = new Timeout(timeout);
-        while (!closed && !buffer.hasRemaining() && !t.elapsed()) {
+        while (!closed && !writerClosed && !buffer.hasRemaining() && !t.elapsed()) {
             // Wake up waiting readers/writers
             notifyAll();
             try {
@@ -55,7 +56,7 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
                 throw new InterruptedIOException();
             }
         }
-        return buffer.hasRemaining() ? 0 : closed ? EOF : READ_EXPIRED;
+        return buffer.hasRemaining() ? 0 : (closed || writerClosed) ? EOF : READ_EXPIRED;
     }
 
     private static boolean rewind(ByteBuffer buffer, ByteBuffer other) {
@@ -157,6 +158,9 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
     }
 
     synchronized void write(byte[] cbuf, int off, int len) throws IOException {
+        if (writerClosed) {
+            throw new ClosedException();
+        }
         while (len > 0) {
             // Blocks until there is new space available for buffering or the
             // reader is closed.
@@ -179,6 +183,17 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
             // Notify readers
             notifyAll();
         }
+    }
+
+    /**
+     * Signals that the write side has been closed and no more data will be written.
+     * Any buffered data can still be read; reads will return {@link #EOF} only after
+     * all buffered data has been consumed. This is analogous to closing the write end
+     * of a Unix pipe: the read end drains remaining data before seeing EOF.
+     */
+    public synchronized void closeWriter() {
+        this.writerClosed = true;
+        notifyAll();
     }
 
     @Override
@@ -206,7 +221,7 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
 
         @Override
         public void close() throws IOException {
-            NonBlockingPumpInputStream.this.close();
+            NonBlockingPumpInputStream.this.closeWriter();
         }
     }
 }

--- a/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
@@ -360,6 +360,72 @@ class NonBlockingTest {
         }
     }
 
+    // --- Pump writer-close tests (issue #2054) ---
+
+    @Test
+    @Timeout(5)
+    void testPumpWriterCloseAllowsReadingBufferedData() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        // Write data and close the writer (simulates piped input at EOF)
+        byte[] data = "Hello\n".getBytes(StandardCharsets.UTF_8);
+        out.write(data);
+        out.flush();
+        out.close();
+
+        // Buffered data should still be readable after writer close
+        byte[] buf = new byte[64];
+        int n = pump.read(buf, 0, buf.length);
+        assertEquals(data.length, n);
+        assertArrayEquals(data, Arrays.copyOf(buf, n));
+
+        // After all data is consumed, should return EOF
+        assertEquals(NonBlockingInputStream.EOF, pump.read(100, false));
+    }
+
+    @Test
+    @Timeout(5)
+    void testPumpWriterCloseReturnsEofWhenEmpty() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        // Close writer without writing any data
+        out.close();
+
+        // Should return EOF immediately
+        assertEquals(NonBlockingInputStream.EOF, pump.read(100, false));
+    }
+
+    @Test
+    @Timeout(5)
+    void testPumpWriterCloseRejectsSubsequentWrites() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        out.write("data".getBytes(StandardCharsets.UTF_8));
+        out.flush();
+        out.close();
+
+        // Writing after close should throw
+        assertThrows(ClosedException.class, () -> out.write("more".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    @Timeout(5)
+    void testPumpFullCloseStillThrowsOnRead() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        out.write("data".getBytes(StandardCharsets.UTF_8));
+        out.flush();
+
+        // Full close (read-side) should throw on subsequent reads
+        pump.close();
+        byte[] buf = new byte[64];
+        assertThrows(ClosedException.class, () -> pump.read(buf, 0, buf.length));
+    }
+
     // --- Pump thread shutdown/close lifecycle tests ---
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #2054

When using `ExternalTerminal` with piped input (e.g., `printf 'cmd1\ncmd2\n' | ssh host`), `LineReader.readLine()` immediately threw `EndOfFileException` instead of reading the buffered commands.

**Root cause:** When `ExternalTerminal`'s pump thread reached EOF on the master input, it called `slaveInput.close()` which set the `closed` flag on `NonBlockingPumpInputStream`. In JLine 4.x's default STRICT close mode, subsequent reads threw `ClosedException` before any buffered data could be consumed.

**Fix:** Introduce a separate writer-close mechanism (`closeWriter()`) in `NonBlockingPumpInputStream` that signals no more data will arrive without preventing reads of already-buffered data. This is analogous to closing the write end of a Unix pipe — the read end drains remaining data before seeing EOF. The pump now closes the write side (`slaveInputPipe`) instead of the read side (`slaveInput`).

## Changes

- **`NonBlockingPumpInputStream`**: Added `writerClosed` flag and `closeWriter()` method. Updated `wait()` to stop waiting when writer is closed. Updated `write()` to reject writes after writer close. Made `NbpOutputStream.close()` call `closeWriter()` instead of `close()`.
- **`ExternalTerminal`**: Changed pump to close `slaveInputPipe` (write side) instead of `slaveInput` (read side) on EOF.

## Test plan

- [x] New unit tests for `NonBlockingPumpInputStream.closeWriter()` behavior
  - Reading buffered data after writer close returns data then EOF
  - Writer close with empty buffer returns EOF immediately
  - Writes after writer close are rejected with `ClosedException`
  - Full close (read-side) still throws `ClosedException` on reads
- [x] New integration tests for piped input scenario in `LineReaderEofTest`
  - `ByteArrayInputStream` with pre-written data (simulating pipe at EOF)
  - Verifies all buffered lines are read before `EndOfFileException`
  - Tests with both default and exec providers
- [x] Existing EOF tests continue to pass
- [x] Full reactor build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EOF handling for piped input that’s already at end-of-file before `readLine()` is called.
  * Refined terminal shutdown cleanup to suppress expected I/O errors during close.
  * Updated non-blocking input so writer-side closure results in EOF only after buffered data is consumed; further writes are rejected.
* **New Features**
  * Added support for explicit writer-side closure on the non-blocking pump input stream.
* **Tests**
  * Expanded JUnit coverage for EOF and writer-close semantics across terminal providers and non-blocking streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->