### PR TITLE
fix: propagate EOF in PtyInputStream to avoid infinite loop (#1961, #1963)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
 
 import org.jline.nativ.JLineLibrary;
 import org.jline.nativ.JLineNativeLoader;
@@ -145,8 +146,9 @@ public abstract class AbstractPty implements Pty {
                 return r;
             } else {
                 setNonBlocking();
-                long start = System.currentTimeMillis();
+                long start = System.nanoTime();
                 while (true) {
+                    long readStart = System.nanoTime();
                     int r = in.read();
                     if (r >= 0) {
                         if (isPeek) {
@@ -154,9 +156,16 @@ public abstract class AbstractPty implements Pty {
                         }
                         return r;
                     }
+                    // r == -1: could be real EOF or VMIN=0/VTIME=1 timeout on a real PTY.
+                    // With VTIME=1 (100ms), a timeout takes ~100ms to return -1.
+                    // Real EOF (pipe closed, PTY slave closed) returns -1 instantly.
+                    long readElapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - readStart);
+                    if (readElapsed < 50) {
+                        return -1;
+                    }
                     checkInterrupted();
-                    long cur = System.currentTimeMillis();
-                    if (timeout > 0 && cur - start > timeout) {
+                    long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+                    if (timeout > 0 && elapsed > timeout) {
                         return NonBlockingInputStream.READ_EXPIRED;
                     }
                 }

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Size;
+import org.jline.utils.NonBlockingInputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.jline.terminal.TerminalBuilder.PROP_NON_BLOCKING_READS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PtyInputStreamTest {
+
+    private String savedNonBlockingReads;
+
+    @BeforeEach
+    void setUp() {
+        savedNonBlockingReads = System.getProperty(PROP_NON_BLOCKING_READS);
+        System.setProperty(PROP_NON_BLOCKING_READS, "true");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedNonBlockingReads != null) {
+            System.setProperty(PROP_NON_BLOCKING_READS, savedNonBlockingReads);
+        } else {
+            System.clearProperty(PROP_NON_BLOCKING_READS);
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void eofPropagation() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
+
+        AbstractPty pty = new AbstractPty(null, null) {
+            @Override
+            protected void doSetAttr(Attributes attr) {}
+
+            @Override
+            protected InputStream doGetSlaveInput() {
+                return pipedIn;
+            }
+
+            @Override
+            public InputStream getMasterInput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getMasterOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getSlaveOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Attributes getAttr() {
+                return new Attributes();
+            }
+
+            @Override
+            public Size getSize() {
+                return new Size(80, 24);
+            }
+
+            @Override
+            public void setSize(Size size) {}
+
+            @Override
+            public void close() {}
+        };
+
+        InputStream slaveInput = pty.getSlaveInput();
+        assertTrue(slaveInput instanceof NonBlockingInputStream);
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        pipedOut.write('A');
+        pipedOut.close();
+
+        int ch = nbis.read(1000);
+        assertEquals('A', ch);
+
+        // Without the fix, PtyInputStream loops until timeout and returns READ_EXPIRED (-2).
+        // With the fix, it detects instant EOF and returns -1.
+        int eof = nbis.read(1000);
+        assertEquals(-1, eof, "Expected EOF (-1) after pipe closed");
+    }
+}


### PR DESCRIPTION
This PR ports a86915dcb592813d4f2d47dbd8a7d24b21ab4ed1 to branch jline-3.x. I made some minor adaptations to make the build pass.