### PR TITLE
fix: allow reading buffered data from closed pump stream (#2054)

### DIFF
--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -8,6 +8,7 @@
  */
 package org.jline.reader.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -18,6 +19,7 @@ import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
+import org.jline.terminal.impl.ExternalTerminal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -37,6 +39,36 @@ class LineReaderEofTest {
     @Timeout(10)
     void eofWithDefaultProvider() throws Exception {
         checkEof(null);
+    }
+
+    /**
+     * Simulates the scenario from issue #2054: piped input through SSH where
+     * all input data arrives and EOF follows immediately before readLine() is called.
+     * The pump thread reads all data and closes slaveInput before the application
+     * starts reading, but the buffered data should still be consumable.
+     */
+    @Test
+    @Timeout(10)
+    void pipedInputWithImmediateEof() throws Exception {
+        // ByteArrayInputStream returns EOF immediately after all data is consumed,
+        // simulating piped SSH input: printf 'cmd1\ncmd2\n' | ssh host
+        byte[] input = "command1\ncommand2\n".getBytes(StandardCharsets.UTF_8);
+        ByteArrayInputStream in = new ByteArrayInputStream(input);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        try (ExternalTerminal terminal = new ExternalTerminal("test", "ansi", in, out, StandardCharsets.UTF_8)) {
+            LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
+
+            // Give the pump thread time to read all data and close slaveInput
+            Thread.sleep(500);
+
+            // Both commands should be readable despite the pump having closed slaveInput
+            assertEquals("command1", lr.readLine());
+            assertEquals("command2", lr.readLine());
+
+            // After all data is consumed, should throw EndOfFileException
+            assertThrows(EndOfFileException.class, () -> lr.readLine());
+        }
     }
 
     private void checkEof(String providerType) throws Exception {

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
@@ -73,6 +73,32 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
         }
     }
 
+    /**
+     * Overrides the base close check to allow reading remaining buffered data
+     * after the stream has been closed on the write side.
+     *
+     * <p>
+     * When the write side is closed (e.g., when the pump thread in
+     * {@link org.jline.terminal.impl.ExternalTerminal ExternalTerminal} hits EOF
+     * on its input source), there may still be unread data in the circular buffer.
+     * The base class would throw {@link ClosedException} immediately, preventing
+     * the consumer from reading that data. Instead, this override defers to the
+     * {@link #wait(ByteBuffer, long)} method, which properly returns buffered data
+     * first and only signals EOF when the buffer is empty.
+     * </p>
+     *
+     * <p>
+     * This is critical for piped input scenarios (e.g., SSH connections with piped
+     * commands like {@code printf 'cmd1\ncmd2\n' | ssh host}) where all input
+     * arrives and EOF is signaled before the application reads any data.
+     * </p>
+     */
+    @Override
+    protected void checkClosed() throws IOException {
+        // No-op: let wait() handle the closed state naturally.
+        // It returns buffered data first, then EOF when the buffer is empty.
+    }
+
     public synchronized int available() {
         int count = readBuffer.remaining();
         if (writeBuffer.position() < readBuffer.position()) {

--- a/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
@@ -250,12 +250,14 @@ class NonBlockingTest {
     }
 
     @Test
-    void testPumpBulkReadClosed() throws IOException {
+    void testPumpBulkReadClosedReturnsEof() throws IOException {
         NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
         pump.close();
 
+        // A closed pump with no buffered data returns EOF rather than throwing.
+        // This allows readers to drain remaining data after the write side closes.
         byte[] buf = new byte[16];
-        assertThrows(ClosedException.class, () -> pump.read(buf, 0, buf.length));
+        assertEquals(-1, pump.read(buf, 0, buf.length));
     }
 
     @Test
@@ -358,6 +360,100 @@ class NonBlockingTest {
         } finally {
             nbis.close();
         }
+    }
+
+    // --- Pump close + drain tests (issue #2054) ---
+
+    @Test
+    void testPumpReadDrainsBufferAfterClose() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        // Write data, then close the stream (simulates pump thread hitting EOF)
+        byte[] data = "Hello".getBytes(StandardCharsets.UTF_8);
+        out.write(data);
+        out.flush();
+        pump.close();
+
+        // All buffered data should still be readable after close
+        byte[] buf = new byte[64];
+        int n = pump.read(buf, 0, buf.length);
+        assertEquals(data.length, n);
+        assertArrayEquals(data, Arrays.copyOf(buf, n));
+
+        // After draining, should return EOF
+        assertEquals(-1, pump.read(buf, 0, buf.length));
+    }
+
+    @Test
+    void testPumpSingleByteReadDrainsBufferAfterClose() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        out.write(new byte[] {'A', 'B', 'C'});
+        out.flush();
+        pump.close();
+
+        // Single-byte reads should still work after close
+        assertEquals('A', pump.read(100, false));
+        assertEquals('B', pump.read(100, false));
+        assertEquals('C', pump.read(100, false));
+        assertEquals(-1, pump.read(100, false));
+    }
+
+    @Test
+    void testPumpReadBufferedDrainsAfterClose() throws IOException {
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        byte[] data = "test data".getBytes(StandardCharsets.UTF_8);
+        out.write(data);
+        out.flush();
+        pump.close();
+
+        byte[] buf = new byte[64];
+        int n = pump.readBuffered(buf, 0, buf.length, 100);
+        assertEquals(data.length, n);
+        assertArrayEquals(data, Arrays.copyOf(buf, n));
+
+        assertEquals(-1, pump.readBuffered(buf, 0, buf.length, 100));
+    }
+
+    @Test
+    @Timeout(5)
+    void testPumpDrainWithConcurrentClose() throws Exception {
+        // Simulates the ExternalTerminal pump thread scenario:
+        // writer thread writes data and then closes the stream,
+        // reader thread must be able to read all data despite the close
+        NonBlockingPumpInputStream pump = new NonBlockingPumpInputStream();
+        OutputStream out = pump.getOutputStream();
+
+        byte[] data = "command1\ncommand2\n".getBytes(StandardCharsets.UTF_8);
+
+        Thread writer = new Thread(() -> {
+            try {
+                out.write(data);
+                out.flush();
+                // Simulate pump thread closing after EOF on input source
+                pump.close();
+            } catch (IOException e) {
+                fail(e);
+            }
+        });
+        writer.start();
+
+        byte[] result = new byte[data.length];
+        int total = 0;
+        while (total < data.length) {
+            int n = pump.read(result, total, result.length - total);
+            if (n == -1) break;
+            if (n == NonBlockingInputStream.READ_EXPIRED) continue;
+            total += n;
+        }
+
+        writer.join(2000);
+        assertEquals(data.length, total, "All data should be readable despite concurrent close");
+        assertArrayEquals(data, result);
     }
 
     // --- Pump thread shutdown/close lifecycle tests ---


### PR DESCRIPTION
## Summary

Fixes #2054 — when using ExternalTerminal with piped input (e.g., `printf 'cmd1\ncmd2\n' | ssh host`), `LineReader.readLine()` immediately throws `EndOfFileException` instead of processing the buffered commands.

**Root cause:** ExternalTerminal's pump thread reads all input from the master stream and then closes `slaveInput` (the `NonBlockingPumpInputStream`). In JLine 4.x strict mode (the default), the next `read()` call throws `ClosedException` via `checkClosed()` *before* the `wait()` method can check for buffered data — even though valid data is still in the circular buffer.

**Fix:** Override `checkClosed()` in `NonBlockingPumpInputStream` to be a no-op, deferring EOF signaling to the existing `wait()` method which already correctly returns buffered data first and only signals EOF when the buffer is empty. This ensures piped input is fully consumed before end-of-file is reported.

The `ClosedException` behavior for fully-closed terminals is preserved because it comes from the `NonBlockingReader` layer (which has its own `checkClosed()`), not from `NonBlockingPumpInputStream`.

## Changes

- `NonBlockingPumpInputStream.checkClosed()` — overridden to allow draining buffered data after close
- `NonBlockingTest` — updated existing test, added 4 new tests for close+drain scenarios
- `LineReaderEofTest` — added end-to-end test simulating piped SSH input with immediate EOF

## Test plan

- [x] All 432 terminal module tests pass
- [x] All 212 reader module tests pass (2 skipped, pre-existing)
- [x] `StrictCloseTest` still passes (ClosedException from reader layer is unaffected)
- [x] Full project build succeeds
- [x] New `pipedInputWithImmediateEof` test validates the exact scenario from the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed and piped input when the source reaches EOF immediately.
  * Buffered input is now fully available to read after the input stream closes.
  * Readers correctly return all remaining lines or data before reporting EOF.
  * Prevented premature closed-stream errors during bulk, single-byte, and buffered reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->