### PR TITLE
fix: clamp out-of-range truecolor SGR components in ScreenTerminal

### DIFF
--- a/terminal/src/main/java/org/jline/utils/ScreenTerminal.java
+++ b/terminal/src/main/java/org/jline/utils/ScreenTerminal.java
@@ -1209,9 +1209,9 @@ public class ScreenTerminal implements Sized {
                     m = ++i < ps.length ? ps[i] : 0;
                     attr = (attr & (0xef000fffL << 32)) | (0x10000000L << 32) | (col24(m) << 44); // foreground
                 } else if (m == 2) {
-                    int r = ++i < ps.length ? ps[i] : 0;
-                    int g = ++i < ps.length ? ps[i] : 0;
-                    int b = ++i < ps.length ? ps[i] : 0;
+                    int r = Math.max(0, Math.min(255, ++i < ps.length ? ps[i] : 0));
+                    int g = Math.max(0, Math.min(255, ++i < ps.length ? ps[i] : 0));
+                    int b = Math.max(0, Math.min(255, ++i < ps.length ? ps[i] : 0));
                     long rgb = ((long) (r >> 4) << 8) | ((long) (g >> 4) << 4) | (b >> 4);
                     attr = (attr & (0xef000fffL << 32)) | (0x10000000L << 32) | (rgb << 44); // foreground
                 }
@@ -1225,9 +1225,9 @@ public class ScreenTerminal implements Sized {
                     m = ++i < ps.length ? ps[i] : 0;
                     attr = (attr & (0xdffff000L << 32)) | (0x20000000L << 32) | (col24(m) << 32); // background
                 } else if (m == 2) {
-                    int r = ++i < ps.length ? ps[i] : 0;
-                    int g = ++i < ps.length ? ps[i] : 0;
-                    int b = ++i < ps.length ? ps[i] : 0;
+                    int r = Math.max(0, Math.min(255, ++i < ps.length ? ps[i] : 0));
+                    int g = Math.max(0, Math.min(255, ++i < ps.length ? ps[i] : 0));
+                    int b = Math.max(0, Math.min(255, ++i < ps.length ? ps[i] : 0));
                     long rgb = ((long) (r >> 4) << 8) | ((long) (g >> 4) << 4) | (b >> 4);
                     attr = (attr & (0xdffff000L << 32)) | (0x20000000L << 32) | (rgb << 32); // background
                 }

--- a/terminal/src/test/java/org/jline/utils/ScreenTerminalTest.java
+++ b/terminal/src/test/java/org/jline/utils/ScreenTerminalTest.java
@@ -266,6 +266,67 @@ class ScreenTerminalTest {
         assertEquals(0xF00, ScreenTerminal.cellForeground(cell));
     }
 
+    /**
+     * Same as {@link #testTrueColorComponentClamped()} but for the background
+     * path (ESC[48;2;r;g;b m).  An out-of-range component must be clamped to
+     * 255 and the correct background-color bits must be set without corrupting
+     * the foreground-set flag or any style bits.
+     */
+    @Test
+    void testTrueColorComponentClampedBackground() {
+        ScreenTerminal terminal = new ScreenTerminal(20, 3);
+        // 16777215 (0xFFFFFF) is far outside the 0..255 range of a channel.
+        terminal.write("\033[48;2;16777215;0;0mX");
+
+        long[] screen = new long[20 * 3];
+        terminal.dump(screen, null);
+        long cell = screen[0];
+
+        assertEquals('X', ScreenTerminal.cellCodePoint(cell));
+        assertTrue(ScreenTerminal.cellHasBackground(cell), "background should be set");
+        assertFalse(ScreenTerminal.cellHasForeground(cell), "foreground must stay unset");
+        assertFalse(ScreenTerminal.cellBold(cell), "bold must not be set");
+        assertFalse(ScreenTerminal.cellItalic(cell), "italic must not be set");
+        assertFalse(ScreenTerminal.cellUnderline(cell), "underline must not be set");
+        assertFalse(ScreenTerminal.cellDim(cell), "dim must not be set");
+        assertFalse(ScreenTerminal.cellInverse(cell), "inverse must not be set");
+        assertFalse(ScreenTerminal.cellConceal(cell), "conceal must not be set");
+        // 16777215 clamped to 255 -> 0xF nibble; green/blue 0
+        assertEquals(0xF00, ScreenTerminal.cellBackground(cell));
+    }
+
+    /**
+     * The lower-bound counterpart to {@link #testTrueColorComponentClamped()}.
+     * The {@code Math.max(0, ...)} guard clamps negative RGB components to 0.
+     * Although the CSI byte-level parser does not forward negative parameter
+     * values (the {@code -} byte has MSB 0x20 which corrupts the function
+     * code), this test verifies the correct behavior when all channels are at
+     * the minimum (0), ensuring the zero boundary of the clamping range works
+     * and no bits bleed into adjacent attribute fields.
+     */
+    @Test
+    void testTrueColorComponentClampedLowerBound() {
+        ScreenTerminal terminal = new ScreenTerminal(20, 3);
+        // All channels at the minimum valid value (0).
+        terminal.write("\033[38;2;0;0;0mX");
+
+        long[] screen = new long[20 * 3];
+        terminal.dump(screen, null);
+        long cell = screen[0];
+
+        assertEquals('X', ScreenTerminal.cellCodePoint(cell));
+        assertTrue(ScreenTerminal.cellHasForeground(cell), "foreground should be set");
+        assertFalse(ScreenTerminal.cellHasBackground(cell), "background must stay unset");
+        assertFalse(ScreenTerminal.cellBold(cell), "bold must not be set");
+        assertFalse(ScreenTerminal.cellItalic(cell), "italic must not be set");
+        assertFalse(ScreenTerminal.cellUnderline(cell), "underline must not be set");
+        assertFalse(ScreenTerminal.cellDim(cell), "dim must not be set");
+        assertFalse(ScreenTerminal.cellInverse(cell), "inverse must not be set");
+        assertFalse(ScreenTerminal.cellConceal(cell), "conceal must not be set");
+        // All channels 0 >> 4 = 0
+        assertEquals(0x000, ScreenTerminal.cellForeground(cell));
+    }
+
     // -----------------------------------------------------------------------
     // Feature tests
     // -----------------------------------------------------------------------

--- a/terminal/src/test/java/org/jline/utils/ScreenTerminalTest.java
+++ b/terminal/src/test/java/org/jline/utils/ScreenTerminalTest.java
@@ -236,6 +236,36 @@ class ScreenTerminalTest {
         assertEquals(11, cursor[1], "Restored cy should be clamped to new height-1");
     }
 
+    /**
+     * Out-of-range true-color SGR components must be clamped to 0..255 before
+     * they are packed into the cell attribute word. A component above 255 used
+     * to shift past the 12-bit color field and flip the adjacent style bits
+     * (bold/italic/underline/inverse/conceal/dim and the fg/bg-set flags), and
+     * that corrupted attribute was then applied to every subsequent cell.
+     */
+    @Test
+    void testTrueColorComponentClamped() {
+        ScreenTerminal terminal = new ScreenTerminal(20, 3);
+        // 16777215 (0xFFFFFF) is far outside the 0..255 range of a channel.
+        terminal.write("\033[38;2;16777215;0;0mX");
+
+        long[] screen = new long[20 * 3];
+        terminal.dump(screen, null);
+        long cell = screen[0];
+
+        assertEquals('X', ScreenTerminal.cellCodePoint(cell));
+        assertTrue(ScreenTerminal.cellHasForeground(cell), "foreground should be set");
+        assertFalse(ScreenTerminal.cellHasBackground(cell), "background must stay unset");
+        assertFalse(ScreenTerminal.cellBold(cell), "bold must not be set");
+        assertFalse(ScreenTerminal.cellItalic(cell), "italic must not be set");
+        assertFalse(ScreenTerminal.cellUnderline(cell), "underline must not be set");
+        assertFalse(ScreenTerminal.cellDim(cell), "dim must not be set");
+        assertFalse(ScreenTerminal.cellInverse(cell), "inverse must not be set");
+        assertFalse(ScreenTerminal.cellConceal(cell), "conceal must not be set");
+        // 16777215 clamped to 255 -> 0xF nibble; green/blue 0
+        assertEquals(0xF00, ScreenTerminal.cellForeground(cell));
+    }
+
     // -----------------------------------------------------------------------
     // Feature tests
     // -----------------------------------------------------------------------


### PR DESCRIPTION
ScreenTerminal.dump() after `\e[38;2;16777215;0;0mX` (a truecolor fg whose red channel is out of the 0..255 range):

    <span style='color:#ff0000;background-color:#ff0000;text-decoration:underline;font-weight:bold;font-style:italic;'>X</span>

csi_SGR packs `38;2;r;g;b` / `48;2;r;g;b` into the cell attribute via `rgb << 44` (fg) and `rgb << 32` (bg), but r/g/b are read from the CSI params unchecked, so a channel above 255 overruns the 12-bit color field and flips the adjacent bold/italic/underline/inverse/conceal/dim and fg/bg-set bits. The corrupted attribute then sticks to every later cell that is written. The emulator renders untrusted application output (WebTerminal, remote telnet/ssh), so the sequence is reachable.

Clamp each channel to 0..255 before packing, at both truecolor sites. Valid colors are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 24-bit terminal true-color (SGR 38/48;2;r;g;b) handling by clamping RGB components to the valid 0–255 range before applying color.
  * Prevented out-of-range color values from corrupting nearby styling/display attributes.

* **Tests**
  * Added regression tests to verify correct clamping for foreground and background true-color, including upper and lower bounds, ensuring styling flags and packed color values remain correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->