### PR TITLE
fix: strip OSC and other escape sequences in ansiAppend

### DIFF
--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -755,7 +755,9 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
                     ansiState = 4; // possible ST: ESC \
                 }
             } else if (ansiState == 4) {
-                ansiState = 0; // consume the byte following ESC (the ST terminator)
+                ansiState = 0; // consume the byte after ESC inside the string sequence
+                // (treats any ESC as ending the sequence, matching xterm;
+                //  strictly only ESC \ is ST per ECMA-48)
             } else {
                 if (ansiState >= 1) {
                     ensureCapacity(length + 1);

--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -741,6 +741,21 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
                     // This is not a SGR code, so ignore
                     ansiState = 0;
                 }
+            } else if (ansiState == 1 && (c == ']' || c == 'P' || c == 'X' || c == '^' || c == '_')) {
+                // OSC (]), DCS (P), SOS (X), PM (^) or APC (_) introducer. These carry a string
+                // payload terminated by BEL or ST (ESC \) and can drive the terminal itself (set
+                // the window title, write the clipboard via OSC 52, ...). When the text is
+                // untrusted (a file shown in Less, a completion candidate) that payload must not
+                // reach the terminal, so drop the whole sequence instead of emitting it.
+                ansiState = 3;
+            } else if (ansiState == 3) {
+                if (c == 7) {
+                    ansiState = 0; // BEL terminates the string
+                } else if (c == 27) {
+                    ansiState = 4; // possible ST: ESC \
+                }
+            } else if (ansiState == 4) {
+                ansiState = 0; // consume the byte following ESC (the ST terminator)
             } else {
                 if (ansiState >= 1) {
                     ensureCapacity(length + 1);

--- a/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
@@ -110,6 +110,20 @@ class AttributedStringTest {
         assertEquals("xy", AttributedString.stripAnsi("x\033P1;2q\033\\y"));
         // APC terminated by ST
         assertEquals("z", AttributedString.stripAnsi("\033_payload\033\\z"));
+        // SOS terminated by ST
+        assertEquals("ab", AttributedString.stripAnsi("a\033Xpayload\033\\b"));
+        // PM terminated by ST
+        assertEquals("cd", AttributedString.stripAnsi("c\033^payload\033\\d"));
+    }
+
+    @Test
+    void stripAnsiConsumesUnterminatedStringSequence() {
+        // A string sequence with no BEL or ST terminator is consumed to the end of the
+        // input; the payload must not leak into the visible text.
+        assertEquals("pre", AttributedString.stripAnsi("pre\033]0;payload"));
+        assertEquals("pre", AttributedString.stripAnsi("pre\033Ppayload"));
+        // Trailing ESC inside the string (start of a potential ST) must not leak either
+        assertEquals("pre", AttributedString.stripAnsi("pre\033]0;payload\033"));
     }
 
     @Test

--- a/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
@@ -89,6 +89,38 @@ class AttributedStringTest {
     }
 
     @Test
+    void fromAnsiDropsOscInjection() {
+        // A window-title OSC (ESC ] 0 ; ... BEL) embedded in otherwise plain text must not
+        // survive into the rendered AttributedString. Otherwise showing an untrusted file or
+        // log in the pager would let it drive the terminal (set the title, write the clipboard
+        // via OSC 52, ...). The raw ESC also used to be counted as a visible column.
+        AttributedString s = AttributedString.fromAnsi("\033]0;pwned\007OK");
+        assertEquals("OK", s.toString());
+        assertEquals("OK", s.toAnsi());
+        assertEquals(2, s.columnLength());
+    }
+
+    @Test
+    void stripAnsiRemovesStringSequences() {
+        // OSC terminated by BEL
+        assertEquals("hello", AttributedString.stripAnsi("\033]0;title\007hello"));
+        // OSC 52 (clipboard) terminated by ST (ESC \)
+        assertEquals("AB", AttributedString.stripAnsi("A\033]52;c;ZXZpbA==\033\\B"));
+        // DCS terminated by ST
+        assertEquals("xy", AttributedString.stripAnsi("x\033P1;2q\033\\y"));
+        // APC terminated by ST
+        assertEquals("z", AttributedString.stripAnsi("\033_payload\033\\z"));
+    }
+
+    @Test
+    void fromAnsiKeepsSgrWhileDroppingOsc() {
+        // Dropping the OSC prefix must not disturb the SGR color styling that follows it.
+        AttributedString s = AttributedString.fromAnsi("\033]0;t\007\033[31mred\033[0m");
+        assertEquals("red", s.toString());
+        assertEquals("\033[31mred\033[0m", s.toAnsi());
+    }
+
+    @Test
     void testBoldThenFaint() {
         AttributedStringBuilder sb = new AttributedStringBuilder();
         sb.styled(AttributedStyle::bold, "bold ");


### PR DESCRIPTION
`stripAnsi` / `fromAnsi` of `\e]0;pwned\ahello`:

    before:  \e]0;pwned\ahello   (raw OSC survives, columnLength 11)
    after:   hello               (SGR styling still parsed as before)

`ansiAppend` parses SGR out of `ESC [ ... m` and drops other CSI, but for the C1 string
sequences (OSC `ESC ]`, DCS `ESC P`, SOS/PM/APC) it flushed the pending ESC straight into
the visible buffer, so the whole sequence survived in the result. `fromAnsi` and `stripAnsi`
both run over untrusted text (a file or log opened in the Less pager, a completion candidate
passed through `stripAnsi`), so an embedded OSC reached the terminal and could set the window
title or write the clipboard via OSC 52; the raw ESC was also counted as a visible column.

Consume OSC/DCS/SOS/PM/APC through their BEL or ST (`ESC \`) terminator and drop them, the
same way non-SGR CSI is already dropped. SGR styling and the enter/exit alt-charset handling
are unchanged; the added test covers both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ANSI parsing by suppressing embedded non-SGR control sequence payloads that could previously show up as visible text.
  * Ensures OSC, DCS, APC, SOS, and PM sequences are stripped whether terminated by BEL or by the standard string terminator.
  * Handles missing terminators safely by consuming the sequence without leaking trailing content, while preserving subsequent styling.
* **Tests**
  * Added coverage for injection and unterminated string-sequence stripping behavior, including verification that SGR styling remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->