### PR TITLE
[backport jline-3.x] fix: guard styleMatches and highlighter rules against ReDoS

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/SyntaxHighlighter.java
+++ b/builtins/src/main/java/org/jline/builtins/SyntaxHighlighter.java
@@ -396,41 +396,47 @@ public class SyntaxHighlighter {
                     break;
                 case START_END:
                     boolean done = false;
-                    Matcher start = rule.getStart().matcher(asb.toAttributedString());
-                    Matcher end = rule.getEnd().matcher(asb.toAttributedString());
-                    while (!done) {
-                        AttributedStringBuilder a = new AttributedStringBuilder();
-                        if (startEndHighlight && ruleStartId == i) {
-                            if (end.find()) {
-                                ruleStartId = 0;
-                                startEndHighlight = false;
-                                a.append(asb.columnSubSequence(0, end.end()), rule.getStyle());
-                                a.append(_highlight(
-                                        asb.columnSubSequence(end.end(), asb.length())
-                                                .toAttributedString(),
-                                        rules));
-                            } else {
-                                a.append(asb, rule.getStyle());
-                                done = true;
-                            }
-                            asb = a;
-                        } else {
-                            if (start.find()) {
-                                a.append(asb.columnSubSequence(0, start.start()));
+                    Matcher start = SafeRegex.matcher(rule.getStart(), asb.toAttributedString());
+                    Matcher end = SafeRegex.matcher(rule.getEnd(), asb.toAttributedString());
+                    try {
+                        while (!done) {
+                            AttributedStringBuilder a = new AttributedStringBuilder();
+                            if (startEndHighlight && ruleStartId == i) {
                                 if (end.find()) {
-                                    a.append(asb.columnSubSequence(start.start(), end.end()), rule.getStyle());
-                                    a.append(asb.columnSubSequence(end.end(), asb.length()));
+                                    ruleStartId = 0;
+                                    startEndHighlight = false;
+                                    a.append(asb.columnSubSequence(0, end.end()), rule.getStyle());
+                                    a.append(_highlight(
+                                            asb.columnSubSequence(end.end(), asb.length())
+                                                    .toAttributedString(),
+                                            rules));
                                 } else {
-                                    ruleStartId = i;
-                                    startEndHighlight = true;
-                                    a.append(asb.columnSubSequence(start.start(), asb.length()), rule.getStyle());
+                                    a.append(asb, rule.getStyle());
                                     done = true;
                                 }
                                 asb = a;
                             } else {
-                                done = true;
+                                if (start.find()) {
+                                    a.append(asb.columnSubSequence(0, start.start()));
+                                    if (end.find()) {
+                                        a.append(asb.columnSubSequence(start.start(), end.end()), rule.getStyle());
+                                        a.append(asb.columnSubSequence(end.end(), asb.length()));
+                                    } else {
+                                        ruleStartId = i;
+                                        startEndHighlight = true;
+                                        a.append(asb.columnSubSequence(start.start(), asb.length()), rule.getStyle());
+                                        done = true;
+                                    }
+                                    asb = a;
+                                } else {
+                                    done = true;
+                                }
                             }
                         }
+                    } catch (RegexTimeoutException e) {
+                        // Stop applying this start/end rule; keep the styling done so far
+                        ruleStartId = 0;
+                        startEndHighlight = false;
                     }
                     break;
                 case PARSER_START_WITH:
@@ -439,7 +445,7 @@ public class SyntaxHighlighter {
                     }
                     break;
                 case PARSER_CONTINUE_AS:
-                    if (continueAs != null && continueAs.toString().matches(rule.getContinueAs() + ".*")) {
+                    if (continueAs != null && SafeRegex.matches(rule.getContinueAsPattern(), continueAs.toString())) {
                         asb.styleMatches(rule.getPattern(), rule.getStyle());
                     }
                     break;
@@ -463,6 +469,7 @@ public class SyntaxHighlighter {
         private Pattern end;
         private String startWith;
         private String continueAs;
+        private Pattern continueAsPattern;
 
         public HighlightRule(AttributedStyle style, Pattern pattern) {
             this.type = RuleType.PATTERN;
@@ -485,6 +492,7 @@ public class SyntaxHighlighter {
                 this.startWith = value;
             } else if (parserRuleType == RuleType.PARSER_CONTINUE_AS) {
                 this.continueAs = value;
+                this.continueAsPattern = Pattern.compile(value + ".*");
             } else {
                 throw new IllegalArgumentException("Bad RuleType: " + parserRuleType);
             }
@@ -525,6 +533,10 @@ public class SyntaxHighlighter {
 
         public String getContinueAs() {
             return continueAs;
+        }
+
+        public Pattern getContinueAsPattern() {
+            return continueAsPattern;
         }
 
         public static RuleType evalRuleType(List<String> colorCfg) {

--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -934,11 +934,15 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
      * @return this builder
      */
     public AttributedStringBuilder styleMatches(Pattern pattern, AttributedStyle s) {
-        Matcher matcher = pattern.matcher(this);
-        while (matcher.find()) {
-            for (int i = matcher.start(); i < matcher.end(); i++) {
-                style[i] = (style[i] & ~s.getMask()) | s.getStyle();
+        Matcher matcher = SafeRegex.matcher(pattern, this);
+        try {
+            while (matcher.find()) {
+                for (int i = matcher.start(); i < matcher.end(); i++) {
+                    style[i] = (style[i] & ~s.getMask()) | s.getStyle();
+                }
             }
+        } catch (RegexTimeoutException e) {
+            // Apply whatever matches we found so far
         }
         return this;
     }
@@ -968,14 +972,18 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
      * @throws IndexOutOfBoundsException if the pattern has fewer capture groups than styles
      */
     public AttributedStringBuilder styleMatches(Pattern pattern, List<AttributedStyle> styles) {
-        Matcher matcher = pattern.matcher(this);
-        while (matcher.find()) {
-            for (int group = 0; group < matcher.groupCount(); group++) {
-                AttributedStyle s = styles.get(group);
-                for (int i = matcher.start(group + 1); i < matcher.end(group + 1); i++) {
-                    style[i] = (style[i] & ~s.getMask()) | s.getStyle();
+        Matcher matcher = SafeRegex.matcher(pattern, this);
+        try {
+            while (matcher.find()) {
+                for (int group = 0; group < matcher.groupCount(); group++) {
+                    AttributedStyle s = styles.get(group);
+                    for (int i = matcher.start(group + 1); i < matcher.end(group + 1); i++) {
+                        style[i] = (style[i] & ~s.getMask()) | s.getStyle();
+                    }
                 }
             }
+        } catch (RegexTimeoutException e) {
+            // Apply whatever matches we found so far
         }
         return this;
     }

--- a/terminal/src/test/java/org/jline/utils/AttributedStringBuilderTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringBuilderTest.java
@@ -8,7 +8,10 @@
  */
 package org.jline.utils;
 
+import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -149,5 +152,54 @@ public class AttributedStringBuilderTest {
     public void testNegativeTabSize() throws Exception {
         AttributedStringBuilder sb = new AttributedStringBuilder();
         assertThrows(IllegalArgumentException.class, () -> sb.tabs(-1));
+    }
+
+    @Test
+    void styleMatchesGuardsAgainstCatastrophicBacktracking() {
+        // (.*a){30} over a run of 'a's forces exponential backtracking in
+        // java.util.regex (still true on current JVMs). styleMatches feeds
+        // arbitrary text through this matcher when highlighting, so without a
+        // deadline the call runs for tens of seconds. SafeRegex caps it at ~1.5s.
+        Pattern evil = Pattern.compile("(.*a){30}");
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        for (int i = 0; i < 50; i++) {
+            sb.append('a');
+        }
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(8),
+                () -> sb.styleMatches(evil, AttributedStyle.DEFAULT.foreground(AttributedStyle.RED)));
+
+        // Non-pathological matching still applies the style and leaves text intact.
+        AttributedStringBuilder ok = new AttributedStringBuilder();
+        ok.append("Error: boom");
+        ok.styleMatches(Pattern.compile("Error"), AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
+        assertEquals("Error: boom", ok.toString());
+        assertTrue(ok.toAnsi().indexOf('\u001b') >= 0, "expected the matched region to be styled");
+    }
+
+    @Test
+    void styleMatchesGroupsGuardsAgainstCatastrophicBacktracking() {
+        // Same evil pattern as above, driven through the multi-group
+        // styleMatches(Pattern, List<AttributedStyle>) overload.
+        Pattern evil = Pattern.compile("(.*a){30}");
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        for (int i = 0; i < 50; i++) {
+            sb.append('a');
+        }
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(8),
+                () -> sb.styleMatches(
+                        evil, Collections.singletonList(AttributedStyle.DEFAULT.foreground(AttributedStyle.RED))));
+
+        // Non-pathological matching still styles each capture group.
+        AttributedStringBuilder ok = new AttributedStringBuilder();
+        ok.append("Error: boom");
+        ok.styleMatches(
+                Pattern.compile("(Error): (boom)"),
+                Arrays.asList(
+                        AttributedStyle.DEFAULT.foreground(AttributedStyle.RED),
+                        AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW)));
+        assertEquals("Error: boom", ok.toString());
+        assertTrue(ok.toAnsi().indexOf('\u001b') >= 0, "expected the matched groups to be styled");
     }
 }


### PR DESCRIPTION
Backport of #2053 (commit dc065af2) to the jline-3.x branch.

## Changes

Extends SafeRegex guards to prevent catastrophic backtracking (ReDoS) in:

1. **`AttributedStringBuilder.styleMatches`** (both overloads) — wraps matcher via `SafeRegex.matcher()` and catches `RegexTimeoutException`
2. **`SyntaxHighlighter._highlight` START_END rules** — wraps start/end matchers with SafeRegex
3. **`SyntaxHighlighter._highlight` PARSER_CONTINUE_AS** — uses `SafeRegex.matches()`
4. **Precompiles `continueAs` pattern** in `HighlightRule` to avoid repeated compilation
5. **Adds tests** for `styleMatches` catastrophic backtracking guards

## Backport adaptations

- Resolved merge conflict in test imports
- Replaced `List.of()` (Java 9+) with `Collections.singletonList()` / `Arrays.asList()` for Java 8 compatibility
- Applied spotless formatting
- Preserved 3.x-specific code (copyright headers, null checks, method visibility)