### PR TITLE
cleanup: safer process stream handling in ExecHelper

### DIFF
--- a/terminal/src/main/java/org/jline/utils/ExecHelper.java
+++ b/terminal/src/main/java/org/jline/utils/ExecHelper.java
@@ -9,7 +9,6 @@
 package org.jline.utils;
 
 import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -78,37 +77,18 @@ public final class ExecHelper {
 
     public static String waitAndCapture(Process p) throws IOException, InterruptedException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        InputStream in = null;
-        InputStream err = null;
-        OutputStream out = null;
-        try {
+        try (InputStream in = p.getInputStream();
+                InputStream err = p.getErrorStream();
+                OutputStream out = p.getOutputStream()) {
             int c;
-            in = p.getInputStream();
             while ((c = in.read()) != -1) {
                 bout.write(c);
             }
-            err = p.getErrorStream();
             while ((c = err.read()) != -1) {
                 bout.write(c);
             }
-            out = p.getOutputStream();
             p.waitFor();
-        } finally {
-            close(in, out, err);
         }
-
         return bout.toString();
-    }
-
-    private static void close(final Closeable... closeables) {
-        for (Closeable c : closeables) {
-            if (c != null) {
-                try {
-                    c.close();
-                } catch (Exception e) {
-                    // Ignore
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Use try-with-resources in `waitAndCapture()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved process output handling and resource cleanup.
  * Preserved existing behavior for capturing standard output and error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->