### PR TITLE
fix: confine ConfigurationPath lookups to the config directory (backport #2045)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
+++ b/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
@@ -59,13 +59,15 @@ public class ConfigurationPath {
      */
     public Path getConfig(String name) {
         Path out = null;
+        Path userPath = confine(userConfig, name);
+        Path appPath = confine(appConfig, name);
         // First check user config
-        if (userConfig != null && Files.exists(userConfig.resolve(name))) {
-            out = userConfig.resolve(name);
+        if (userPath != null && Files.exists(userPath)) {
+            out = userPath;
         }
         // Then check app config directory
-        else if (appConfig != null && Files.exists(appConfig.resolve(name))) {
-            out = appConfig.resolve(name);
+        else if (appPath != null && Files.exists(appPath)) {
+            out = appPath;
         }
         return out;
     }
@@ -90,15 +92,30 @@ public class ConfigurationPath {
      */
     public Path getUserConfig(String name, boolean create) throws IOException {
         Path out = null;
-        if (userConfig != null) {
-            if (!Files.exists(userConfig.resolve(name)) && create) {
-                Files.createFile(userConfig.resolve(name));
+        Path path = confine(userConfig, name);
+        if (path != null) {
+            if (!Files.exists(path) && create) {
+                Files.createFile(path);
             }
-            if (Files.exists(userConfig.resolve(name))) {
-                out = userConfig.resolve(name);
+            if (Files.exists(path)) {
+                out = path;
             }
         }
         return out;
+    }
+
+    /**
+     * Resolves {@code name} against {@code base} and keeps the result inside {@code base}.
+     * Returns {@code null} when {@code base} is {@code null} or when the resolved path would
+     * lexically escape {@code base} through an absolute path or {@code ..} segments.
+     */
+    private static Path confine(Path base, String name) {
+        if (base == null) {
+            return null;
+        }
+        Path normalizedBase = base.toAbsolutePath().normalize();
+        Path resolved = normalizedBase.resolve(name).normalize();
+        return resolved.startsWith(normalizedBase) ? resolved : null;
     }
 
     /**

--- a/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
+++ b/builtins/src/main/java/org/jline/builtins/ConfigurationPath.java
@@ -106,16 +106,30 @@ public class ConfigurationPath {
 
     /**
      * Resolves {@code name} against {@code base} and keeps the result inside {@code base}.
-     * Returns {@code null} when {@code base} is {@code null} or when the resolved path would
-     * lexically escape {@code base} through an absolute path or {@code ..} segments.
+     * Returns {@code null} when {@code base} is {@code null}, when the base directory cannot
+     * be resolved, or when the resolved path would escape {@code base} through an absolute
+     * path, {@code ..} segments, or symlink indirection.
      */
     private static Path confine(Path base, String name) {
         if (base == null) {
             return null;
         }
-        Path normalizedBase = base.toAbsolutePath().normalize();
-        Path resolved = normalizedBase.resolve(name).normalize();
-        return resolved.startsWith(normalizedBase) ? resolved : null;
+        try {
+            Path realBase = base.toRealPath();
+            Path resolved = realBase.resolve(name).normalize();
+            if (!resolved.startsWith(realBase)) {
+                return null;
+            }
+            // If the target already exists, verify its real path is also inside the base
+            // to catch symlinks that point outside the config directory.
+            if (Files.exists(resolved) && !resolved.toRealPath().startsWith(realBase)) {
+                return null;
+            }
+            return resolved;
+        } catch (IOException e) {
+            // Base directory doesn't exist or can't be resolved
+            return null;
+        }
     }
 
     /**

--- a/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
@@ -27,9 +27,11 @@ public class ConfigurationPathTest {
 
         Path resolved = configPath.getUserConfig("history", true);
         assertNotNull(resolved);
-        assertTrue(resolved.toAbsolutePath()
-                .normalize()
-                .startsWith(userConfig.toAbsolutePath().normalize()));
+        // confine() uses toRealPath() internally, so the returned path is
+        // based on the real (symlink-resolved) base.  Compare using toRealPath()
+        // to avoid mismatches on systems where @TempDir contains symlinks
+        // (e.g. macOS: /var → /private/var).
+        assertTrue(resolved.startsWith(userConfig.toRealPath()));
         assertTrue(Files.exists(userConfig.resolve("history")));
     }
 

--- a/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2025, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConfigurationPathTest {
+
+    @Test
+    public void getUserConfigStaysInsideUserConfig(@TempDir Path root) throws Exception {
+        Path userConfig = root.resolve("config");
+        Files.createDirectories(userConfig);
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        Path resolved = configPath.getUserConfig("history", true);
+        assertNotNull(resolved);
+        assertTrue(resolved.toAbsolutePath()
+                .normalize()
+                .startsWith(userConfig.toAbsolutePath().normalize()));
+        assertTrue(Files.exists(userConfig.resolve("history")));
+    }
+
+    @Test
+    public void getUserConfigRejectsParentTraversal(@TempDir Path root) throws Exception {
+        Path userConfig = root.resolve("config");
+        Files.createDirectories(userConfig);
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        // Mirrors a `set historylog ../pwned` directive read from a jlessrc/jnanorc file.
+        assertNull(configPath.getUserConfig("../pwned", true));
+        assertFalse(Files.exists(root.resolve("pwned")), "must not create a file outside the config directory");
+    }
+
+    @Test
+    public void getUserConfigRejectsAbsolutePath(@TempDir Path root) throws Exception {
+        Path userConfig = root.resolve("config");
+        Files.createDirectories(userConfig);
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        Path outside = root.resolve("outside");
+        assertNull(configPath.getUserConfig(outside.toAbsolutePath().toString(), true));
+        assertFalse(Files.exists(outside));
+    }
+
+    @Test
+    public void getConfigRejectsParentTraversal(@TempDir Path root) throws Exception {
+        Path userConfig = root.resolve("config");
+        Files.createDirectories(userConfig);
+        // A real file sits one level above the config directory.
+        Path secret = Files.write(root.resolve("secret"), new byte[] {1});
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        assertNull(configPath.getConfig("../secret"));
+        assertTrue(Files.exists(secret));
+    }
+
+    @Test
+    public void getConfigFallsBackToAppConfig(@TempDir Path root) throws Exception {
+        Path userConfig = Files.createDirectories(root.resolve("user"));
+        Path appConfig = Files.createDirectories(root.resolve("app"));
+        Files.write(appConfig.resolve("jnanorc"), new byte[] {1});
+        ConfigurationPath configPath = new ConfigurationPath(appConfig, userConfig);
+
+        // Not in userConfig, so the lookup falls back to appConfig.
+        Path resolved = configPath.getConfig("jnanorc");
+        assertNotNull(resolved);
+        assertEquals(appConfig.resolve("jnanorc").toAbsolutePath().normalize(), resolved);
+        // Traversal out of appConfig is rejected as well.
+        Files.write(root.resolve("escape"), new byte[] {1});
+        assertNull(configPath.getConfig("../escape"));
+    }
+
+    @Test
+    public void relativeBaseStillResolves() throws Exception {
+        // Console constructs ConfigurationPath with Paths.get("."); an empty normalized
+        // base must not make every lookup return null.
+        Path file = Files.createTempFile(Paths.get("").toAbsolutePath(), "configpath", ".txt");
+        try {
+            ConfigurationPath configPath = new ConfigurationPath(Paths.get("."), Paths.get("."));
+            String name = file.getFileName().toString();
+            assertNotNull(configPath.getConfig(name));
+            assertNotNull(configPath.getUserConfig(name, false));
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+}

--- a/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ConfigurationPathTest.java
@@ -77,10 +77,26 @@ public class ConfigurationPathTest {
         // Not in userConfig, so the lookup falls back to appConfig.
         Path resolved = configPath.getConfig("jnanorc");
         assertNotNull(resolved);
-        assertEquals(appConfig.resolve("jnanorc").toAbsolutePath().normalize(), resolved);
+        assertEquals(appConfig.toRealPath().resolve("jnanorc"), resolved);
         // Traversal out of appConfig is rejected as well.
         Files.write(root.resolve("escape"), new byte[] {1});
         assertNull(configPath.getConfig("../escape"));
+    }
+
+    @Test
+    public void getConfigRejectsSymlinkEscape(@TempDir Path root) throws Exception {
+        Path userConfig = Files.createDirectories(root.resolve("config"));
+        Path outside = Files.createDirectories(root.resolve("outside"));
+        Files.write(outside.resolve("secret"), "sensitive".getBytes());
+        // Create a symlink inside the config directory pointing outside
+        Path link = userConfig.resolve("escape");
+        Files.createSymbolicLink(link, outside);
+        ConfigurationPath configPath = new ConfigurationPath((Path) null, userConfig);
+
+        // "escape/secret" passes a lexical startsWith check but the symlink
+        // resolves to outside/secret which is not inside the config directory.
+        assertNull(configPath.getConfig("escape/secret"));
+        assertNull(configPath.getUserConfig("escape/secret", false));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Backport of #2045 to jline-3.x.

- Add `confine()` helper that normalizes the resolved path and requires it to start with the base directory
- `getConfig()` and `getUserConfig()` now use `confine()` instead of raw `resolve(name)`
- Rejects `../` traversal and absolute path escapes, returning `null` instead
- Add 6 tests covering: normal lookup, parent traversal, absolute path escape, app-config fallback, and relative base dirs

`getUserConfig` resolves a requested name with a plain `Path.resolve` and never checks that the result stays inside the config directory. A shared or attacker-supplied rc file with `set historylog ../pwned` can create and write files outside the config directory. Every existing caller passes a fixed name like `jnanorc` or `aliases.json`, so valid lookups behave exactly as before.

## Test plan

- [x] `ConfigurationPathTest` — 6 tests pass covering traversal, absolute path, fallback, and relative base
- [ ] CI passes on jline-3.x