### PR TITLE
fix: backport OSC/DCS/SOS/PM/APC escape stripping to 3.x (#2099)

### DIFF
--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -736,6 +736,23 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
                     // This is not a SGR code, so ignore
                     ansiState = 0;
                 }
+            } else if (ansiState == 1 && (c == ']' || c == 'P' || c == 'X' || c == '^' || c == '_')) {
+                // OSC (]), DCS (P), SOS (X), PM (^) or APC (_) introducer. These carry a string
+                // payload terminated by BEL or ST (ESC \) and can drive the terminal itself (set
+                // the window title, write the clipboard via OSC 52, ...). When the text is
+                // untrusted (a file shown in Less, a completion candidate) that payload must not
+                // reach the terminal, so drop the whole sequence instead of emitting it.
+                ansiState = 3;
+            } else if (ansiState == 3) {
+                if (c == 7) {
+                    ansiState = 0; // BEL terminates the string
+                } else if (c == 27) {
+                    ansiState = 4; // possible ST: ESC \
+                }
+            } else if (ansiState == 4) {
+                ansiState = 0; // consume the byte after ESC inside the string sequence
+                // (treats any ESC as ending the sequence, matching xterm;
+                //  strictly only ESC \ is ST per ECMA-48)
             } else {
                 if (ansiState >= 1) {
                     ensureCapacity(length + 1);

--- a/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringTest.java
@@ -89,6 +89,46 @@ public class AttributedStringTest {
     }
 
     @Test
+    public void fromAnsiDropsOscInjection() {
+        // A window-title OSC (ESC ] 0 ; ... BEL) embedded in otherwise plain text must not
+        // survive into the rendered AttributedString.
+        AttributedString s = AttributedString.fromAnsi("\033]0;pwned\007OK");
+        assertEquals("OK", s.toString());
+        assertEquals("OK", s.toAnsi());
+        assertEquals(2, s.columnLength());
+    }
+
+    @Test
+    public void stripAnsiRemovesStringSequences() {
+        // OSC terminated by BEL
+        assertEquals("hello", AttributedString.stripAnsi("\033]0;title\007hello"));
+        // OSC 52 (clipboard) terminated by ST (ESC \)
+        assertEquals("AB", AttributedString.stripAnsi("A\033]52;c;ZXZpbA==\033\\B"));
+        // DCS terminated by ST
+        assertEquals("xy", AttributedString.stripAnsi("x\033P1;2q\033\\y"));
+        // APC terminated by ST
+        assertEquals("z", AttributedString.stripAnsi("\033_payload\033\\z"));
+        // SOS terminated by ST
+        assertEquals("ab", AttributedString.stripAnsi("a\033Xpayload\033\\b"));
+        // PM terminated by ST
+        assertEquals("cd", AttributedString.stripAnsi("c\033^payload\033\\d"));
+    }
+
+    @Test
+    public void stripAnsiConsumesUnterminatedStringSequence() {
+        assertEquals("pre", AttributedString.stripAnsi("pre\033]0;payload"));
+        assertEquals("pre", AttributedString.stripAnsi("pre\033Ppayload"));
+        assertEquals("pre", AttributedString.stripAnsi("pre\033]0;payload\033"));
+    }
+
+    @Test
+    public void fromAnsiKeepsSgrWhileDroppingOsc() {
+        AttributedString s = AttributedString.fromAnsi("\033]0;t\007\033[31mred\033[0m");
+        assertEquals("red", s.toString());
+        assertEquals("\033[31mred\033[0m", s.toAnsi());
+    }
+
+    @Test
     public void testBoldThenFaint() {
         AttributedStringBuilder sb = new AttributedStringBuilder();
         sb.styled(AttributedStyle::bold, "bold ");


### PR DESCRIPTION
## Summary

Backport of #2099 to the `jline-3.x` maintenance branch.

- Strip OSC (ESC ]), DCS (ESC P), SOS (ESC X), PM (ESC ^), and APC (ESC _) escape sequences in `AttributedStringBuilder.ansiAppend()`
- Prevents untrusted text from injecting terminal commands (window title, clipboard via OSC 52, etc.)
- Handles both BEL and ST (ESC \) terminators
- Safely consumes unterminated sequences at end of input
- Includes 4 new test cases covering all sequence types, terminator variants, unterminated sequences, and SGR+OSC interaction

## Test plan
- [x] Local build passes (`./mvnw verify` in terminal module)
- [ ] CI passes on jline-3.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)