### PR TITLE
fix: use Arena.ofAuto instead of Arena.ofShared in FfmSignalHandler (fixes #2117)

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmSignalHandler.java
@@ -29,7 +29,7 @@ import java.util.concurrent.locks.LockSupport;
  * <ul>
  *   <li>No dependency on internal JVM APIs ({@code sun.misc.Signal})</li>
  *   <li>{@code SA_RESTART} flag to automatically restart interrupted system calls</li>
- *   <li>Arena-scoped handler lifetime</li>
+ *   <li>GC-managed handler lifetime (uses {@link Arena#ofAuto()} for GraalVM native-image compatibility)</li>
  * </ul>
  *
  * <p><b>Async-signal-safety caveat:</b> The upcall stub used as the native signal handler
@@ -227,7 +227,7 @@ class FfmSignalHandler {
     /**
      * Token returned by {@link #register} for later use with {@link #unregister}.
      */
-    record Registration(int signum, Arena arena, MemorySegment oldAction, Runnable previousHandler) {}
+    record Registration(int signum, MemorySegment oldAction, Runnable previousHandler) {}
 
     // --- Public API ---
 
@@ -245,7 +245,7 @@ class FfmSignalHandler {
      *
      * @param name    signal name (e.g. "WINCH", "INT")
      * @param handler the Java callback to invoke when the signal is dispatched
-     * @return a {@link Registration} token encapsulating the signum, native arena and saved old action (and the previous Java handler when preserved), or {@code null} if FFM support is unavailable or the signal name is unsupported
+     * @return a {@link Registration} token retaining the signum, the saved {@code oldAction} segment for later restoration, and the previous Java handler (when preserved), or {@code null} if FFM support is unavailable or the signal name is unsupported
      */
     static Object register(String name, Runnable handler) {
         if (!AVAILABLE) {
@@ -260,7 +260,7 @@ class FfmSignalHandler {
         // immediately after the native install are not lost.
         Runnable previousHandler = handlers.put(signum, handler);
 
-        Arena arena = Arena.ofShared();
+        Arena arena = Arena.ofAuto();
         MemorySegment oldAct = null;
         boolean nativeInstalled = false;
         try {
@@ -273,7 +273,6 @@ class FfmSignalHandler {
             if (res != 0) {
                 logger.log(Level.DEBUG, "sigaction() failed for signal {0} (signum={1})", new Object[] {name, signum});
                 restoreHandler(signum, previousHandler);
-                arena.close();
                 return null;
             }
             nativeInstalled = true;
@@ -281,7 +280,7 @@ class FfmSignalHandler {
             // Only preserve previousHandler in Registration when the old native
             // disposition was our upcall stub (otherwise it belongs to an external handler)
             Runnable saved = isOurUpcallStub(oldAct) ? previousHandler : null;
-            return new Registration(signum, arena, oldAct, saved);
+            return new Registration(signum, oldAct, saved);
         } catch (Throwable t) {
             logger.log(Level.DEBUG, "Error registering FFM signal handler for {0}", name);
             logger.log(Level.DEBUG, EXCEPTION_DETAILS, t);
@@ -289,7 +288,6 @@ class FfmSignalHandler {
                 bestEffortRestore(signum, oldAct);
             }
             restoreHandler(signum, previousHandler);
-            arena.close();
             return null;
         }
     }
@@ -309,7 +307,7 @@ class FfmSignalHandler {
             return null;
         }
 
-        Arena arena = Arena.ofShared();
+        Arena arena = Arena.ofAuto();
         try {
             MemorySegment oldAct = arena.allocate(sigactionLayout);
             MemorySegment newAct = arena.allocate(sigactionLayout);
@@ -319,17 +317,15 @@ class FfmSignalHandler {
             int res = (int) sigaction_mh.invoke(signum, newAct, oldAct);
             if (res != 0) {
                 logger.log(Level.DEBUG, "sigaction(SIG_DFL) failed for signal {0}", name);
-                arena.close();
                 return null;
             }
             // Save the previous Java handler in case unregister() needs to restore it
             Runnable previousHandler = handlers.remove(signum);
             stopDispatcherIfIdle();
-            return new Registration(signum, arena, oldAct, previousHandler);
+            return new Registration(signum, oldAct, previousHandler);
         } catch (Throwable t) {
             logger.log(Level.DEBUG, "Error registering default handler for {0}", name);
             logger.log(Level.DEBUG, EXCEPTION_DETAILS, t);
-            arena.close();
             return null;
         }
     }
@@ -362,8 +358,6 @@ class FfmSignalHandler {
         } catch (Throwable t) {
             logger.log(Level.DEBUG, "Error unregistering FFM signal handler for {0}", name);
             logger.log(Level.DEBUG, EXCEPTION_DETAILS, t);
-        } finally {
-            reg.arena().close();
         }
     }
 


### PR DESCRIPTION
## Summary

Replace `Arena.ofShared()` with `Arena.ofAuto()` in `FfmSignalHandler` to fix GraalVM native-image compatibility.

`Arena.ofShared()` requires the `-H:+SharedArenaSupport` flag when building a GraalVM native image. Without the flag, every terminal interaction prints an error: `Support for Arena.ofShared is not active: enable with -H:+SharedArenaSupport`. This broke all FFM-terminal JLine consumers in native images (e.g., babashka).

### Changes

- **`Arena.ofShared()` → `Arena.ofAuto()`** in `register()` and `registerDefault()` — the only two `ofShared` call sites in the codebase
- **Remove explicit `arena.close()` calls** — `Arena.ofAuto()` does not support `close()` (throws `UnsupportedOperationException`); native memory is instead reclaimed by the GC when the `Registration` becomes unreachable
- **Remove `arena` field from `Registration` record** — it was only needed for the explicit close; the `oldAction` `MemorySegment` keeps the arena alive through its internal scope reference

### Why `ofAuto` is safe here

The arena backs a signal handler registration that lives from `register()` to `unregister()`. The `Registration` record holds the `oldAction` segment (allocated from the arena), keeping the arena alive. After `unregister()` restores the previous signal handler and the caller drops the `Registration` reference, the GC can reclaim the native memory. This matches the lifecycle perfectly — the existing `ofShared` + explicit close was strictly a convenience, not a correctness requirement.

Fixes #2117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal-handler lifecycle management to reduce the risk of premature cleanup or related failures.
  * Updated signal-handler registration and unregistration behavior for more reliable operation.
* **Refactor**
  * Simplified the stored registration state to better align handler lifetime management with automatic GC control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->