### PR TITLE
chore: remove 4.0.x from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,18 +34,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "4.0.x"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "4.0.x"
-
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "daily"
     target-branch: "jline-3.x"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
The 4.0.x branch doesn't need its own Dependabot updates — dependency bumps land on master and get cherry-picked to 4.0.x as needed.

This removes the maven and github-actions Dependabot entries that target 4.0.x, keeping only master and jline-3.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configurations to target the `master` branch.
  * Preserved existing update configurations for the `jline-3.x` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->