### PR TITLE
fix: reject overlong hex components in OSC color responses (3.x backport)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPosixTerminal.java
@@ -253,7 +253,10 @@ public abstract class AbstractPosixTerminal extends AbstractTerminal {
             }
         }
 
-        if (rgb.size() != 3) {
+        if (rgb.size() != 3
+                || !isValidComponent(rgb.get(0))
+                || !isValidComponent(rgb.get(1))
+                || !isValidComponent(rgb.get(2))) {
             return -1;
         }
 
@@ -263,5 +266,25 @@ public abstract class AbstractPosixTerminal extends AbstractTerminal {
         double b = Integer.parseInt(rgb.get(2), 16) / ((1 << (4 * rgb.get(2).length())) - 1.0);
 
         return (int) ((Math.round(r * 255) << 16) + (Math.round(g * 255) << 8) + Math.round(b * 255));
+    }
+
+    /**
+     * A valid OSC color component is 1 to 4 hex digits ({@code R}, {@code RR}, {@code RRR}
+     * or {@code RRRR}). Rejecting longer values keeps {@code Integer.parseInt} within {@code int}
+     * range and keeps {@code 1 << (4 * len)} below 32, so the divisor in the caller
+     * cannot wrap to zero.
+     */
+    private static boolean isValidComponent(String s) {
+        int len = s.length();
+        if (len < 1 || len > 4) {
+            return false;
+        }
+        for (int i = 0; i < len; i++) {
+            char c = s.charAt(i);
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/terminal/src/main/java/org/jline/utils/ColorPalette.java
+++ b/terminal/src/main/java/org/jline/utils/ColorPalette.java
@@ -203,6 +203,26 @@ public class ColorPalette {
         return distance;
     }
 
+    /**
+     * A valid OSC 4 color component is 1 to 4 hex digits ({@code R}, {@code RR}, {@code RRR}
+     * or {@code RRRR}). Rejecting longer or non-hex values keeps {@code Integer.parseInt} within
+     * {@code int} range and keeps {@code 1 << (4 * len)} below 32, so the divisor below cannot
+     * wrap to zero.
+     */
+    private static boolean isValidComponent(String s) {
+        int len = s.length();
+        if (len < 1 || len > 4) {
+            return false;
+        }
+        for (int i = 0; i < len; i++) {
+            char c = s.charAt(i);
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static int[] doLoad(Terminal terminal) throws IOException {
         PrintWriter writer = terminal.writer();
         NonBlockingReader reader = terminal.reader();
@@ -272,7 +292,10 @@ public class ColorPalette {
                         sb.setLength(0);
                     }
                 }
-                if (rgb.size() != 3) {
+                if (rgb.size() != 3
+                        || !isValidComponent(rgb.get(0))
+                        || !isValidComponent(rgb.get(1))
+                        || !isValidComponent(rgb.get(2))) {
                     return null;
                 }
                 double r = Integer.parseInt(rgb.get(0), 16)

--- a/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
@@ -11,7 +11,6 @@ package org.jline.terminal.impl;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.stream.Stream;
 
 import org.easymock.EasyMock;
 import org.jline.terminal.Attributes;
@@ -19,9 +18,6 @@ import org.jline.terminal.Terminal.SignalHandler;
 import org.jline.terminal.spi.Pty;
 import org.jline.utils.NonBlockingReader;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -83,23 +79,43 @@ public class ColorParsingTest {
         }
     }
 
-    static Stream<Arguments> malformedComponentScenarios() {
-        return Stream.of(
-                Arguments.of("\033]10;rgb:10000000/00/00\007", 10, "8-digit component wraps 1 << 32 to 1"),
-                Arguments.of("\033]11;rgb:f0000000/00/00\007", 11, "8-digit component overflowing int"),
-                Arguments.of("\033]10;rgb:fffff/00/00\007", 10, "5-digit component"));
-    }
-
-    @ParameterizedTest(name = "parseColorResponse returns -1 on {2}")
-    @MethodSource("malformedComponentScenarios")
-    public void testParseColorResponseRejectsMalformedComponents(String input, int colorType, String scenario)
-            throws Exception {
-        NonBlockingReader reader = createReader(input);
+    @Test
+    public void testParseColorResponseRejectsShiftWrapComponent() throws Exception {
+        // 8-digit component wraps 1 << 32 to 1
+        NonBlockingReader reader = createReader("\033]10;rgb:10000000/00/00\007");
 
         AbstractPosixTerminal terminal = createTerminal();
         try {
-            int result = terminal.parseColorResponse(reader, colorType);
-            assertEquals(-1, result, "parseColorResponse should return -1 on " + scenario);
+            int result = terminal.parseColorResponse(reader, 10);
+            assertEquals(-1, result, "parseColorResponse should return -1 on 8-digit component");
+        } finally {
+            terminal.close();
+        }
+    }
+
+    @Test
+    public void testParseColorResponseRejectsOverflowingComponent() throws Exception {
+        // 8-digit component with high nibble overflows int
+        NonBlockingReader reader = createReader("\033]11;rgb:f0000000/00/00\007");
+
+        AbstractPosixTerminal terminal = createTerminal();
+        try {
+            int result = terminal.parseColorResponse(reader, 11);
+            assertEquals(-1, result, "parseColorResponse should return -1 on overflowing component");
+        } finally {
+            terminal.close();
+        }
+    }
+
+    @Test
+    public void testParseColorResponseRejectsFiveDigitComponent() throws Exception {
+        // 5-digit component exceeds valid 1-4 hex digit range
+        NonBlockingReader reader = createReader("\033]10;rgb:fffff/00/00\007");
+
+        AbstractPosixTerminal terminal = createTerminal();
+        try {
+            int result = terminal.parseColorResponse(reader, 10);
+            assertEquals(-1, result, "parseColorResponse should return -1 on 5-digit component");
         } finally {
             terminal.close();
         }

--- a/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/ColorParsingTest.java
@@ -11,6 +11,7 @@ package org.jline.terminal.impl;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.stream.Stream;
 
 import org.easymock.EasyMock;
 import org.jline.terminal.Attributes;
@@ -18,6 +19,9 @@ import org.jline.terminal.Terminal.SignalHandler;
 import org.jline.terminal.spi.Pty;
 import org.jline.utils.NonBlockingReader;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -74,6 +78,41 @@ public class ColorParsingTest {
         try {
             int result = terminal.parseColorResponse(reader, 11);
             assertEquals(0x000000, result, "parseColorResponse should parse black color correctly");
+        } finally {
+            terminal.close();
+        }
+    }
+
+    static Stream<Arguments> malformedComponentScenarios() {
+        return Stream.of(
+                Arguments.of("\033]10;rgb:10000000/00/00\007", 10, "8-digit component wraps 1 << 32 to 1"),
+                Arguments.of("\033]11;rgb:f0000000/00/00\007", 11, "8-digit component overflowing int"),
+                Arguments.of("\033]10;rgb:fffff/00/00\007", 10, "5-digit component"));
+    }
+
+    @ParameterizedTest(name = "parseColorResponse returns -1 on {2}")
+    @MethodSource("malformedComponentScenarios")
+    public void testParseColorResponseRejectsMalformedComponents(String input, int colorType, String scenario)
+            throws Exception {
+        NonBlockingReader reader = createReader(input);
+
+        AbstractPosixTerminal terminal = createTerminal();
+        try {
+            int result = terminal.parseColorResponse(reader, colorType);
+            assertEquals(-1, result, "parseColorResponse should return -1 on " + scenario);
+        } finally {
+            terminal.close();
+        }
+    }
+
+    @Test
+    public void testParseColorResponseWithMaxWidthComponents() throws Exception {
+        NonBlockingReader reader = createReader("\033]10;rgb:ffff/ffff/ffff\007");
+
+        AbstractPosixTerminal terminal = createTerminal();
+        try {
+            int result = terminal.parseColorResponse(reader, 10);
+            assertEquals(0xFFFFFF, result, "parseColorResponse should accept 4-digit components");
         } finally {
             terminal.close();
         }


### PR DESCRIPTION
Backport of #2105 to the 3.x maintenance branch.

`parseColorResponse` (OSC 10/11) and `ColorPalette.doLoad` (OSC 4) accumulate each `rgb:` component with no length bound, then divide the parsed value by `((1 << (4 * len)) - 1.0)`. The shift is a 32-bit `int` shift and Java masks the count to its low 5 bits, so a length-8 component makes `1 << 32 == 1`, the divisor becomes `0.0`, and the query returns a bogus negative color instead of a valid `0xRRGGBB` value or the `-1` sentinel.

Validate each component as 1 to 4 hex digits before conversion at both parsers. In 3.x, the `parseColorResponse` code lives in `AbstractPosixTerminal` rather than the extracted `ColorSupport` class used on master.