### PR TITLE
fix: look up openpty in libc.so.6 for glibc 2.34+

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -328,6 +328,19 @@ class CLibrary {
                     suppressed.add(t);
                 }
             }
+            // On glibc 2.34+, openpty was merged from libutil into libc.so.6.
+            // SymbolLookup.libraryLookup searches all exported symbols in the specified
+            // library, unlike defaultLookup() which only exposes C standard symbols.
+            if (openPtyAddr.isEmpty() && OSUtils.IS_LINUX) {
+                try {
+                    SymbolLookup libcLookup = SymbolLookup.libraryLookup("libc.so.6", Arena.global());
+                    openPtyAddr = libcLookup.find("openpty");
+                } catch (Throwable t) {
+                    suppressed.add(t);
+                }
+            }
+            // On older glibc (< 2.34), openpty is in a separate libutil.so.
+            // Search for versioned libutil.so.* files in the Debian/Ubuntu multiarch path.
             if (openPtyAddr.isEmpty() && OSUtils.IS_LINUX) {
                 String hwName;
                 try {


### PR DESCRIPTION
## Problem

On modern Linux distributions with glibc 2.34+ (Ubuntu 22.04+, Debian 12+, RHEL 9, Fedora 35+, Amazon Linux 2023), the FFM terminal provider fails with:

```
Unable to find openpty native method in static libraries and unable to load the util library.
java.lang.UnsatisfiedLinkError: no util in java.library.path
```

Starting with glibc 2.34, `openpty` was [merged from `libutil` into `libc.so.6`](https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html) and the standalone `libutil.so` no longer exists. The FFM provider's existing fallback chain only tried to load `libutil`, which fails on these systems.

## Fix

Add a fallback that uses `SymbolLookup.libraryLookup("libc.so.6", Arena.global())` to explicitly search for `openpty` in libc. Unlike `defaultLookup()` which only exposes C standard symbols, `libraryLookup` searches **all** exported symbols in the specified library. This new fallback is tried before the existing Debian-specific `libutil.so.*` search, since on glibc 2.34+ the function is in libc. The existing `libutil` fallbacks are preserved for older glibc systems.

## Lookup chain after this change

1. Default lookup (`loaderLookup` + `defaultLookup`) — works if openpty happens to be in the default symbol set
2. `System.loadLibrary("util")` — works on older glibc where `libutil.so` exists in `java.library.path`
3. Custom path via `org.jline.ffm.libutil` system property
4. AIX: `System.loadLibrary("bsd")`
5. **NEW — Linux: `SymbolLookup.libraryLookup("libc.so.6")` — works on glibc 2.34+ where openpty is in libc**
6. Linux: search for versioned `libutil.so.*` files in Debian multiarch paths — works on older Debian/Ubuntu

Fixes #2068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux terminal compatibility by adding an additional fallback for locating the system’s `openpty` functionality.
  * Preserved existing library lookup behavior when the new fallback is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->