### PR TITLE
fix: search multiple lib paths for versioned libutil.so

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -22,6 +22,7 @@ import java.lang.invoke.VarHandle;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -340,56 +341,8 @@ class CLibrary {
                 }
             }
             // On older glibc (< 2.34), openpty is in a separate libutil.so.
-            // Search for versioned libutil.so.* files in standard library paths.
-            // We search multiple directories because:
-            //   - Debian/Ubuntu multiarch: /usr/lib/<arch>-linux-gnu/ and /lib/<arch>-linux-gnu/
-            //     (on pre-usrmerge systems like Ubuntu 18, /lib is separate from /usr/lib)
-            //   - RHEL/Fedora/CentOS: /usr/lib64/ and /lib64/ (64-bit), /usr/lib/ and /lib/ (32-bit)
             if (openPtyAddr.isEmpty() && OSUtils.IS_LINUX) {
-                try {
-                    Process p = Runtime.getRuntime().exec(new String[] {"uname", "-m"});
-                    p.waitFor();
-                    try (InputStream in = p.getInputStream()) {
-                        String hwName = readFully(in).trim();
-                        String multiarchDir = hwName + "-linux-gnu";
-                        List<Path> searchDirs = new ArrayList<>();
-                        // Debian/Ubuntu multiarch paths
-                        searchDirs.add(Path.of("/usr/lib", multiarchDir));
-                        searchDirs.add(Path.of("/lib", multiarchDir));
-                        // RHEL/Fedora paths
-                        searchDirs.add(Path.of("/usr/lib64"));
-                        searchDirs.add(Path.of("/lib64"));
-                        // Generic fallback
-                        searchDirs.add(Path.of("/usr/lib"));
-                        searchDirs.add(Path.of("/lib"));
-                        for (Path libDir : searchDirs) {
-                            if (openPtyAddr.isPresent()) {
-                                break;
-                            }
-                            if (!Files.isDirectory(libDir)) {
-                                continue;
-                            }
-                            try (Stream<Path> stream = Files.list(libDir)) {
-                                List<Path> libs = stream.filter(
-                                                l -> l.getFileName().toString().startsWith("libutil.so."))
-                                        .collect(Collectors.toList());
-                                for (Path lib : libs) {
-                                    try {
-                                        System.load(lib.toString());
-                                        openPtyAddr = lookup.find("openpty");
-                                        if (openPtyAddr.isPresent()) {
-                                            break;
-                                        }
-                                    } catch (Throwable t) {
-                                        suppressed.add(t);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } catch (Throwable t) {
-                    suppressed.add(t);
-                }
+                openPtyAddr = findVersionedLibutil(lookup, suppressed);
             }
             if (openPtyAddr.isEmpty()) {
                 for (Throwable t : suppressed) {
@@ -429,6 +382,73 @@ class CLibrary {
             b.write(buf, 0, readLen);
         }
         return b.toString();
+    }
+
+    /**
+     * Searches for a versioned {@code libutil.so.*} in standard Linux library directories and
+     * returns the {@code openpty} symbol address if found.
+     *
+     * <p>Multiple directories are searched because the library location varies by distribution
+     * and by whether the system has completed the
+     * <a href="https://wiki.debian.org/UsrMerge">usrmerge</a>:
+     * <ul>
+     *   <li>Debian/Ubuntu multiarch: {@code /usr/lib/<arch>-linux-gnu/} and
+     *       {@code /lib/<arch>-linux-gnu/} (pre-usrmerge systems like Ubuntu 18 use {@code /lib})</li>
+     *   <li>RHEL/Fedora/CentOS 64-bit: {@code /usr/lib64/} and {@code /lib64/}</li>
+     *   <li>Generic fallback: {@code /usr/lib/} and {@code /lib/}</li>
+     * </ul>
+     *
+     * <p>Within each directory, versioned {@code libutil.so.*} files are tried in descending
+     * order (highest version first) so the newest library is preferred.
+     *
+     * @param lookup    the symbol lookup to query after loading the library
+     * @param suppressed list to collect any exceptions encountered during the search
+     * @return the {@code openpty} symbol address, or {@link Optional#empty()} if not found
+     */
+    private static Optional<MemorySegment> findVersionedLibutil(SymbolLookup lookup, List<Throwable> suppressed) {
+        try {
+            Process p = Runtime.getRuntime().exec(new String[] {"uname", "-m"});
+            p.waitFor();
+            try (InputStream in = p.getInputStream()) {
+                String hwName = readFully(in).trim();
+                String multiarchDir = hwName + "-linux-gnu";
+                List<Path> searchDirs = new ArrayList<>();
+                // Debian/Ubuntu multiarch paths
+                searchDirs.add(Path.of("/usr/lib", multiarchDir));
+                searchDirs.add(Path.of("/lib", multiarchDir));
+                // RHEL/Fedora paths
+                searchDirs.add(Path.of("/usr/lib64"));
+                searchDirs.add(Path.of("/lib64"));
+                // Generic fallback
+                searchDirs.add(Path.of("/usr/lib"));
+                searchDirs.add(Path.of("/lib"));
+                for (Path libDir : searchDirs) {
+                    if (!Files.isDirectory(libDir)) {
+                        continue;
+                    }
+                    try (Stream<Path> stream = Files.list(libDir)) {
+                        List<Path> libs = stream.filter(
+                                        l -> l.getFileName().toString().startsWith("libutil.so."))
+                                .sorted(Comparator.comparing(Path::getFileName).reversed())
+                                .collect(Collectors.toList());
+                        for (Path lib : libs) {
+                            try {
+                                System.load(lib.toString());
+                                Optional<MemorySegment> addr = lookup.find("openpty");
+                                if (addr.isPresent()) {
+                                    return addr;
+                                }
+                            } catch (Throwable t) {
+                                suppressed.add(t);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            suppressed.add(t);
+        }
+        return Optional.empty();
     }
 
     static Size getTerminalSize(int fd) {

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -406,47 +406,54 @@ class CLibrary {
      * @return the {@code openpty} symbol address, or {@link Optional#empty()} if not found
      */
     private static Optional<MemorySegment> findVersionedLibutil(SymbolLookup lookup, List<Throwable> suppressed) {
+        List<Path> searchDirs = new ArrayList<>();
+
+        // Detect architecture for Debian/Ubuntu multiarch paths.
+        // Isolated so that a uname failure doesn't prevent searching the
+        // architecture-independent paths (RHEL/Fedora, generic).
         try {
-            Process p = Runtime.getRuntime().exec(new String[] {"uname", "-m"});
-            p.waitFor();
+            Process p = new ProcessBuilder("uname", "-m").start();
             try (InputStream in = p.getInputStream()) {
                 String hwName = readFully(in).trim();
                 String multiarchDir = hwName + "-linux-gnu";
-                List<Path> searchDirs = new ArrayList<>();
                 // Debian/Ubuntu multiarch paths
                 searchDirs.add(Path.of("/usr/lib", multiarchDir));
                 searchDirs.add(Path.of("/lib", multiarchDir));
-                // RHEL/Fedora paths
-                searchDirs.add(Path.of("/usr/lib64"));
-                searchDirs.add(Path.of("/lib64"));
-                // Generic fallback
-                searchDirs.add(Path.of("/usr/lib"));
-                searchDirs.add(Path.of("/lib"));
-                for (Path libDir : searchDirs) {
-                    if (!Files.isDirectory(libDir)) {
-                        continue;
-                    }
-                    try (Stream<Path> stream = Files.list(libDir)) {
-                        List<Path> libs = stream.filter(
-                                        l -> l.getFileName().toString().startsWith("libutil.so."))
-                                .sorted(Comparator.comparing(Path::getFileName).reversed())
-                                .collect(Collectors.toList());
-                        for (Path lib : libs) {
-                            try {
-                                System.load(lib.toString());
-                                Optional<MemorySegment> addr = lookup.find("openpty");
-                                if (addr.isPresent()) {
-                                    return addr;
-                                }
-                            } catch (Throwable t) {
-                                suppressed.add(t);
-                            }
-                        }
-                    }
-                }
             }
+            p.waitFor();
         } catch (Throwable t) {
             suppressed.add(t);
+        }
+
+        // RHEL/Fedora paths
+        searchDirs.add(Path.of("/usr/lib64"));
+        searchDirs.add(Path.of("/lib64"));
+        // Generic fallback
+        searchDirs.add(Path.of("/usr/lib"));
+        searchDirs.add(Path.of("/lib"));
+
+        for (Path libDir : searchDirs) {
+            if (!Files.isDirectory(libDir)) {
+                continue;
+            }
+            try (Stream<Path> stream = Files.list(libDir)) {
+                List<Path> libs = stream.filter(l -> l.getFileName().toString().startsWith("libutil.so."))
+                        .sorted(Comparator.comparing(Path::getFileName).reversed())
+                        .collect(Collectors.toList());
+                for (Path lib : libs) {
+                    try {
+                        System.load(lib.toString());
+                        Optional<MemorySegment> addr = lookup.find("openpty");
+                        if (addr.isPresent()) {
+                            return addr;
+                        }
+                    } catch (Throwable t) {
+                        suppressed.add(t);
+                    }
+                }
+            } catch (Throwable t) {
+                suppressed.add(t);
+            }
         }
         return Optional.empty();
     }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -421,6 +421,9 @@ class CLibrary {
                 searchDirs.add(Path.of("/lib", multiarchDir));
             }
             p.waitFor();
+        } catch (InterruptedException t) {
+            Thread.currentThread().interrupt();
+            suppressed.add(t);
         } catch (Exception t) {
             suppressed.add(t);
         }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -421,7 +421,7 @@ class CLibrary {
                 searchDirs.add(Path.of("/lib", multiarchDir));
             }
             p.waitFor();
-        } catch (Throwable t) {
+        } catch (Exception t) {
             suppressed.add(t);
         }
 

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -412,7 +412,7 @@ class CLibrary {
         // Isolated so that a uname failure doesn't prevent searching the
         // architecture-independent paths (RHEL/Fedora, generic).
         try {
-            Process p = new ProcessBuilder("uname", "-m").start();
+            Process p = new ProcessBuilder("/usr/bin/uname", "-m").start();
             try (InputStream in = p.getInputStream()) {
                 String hwName = readFully(in).trim();
                 String multiarchDir = hwName + "-linux-gnu";

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -340,28 +340,49 @@ class CLibrary {
                 }
             }
             // On older glibc (< 2.34), openpty is in a separate libutil.so.
-            // Search for versioned libutil.so.* files in the Debian/Ubuntu multiarch path.
+            // Search for versioned libutil.so.* files in standard library paths.
+            // We search multiple directories because:
+            //   - Debian/Ubuntu multiarch: /usr/lib/<arch>-linux-gnu/ and /lib/<arch>-linux-gnu/
+            //     (on pre-usrmerge systems like Ubuntu 18, /lib is separate from /usr/lib)
+            //   - RHEL/Fedora/CentOS: /usr/lib64/ and /lib64/ (64-bit), /usr/lib/ and /lib/ (32-bit)
             if (openPtyAddr.isEmpty() && OSUtils.IS_LINUX) {
-                String hwName;
                 try {
                     Process p = Runtime.getRuntime().exec(new String[] {"uname", "-m"});
                     p.waitFor();
                     try (InputStream in = p.getInputStream()) {
-                        hwName = readFully(in).trim();
-                        Path libDir = Path.of("/usr/lib", hwName + "-linux-gnu");
-                        try (Stream<Path> stream = Files.list(libDir)) {
-                            List<Path> libs = stream.filter(
-                                            l -> l.getFileName().toString().startsWith("libutil.so."))
-                                    .collect(Collectors.toList());
-                            for (Path lib : libs) {
-                                try {
-                                    System.load(lib.toString());
-                                    openPtyAddr = lookup.find("openpty");
-                                    if (openPtyAddr.isPresent()) {
-                                        break;
+                        String hwName = readFully(in).trim();
+                        String multiarchDir = hwName + "-linux-gnu";
+                        List<Path> searchDirs = new ArrayList<>();
+                        // Debian/Ubuntu multiarch paths
+                        searchDirs.add(Path.of("/usr/lib", multiarchDir));
+                        searchDirs.add(Path.of("/lib", multiarchDir));
+                        // RHEL/Fedora paths
+                        searchDirs.add(Path.of("/usr/lib64"));
+                        searchDirs.add(Path.of("/lib64"));
+                        // Generic fallback
+                        searchDirs.add(Path.of("/usr/lib"));
+                        searchDirs.add(Path.of("/lib"));
+                        for (Path libDir : searchDirs) {
+                            if (openPtyAddr.isPresent()) {
+                                break;
+                            }
+                            if (!Files.isDirectory(libDir)) {
+                                continue;
+                            }
+                            try (Stream<Path> stream = Files.list(libDir)) {
+                                List<Path> libs = stream.filter(
+                                                l -> l.getFileName().toString().startsWith("libutil.so."))
+                                        .collect(Collectors.toList());
+                                for (Path lib : libs) {
+                                    try {
+                                        System.load(lib.toString());
+                                        openPtyAddr = lookup.find("openpty");
+                                        if (openPtyAddr.isPresent()) {
+                                            break;
+                                        }
+                                    } catch (Throwable t) {
+                                        suppressed.add(t);
                                     }
-                                } catch (Throwable t) {
-                                    suppressed.add(t);
                                 }
                             }
                         }


### PR DESCRIPTION
## Problem

The versioned `libutil.so.*` fallback search (step 6 in the `openpty` lookup chain) only looks in `/usr/lib/<arch>-linux-gnu/`. This fails on:

1. **Pre-usrmerge systems** (Ubuntu 18, older Debian) where the library lives in `/lib/<arch>-linux-gnu/` — the `/lib` → `/usr/lib` symlink only exists on systems that completed the [usrmerge](https://wiki.debian.org/UsrMerge) (Ubuntu 20+, Debian 12+).

2. **RHEL/Fedora/CentOS systems** where the library path is `/lib64/` or `/usr/lib64/`, not the Debian multiarch layout.

This addresses the concern raised by @BloodEko in https://github.com/jline/jline3/issues/2068#issuecomment-4962636292 and https://github.com/jline/jline3/issues/2068#issuecomment-4994858943 — the `libc.so.6` fix from #2071 only helps glibc 2.34+ (where `defaultLookup()` already works anyway), but doesn't fix the actual failure on older glibc systems where `libutil.so.1` exists but can't be found by the versioned search.

## Fix

Expand the versioned `libutil.so.*` search to cover multiple standard library directories:

| Path | Covers |
|---|---|
| `/usr/lib/<arch>-linux-gnu/` | Debian/Ubuntu multiarch (post-usrmerge) |
| `/lib/<arch>-linux-gnu/` | Debian/Ubuntu multiarch (pre-usrmerge, e.g. Ubuntu 18) |
| `/usr/lib64/` | RHEL/Fedora/CentOS 64-bit (post-usrmerge) |
| `/lib64/` | RHEL/Fedora/CentOS 64-bit (pre-usrmerge) |
| `/usr/lib/` | Generic fallback |
| `/lib/` | Generic fallback |

Directories that don't exist are skipped (`Files.isDirectory` check). The search stops as soon as `openpty` is found.

## Lookup chain after this change

1. Default lookup (`loaderLookup` + `defaultLookup`)
2. `System.loadLibrary("util")`
3. Custom path via `org.jline.ffm.libutil` system property
4. AIX: `System.loadLibrary("bsd")`
5. Linux: `SymbolLookup.libraryLookup("libc.so.6")` — glibc 2.34+
6. **Linux: search for versioned `libutil.so.*` in multiple standard lib directories** ← expanded

Fixes #2068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux terminal support by more reliably resolving native pseudoterminal functionality on systems with older libraries and varying multi-architecture layouts.
  * When multiple `libutil` versions are available, the system now probes candidates in priority order and continues gracefully if some candidates can’t be loaded or don’t provide the needed native symbol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->