### PR TITLE
fix: backport libutil search paths and OSC stripping to 3.x (#2100, #2099)

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.List;
@@ -506,35 +507,8 @@ class CLibrary {
                 }
             }
             // On older glibc (< 2.34), openpty is in a separate libutil.so.
-            // Search for versioned libutil.so.* files in the Debian/Ubuntu multiarch path.
             if (openPtyAddr.isEmpty() && OSUtils.IS_LINUX) {
-                String hwName;
-                try {
-                    Process p = Runtime.getRuntime().exec(new String[] {"uname", "-m"});
-                    p.waitFor();
-                    try (InputStream in = p.getInputStream()) {
-                        hwName = readFully(in).trim();
-                        Path libDir = Paths.get("/usr/lib", hwName + "-linux-gnu");
-                        try (Stream<Path> stream = Files.list(libDir)) {
-                            List<Path> libs = stream.filter(
-                                            l -> l.getFileName().toString().startsWith("libutil.so."))
-                                    .collect(Collectors.toList());
-                            for (Path lib : libs) {
-                                try {
-                                    System.load(lib.toString());
-                                    openPtyAddr = lookup.find("openpty");
-                                    if (openPtyAddr.isPresent()) {
-                                        break;
-                                    }
-                                } catch (Throwable t) {
-                                    suppressed.add(t);
-                                }
-                            }
-                        }
-                    }
-                } catch (Throwable t) {
-                    suppressed.add(t);
-                }
+                openPtyAddr = findVersionedLibutil(lookup, suppressed);
             }
             if (openPtyAddr.isEmpty()) {
                 for (Throwable t : suppressed) {
@@ -574,6 +548,80 @@ class CLibrary {
             b.write(buf, 0, readLen);
         }
         return b.toString();
+    }
+
+    /**
+     * Searches for a versioned {@code libutil.so.*} in standard Linux library directories and
+     * returns the {@code openpty} symbol address if found.
+     *
+     * <p>Multiple directories are searched because the library location varies by distribution
+     * and by whether the system has completed the
+     * <a href="https://wiki.debian.org/UsrMerge">usrmerge</a>:
+     * <ul>
+     *   <li>Debian/Ubuntu multiarch: {@code /usr/lib/<arch>-linux-gnu/} and
+     *       {@code /lib/<arch>-linux-gnu/} (pre-usrmerge systems like Ubuntu 18 use {@code /lib})</li>
+     *   <li>RHEL/Fedora/CentOS 64-bit: {@code /usr/lib64/} and {@code /lib64/}</li>
+     *   <li>Generic fallback: {@code /usr/lib/} and {@code /lib/}</li>
+     * </ul>
+     *
+     * <p>Within each directory, versioned {@code libutil.so.*} files are tried in descending
+     * order (highest version first) so the newest library is preferred.
+     *
+     * @param lookup    the symbol lookup to query after loading the library
+     * @param suppressed list to collect any exceptions encountered during the search
+     * @return the {@code openpty} symbol address, or {@link Optional#empty()} if not found
+     */
+    private static Optional<MemorySegment> findVersionedLibutil(SymbolLookup lookup, List<Throwable> suppressed) {
+        List<Path> searchDirs = new ArrayList<>();
+
+        // Detect architecture for Debian/Ubuntu multiarch paths.
+        // Isolated so that a uname failure doesn't prevent searching the
+        // architecture-independent paths (RHEL/Fedora, generic).
+        try {
+            Process p = new ProcessBuilder("/usr/bin/uname", "-m").start();
+            try (InputStream in = p.getInputStream()) {
+                String hwName = readFully(in).trim();
+                String multiarchDir = hwName + "-linux-gnu";
+                // Debian/Ubuntu multiarch paths
+                searchDirs.add(Paths.get("/usr/lib", multiarchDir));
+                searchDirs.add(Paths.get("/lib", multiarchDir));
+            }
+            p.waitFor();
+        } catch (Throwable t) {
+            suppressed.add(t);
+        }
+
+        // RHEL/Fedora paths
+        searchDirs.add(Paths.get("/usr/lib64"));
+        searchDirs.add(Paths.get("/lib64"));
+        // Generic fallback
+        searchDirs.add(Paths.get("/usr/lib"));
+        searchDirs.add(Paths.get("/lib"));
+
+        for (Path libDir : searchDirs) {
+            if (!Files.isDirectory(libDir)) {
+                continue;
+            }
+            try (Stream<Path> stream = Files.list(libDir)) {
+                List<Path> libs = stream.filter(l -> l.getFileName().toString().startsWith("libutil.so."))
+                        .sorted(Comparator.comparing(Path::getFileName).reversed())
+                        .collect(Collectors.toList());
+                for (Path lib : libs) {
+                    try {
+                        System.load(lib.toString());
+                        Optional<MemorySegment> addr = lookup.find("openpty");
+                        if (addr.isPresent()) {
+                            return addr;
+                        }
+                    } catch (Throwable t) {
+                        suppressed.add(t);
+                    }
+                }
+            } catch (Throwable t) {
+                suppressed.add(t);
+            }
+        }
+        return Optional.empty();
     }
 
     static Size getTerminalSize(int fd) {

--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -736,6 +736,23 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
                     // This is not a SGR code, so ignore
                     ansiState = 0;
                 }
+            } else if (ansiState == 1 && (c == ']' || c == 'P' || c == 'X' || c == '^' || c == '_')) {
+                // OSC (]), DCS (P), SOS (X), PM (^) or APC (_) introducer. These carry a string
+                // payload terminated by BEL or ST (ESC \) and can drive the terminal itself (set
+                // the window title, write the clipboard via OSC 52, ...). When the text is
+                // untrusted (a file shown in Less, a completion candidate) that payload must not
+                // reach the terminal, so drop the whole sequence instead of emitting it.
+                ansiState = 3;
+            } else if (ansiState == 3) {
+                if (c == 7) {
+                    ansiState = 0; // BEL terminates the string
+                } else if (c == 27) {
+                    ansiState = 4; // possible ST: ESC \
+                }
+            } else if (ansiState == 4) {
+                ansiState = 0; // consume the byte after ESC inside the string sequence
+                // (treats any ESC as ending the sequence, matching xterm;
+                //  strictly only ESC \ is ST per ECMA-48)
             } else {
                 if (ansiState >= 1) {
                     ensureCapacity(length + 1);

--- a/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
@@ -89,6 +89,46 @@ public class AttributedStringTest {
     }
 
     @Test
+    public void fromAnsiDropsOscInjection() {
+        // A window-title OSC (ESC ] 0 ; ... BEL) embedded in otherwise plain text must not
+        // survive into the rendered AttributedString.
+        AttributedString s = AttributedString.fromAnsi("\033]0;pwned\007OK");
+        assertEquals("OK", s.toString());
+        assertEquals("OK", s.toAnsi());
+        assertEquals(2, s.columnLength());
+    }
+
+    @Test
+    public void stripAnsiRemovesStringSequences() {
+        // OSC terminated by BEL
+        assertEquals("hello", AttributedString.stripAnsi("\033]0;title\007hello"));
+        // OSC 52 (clipboard) terminated by ST (ESC \)
+        assertEquals("AB", AttributedString.stripAnsi("A\033]52;c;ZXZpbA==\033\\B"));
+        // DCS terminated by ST
+        assertEquals("xy", AttributedString.stripAnsi("x\033P1;2q\033\\y"));
+        // APC terminated by ST
+        assertEquals("z", AttributedString.stripAnsi("\033_payload\033\\z"));
+        // SOS terminated by ST
+        assertEquals("ab", AttributedString.stripAnsi("a\033Xpayload\033\\b"));
+        // PM terminated by ST
+        assertEquals("cd", AttributedString.stripAnsi("c\033^payload\033\\d"));
+    }
+
+    @Test
+    public void stripAnsiConsumesUnterminatedStringSequence() {
+        assertEquals("pre", AttributedString.stripAnsi("pre\033]0;payload"));
+        assertEquals("pre", AttributedString.stripAnsi("pre\033Ppayload"));
+        assertEquals("pre", AttributedString.stripAnsi("pre\033]0;payload\033"));
+    }
+
+    @Test
+    public void fromAnsiKeepsSgrWhileDroppingOsc() {
+        AttributedString s = AttributedString.fromAnsi("\033]0;t\007\033[31mred\033[0m");
+        assertEquals("red", s.toString());
+        assertEquals("\033[31mred\033[0m", s.toAnsi());
+    }
+
+    @Test
     public void testBoldThenFaint() {
         AttributedStringBuilder sb = new AttributedStringBuilder();
         sb.styled(AttributedStyle::bold, "bold ");


### PR DESCRIPTION
## Summary

Backport of two bugfixes from master to the `jline-3.x` maintenance branch:

### 1. Search multiple lib paths for versioned libutil.so (backport of #2100)

The versioned `libutil.so.*` fallback only searched `/usr/lib/<arch>-linux-gnu/`, which fails on:
- **Pre-usrmerge systems** (Ubuntu 18) where the library is in `/lib/<arch>-linux-gnu/`
- **RHEL/Fedora/CentOS** where the path is `/lib64/` or `/usr/lib64/`

Expanded to search all standard Linux library directories, sorted by version descending (newest first).

### 2. Strip OSC and other escape sequences in ansiAppend (backport of #2099)

`ansiAppend` parsed SGR out of `ESC [ ... m` and dropped other CSI, but for C1 string sequences (OSC `ESC ]`, DCS `ESC P`, SOS `ESC X`, PM `ESC ^`, APC `ESC _`) it flushed the pending ESC into the visible buffer, so the whole payload survived. This allowed untrusted text (e.g. a file shown in Less) to set the window title or write the clipboard via OSC 52.

Now consumes these sequences through their BEL or ST (`ESC \`) terminator and drops them.

## Test plan

- [x] `terminal-ffm` tests pass (openpty lookup)
- [x] `AttributedStringTest` passes with 4 new tests covering OSC/DCS/SOS/PM/APC stripping
- [ ] CI matrix (Linux/macOS/Windows × Java 22/25)