### PR TITLE
chore: clarify merge policy to require label, milestone, and assignee

### DIFF
--- a/.oss-ai-helper-rules/project-guidelines.md
+++ b/.oss-ai-helper-rules/project-guidelines.md
@@ -12,11 +12,14 @@ This rule file contains branching, commit, PR, and task-finding conventions for 
 - **Commit format (quick-fix):** `chore: <brief description>`
 - **Commit format (ci-issue):** `ci: <brief description>`
 - **PR creation:** always
-- **Merge policy:** when merging a PR, categorize it with a label (e.g., `bug`, `enhancement`, `documentation`) and assign it to the next milestone
+- **Merge policy:** before merging a PR, complete all three steps:
+  1. **Label** — categorize with the appropriate label (`bug`, `enhancement`, `fix`, `documentation`, `build`, `chore`, `test`, `dependencies`, etc.). Labels drive the release notes.
+  2. **Milestone** — assign to the target release milestone (check open milestones: e.g., `4.4.0`, `3.30.17`, `5.0.0`). Use the next patch/minor for the branch the PR targets.
+  3. **Assign** — assign the PR to its author (or the contributor who did the work). Do not change existing assignees on linked issues.
 - **Find-task source:** GitHub labels
 - **Find-task beginner label:** `good first issue`
 - **Find-task experienced label:** `help wanted`
 - **Scope-too-large redirect:** create a GitHub issue
 
 ## Version
-1735c1f2a22808a1a3d7837db0eca9714a66f4e8
+b1ca3bf14c7f191083ce24523e4098bbccd01a73

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ Spotless enforces this header automatically via `spotless:apply`.
 - **Always squash merge.** The squash commit message must be a single `<type>: <description>` line that summarizes the entire diff (not a list of individual commits).
 - **Label the PR** before merging to categorize it (e.g., `enhancement`, `bug`, `documentation`). Labels drive the release notes.
 - **Set the milestone** on the PR to the target release version before merging.
+- **Assign the PR** to its author (or the contributor who did the work). Do not change existing assignees on linked issues.
 
 ### Backporting Workflow
 


### PR DESCRIPTION
## Summary

Update `.oss-ai-helper-rules/project-guidelines.md` to make the pre-merge checklist explicit:

1. **Label** — categorize the PR with the appropriate label (drives release notes)
2. **Milestone** — assign to the target release milestone
3. **Assign** — assign the PR to its author; for linked issues, assign the issue too

Previously the merge policy was a single line mentioning labels and milestones. This makes all three steps clear and lists the available labels and current open milestones as examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded merge policy guidance to require label selection, milestone assignment, and assignee selection before merging.
  * Updated the guideline version information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->