### PR TITLE
fix: check closed flag in PtyInputStream to prevent hang on empty input

### DIFF
--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -127,7 +127,17 @@ class LineReaderEofTest {
     }
 
     private void checkEmptyInput(String providerType) throws Exception {
-        InputStream in = new ByteArrayInputStream(new byte[0]);
+        CountDownLatch inputEof = new CountDownLatch(1);
+        InputStream in = new ByteArrayInputStream(new byte[0]) {
+            @Override
+            public int read(byte[] b, int off, int len) {
+                int result = super.read(b, off, len);
+                if (result == -1) {
+                    inputEof.countDown();
+                }
+                return result;
+            }
+        };
         ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
 
         TerminalBuilder builder = TerminalBuilder.builder().streams(in, out);
@@ -147,9 +157,10 @@ class LineReaderEofTest {
         }
 
         try {
+            // Wait for the pump thread to observe EOF on the empty stream
+            assertTrue(inputEof.await(5, TimeUnit.SECONDS), "Pump did not reach EOF within timeout");
+
             LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
-            // Give pumpIn thread time to detect EOF on the empty stream
-            Thread.sleep(200);
             assertThrows(EndOfFileException.class, () -> lr.readLine());
         } finally {
             terminal.close();

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -109,6 +109,53 @@ class LineReaderEofTest {
         }
     }
 
+    /**
+     * Tests that an empty input stream causes readLine() to throw
+     * EndOfFileException rather than blocking forever.
+     * See https://github.com/jline/jline3/issues/2077
+     */
+    @Test
+    @Timeout(10)
+    void emptyInputStreamThrowsEof() throws Exception {
+        checkEmptyInput(null);
+    }
+
+    @Test
+    @Timeout(10)
+    void emptyInputStreamThrowsEofWithExecProvider() throws Exception {
+        checkEmptyInput(TerminalBuilder.PROP_PROVIDER_EXEC);
+    }
+
+    private void checkEmptyInput(String providerType) throws Exception {
+        InputStream in = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+
+        TerminalBuilder builder = TerminalBuilder.builder().streams(in, out);
+        if (providerType != null) {
+            builder.providers(providerType);
+        }
+
+        Terminal terminal;
+        try {
+            terminal = builder.build();
+        } catch (Exception e) {
+            if (providerType == null) {
+                throw e;
+            }
+            assumeTrue(false, "Provider '" + providerType + "' not available: " + e.getMessage());
+            return;
+        }
+
+        try {
+            LineReader lr = LineReaderBuilder.builder().terminal(terminal).build();
+            // Give pumpIn thread time to detect EOF on the empty stream
+            Thread.sleep(200);
+            assertThrows(EndOfFileException.class, () -> lr.readLine());
+        } finally {
+            terminal.close();
+        }
+    }
+
     private void checkEof(String providerType) throws Exception {
         PipedInputStream in = new PipedInputStream();
         PipedOutputStream outIn = new PipedOutputStream(in);

--- a/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/LineReaderEofTest.java
@@ -64,10 +64,21 @@ class LineReaderEofTest {
 
     private void checkPipedInput(String providerType) throws Exception {
         // Simulate piped input: all data written and stream closed before terminal reads.
-        // The CountDownLatch fires when the pump's read() returns -1, which is after
-        // all processInputBytes() calls — so all data is already in the buffer.
+        // The CountDownLatch fires when any read method returns -1 (EOF), which is after
+        // all data has been pumped to the terminal's buffer.
+        // PosixPtyTerminal's pumpIn calls read() (no-arg), while ExternalTerminal's
+        // pump may call read(byte[], int, int), so both must be overridden.
         CountDownLatch inputEof = new CountDownLatch(1);
         InputStream in = new ByteArrayInputStream("command1\ncommand2\n".getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public synchronized int read() {
+                int result = super.read();
+                if (result == -1) {
+                    inputEof.countDown();
+                }
+                return result;
+            }
+
             @Override
             public int read(byte[] b, int off, int len) {
                 int result = super.read(b, off, len);
@@ -129,6 +140,15 @@ class LineReaderEofTest {
     private void checkEmptyInput(String providerType) throws Exception {
         CountDownLatch inputEof = new CountDownLatch(1);
         InputStream in = new ByteArrayInputStream(new byte[0]) {
+            @Override
+            public synchronized int read() {
+                int result = super.read();
+                if (result == -1) {
+                    inputEof.countDown();
+                }
+                return result;
+            }
+
             @Override
             public int read(byte[] b, int off, int len) {
                 int result = super.read(b, off, len);

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -137,6 +137,11 @@ public abstract class AbstractPty implements Pty {
 
         @Override
         public int read(long timeout, boolean isPeek) throws IOException {
+            // Check if the stream was closed (e.g., by pumpIn after detecting EOF
+            // on the user's input stream). Return EOF so the caller can handle it.
+            if (closed) {
+                return -1;
+            }
             checkInterrupted();
             if (c != 0) {
                 int r = c;
@@ -148,6 +153,11 @@ public abstract class AbstractPty implements Pty {
                 setNonBlocking();
                 long start = System.nanoTime();
                 while (true) {
+                    // Re-check closed inside the loop: pumpIn may close
+                    // the stream while we are retrying after a VTIME timeout.
+                    if (closed) {
+                        return -1;
+                    }
                     long readStart = System.nanoTime();
                     int r = in.read();
                     if (r >= 0) {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -137,11 +137,6 @@ public abstract class AbstractPty implements Pty {
 
         @Override
         public int read(long timeout, boolean isPeek) throws IOException {
-            // Check if the stream was closed (e.g., by pumpIn after detecting EOF
-            // on the user's input stream). Return EOF so the caller can handle it.
-            if (closed) {
-                return -1;
-            }
             checkInterrupted();
             if (c != 0) {
                 int r = c;
@@ -153,11 +148,6 @@ public abstract class AbstractPty implements Pty {
                 setNonBlocking();
                 long start = System.nanoTime();
                 while (true) {
-                    // Re-check closed inside the loop: pumpIn may close
-                    // the stream while we are retrying after a VTIME timeout.
-                    if (closed) {
-                        return -1;
-                    }
                     long readStart = System.nanoTime();
                     int r = in.read();
                     if (r >= 0) {
@@ -167,6 +157,16 @@ public abstract class AbstractPty implements Pty {
                         return r;
                     }
                     // r == -1: could be real EOF or VMIN=0/VTIME=1 timeout on a real PTY.
+                    // Check the closed flag first: if pumpIn has already closed this
+                    // stream after detecting EOF on the user's input, then this -1 is
+                    // a real EOF, not a VTIME timeout.  We must check this *after*
+                    // in.read() so that any data buffered in the PTY slave is drained
+                    // before we report EOF.  Checking before in.read() would discard
+                    // buffered data because pumpIn may close the stream while the PTY
+                    // kernel still holds unread bytes on the slave side.
+                    if (closed) {
+                        return -1;
+                    }
                     // With VTIME=1 (100ms), a timeout takes ~100ms to return -1.
                     // Real EOF (pipe closed, PTY slave closed) returns -1 instantly.
                     long readElapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - readStart);

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
@@ -8,7 +8,9 @@
  */
 package org.jline.terminal.impl;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -68,25 +70,71 @@ class PtyInputStreamTest {
      * Tests that PtyInputStream.read() returns EOF when the stream has been
      * closed externally (e.g., by pumpIn() after detecting EOF on the user's
      * input stream). This is the fix for #2077.
+     *
+     * <p>Uses a custom InputStream that simulates VTIME=1 behavior on a real
+     * PTY: returning -1 after ~100ms when no data is available.  Without the
+     * closed-flag check inside the retry loop, the VTIME timing heuristic
+     * (readElapsed &ge; 50ms) would cause PtyInputStream to retry forever.</p>
      */
     @Test
     @Timeout(10)
     void readReturnsEofAfterClose() throws Exception {
+        // Simulate a PTY slave with VTIME=1: returns -1 after ~100ms when no
+        // data is available.  A plain PipedInputStream can't be used here
+        // because it blocks indefinitely (it doesn't respect VMIN/VTIME).
+        InputStream vtimeStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new InterruptedIOException();
+                }
+                return -1;
+            }
+        };
+
+        NonBlockingInputStream nbis = createPtyInputStream(vtimeStream);
+
+        // Simulate what pumpIn() does when it detects EOF: close the PtyInputStream.
+        nbis.close();
+
+        // Without the closed-flag check after in.read(), this would loop forever
+        // because the VTIME-like delay (100ms > 50ms) prevents the timing heuristic
+        // from detecting it as real EOF.
+        int result = nbis.read(5000);
+        assertEquals(-1, result, "Expected EOF (-1) after stream closed");
+    }
+
+    /**
+     * Tests that PtyInputStream drains buffered data even after the stream
+     * has been closed (e.g., by pumpIn).  The closed flag must only take
+     * effect after in.read() returns -1, not before reading.
+     */
+    @Test
+    @Timeout(10)
+    void readDrainsDataBeforeReportingEof() throws Exception {
         PipedInputStream pipedIn = new PipedInputStream();
-        // Keep the pipe open so the timing heuristic alone won't detect EOF
         PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
 
         NonBlockingInputStream nbis = createPtyInputStream(pipedIn);
 
-        // Simulate what pumpIn() does when it detects EOF: close the PtyInputStream
+        // Write data then close the pipe (simulates data already in PTY buffer)
+        pipedOut.write('X');
+        pipedOut.write('Y');
+        pipedOut.close();
+
+        // Close the PtyInputStream (simulates pumpIn closing after EOF)
         nbis.close();
 
-        // Without the closed-flag check, this would block on the pipe read forever.
-        // With the fix, it returns EOF (-1) immediately.
-        int result = nbis.read(1000);
-        assertEquals(-1, result, "Expected EOF (-1) after stream closed");
+        // Data must still be readable despite closed flag being set
+        assertEquals('X', nbis.read(1000), "First byte should be readable after close");
+        assertEquals('Y', nbis.read(1000), "Second byte should be readable after close");
 
-        pipedOut.close();
+        // After data is drained, EOF should be returned
+        int eof = nbis.read(1000);
+        assertEquals(-1, eof, "Expected EOF (-1) after all data drained");
     }
 
     private NonBlockingInputStream createPtyInputStream(InputStream slaveInput) throws Exception {

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
@@ -50,50 +50,7 @@ class PtyInputStreamTest {
         PipedInputStream pipedIn = new PipedInputStream();
         PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
 
-        AbstractPty pty = new AbstractPty(null, null) {
-            @Override
-            protected void doSetAttr(Attributes attr) {}
-
-            @Override
-            protected InputStream doGetSlaveInput() {
-                return pipedIn;
-            }
-
-            @Override
-            public InputStream getMasterInput() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public OutputStream getMasterOutput() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public OutputStream getSlaveOutput() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public Attributes getAttr() {
-                return new Attributes();
-            }
-
-            @Override
-            public Size getSize() {
-                return new Size(80, 24);
-            }
-
-            @Override
-            public void setSize(Size size) {}
-
-            @Override
-            public void close() {}
-        };
-
-        InputStream slaveInput = pty.getSlaveInput();
-        assertTrue(slaveInput instanceof NonBlockingInputStream);
-        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+        NonBlockingInputStream nbis = createPtyInputStream(pipedIn);
 
         pipedOut.write('A');
         pipedOut.close();
@@ -119,13 +76,27 @@ class PtyInputStreamTest {
         // Keep the pipe open so the timing heuristic alone won't detect EOF
         PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
 
+        NonBlockingInputStream nbis = createPtyInputStream(pipedIn);
+
+        // Simulate what pumpIn() does when it detects EOF: close the PtyInputStream
+        nbis.close();
+
+        // Without the closed-flag check, this would block on the pipe read forever.
+        // With the fix, it returns EOF (-1) immediately.
+        int result = nbis.read(1000);
+        assertEquals(-1, result, "Expected EOF (-1) after stream closed");
+
+        pipedOut.close();
+    }
+
+    private NonBlockingInputStream createPtyInputStream(InputStream slaveInput) throws Exception {
         AbstractPty pty = new AbstractPty(null, null) {
             @Override
             protected void doSetAttr(Attributes attr) {}
 
             @Override
             protected InputStream doGetSlaveInput() {
-                return pipedIn;
+                return slaveInput;
             }
 
             @Override
@@ -160,18 +131,8 @@ class PtyInputStreamTest {
             public void close() {}
         };
 
-        InputStream slaveInput = pty.getSlaveInput();
-        assertTrue(slaveInput instanceof NonBlockingInputStream);
-        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
-
-        // Simulate what pumpIn() does when it detects EOF: close the PtyInputStream
-        nbis.close();
-
-        // Without the closed-flag check, this would block on the pipe read forever.
-        // With the fix, it returns EOF (-1) immediately.
-        int result = nbis.read(1000);
-        assertEquals(-1, result, "Expected EOF (-1) after stream closed");
-
-        pipedOut.close();
+        InputStream input = pty.getSlaveInput();
+        assertTrue(input instanceof NonBlockingInputStream);
+        return (NonBlockingInputStream) input;
     }
 }

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamTest.java
@@ -106,4 +106,72 @@ class PtyInputStreamTest {
         int eof = nbis.read(1000);
         assertEquals(-1, eof, "Expected EOF (-1) after pipe closed");
     }
+
+    /**
+     * Tests that PtyInputStream.read() returns EOF when the stream has been
+     * closed externally (e.g., by pumpIn() after detecting EOF on the user's
+     * input stream). This is the fix for #2077.
+     */
+    @Test
+    @Timeout(10)
+    void readReturnsEofAfterClose() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        // Keep the pipe open so the timing heuristic alone won't detect EOF
+        PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
+
+        AbstractPty pty = new AbstractPty(null, null) {
+            @Override
+            protected void doSetAttr(Attributes attr) {}
+
+            @Override
+            protected InputStream doGetSlaveInput() {
+                return pipedIn;
+            }
+
+            @Override
+            public InputStream getMasterInput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getMasterOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getSlaveOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Attributes getAttr() {
+                return new Attributes();
+            }
+
+            @Override
+            public Size getSize() {
+                return new Size(80, 24);
+            }
+
+            @Override
+            public void setSize(Size size) {}
+
+            @Override
+            public void close() {}
+        };
+
+        InputStream slaveInput = pty.getSlaveInput();
+        assertTrue(slaveInput instanceof NonBlockingInputStream);
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        // Simulate what pumpIn() does when it detects EOF: close the PtyInputStream
+        nbis.close();
+
+        // Without the closed-flag check, this would block on the pipe read forever.
+        // With the fix, it returns EOF (-1) immediately.
+        int result = nbis.read(1000);
+        assertEquals(-1, result, "Expected EOF (-1) after stream closed");
+
+        pipedOut.close();
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #2077.

When a terminal is built with an empty `InputStream` via `.streams()`, `readLine()` blocks forever instead of throwing `EndOfFileException`. The `pumpIn` thread correctly detects EOF on the user's stream and closes the `PtyInputStream`, but `PtyInputStream.read()` never checked the `closed` flag — it continued retrying the PTY slave read, which returns -1 after ~100ms (VTIME timeout), and the timing heuristic misinterpreted this as a retry-worthy timeout rather than real EOF.

### Root cause

The `PtyInputStream.read()` method on `jline-3.x` was missing a `closed` flag check that exists on `master` (4.x). On 4.x, `PtyInputStream.read()` calls `checkClosed()` which throws `ClosedException` in strict mode (the 4.x default). On 3.x, the default close mode is `WARN` (non-throwing), so this PR checks the `closed` flag directly and returns EOF (-1) instead.

### Changes

- **`AbstractPty.PtyInputStream.read()`**: Added `closed` flag checks both before entering the read loop and inside the VTIME retry loop (to handle the case where `pumpIn` closes the stream mid-iteration)
- **`PtyInputStreamTest`**: Added test that verifies `PtyInputStream.read()` returns EOF after the stream is closed
- **`LineReaderEofTest`**: Added tests for the empty input stream scenario (the reporter's exact reproducer) with both default and exec providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-of-file handling for terminal input streams after they are closed.
  * Prevented reads from blocking or retrying indefinitely after closure.
  * Ensured empty input immediately raises the expected end-of-file error.
  * Corrected EOF propagation after pipe input is closed.

* **Tests**
  * Added coverage for empty terminal input and closed-stream behavior across supported terminal providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->