### PR TITLE
fix: disable Read File command in nano restricted mode (backport #2055)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -2474,6 +2474,10 @@ public class Nano implements Editor {
     }
 
     void read() {
+        if (restricted) {
+            setMessage("This function is disabled in restricted mode");
+            return;
+        }
         KeyMap<Operation> readKeyMap = new KeyMap<>();
         readKeyMap.setUnicode(Operation.INSERT);
         for (char i = 32; i < 256; i++) {
@@ -2732,7 +2736,9 @@ public class Nano implements Editor {
         if (!view) {
             s.put("^O", "WriteOut");
         }
-        s.put("^R", "Read File");
+        if (!restricted) {
+            s.put("^R", "Read File");
+        }
         s.put("^Y", "Prev Page");
         if (!view) {
             s.put("^K", "Cut Text");

--- a/builtins/src/test/java/org/jline/builtins/NanoTest.java
+++ b/builtins/src/test/java/org/jline/builtins/NanoTest.java
@@ -10,13 +10,19 @@ package org.jline.builtins;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.jline.keymap.KeyMap;
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.InputFlag;
 import org.jline.terminal.Size;
 import org.jline.terminal.impl.LineDisciplineTerminal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class NanoTest {
 
@@ -37,5 +43,45 @@ public class NanoTest {
                 Paths.get("target/test.txt"),
                 Options.compile(Nano.usage()).parse(argv));
         nano.run();
+    }
+
+    @Test
+    @Timeout(10)
+    public void restrictedModeDoesNotReadArbitraryFiles() throws Exception {
+        Path root = Files.createTempDirectory("nano-restricted-root");
+        Path secret = Files.createTempFile("nano-restricted-secret", ".txt");
+        String marker = "SECRET_OUTSIDE_ROOT_a1b2c3d4";
+        Files.write(secret, marker.getBytes(StandardCharsets.UTF_8));
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            LineDisciplineTerminal terminal =
+                    new LineDisciplineTerminal("nano", "xterm", output, StandardCharsets.UTF_8);
+            terminal.setSize(new Size(80, 25));
+            // Deliver Enter as a raw CR (nano runs in raw mode; avoid CR->NL translation)
+            Attributes attrs = terminal.getAttributes();
+            attrs.setInputFlag(InputFlag.ICRNL, false);
+            terminal.setAttributes(attrs);
+            // ^R (Read File), type an absolute path escaping the root, accept
+            terminal.processInputByte(KeyMap.ctrl('R').getBytes()[0]);
+            for (byte b : secret.toAbsolutePath().toString().getBytes(StandardCharsets.UTF_8)) {
+                terminal.processInputByte(b);
+            }
+            terminal.processInputByte('\r');
+            // Quit both the (possibly opened) buffer and the original one, discarding changes
+            terminal.processInputByte(KeyMap.ctrl('X').getBytes()[0]);
+            terminal.processInputByte('n');
+            terminal.processInputByte(KeyMap.ctrl('X').getBytes()[0]);
+            terminal.processInputByte('n');
+            String[] argv = {"--ignorercfiles", "--restricted"};
+            Nano nano = new Nano(terminal, root, Options.compile(Nano.usage()).parse(argv));
+            nano.run();
+            terminal.close();
+            assertFalse(
+                    output.toString(StandardCharsets.UTF_8.name()).contains(marker),
+                    "restricted mode must not read files outside the specified one");
+        } finally {
+            Files.deleteIfExists(secret);
+            Files.deleteIfExists(root);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Backport of #2055 to jline-3.x.

- Gate `read()` on the `restricted` flag — `^R` is a no-op in restricted mode, showing "This function is disabled in restricted mode"
- Hide the `^R` shortcut from the bar when restricted mode is active
- Add test verifying restricted mode blocks reading arbitrary files

Restricted mode (`-R`, `rnano`) already blocks writing to another file, but the Read File command (`^R`) was never gated. A user confined to editing one file could read any file the process can access via `^R /etc/passwd <Enter>`.

## Test plan

- [x] `NanoTest#restrictedModeDoesNotReadArbitraryFiles` passes — confirms `^R` cannot read files outside the root in restricted mode
- [x] `NanoTest#nanoBufferLineOverflow` still passes — existing test unaffected
- [ ] CI passes on jline-3.x