### PR TITLE
feat: allow customizing the help source in Less pager (fixes #2056)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,12 @@ Spotless enforces this header automatically via `spotless:apply`.
 4. Artifacts must be manually published through central.sonatype.com portal after the workflow completes
 5. Create GitHub release notes via `gh release create`
 
+### Merging PRs
+
+- **Always squash merge.** The squash commit message must be a single `<type>: <description>` line that summarizes the entire diff (not a list of individual commits).
+- **Label the PR** before merging to categorize it (e.g., `enhancement`, `bug`, `documentation`). Labels drive the release notes.
+- **Set the milestone** on the PR to the target release version before merging.
+
 ### Backporting Workflow
 
 1. Cherry-pick bugfix commits from `master` to `4.0.x` and/or `jline-3.x`

--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -87,6 +87,7 @@ public class Less {
     protected List<Integer> tabs = Collections.singletonList(4);
     protected String syntaxName;
     protected String defaultPrompt;
+    protected Source helpSource;
     private String historyLog = null;
 
     protected final Terminal terminal;
@@ -326,6 +327,21 @@ public class Less {
         return this;
     }
 
+    /**
+     * Sets a custom help source displayed when the user presses {@code h} or {@code H}.
+     * If not set, the built-in {@code less-help.txt} resource is shown. This is useful
+     * for applications that embed Less and want to provide context-specific help text
+     * instead of the default help, which references command-line options and uses the
+     * term "LESS".
+     *
+     * @param helpSource a {@link Source} providing the custom help content
+     * @return this {@code Less} instance for chaining
+     */
+    public Less helpSource(Source helpSource) {
+        this.helpSource = helpSource;
+        return this;
+    }
+
     public void handle(Signal signal) {
         size = terminal.getSize();
         try {
@@ -344,7 +360,10 @@ public class Less {
         if (sources == null || sources.isEmpty()) {
             throw new IllegalArgumentException("No sources");
         }
-        sources.add(0, new ResourceSource("less-help.txt", "HELP -- Press SPACE for more, or q when done"));
+        Source help = helpSource != null
+                ? helpSource
+                : new ResourceSource("less-help.txt", "HELP -- Press SPACE for more, or q when done");
+        sources.add(0, help);
         this.sources = sources;
 
         sourceIdx = 1;

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
+import org.jline.builtins.Source.InputStreamSource;
 import org.jline.terminal.Size;
 import org.jline.terminal.impl.LineDisciplineTerminal;
 import org.junit.jupiter.api.Test;
@@ -244,6 +245,60 @@ class LessTest {
             // With an empty source and empty prompt, ':' should not appear in the visible output.
             String plainText = stripAnsi(output.toString(StandardCharsets.UTF_8));
             assertFalse(plainText.contains(":"), "Empty defaultPrompt should not fall back to the ':' default");
+        }
+    }
+
+    // --- helpSource tests ---
+
+    @Test
+    void helpSourceSetterUpdatesFieldAndReturnsSameInstance() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = new Less(terminal, Path.of("."));
+            assertNull(less.helpSource, "helpSource should be null by default");
+
+            java.io.ByteArrayInputStream helpContent =
+                    new java.io.ByteArrayInputStream("Custom Help".getBytes(StandardCharsets.UTF_8));
+            Source customHelp = new InputStreamSource(helpContent, true, "Custom Help");
+            Less returned = less.helpSource(customHelp);
+
+            assertSame(less, returned, "helpSource() should return 'this' for chaining");
+            assertSame(customHelp, less.helpSource, "helpSource field should be set to the provided Source");
+        }
+    }
+
+    @Test
+    void helpSourceDefaultIsNull() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = new Less(terminal, Path.of("."));
+            assertNull(less.helpSource, "helpSource should be null when not explicitly set");
+        }
+    }
+
+    @Test
+    void helpSourceWithConstructorOptionsDefaultsToNull() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Options opts = Options.compile(Less.usage()).parse(new String[] {});
+            Less less = new Less(terminal, Path.of("."), opts);
+            assertNull(less.helpSource, "helpSource should be null even with Options provided");
+        }
+    }
+
+    @Test
+    void helpSourceSetterAllowsChaining() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            java.io.ByteArrayInputStream helpContent =
+                    new java.io.ByteArrayInputStream("Help".getBytes(StandardCharsets.UTF_8));
+            Source customHelp = new InputStreamSource(helpContent, true, "Help");
+
+            Less less =
+                    new Less(terminal, Path.of(".")).defaultPrompt("prompt>").helpSource(customHelp);
+
+            assertEquals("prompt>", less.defaultPrompt);
+            assertSame(customHelp, less.helpSource);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `helpSource(Source)` fluent setter to `Less` that lets applications embedding the Less pager provide custom help text displayed when the user presses `h`/`H`
- When not set, the built-in `less-help.txt` resource is used as before (fully backward-compatible)
- Accepts any `Source` implementation (`ResourceSource`, `PathSource`, `URLSource`, `InputStreamSource`, etc.), giving maximum flexibility

Fixes #2056

## Motivation

When Less is embedded in an application, the default help text references command-line options and the term "LESS" which are not applicable. The existing workarounds (classpath manipulation or JAR repackaging) are fragile and version-dependent. This change provides a clean, supported API to customize the help content.

## Usage

```java
Less less = new Less(terminal, currentDir)
    .helpSource(new Source.ResourceSource("my-app-help.txt", "APP HELP"));
```

Or with inline content:

```java
byte[] helpBytes = "My custom help text...".getBytes(StandardCharsets.UTF_8);
Source help = new Source.InputStreamSource(
    new ByteArrayInputStream(helpBytes), true, "HELP");
Less less = new Less(terminal, currentDir).helpSource(help);
```

## Test plan

- [x] `helpSourceSetterUpdatesFieldAndReturnsSameInstance` — verifies setter stores the source and returns `this`
- [x] `helpSourceDefaultIsNull` — verifies default is null (backward-compatible)
- [x] `helpSourceWithConstructorOptionsDefaultsToNull` — verifies constructor doesn't interfere
- [x] `helpSourceSetterAllowsChaining` — verifies fluent chaining with `defaultPrompt()`
- [x] All 17 existing+new LessTest tests pass
- [x] Full project build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for providing custom help content in the pager.
  * Custom help can be set via a fluent `helpSource(...)` configuration; it’s used when provided.
  * If no custom help is set, the built-in help page is shown.

* **Tests**
  * Added tests for default behavior, setting custom help content, and fluent chaining (including interaction with other pager settings).

* **Documentation**
  * Updated PR merging guidance to require squash-merge conventions and milestone/label steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->