### PR TITLE
fix: stop answering DSR 7/8 with plain text in ScreenTerminal

### DIFF
--- a/terminal/src/main/java/org/jline/utils/ScreenTerminal.java
+++ b/terminal/src/main/java/org/jline/utils/ScreenTerminal.java
@@ -1269,10 +1269,6 @@ public class ScreenTerminal implements Sized {
             vt100_out = "\u001b[0n";
         } else if ("6".equals(ps[0])) {
             vt100_out = "\u001b[" + (cy + 1) + ";" + (cx + 1) + "R";
-        } else if ("7".equals(ps[0])) {
-            vt100_out = "gogo-term";
-        } else if ("8".equals(ps[0])) {
-            vt100_out = "1.0-SNAPSHOT";
         } else if ("?6".equals(ps[0])) {
             vt100_out = "\u001b[" + (cy + 1) + ";" + (cx + 1) + ";0R";
         } else if ("?15".equals(ps[0])) {
@@ -1284,6 +1280,9 @@ public class ScreenTerminal implements Sized {
         } else if ("?53".equals(ps[0])) {
             vt100_out = "\u001b[?53n";
         }
+        // Replies are fed back as terminal input, so only control sequences are
+        // sent: 7 (terminal name) and 8 (firmware version) are not ECMA-48 DSR
+        // requests and answering them typed plain text into the application.
         // ?75 : Data Integrity report
         // ?62 : Macro Space report
         // ?63 : Memory Checksum report

--- a/terminal/src/test/java/org/jline/utils/ScreenTerminalTest.java
+++ b/terminal/src/test/java/org/jline/utils/ScreenTerminalTest.java
@@ -1292,7 +1292,7 @@ class ScreenTerminalTest {
     void testDsrReplyIsNotTypedIntoTerminalInput() throws IOException {
         ScreenTerminal.VirtualTerminal vt = ScreenTerminal.withTerminal("test", "xterm", 80, 24);
         try (Terminal terminal = vt.terminal()) {
-            terminal.writer().write("\033[7n");
+            terminal.writer().write("\033[7n\033[8n");
             terminal.writer().flush();
 
             assertEquals(

--- a/terminal/src/test/java/org/jline/utils/ScreenTerminalTest.java
+++ b/terminal/src/test/java/org/jline/utils/ScreenTerminalTest.java
@@ -1262,4 +1262,43 @@ class ScreenTerminalTest {
 
         assertFalse(screen.isSynchronizedOutput());
     }
+
+    /**
+     * DSR replies are fed back as terminal input, so every reply must be a
+     * control sequence the application consumes as a report. Requests outside
+     * the ECMA-48 set are left unanswered.
+     */
+    @Test
+    void testDsrDoesNotReplyWithPlainText() {
+        ScreenTerminal screen = new ScreenTerminal(80, 24);
+
+        screen.write("\033[7n");
+        assertEquals("", screen.read(), "DSR 7 must not reply");
+        screen.write("\033[8n");
+        assertEquals("", screen.read(), "DSR 8 must not reply");
+
+        // The standard reports still answer
+        screen.write("\033[5n");
+        assertEquals("\033[0n", screen.read());
+        screen.write("\033[6n");
+        assertEquals("\033[1;1R", screen.read());
+    }
+
+    /**
+     * A wired screen feeds its replies to the terminal input, so output
+     * carrying an unanswered request must not put anything there.
+     */
+    @Test
+    void testDsrReplyIsNotTypedIntoTerminalInput() throws IOException {
+        ScreenTerminal.VirtualTerminal vt = ScreenTerminal.withTerminal("test", "xterm", 80, 24);
+        try (Terminal terminal = vt.terminal()) {
+            terminal.writer().write("\033[7n");
+            terminal.writer().flush();
+
+            assertEquals(
+                    NonBlockingReader.READ_EXPIRED,
+                    terminal.reader().read(200L),
+                    "screen reply reached the terminal input");
+        }
+    }
 }


### PR DESCRIPTION
`ScreenTerminal` wired to a `LineDisciplineTerminal`, application prints `\e[7n`:

    before:  terminal.reader().read(200) -> 103   ('g', first char of "gogo-term")
    after:   terminal.reader().read(200) -> -2    (READ_EXPIRED)

`csi_DSR` answered `CSI 7 n` and `CSI 8 n` with the bare strings `gogo-term` and
`1.0-SNAPSHOT`. Replies land in `vt100_out`, which `ScreenTerminalOutputStream.flush()`
hands to the feedback stream set up by `wireTerminal`, i.e.
`LineDisciplineTerminal.processInputByte`. Every other reply here is a framed control
sequence the reading application consumes as a report, so these two arrive as ordinary
keystrokes: anything printed through the screen (a file opened in a pager, a log line, a
remote peer's output in a WebTerminal or SwingTerminal session) can type text into the
session the LineReader is reading.

Neither 7 nor 8 is an ECMA-48 DSR request and nothing in jline queries them, so both
branches are dropped. The standard reports (5, 6, ?6, ?15, ?25, ?26, ?53) are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected terminal status-report handling so unsupported requests no longer return misleading terminal information.
  * Preserved standard cursor position and terminal size status responses.
  * Prevented unanswered status requests from appearing as user input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->