### PR TITLE
fix: reject theme path traversal in highlighter command

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Commands.java
+++ b/builtins/src/main/java/org/jline/builtins/Commands.java
@@ -2001,6 +2001,11 @@ public class Commands {
      * @return the path with the file name replaced
      */
     private static String replaceFileName(Path path, String name) {
+        // name is a theme file name inside path's directory; a separator or ".." segment
+        // would let it point elsewhere (e.g. "../../etc/passwd"), so reject those.
+        if (name.indexOf('/') >= 0 || name.indexOf('\\') >= 0 || name.equals("..") || name.equals(".")) {
+            throw new IllegalArgumentException("Invalid theme name: " + name);
+        }
         int nameLength = path.getFileName().toString().length();
         int pathLength = path.toString().length();
         return (path.toString().substring(0, pathLength - nameLength) + name).replace("\\", "\\\\");

--- a/builtins/src/test/java/org/jline/builtins/CommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CommandsTest.java
@@ -12,6 +12,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.jline.reader.History;
 import org.jline.reader.LineReader;
@@ -21,8 +22,11 @@ import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CommandsTest {
     @Test
@@ -65,5 +69,66 @@ class CommandsTest {
         } catch (Exception e) {
             throw new RuntimeException("Test failed", e);
         }
+    }
+
+    @Test
+    void highlighterViewRejectsThemePathTraversal(@TempDir Path tmp) throws Exception {
+        Path configDir = Files.createDirectory(tmp.resolve("config"));
+        Files.write(configDir.resolve("jnanorc"), List.of("theme dark.nanorctheme"));
+        Files.write(configDir.resolve("dark.nanorctheme"), List.of("DEFAULT white"));
+        // sits one level above the theme directory; the viewer must not reach it
+        Files.write(tmp.resolve("outside.nanorctheme"), List.of("SECRET_TOKEN white"));
+
+        ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+        ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        ByteArrayOutputStream termBytes = new ByteArrayOutputStream();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .dumb(true)
+                .streams(new ByteArrayInputStream(new byte[0]), termBytes)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+            ConfigurationPath configPath = new ConfigurationPath(configDir, configDir);
+            Commands.highlighter(
+                    reader,
+                    terminal,
+                    new PrintStream(outBytes),
+                    new PrintStream(errBytes),
+                    new String[] {"--view", "../outside.nanorctheme"},
+                    configPath);
+        }
+        String out = outBytes.toString(StandardCharsets.UTF_8);
+        String err = errBytes.toString(StandardCharsets.UTF_8);
+        String term = termBytes.toString(StandardCharsets.UTF_8);
+        assertTrue(err.contains("Invalid theme name"), "traversal should be rejected, err=" + err);
+        assertFalse(out.contains("outside"), "escaped path must not be resolved, out=" + out);
+        assertFalse(term.contains("SECRET_TOKEN"), "content outside the theme dir must not leak");
+    }
+
+    @Test
+    void highlighterViewReadsThemeInConfigDir(@TempDir Path tmp) throws Exception {
+        Path configDir = Files.createDirectory(tmp.resolve("config"));
+        Files.write(configDir.resolve("jnanorc"), List.of("theme dark.nanorctheme"));
+        Files.write(configDir.resolve("dark.nanorctheme"), List.of("DEFAULT white"));
+
+        ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+        ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .dumb(true)
+                .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream())
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+            ConfigurationPath configPath = new ConfigurationPath(configDir, configDir);
+            Commands.highlighter(
+                    reader,
+                    terminal,
+                    new PrintStream(outBytes),
+                    new PrintStream(errBytes),
+                    new String[] {"--view", "dark.nanorctheme"},
+                    configPath);
+        }
+        String out = outBytes.toString(StandardCharsets.UTF_8);
+        String err = errBytes.toString(StandardCharsets.UTF_8);
+        assertFalse(err.contains("Invalid theme name"), "valid theme name must be accepted, err=" + err);
+        assertTrue(out.contains("dark.nanorctheme"), "theme path should be printed, out=" + out);
     }
 }

--- a/builtins/src/test/java/org/jline/builtins/CommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CommandsTest.java
@@ -79,29 +79,32 @@ class CommandsTest {
         // sits one level above the theme directory; the viewer must not reach it
         Files.write(tmp.resolve("outside.nanorctheme"), List.of("SECRET_TOKEN white"));
 
-        ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
-        ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
-        ByteArrayOutputStream termBytes = new ByteArrayOutputStream();
-        try (Terminal terminal = TerminalBuilder.builder()
-                .dumb(true)
-                .streams(new ByteArrayInputStream(new byte[0]), termBytes)
-                .build()) {
-            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
-            ConfigurationPath configPath = new ConfigurationPath(configDir, configDir);
-            Commands.highlighter(
-                    reader,
-                    terminal,
-                    new PrintStream(outBytes),
-                    new PrintStream(errBytes),
-                    new String[] {"--view", "../outside.nanorctheme"},
-                    configPath);
+        for (String name : new String[] {"../outside.nanorctheme", "..\\outside.nanorctheme"}) {
+            ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+            ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+            ByteArrayOutputStream termBytes = new ByteArrayOutputStream();
+            try (Terminal terminal = TerminalBuilder.builder()
+                    .dumb(true)
+                    .streams(new ByteArrayInputStream(new byte[0]), termBytes)
+                    .build()) {
+                LineReader reader =
+                        LineReaderBuilder.builder().terminal(terminal).build();
+                ConfigurationPath configPath = new ConfigurationPath(configDir, configDir);
+                Commands.highlighter(
+                        reader,
+                        terminal,
+                        new PrintStream(outBytes),
+                        new PrintStream(errBytes),
+                        new String[] {"--view", name},
+                        configPath);
+            }
+            String out = outBytes.toString(StandardCharsets.UTF_8);
+            String err = errBytes.toString(StandardCharsets.UTF_8);
+            String term = termBytes.toString(StandardCharsets.UTF_8);
+            assertTrue(err.contains("Invalid theme name"), name + " should be rejected, err=" + err);
+            assertFalse(out.contains("outside"), name + " must not be resolved, out=" + out);
+            assertFalse(term.contains("SECRET_TOKEN"), "content outside the theme dir must not leak");
         }
-        String out = outBytes.toString(StandardCharsets.UTF_8);
-        String err = errBytes.toString(StandardCharsets.UTF_8);
-        String term = termBytes.toString(StandardCharsets.UTF_8);
-        assertTrue(err.contains("Invalid theme name"), "traversal should be rejected, err=" + err);
-        assertFalse(out.contains("outside"), "escaped path must not be resolved, out=" + out);
-        assertFalse(term.contains("SECRET_TOKEN"), "content outside the theme dir must not leak");
     }
 
     @Test


### PR DESCRIPTION
`highlighter --view`/`--switch` pass a theme file name to replaceFileName, which strips the current theme's file name off the theme path and concatenates the raw argument with no validation:

    highlighter --view ../../../../etc/passwd
    replaceFileName         -> <themedir>/../../../../etc/passwd
    Files.newBufferedReader -> /etc/passwd

--view prints the resolved absolute path and reads the target (path oracle plus partial disclosure of `[A-Z_]+` token lines); --switch writes the escaped path into the jnanorc/jlessrc `theme` directive. replaceFileName is the shared sink behind all three theme handlers, so the name check lives there: reject a path separator or a `..` segment. Bare theme names and the `*.nanorctheme` list glob stay valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stronger theme name validation, rejecting invalid inputs that could enable path traversal.
  * Prevented theme loading from accessing files outside the configured theme directory.
  * Verified valid theme names still resolve successfully and render correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->