### PR TITLE
fix: backport #2054 — drain buffered data before EOF in NonBlockingPumpInputStream

### DIFF
--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2002-2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class LineReaderEofTest {
+
+    @Test
+    @Timeout(10)
+    void eofWithExecProvider() throws Exception {
+        checkEof(TerminalBuilder.PROP_PROVIDER_EXEC);
+    }
+
+    @Test
+    @Timeout(10)
+    void eofWithDefaultProvider() throws Exception {
+        checkEof(null);
+    }
+
+    /**
+     * Tests that piped input is correctly read even when the input stream
+     * is already at EOF before readLine() is called. This simulates the
+     * scenario of {@code printf 'cmd1\ncmd2\n' | ssh host}.
+     * See https://github.com/jline/jline3/issues/2054
+     */
+    @Test
+    @Timeout(10)
+    void pipedInputReadBeforeEof() throws Exception {
+        checkPipedInput(null);
+    }
+
+    @Test
+    @Timeout(10)
+    void pipedInputReadBeforeEofWithExecProvider() throws Exception {
+        checkPipedInput(TerminalBuilder.PROP_PROVIDER_EXEC);
+    }
+
+    private void checkPipedInput(String providerType) throws Exception {
+        // Simulate piped input: all data written and stream closed before terminal reads.
+        // The CountDownLatch fires when the pump's read() returns -1, which is after
+        // all processInputBytes() calls — so all data is already in the buffer.
+        CountDownLatch inputEof = new CountDownLatch(1);
+        InputStream in = new ByteArrayInputStream("command1\ncommand2\n".getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public int read(byte[] b, int off, int len) {
+                int result = super.read(b, off, len);
+                if (result == -1) {
+                    inputEof.countDown();
+                }
+                return result;
+            }
+        };
+        ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+
+        TerminalBuilder builder = TerminalBuilder.builder().streams(in, out);
+        if (providerType != null) {
+            builder.providers(providerType);
+        }
+
+        Terminal terminal;
+        try {
+            terminal = builder.build();
+        } catch (Exception e) {
+            if (providerType == null) {
+                throw e;
+            }
+            assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
+            return;
+        }
+
+        try {
+            // Wait for the pump thread to observe EOF on the input stream,
+            // guaranteeing all data has been written to the terminal's buffer.
+            assertTrue(inputEof.await(5, TimeUnit.SECONDS), "Pump did not reach EOF within timeout");
+
+            LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
+            assertEquals("command1", lr.readLine());
+            assertEquals("command2", lr.readLine());
+            assertThrows(EndOfFileException.class, () -> lr.readLine());
+        } finally {
+            terminal.close();
+        }
+    }
+
+    private void checkEof(String providerType) throws Exception {
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write("hello\n".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+
+        TerminalBuilder builder = TerminalBuilder.builder().streams(in, out);
+        if (providerType != null) {
+            builder.providers(providerType);
+        }
+
+        Terminal terminal;
+        try {
+            terminal = builder.build();
+        } catch (Exception e) {
+            if (providerType == null) {
+                throw e;
+            }
+            assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
+            return;
+        }
+
+        try {
+            LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
+            assertEquals("hello", lr.readLine());
+            outIn.close();
+            // readLine() will block until the pump detects the closed pipe and signals EOF
+            assertThrows(EndOfFileException.class, () -> lr.readLine());
+        } finally {
+            terminal.close();
+        }
+    }
+}

--- a/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ExternalTerminal.java
@@ -302,14 +302,20 @@ public class ExternalTerminal extends LineDisciplineTerminal {
                 }
             }
         } catch (IOException e) {
-            processIOException(e);
+            // If the terminal is being shut down (doClose set the closed flag),
+            // the exception is expected and should not be propagated to readers.
+            // This avoids storing a ClosedException that would be rethrown by
+            // checkIoException() and bypass the configured close mode (e.g., warn).
+            if (!closed.get()) {
+                processIOException(e);
+            }
         } finally {
             synchronized (lock) {
                 pumpThread = null;
             }
         }
         try {
-            slaveInput.close();
+            slaveInputPipe.close();
         } catch (IOException e) {
             // ignore
         }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingPumpInputStream.java
@@ -24,6 +24,7 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
     private final OutputStream output;
 
     private boolean closed;
+    private boolean writerClosed;
 
     private IOException ioException;
 
@@ -46,7 +47,7 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
 
     private int wait(ByteBuffer buffer, long timeout) throws IOException {
         Timeout t = new Timeout(timeout);
-        while (!closed && !buffer.hasRemaining() && !t.elapsed()) {
+        while (!closed && !writerClosed && !buffer.hasRemaining() && !t.elapsed()) {
             // Wake up waiting readers/writers
             notifyAll();
             try {
@@ -57,7 +58,13 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
                 throw new InterruptedIOException();
             }
         }
-        return buffer.hasRemaining() ? 0 : closed ? EOF : READ_EXPIRED;
+        if (buffer.hasRemaining()) {
+            return 0;
+        } else if (closed || writerClosed) {
+            return EOF;
+        } else {
+            return READ_EXPIRED;
+        }
     }
 
     private static boolean rewind(ByteBuffer buffer, ByteBuffer other) {
@@ -131,6 +138,9 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
     }
 
     synchronized void write(byte[] cbuf, int off, int len) throws IOException {
+        if (writerClosed) {
+            throw new ClosedException();
+        }
         while (len > 0) {
             // Blocks until there is new space available for buffering or the
             // reader is closed.
@@ -153,6 +163,17 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
             // Notify readers
             notifyAll();
         }
+    }
+
+    /**
+     * Signals that the write side has been closed and no more data will be written.
+     * Any buffered data can still be read; reads will return {@link #EOF} only after
+     * all buffered data has been consumed. This is analogous to closing the write end
+     * of a Unix pipe: the read end drains remaining data before seeing EOF.
+     */
+    public synchronized void closeWriter() {
+        this.writerClosed = true;
+        notifyAll();
     }
 
     @Override
@@ -181,7 +202,7 @@ public class NonBlockingPumpInputStream extends NonBlockingInputStream {
 
         @Override
         public void close() throws IOException {
-            NonBlockingPumpInputStream.this.close();
+            NonBlockingPumpInputStream.this.closeWriter();
         }
     }
 }

--- a/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -176,5 +177,41 @@ public class NonBlockingTest {
             assertEquals(bytes[i], b, "Mismatch at " + i);
         }
         assertEquals(NonBlockingInputStream.READ_EXPIRED, is.read(100));
+    }
+
+    @Test
+    public void testPumpWriterCloseAllowsReadingBufferedData() throws IOException {
+        NonBlockingPumpInputStream nbis = new NonBlockingPumpInputStream();
+        nbis.getOutputStream().write(new byte[] {1, 2, 3});
+        nbis.getOutputStream().close(); // writer close — buffered data should still be readable
+        assertEquals(1, nbis.read(100, false));
+        assertEquals(2, nbis.read(100, false));
+        assertEquals(3, nbis.read(100, false));
+        assertEquals(NonBlockingInputStream.EOF, nbis.read(100, false));
+    }
+
+    @Test
+    public void testPumpWriterCloseReturnsEofWhenEmpty() throws IOException {
+        NonBlockingPumpInputStream nbis = new NonBlockingPumpInputStream();
+        nbis.getOutputStream().close();
+        assertEquals(NonBlockingInputStream.EOF, nbis.read(100, false));
+    }
+
+    @Test
+    public void testPumpWriterCloseRejectsSubsequentWrites() throws IOException {
+        NonBlockingPumpInputStream nbis = new NonBlockingPumpInputStream();
+        nbis.getOutputStream().close();
+        assertThrows(ClosedException.class, () -> nbis.getOutputStream().write(new byte[] {1}));
+    }
+
+    @Test
+    public void testPumpFullCloseStillThrowsOnRead() throws IOException {
+        NonBlockingPumpInputStream nbis = new NonBlockingPumpInputStream();
+        nbis.getOutputStream().write(new byte[] {1, 2, 3});
+        nbis.close(); // full close (read side)
+        // checkClosed() in read() should detect the closed state
+        // In WARN mode (3.x default) this logs but continues;
+        // the wait() sees closed=true and returns EOF
+        // In STRICT mode this throws ClosedException
     }
 }

--- a/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
+++ b/terminal/src/test/java/org/jline/utils/NonBlockingTest.java
@@ -205,13 +205,15 @@ public class NonBlockingTest {
     }
 
     @Test
-    public void testPumpFullCloseStillThrowsOnRead() throws IOException {
+    public void testPumpFullCloseReturnsEofInWarnMode() throws IOException {
         NonBlockingPumpInputStream nbis = new NonBlockingPumpInputStream();
         nbis.getOutputStream().write(new byte[] {1, 2, 3});
-        nbis.close(); // full close (read side)
-        // checkClosed() in read() should detect the closed state
-        // In WARN mode (3.x default) this logs but continues;
-        // the wait() sees closed=true and returns EOF
-        // In STRICT mode this throws ClosedException
+        nbis.close();
+        // Default close mode is WARN: checkClosed() logs but does not throw.
+        // Buffered data remains readable; EOF follows after drain.
+        assertEquals(1, nbis.read(100, false));
+        assertEquals(2, nbis.read(100, false));
+        assertEquals(3, nbis.read(100, false));
+        assertEquals(NonBlockingInputStream.EOF, nbis.read(100, false));
     }
 }


### PR DESCRIPTION
## Summary

Backport of #2063 to the `jline-3.x` branch.

- Adds writer-close semantics (`closeWriter()`) to `NonBlockingPumpInputStream` so the pump thread closes only the write side when input EOF is reached — buffered data remains readable
- Changes `ExternalTerminal.pump()` to call `slaveInputPipe.close()` (write side) instead of `slaveInput.close()` (read side)
- Guards `processIOException()` in the pump's catch block to suppress expected `ClosedException` during terminal shutdown

**Impact on 3.x:** In the default `WARN` close mode, this eliminates spurious "accessing a closed input stream" warnings when piped input is used. In `STRICT` mode, it fixes `EndOfFileException` being thrown before buffered commands are read.

Fixes #2054