### PR TITLE
fix: look up openpty in libc.so.6 for glibc 2.34+ (backport)

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -494,6 +494,19 @@ class CLibrary {
                     }
                 }
             }
+            // On glibc 2.34+, openpty was merged from libutil into libc.so.6.
+            // SymbolLookup.libraryLookup searches all exported symbols in the specified
+            // library, unlike defaultLookup() which only exposes C standard symbols.
+            if (openPtyAddr.isEmpty() && OSUtils.IS_LINUX) {
+                try {
+                    SymbolLookup libcLookup = SymbolLookup.libraryLookup("libc.so.6", Arena.global());
+                    openPtyAddr = libcLookup.find("openpty");
+                } catch (Throwable t) {
+                    suppressed.add(t);
+                }
+            }
+            // On older glibc (< 2.34), openpty is in a separate libutil.so.
+            // Search for versioned libutil.so.* files in the Debian/Ubuntu multiarch path.
             if (openPtyAddr.isEmpty() && OSUtils.IS_LINUX) {
                 String hwName;
                 try {


### PR DESCRIPTION
Backport of #2071 to the `jline-3.x` maintenance branch.

## Problem

On modern Linux distributions with glibc 2.34+ (Ubuntu 22.04+, Debian 12+, RHEL 9, Fedora 35+), the FFM terminal provider fails with:

```
Unable to find openpty native method in static libraries and unable to load the util library.
java.lang.UnsatisfiedLinkError: no util in java.library.path
```

Starting with glibc 2.34, `openpty` was merged from `libutil` into `libc.so.6` and the standalone `libutil.so` no longer exists.

## Fix

Add a fallback that uses `SymbolLookup.libraryLookup("libc.so.6", Arena.global())` to explicitly search for `openpty` in libc before attempting the `libutil` path.

Fixes #2068