### PR TITLE
fix: reject overlong hex components in OSC color responses

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/ColorSupport.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ColorSupport.java
@@ -46,9 +46,9 @@ public class ColorSupport {
         }
         List<String> rgb = readRgbValues(reader);
         if (rgb.size() != 3
-                || rgb.get(0).isEmpty()
-                || rgb.get(1).isEmpty()
-                || rgb.get(2).isEmpty()) {
+                || !isValidComponent(rgb.get(0))
+                || !isValidComponent(rgb.get(1))
+                || !isValidComponent(rgb.get(2))) {
             return -1;
         }
         return convertRgbToInt(rgb);
@@ -124,6 +124,25 @@ public class ColorSupport {
 
     private static boolean isHexChar(int c) {
         return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+    }
+
+    /**
+     * A valid OSC color component is 1 to 4 hex digits ({@code R}, {@code RR}, {@code RRR}
+     * or {@code RRRR}). Rejecting longer values keeps {@code Integer.parseInt} within {@code int}
+     * range and keeps {@code 1 << (4 * len)} below 32, so the divisor in {@link #convertRgbToInt}
+     * cannot wrap to zero.
+     */
+    private static boolean isValidComponent(String s) {
+        int len = s.length();
+        if (len < 1 || len > 4) {
+            return false;
+        }
+        for (int i = 0; i < len; i++) {
+            if (!isHexChar(s.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static int convertRgbToInt(List<String> rgb) {

--- a/terminal/src/main/java/org/jline/utils/ColorPalette.java
+++ b/terminal/src/main/java/org/jline/utils/ColorPalette.java
@@ -203,6 +203,26 @@ public class ColorPalette {
         return distance;
     }
 
+    /**
+     * A valid OSC 4 color component is 1 to 4 hex digits ({@code R}, {@code RR}, {@code RRR}
+     * or {@code RRRR}). Rejecting longer or non-hex values keeps {@code Integer.parseInt} within
+     * {@code int} range and keeps {@code 1 << (4 * len)} below 32, so the divisor below cannot
+     * wrap to zero.
+     */
+    private static boolean isValidComponent(String s) {
+        int len = s.length();
+        if (len < 1 || len > 4) {
+            return false;
+        }
+        for (int i = 0; i < len; i++) {
+            char c = s.charAt(i);
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static int[] doLoad(Terminal terminal) throws IOException {
         PrintWriter writer = terminal.writer();
         NonBlockingReader reader = terminal.reader();
@@ -272,7 +292,10 @@ public class ColorPalette {
                         sb.setLength(0);
                     }
                 }
-                if (rgb.size() != 3) {
+                if (rgb.size() != 3
+                        || !isValidComponent(rgb.get(0))
+                        || !isValidComponent(rgb.get(1))
+                        || !isValidComponent(rgb.get(2))) {
                     return null;
                 }
                 double r = Integer.parseInt(rgb.get(0), 16)

--- a/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
@@ -35,6 +35,29 @@ class ColorParsingTest {
         assertEquals(-1, result, "parseColorResponse should return -1 on " + scenario);
     }
 
+    static Stream<Arguments> malformedComponentScenarios() {
+        return Stream.of(
+                Arguments.of("\033]10;rgb:10000000/00/00\007", 10, "8-digit component wraps 1 << 32 to 1"),
+                Arguments.of("\033]11;rgb:f0000000/00/00\007", 11, "8-digit component overflowing int"),
+                Arguments.of("\033]10;rgb:fffff/00/00\007", 10, "5-digit component"));
+    }
+
+    @ParameterizedTest(name = "parseColorResponse returns -1 on {2}")
+    @MethodSource("malformedComponentScenarios")
+    void testParseColorResponseRejectsMalformedComponents(String input, int colorType, String scenario)
+            throws Exception {
+        NonBlockingReader reader = createReader(input);
+        int result = ColorSupport.parseColorResponse(reader, colorType);
+        assertEquals(-1, result, "parseColorResponse should return -1 on " + scenario);
+    }
+
+    @Test
+    void testParseColorResponseWithMaxWidthComponents() throws Exception {
+        NonBlockingReader reader = createReader("\033]10;rgb:ffff/ffff/ffff\007");
+        int result = ColorSupport.parseColorResponse(reader, 10);
+        assertEquals(0xFFFFFF, result, "parseColorResponse should accept 4-digit components");
+    }
+
     @Test
     void testParseColorResponseWithValidBellTerminator() throws Exception {
         NonBlockingReader reader = createReader("\033]10;rgb:ff/ff/ff\007");


### PR DESCRIPTION
    ColorParsingTest.testParseColorResponseRejectsMalformedComponents:51
      parseColorResponse should return -1 on 8-digit component wraps 1 << 32 to 1
      ==> expected: <-1> but was: <-65536>
    » NumberFormat For input string: "f0000000" under radix 16

`ColorSupport.parseColorResponse` (OSC 10/11 default fg/bg) and `ColorPalette.doLoad`
(OSC 4 palette) accumulate each `rgb:` component with no length bound, then divide the
parsed value by `((1 << (4 * len)) - 1.0)`. The shift is a 32-bit `int` shift and Java
masks the count to its low 5 bits, so a length-8 component makes `1 << 32 == 1`, the
divisor becomes `0.0`, and the query returns a bogus negative color (`0xFFFF0000`)
instead of a `0xRRGGBB` value or the `-1` sentinel. A length-8+ component whose leading
nibble is `>= 8` instead throws `NumberFormatException` out of
`getDefaultForegroundColor`/`getDefaultBackgroundColor`. The response bytes come from the
terminal, so a program running in the pty or a remote ssh/telnet peer can supply them.

Validate each component as 1 to 4 hex digits (the documented `rgb:RRRR/GGGG/BBBB` form)
before conversion at both parsers, keeping `4 * len <= 16`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of terminal RGB color responses.
  * Malformed or oversized hexadecimal color components are now rejected instead of being interpreted as invalid or incorrect colors.
  * Improved reliability when loading terminal color palettes from OSC responses.

* **Tests**
  * Added coverage for malformed RGB components, including values that could previously overflow or wrap during parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->