### PR TITLE
fix: improve provider discovery for custom classloader environments

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
+++ b/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java
@@ -383,6 +383,7 @@ public final class TerminalBuilder {
     private boolean paused = false;
     private Boolean graphemeCluster;
     private UnaryOperator<String> env;
+    private ClassLoader classLoader;
 
     private TerminalBuilder() {}
 
@@ -437,6 +438,41 @@ public final class TerminalBuilder {
      */
     public TerminalBuilder providers(String providers) {
         this.providers = providers;
+        return this;
+    }
+
+    /**
+     * Sets an explicit classloader for terminal provider discovery.
+     *
+     * <p>
+     * When JLine is loaded through a custom classloader (e.g., OSGi containers,
+     * application servers, plugin systems), the default provider discovery may fail
+     * because the thread's context classloader cannot locate the provider resource
+     * files bundled in the JLine JARs. This method allows specifying the classloader
+     * that has access to those JARs.
+     * </p>
+     *
+     * <p>
+     * The specified classloader is tried first during provider discovery, before falling
+     * back to the thread context classloader and JLine's own classloader. See
+     * {@link TerminalProvider#load(String, ClassLoader)} for the full resolution order.
+     * </p>
+     *
+     * <p><b>Example — plugin system where JLine is loaded at runtime:</b></p>
+     * <pre>
+     * Terminal terminal = TerminalBuilder.builder()
+     *     .streams(inputStream, outputStream)
+     *     .classLoader(getClass().getClassLoader())
+     *     .build();
+     * </pre>
+     *
+     * @param classLoader the classloader to use for provider discovery, or {@code null}
+     *                    to use the default resolution strategy
+     * @return this builder
+     * @see TerminalProvider#load(String, ClassLoader)
+     */
+    public TerminalBuilder classLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
         return this;
     }
 
@@ -1269,11 +1305,11 @@ public final class TerminalBuilder {
     public List<TerminalProvider> getProviders(String provider, IllegalStateException exception) {
         List<TerminalProvider> providers = new ArrayList<>();
         // Check ffm provider
-        checkProvider(provider, exception, providers, ffm, PROP_FFM, PROP_PROVIDER_FFM);
+        checkProvider(provider, exception, providers, ffm, PROP_FFM, PROP_PROVIDER_FFM, classLoader);
         // Check jni provider
-        checkProvider(provider, exception, providers, jni, PROP_JNI, PROP_PROVIDER_JNI);
+        checkProvider(provider, exception, providers, jni, PROP_JNI, PROP_PROVIDER_JNI, classLoader);
         // Check exec provider
-        checkProvider(provider, exception, providers, exec, PROP_EXEC, PROP_PROVIDER_EXEC);
+        checkProvider(provider, exception, providers, exec, PROP_EXEC, PROP_PROVIDER_EXEC, classLoader);
         // Order providers
         List<String> order = Arrays.asList(
                 (this.providers != null ? this.providers : System.getProperty(PROP_PROVIDERS, PROP_PROVIDERS_DEFAULT))
@@ -1293,14 +1329,15 @@ public final class TerminalBuilder {
             List<TerminalProvider> providers,
             Boolean load,
             String property,
-            String name) {
+            String name,
+            ClassLoader classLoader) {
         Boolean doLoad = provider != null ? (Boolean) name.equals(provider) : load;
         if (doLoad == null) {
             doLoad = getBoolean(property, true);
         }
         if (doLoad) {
             try {
-                TerminalProvider prov = TerminalProvider.load(name);
+                TerminalProvider prov = TerminalProvider.load(name, classLoader);
                 prov.isSystemStream(SystemStream.Output);
                 providers.add(prov);
             } catch (Throwable t) {

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -15,6 +15,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
@@ -373,15 +375,24 @@ public interface TerminalProvider {
         // JLine JARs are loaded by a classloader that is not the thread's context classloader.
         ClassLoader contextCl = Thread.currentThread().getContextClassLoader();
         ClassLoader jlineCl = TerminalProvider.class.getClassLoader();
-        ClassLoader[] candidates = new ClassLoader[] {classLoader, contextCl, jlineCl};
+
+        // Deduplicate: in a standard setup the context classloader and JLine's
+        // own classloader are often the same instance — skip redundant lookups.
+        List<ClassLoader> candidates = new ArrayList<>(3);
+        if (classLoader != null) {
+            candidates.add(classLoader);
+        }
+        if (contextCl != null && contextCl != classLoader) {
+            candidates.add(contextCl);
+        }
+        if (jlineCl != null && jlineCl != classLoader && jlineCl != contextCl) {
+            candidates.add(jlineCl);
+        }
 
         String providerResource = "META-INF/jline/providers/" + name;
         IOException loadError = null;
 
         for (ClassLoader cl : candidates) {
-            if (cl == null) {
-                continue;
-            }
             try {
                 TerminalProvider result = tryLoadProvider(cl, providerResource, name);
                 if (result != null) {

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -273,7 +273,24 @@ public interface TerminalProvider {
     }
 
     /**
-     * Loads a terminal provider with the specified name.
+     * Loads a terminal provider with the specified name using the default classloader
+     * resolution strategy.
+     *
+     * <p>
+     * This is equivalent to calling {@link #load(String, ClassLoader) load(name, null)}.
+     * </p>
+     *
+     * @param name the name of the provider to load (e.g., "ffm", "jni", "exec", "dumb")
+     * @return the loaded terminal provider
+     * @throws IOException if the provider cannot be loaded or is not found
+     * @see #load(String, ClassLoader)
+     */
+    static TerminalProvider load(String name) throws IOException {
+        return load(name, null);
+    }
+
+    /**
+     * Loads a terminal provider with the specified name, using an optional explicit classloader.
      *
      * <h2>Provider Discovery Mechanism</h2>
      * <p>
@@ -287,6 +304,27 @@ public interface TerminalProvider {
      * because it allows loading a specific provider by name without instantiating all
      * available providers. This is critical for providers that may fail to initialize
      * due to missing native libraries (JNI, FFM) or other platform-specific dependencies.
+     * </p>
+     *
+     * <h2>Classloader Resolution</h2>
+     * <p>
+     * The classloader used for provider discovery is resolved in this order:
+     * </p>
+     * <ol>
+     *   <li>The explicit {@code classLoader} parameter, if non-null</li>
+     *   <li>The thread's {@linkplain Thread#getContextClassLoader() context classloader}</li>
+     *   <li>The classloader that loaded the {@code TerminalProvider} class itself</li>
+     * </ol>
+     * <p>
+     * Each classloader is tried in order until the provider resource file is found. This
+     * fallback chain ensures provider discovery works in environments with non-standard
+     * classloader hierarchies, such as OSGi containers, application servers, and plugin
+     * systems that load JLine through a child classloader that is not the thread's context
+     * classloader.
+     * </p>
+     * <p>
+     * The explicit classloader can be set via
+     * {@link org.jline.terminal.TerminalBuilder#classLoader(ClassLoader)}.
      * </p>
      *
      * <h2>Dual-Purpose Service Files</h2>
@@ -321,22 +359,35 @@ public interface TerminalProvider {
      * </pre>
      *
      * @param name the name of the provider to load (e.g., "ffm", "jni", "exec", "dumb")
+     * @param classLoader an explicit classloader to try first, or {@code null} to use the
+     *                    default resolution strategy (context classloader, then JLine's own classloader)
      * @return the loaded terminal provider
      * @throws IOException if the provider cannot be loaded or is not found
      */
-    static TerminalProvider load(String name) throws IOException {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        if (cl == null) {
-            cl = TerminalProvider.class.getClassLoader();
-        }
+    static TerminalProvider load(String name, ClassLoader classLoader) throws IOException {
+        // Build the list of classloaders to try, in priority order:
+        //   1. Explicit classloader (if provided)
+        //   2. Thread context classloader
+        //   3. The classloader that loaded TerminalProvider itself
+        // This fallback chain handles plugin systems and OSGi containers where
+        // JLine JARs are loaded by a classloader that is not the thread's context classloader.
+        ClassLoader contextCl = Thread.currentThread().getContextClassLoader();
+        ClassLoader jlineCl = TerminalProvider.class.getClassLoader();
 
-        // Read the provider-specific resource file to get the class name.
-        // We use META-INF/jline/providers/{name} instead of ServiceLoader to avoid
-        // instantiating all providers when we only need one. This is critical because
-        // some providers (JNI, FFM) may fail to load due to missing native libraries.
         String providerResource = "META-INF/jline/providers/" + name;
-        try (InputStream is = cl.getResourceAsStream(providerResource)) {
-            if (is != null) {
+        IOException loadError = null;
+
+        // Try each classloader until the resource is found
+        ClassLoader[] candidates = new ClassLoader[] {classLoader, contextCl, jlineCl};
+        for (ClassLoader cl : candidates) {
+            if (cl == null) {
+                continue;
+            }
+            InputStream is = cl.getResourceAsStream(providerResource);
+            if (is == null) {
+                continue;
+            }
+            try (is) {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
                 String line;
                 while ((line = reader.readLine()) != null) {
@@ -357,14 +408,23 @@ public interface TerminalProvider {
                         Class<?> providerClass = cl.loadClass(line);
                         return (TerminalProvider) providerClass.getConstructor().newInstance();
                     } catch (Exception | LinkageError e) {
-                        throw new IOException("Unable to load terminal provider " + name + ": " + e.getMessage(), e);
+                        loadError =
+                                new IOException("Unable to load terminal provider " + name + ": " + e.getMessage(), e);
+                        break;
                     }
                 }
+            } catch (IOException e) {
+                loadError = new IOException("Error reading provider resource file: " + e.getMessage(), e);
             }
-        } catch (IOException e) {
-            throw new IOException("Error reading provider resource file: " + e.getMessage(), e);
         }
 
-        throw new IOException("Unable to find terminal provider " + name);
+        if (loadError != null) {
+            throw loadError;
+        }
+        throw new IOException("Unable to find terminal provider " + name
+                + ". The provider resource file META-INF/jline/providers/" + name
+                + " was not found by any classloader. If JLine is loaded by a custom classloader"
+                + " (e.g., OSGi, plugin system), use TerminalBuilder.classLoader() to specify"
+                + " the classloader that can access the JLine provider JARs.");
     }
 }

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -400,6 +400,11 @@ public interface TerminalProvider {
                 }
             } catch (IOException e) {
                 loadError = e;
+            } catch (RuntimeException e) {
+                // Tolerate misbehaving classloaders (e.g., SecurityException from
+                // OSGi/plugin systems) so remaining candidates still get a chance.
+                loadError = new IOException(
+                        "Unable to search classloader " + cl + " for provider " + name + ": " + e.getMessage(), e);
             }
         }
 

--- a/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
+++ b/terminal/src/main/java/org/jline/terminal/spi/TerminalProvider.java
@@ -365,7 +365,7 @@ public interface TerminalProvider {
      * @throws IOException if the provider cannot be loaded or is not found
      */
     static TerminalProvider load(String name, ClassLoader classLoader) throws IOException {
-        // Build the list of classloaders to try, in priority order:
+        // Try classloaders in priority order:
         //   1. Explicit classloader (if provided)
         //   2. Thread context classloader
         //   3. The classloader that loaded TerminalProvider itself
@@ -373,48 +373,22 @@ public interface TerminalProvider {
         // JLine JARs are loaded by a classloader that is not the thread's context classloader.
         ClassLoader contextCl = Thread.currentThread().getContextClassLoader();
         ClassLoader jlineCl = TerminalProvider.class.getClassLoader();
+        ClassLoader[] candidates = new ClassLoader[] {classLoader, contextCl, jlineCl};
 
         String providerResource = "META-INF/jline/providers/" + name;
         IOException loadError = null;
 
-        // Try each classloader until the resource is found
-        ClassLoader[] candidates = new ClassLoader[] {classLoader, contextCl, jlineCl};
         for (ClassLoader cl : candidates) {
             if (cl == null) {
                 continue;
             }
-            InputStream is = cl.getResourceAsStream(providerResource);
-            if (is == null) {
-                continue;
-            }
-            try (is) {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    // Remove comments and trim whitespace
-                    int commentIndex = line.indexOf('#');
-                    if (commentIndex >= 0) {
-                        line = line.substring(0, commentIndex);
-                    }
-                    line = line.trim();
-
-                    // Skip empty lines
-                    if (line.isEmpty()) {
-                        continue;
-                    }
-
-                    // Found a provider class name, try to load it
-                    try {
-                        Class<?> providerClass = cl.loadClass(line);
-                        return (TerminalProvider) providerClass.getConstructor().newInstance();
-                    } catch (Exception | LinkageError e) {
-                        loadError =
-                                new IOException("Unable to load terminal provider " + name + ": " + e.getMessage(), e);
-                        break;
-                    }
+            try {
+                TerminalProvider result = tryLoadProvider(cl, providerResource, name);
+                if (result != null) {
+                    return result;
                 }
             } catch (IOException e) {
-                loadError = new IOException("Error reading provider resource file: " + e.getMessage(), e);
+                loadError = e;
             }
         }
 
@@ -422,9 +396,48 @@ public interface TerminalProvider {
             throw loadError;
         }
         throw new IOException("Unable to find terminal provider " + name
-                + ". The provider resource file META-INF/jline/providers/" + name
+                + ". The provider resource file " + providerResource
                 + " was not found by any classloader. If JLine is loaded by a custom classloader"
-                + " (e.g., OSGi, plugin system), use TerminalBuilder.classLoader() to specify"
-                + " the classloader that can access the JLine provider JARs.");
+                + " (e.g., OSGi, plugin system), configure the builder with"
+                + " TerminalBuilder.builder().classLoader(loader) to specify"
+                + " a classloader that can access the JLine provider JARs.");
+    }
+
+    /**
+     * Attempts to load a provider using a single classloader.
+     *
+     * @return the loaded provider, or {@code null} if the resource was not found by this classloader
+     * @throws IOException if the resource was found but the provider class could not be loaded
+     */
+    private static TerminalProvider tryLoadProvider(ClassLoader cl, String providerResource, String name)
+            throws IOException {
+        InputStream is = cl.getResourceAsStream(providerResource);
+        if (is == null) {
+            return null;
+        }
+        try (is) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // Remove comments and trim whitespace
+                int commentIndex = line.indexOf('#');
+                if (commentIndex >= 0) {
+                    line = line.substring(0, commentIndex);
+                }
+                line = line.trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+
+                // Found a provider class name, try to load it
+                try {
+                    Class<?> providerClass = cl.loadClass(line);
+                    return (TerminalProvider) providerClass.getConstructor().newInstance();
+                } catch (Exception | LinkageError e) {
+                    throw new IOException("Unable to load terminal provider " + name + ": " + e.getMessage(), e);
+                }
+            }
+        }
+        return null;
     }
 }

--- a/terminal/src/test/java/org/jline/terminal/spi/TerminalProviderLoaderTest.java
+++ b/terminal/src/test/java/org/jline/terminal/spi/TerminalProviderLoaderTest.java
@@ -162,8 +162,8 @@ class TerminalProviderLoaderTest {
     void errorMessageMentionsClassLoaderHint() {
         IOException ex = assertThrows(IOException.class, () -> TerminalProvider.load("nonexistent", null));
         assertTrue(
-                ex.getMessage().contains("TerminalBuilder.classLoader()"),
-                "Error should suggest TerminalBuilder.classLoader() as a fix");
+                ex.getMessage().contains("TerminalBuilder.builder().classLoader("),
+                "Error should suggest TerminalBuilder.builder().classLoader() as a fix");
     }
 
     // ------------------------------------------------------------------
@@ -197,7 +197,7 @@ class TerminalProviderLoaderTest {
             IOException ex = assertThrows(IOException.class, () -> TerminalProvider.load("nonexistent", hiding));
             assertTrue(ex.getMessage().contains("nonexistent"));
             assertTrue(ex.getMessage().contains("META-INF/jline/providers/"));
-            assertTrue(ex.getMessage().contains("TerminalBuilder.classLoader()"));
+            assertTrue(ex.getMessage().contains("TerminalBuilder.builder().classLoader("));
         } finally {
             Thread.currentThread().setContextClassLoader(original);
         }

--- a/terminal/src/test/java/org/jline/terminal/spi/TerminalProviderLoaderTest.java
+++ b/terminal/src/test/java/org/jline/terminal/spi/TerminalProviderLoaderTest.java
@@ -88,6 +88,21 @@ class TerminalProviderLoaderTest {
         }
     }
 
+    /**
+     * A classloader that throws a {@link SecurityException} on every resource
+     * lookup. Simulates a misbehaving classloader in a restrictive container.
+     */
+    private static class ThrowingClassLoader extends ClassLoader {
+        ThrowingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            throw new SecurityException("Simulated restrictive classloader");
+        }
+    }
+
     // ------------------------------------------------------------------
     // Basic load(name) tests
     // ------------------------------------------------------------------
@@ -201,5 +216,19 @@ class TerminalProviderLoaderTest {
         } finally {
             Thread.currentThread().setContextClassLoader(original);
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Misbehaving classloader resilience
+    // ------------------------------------------------------------------
+
+    @Test
+    void throwingClassLoaderSkippedAndFallbackSucceeds() throws IOException {
+        // A misbehaving explicit classloader (throws SecurityException) should
+        // be caught and skipped, allowing the fallback to JLine's own classloader.
+        ClassLoader throwing = new ThrowingClassLoader(getClass().getClassLoader());
+        TerminalProvider provider = TerminalProvider.load("exec", throwing);
+        assertNotNull(provider);
+        assertEquals("exec", provider.name());
     }
 }

--- a/terminal/src/test/java/org/jline/terminal/spi/TerminalProviderLoaderTest.java
+++ b/terminal/src/test/java/org/jline/terminal/spi/TerminalProviderLoaderTest.java
@@ -121,7 +121,7 @@ class TerminalProviderLoaderTest {
     // ------------------------------------------------------------------
 
     @Test
-    void fallbackToJLineClassLoaderWhenContextHidesResources() throws Exception {
+    void fallbackToJLineClassLoaderWhenContextHidesResources() throws IOException {
         // Simulate the issue #2110 scenario: thread context classloader
         // cannot see META-INF/jline/providers/* but JLine's own classloader can.
         ClassLoader original = Thread.currentThread().getContextClassLoader();
@@ -138,7 +138,7 @@ class TerminalProviderLoaderTest {
     }
 
     @Test
-    void explicitClassLoaderTakesPriority() throws Exception {
+    void explicitClassLoaderTakesPriority() throws IOException {
         // Even when the context classloader can find "exec", an explicit
         // classloader pointing to "dumb" should win (it is tried first).
         ClassLoader explicitCl = new SyntheticProviderClassLoader(
@@ -171,7 +171,7 @@ class TerminalProviderLoaderTest {
     // ------------------------------------------------------------------
 
     @Test
-    void explicitClassLoaderWorksWhenContextHidesResources() throws Exception {
+    void explicitClassLoaderWorksWhenContextHidesResources() throws IOException {
         ClassLoader original = Thread.currentThread().getContextClassLoader();
         ClassLoader hiding = new ResourceHidingClassLoader(original);
         Thread.currentThread().setContextClassLoader(hiding);
@@ -187,7 +187,7 @@ class TerminalProviderLoaderTest {
     }
 
     @Test
-    void allClassLoadersFailGivesActionableError() throws Exception {
+    void allClassLoadersFailGivesActionableError() {
         ClassLoader original = Thread.currentThread().getContextClassLoader();
         ClassLoader hiding = new ResourceHidingClassLoader(original);
         Thread.currentThread().setContextClassLoader(hiding);

--- a/terminal/src/test/java/org/jline/terminal/spi/TerminalProviderLoaderTest.java
+++ b/terminal/src/test/java/org/jline/terminal/spi/TerminalProviderLoaderTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.spi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link TerminalProvider#load(String)} and
+ * {@link TerminalProvider#load(String, ClassLoader)} classloader resolution.
+ */
+@SuppressWarnings("missing-explicit-ctor")
+class TerminalProviderLoaderTest {
+
+    /**
+     * A classloader that hides all {@code META-INF/jline/providers/} resources
+     * and delegates class loading to its parent. This simulates the thread
+     * context classloader in a plugin system that cannot see JLine resources.
+     */
+    private static class ResourceHidingClassLoader extends ClassLoader {
+        ResourceHidingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (name != null && name.startsWith("META-INF/jline/providers/")) {
+                return null;
+            }
+            return super.getResourceAsStream(name);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (name != null && name.startsWith("META-INF/jline/providers/")) {
+                return null;
+            }
+            return super.getResource(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (name != null && name.startsWith("META-INF/jline/providers/")) {
+                return Collections.emptyEnumeration();
+            }
+            return super.getResources(name);
+        }
+    }
+
+    /**
+     * A classloader that provides a synthetic provider resource pointing to a
+     * given class name, without delegating resource lookups to its parent.
+     */
+    private static class SyntheticProviderClassLoader extends ClassLoader {
+        private final String providerName;
+        private final String className;
+
+        SyntheticProviderClassLoader(ClassLoader parent, String providerName, String className) {
+            super(parent);
+            this.providerName = providerName;
+            this.className = className;
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (("META-INF/jline/providers/" + providerName).equals(name)) {
+                return new ByteArrayInputStream(className.getBytes(StandardCharsets.UTF_8));
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Basic load(name) tests
+    // ------------------------------------------------------------------
+
+    @Test
+    void loadExecProvider() throws IOException {
+        // "exec" provider lives in the terminal module itself, always available
+        TerminalProvider provider = TerminalProvider.load("exec");
+        assertNotNull(provider);
+        assertEquals("exec", provider.name());
+    }
+
+    @Test
+    void loadDumbProvider() throws IOException {
+        TerminalProvider provider = TerminalProvider.load("dumb");
+        assertNotNull(provider);
+        assertEquals("dumb", provider.name());
+    }
+
+    @Test
+    void loadNonExistentProviderThrows() {
+        IOException ex = assertThrows(IOException.class, () -> TerminalProvider.load("nonexistent"));
+        assertTrue(ex.getMessage().contains("nonexistent"), "Message should name the provider");
+        assertTrue(
+                ex.getMessage().contains("META-INF/jline/providers/"),
+                "Message should mention the resource path being searched");
+    }
+
+    // ------------------------------------------------------------------
+    // Classloader fallback chain tests
+    // ------------------------------------------------------------------
+
+    @Test
+    void fallbackToJLineClassLoaderWhenContextHidesResources() throws Exception {
+        // Simulate the issue #2110 scenario: thread context classloader
+        // cannot see META-INF/jline/providers/* but JLine's own classloader can.
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+        ClassLoader hiding = new ResourceHidingClassLoader(original);
+        Thread.currentThread().setContextClassLoader(hiding);
+        try {
+            // load(name) should still succeed by falling back to TerminalProvider's classloader
+            TerminalProvider provider = TerminalProvider.load("exec");
+            assertNotNull(provider);
+            assertEquals("exec", provider.name());
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+
+    @Test
+    void explicitClassLoaderTakesPriority() throws Exception {
+        // Even when the context classloader can find "exec", an explicit
+        // classloader pointing to "dumb" should win (it is tried first).
+        ClassLoader explicitCl = new SyntheticProviderClassLoader(
+                getClass().getClassLoader(), "exec", "org.jline.terminal.impl.DumbTerminalProvider");
+
+        TerminalProvider provider = TerminalProvider.load("exec", explicitCl);
+        assertNotNull(provider);
+        // The explicit classloader's resource mapped "exec" -> DumbTerminalProvider
+        assertEquals("dumb", provider.name());
+    }
+
+    @Test
+    void nullExplicitClassLoaderFallsBackNormally() throws IOException {
+        // Passing null as the explicit classloader should behave the same as load(name)
+        TerminalProvider provider = TerminalProvider.load("exec", null);
+        assertNotNull(provider);
+        assertEquals("exec", provider.name());
+    }
+
+    @Test
+    void errorMessageMentionsClassLoaderHint() {
+        IOException ex = assertThrows(IOException.class, () -> TerminalProvider.load("nonexistent", null));
+        assertTrue(
+                ex.getMessage().contains("TerminalBuilder.classLoader()"),
+                "Error should suggest TerminalBuilder.classLoader() as a fix");
+    }
+
+    // ------------------------------------------------------------------
+    // Combined context-hiding + explicit classloader
+    // ------------------------------------------------------------------
+
+    @Test
+    void explicitClassLoaderWorksWhenContextHidesResources() throws Exception {
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+        ClassLoader hiding = new ResourceHidingClassLoader(original);
+        Thread.currentThread().setContextClassLoader(hiding);
+        try {
+            // Context classloader hides resources, but an explicit classloader
+            // that can see them should succeed.
+            TerminalProvider provider = TerminalProvider.load("exec", original);
+            assertNotNull(provider);
+            assertEquals("exec", provider.name());
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+
+    @Test
+    void allClassLoadersFailGivesActionableError() throws Exception {
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+        ClassLoader hiding = new ResourceHidingClassLoader(original);
+        Thread.currentThread().setContextClassLoader(hiding);
+        try {
+            // Explicit classloader also hides resources, and JLine's own classloader
+            // cannot find "nonexistent" — all three candidates fail.
+            IOException ex = assertThrows(IOException.class, () -> TerminalProvider.load("nonexistent", hiding));
+            assertTrue(ex.getMessage().contains("nonexistent"));
+            assertTrue(ex.getMessage().contains("META-INF/jline/providers/"));
+            assertTrue(ex.getMessage().contains("TerminalBuilder.classLoader()"));
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+}


### PR DESCRIPTION
Closes #2110

## Summary

`TerminalProvider.load()` only tried the thread context classloader to find provider resource files (`META-INF/jline/providers/{name}`). This fails when JLine JARs are loaded by a custom/child classloader (plugin systems, OSGi containers, application servers) because the thread context classloader cannot see resources inside those JARs.

**Changes:**

- **Classloader fallback chain** in `TerminalProvider.load()` — tries classloaders in order: explicit → thread context → `TerminalProvider.class.getClassLoader()`. The last fallback is the classloader that loaded JLine itself, which can always find JLine's own resources
- **New `TerminalBuilder.classLoader(ClassLoader)` method** — lets callers specify the classloader explicitly for environments where even the automatic fallback isn't sufficient
- **Improved error message** — when no classloader can find the provider, the message now names the resource path being searched and suggests `TerminalBuilder.classLoader()` as a fix

## Test plan

- [x] `./mvx mvn test -pl terminal` — 445 tests pass
- [x] `./mvx mvn install -DskipTests -pl terminal-jni,terminal-ffm` — dependent modules compile cleanly
- [x] Spotless formatting verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fluent option to set a custom classloader for terminal provider discovery.
  * Provider discovery now resolves implementations using an explicit classloader, then the thread context classloader, then JLine’s own classloader.
* **Bug Fixes**
  * Improved provider loading robustness, continuing across classloaders when resources can’t be accessed and tolerating misbehaving classloaders.
  * Missing-provider errors now include the searched resource path and guidance for custom classloader configuration.
* **Tests**
  * Added JUnit coverage for successful provider loading and detailed error handling across classloader scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->