### PR TITLE
fix: strip control characters from ssh banner and prompts

### DIFF
--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
@@ -450,7 +450,7 @@ public class Ssh {
 
         @Override
         public void welcome(ClientSession session, String banner, String lang) {
-            terminal.writer().println(banner);
+            terminal.writer().println(printable(banner));
         }
 
         @Override
@@ -459,7 +459,7 @@ public class Ssh {
             String[] answers = new String[prompt.length];
             try {
                 for (int i = 0; i < prompt.length; i++) {
-                    answers[i] = readLine(prompt[i], echo[i]);
+                    answers[i] = readLine(printable(prompt[i]), echo[i]);
                 }
             } catch (Exception e) {
                 stderr.append(e.getClass().getSimpleName())
@@ -477,20 +477,39 @@ public class Ssh {
         @Override
         public void serverVersionInfo(ClientSession session, List<String> lines) {
             for (String l : lines) {
-                terminal.writer().append('\t').println(l);
+                terminal.writer().append('\t').println(printable(l));
             }
         }
 
         @Override
         public String getUpdatedPassword(ClientSession session, String prompt, String lang) {
             try {
-                return readLine(prompt, false);
+                return readLine(printable(prompt), false);
             } catch (Exception e) {
                 stderr.append(e.getClass().getSimpleName())
                         .append(" while reading password: ")
                         .println(e.getMessage());
             }
             return null;
+        }
+
+        /**
+         * Drops control characters from text the server chose. Identification lines, the welcome
+         * banner and keyboard-interactive prompts all reach the terminal before the session is
+         * authenticated, so the peer must not be able to smuggle escape sequences through them.
+         * Line breaks and tabs are kept so multi-line banners still render.
+         */
+        private static String printable(String text) {
+            if (text == null) {
+                return null;
+            }
+            StringBuilder sb = new StringBuilder(text.length());
+            text.codePoints().forEach(cp -> {
+                if (cp == '\n' || cp == '\t' || !Character.isISOControl(cp)) {
+                    sb.appendCodePoint(cp);
+                }
+            });
+            return sb.toString();
         }
 
         private String readLine(String prompt, boolean echo) {

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
@@ -497,7 +497,8 @@ public class Ssh {
          * Drops control characters from text the server chose. Identification lines, the welcome
          * banner and keyboard-interactive prompts all reach the terminal before the session is
          * authenticated, so the peer must not be able to smuggle escape sequences through them.
-         * Line breaks and tabs are kept so multi-line banners still render.
+         * Newlines ({@code \n}) and tabs are kept so multi-line banners still render;
+         * {@code \r} is stripped along with the other control characters.
          */
         private static String printable(String text) {
             if (text == null) {

--- a/remote-ssh/src/test/java/org/jline/builtins/ssh/SshServerTextTest.java
+++ b/remote-ssh/src/test/java/org/jline/builtins/ssh/SshServerTextTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins.ssh;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.core.CoreModuleProperties;
+import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.ExitCallback;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.UserAuthNoneFactory;
+import org.apache.sshd.server.channel.ChannelSession;
+import org.apache.sshd.server.command.Command;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.shell.ShellFactory;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.LineDisciplineTerminal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(30)
+class SshServerTextTest {
+
+    /** Window title change, screen wipe and a fake password prompt, all inside the banner. */
+    private static final String HOSTILE_BANNER = "Authorized access only\n\033]0;pwned\007\033[2J\033[1;1HPassword:";
+
+    @Test
+    void welcomeBannerCannotDriveTheTerminal() throws Exception {
+        String out = runWithBanner(HOSTILE_BANNER);
+        assertTrue(out.contains("Authorized access only"), "banner text must still be shown: " + out);
+        assertFalse(out.contains("\033"), "banner must not put an escape character on the terminal: " + out);
+        assertFalse(out.contains("\007"), "banner must not put a BEL on the terminal: " + out);
+    }
+
+    /**
+     * Drives {@link Ssh#ssh} against an in-process server that sends {@code banner} as its
+     * pre-authentication welcome banner, and returns what the client wrote to its terminal.
+     */
+    private String runWithBanner(String banner) throws Exception {
+        SshServer sshd = SshServer.setUpDefaultServer();
+        sshd.setPort(0);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(Path.of("target/banner-hostkey.ser")));
+        sshd.setUserAuthFactories(Collections.singletonList(UserAuthNoneFactory.INSTANCE));
+        CoreModuleProperties.WELCOME_BANNER.set(sshd, banner);
+        sshd.setShellFactory(new ImmediateExitShellFactory());
+        sshd.start();
+
+        ByteArrayOutputStream terminalOut = new ByteArrayOutputStream();
+        Terminal terminal = new LineDisciplineTerminal("banner-test", "xterm", terminalOut, StandardCharsets.UTF_8);
+        try {
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+            Ssh ssh = new Ssh(null, null, null, SshClient::setUpDefaultClient);
+            String[] argv = new String[] {"ssh", "localhost:" + sshd.getPort()};
+            PrintStream out = new PrintStream(new ByteArrayOutputStream());
+
+            Thread runner = new Thread(() -> {
+                try {
+                    ssh.ssh(terminal, reader, "test", new ByteArrayInputStream(new byte[0]), out, out, argv);
+                } catch (Exception e) {
+                    // connection/shell teardown races are irrelevant to what we assert
+                }
+            });
+            runner.setDaemon(true);
+            runner.start();
+            runner.join(20000);
+            if (runner.isAlive()) {
+                runner.interrupt();
+                throw new IllegalStateException("ssh() did not return within the timeout");
+            }
+            terminal.writer().flush();
+            return terminalOut.toString(StandardCharsets.UTF_8);
+        } finally {
+            terminal.close();
+            sshd.stop(true);
+        }
+    }
+
+    /** Server shell that closes the channel as soon as it starts, so the client's shell loop returns. */
+    private static class ImmediateExitShellFactory implements ShellFactory {
+        @Override
+        public Command createShell(ChannelSession channel) {
+            return new Command() {
+                private ExitCallback callback;
+
+                @Override
+                public void setInputStream(InputStream in) {}
+
+                @Override
+                public void setOutputStream(OutputStream out) {}
+
+                @Override
+                public void setErrorStream(OutputStream err) {}
+
+                @Override
+                public void setExitCallback(ExitCallback callback) {
+                    this.callback = callback;
+                }
+
+                @Override
+                public void start(ChannelSession channel, Environment env) throws IOException {
+                    callback.onExit(0);
+                }
+
+                @Override
+                public void destroy(ChannelSession channel) {}
+            };
+        }
+    }
+}

--- a/remote-ssh/src/test/java/org/jline/builtins/ssh/SshServerTextTest.java
+++ b/remote-ssh/src/test/java/org/jline/builtins/ssh/SshServerTextTest.java
@@ -34,6 +34,7 @@ import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.LineDisciplineTerminal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,6 +44,9 @@ class SshServerTextTest {
 
     /** Window title change, screen wipe and a fake password prompt, all inside the banner. */
     private static final String HOSTILE_BANNER = "Authorized access only\n\033]0;pwned\007\033[2J\033[1;1HPassword:";
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void welcomeBannerCannotDriveTheTerminal() throws Exception {
@@ -59,7 +63,7 @@ class SshServerTextTest {
     private String runWithBanner(String banner) throws Exception {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(Path.of("target/banner-hostkey.ser")));
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(tempDir.resolve("banner-hostkey.ser")));
         sshd.setUserAuthFactories(Collections.singletonList(UserAuthNoneFactory.INSTANCE));
         CoreModuleProperties.WELCOME_BANNER.set(sshd, banner);
         sshd.setShellFactory(new ImmediateExitShellFactory());

--- a/remote-ssh/src/test/java/org/jline/builtins/ssh/SshServerTextTest.java
+++ b/remote-ssh/src/test/java/org/jline/builtins/ssh/SshServerTextTest.java
@@ -107,13 +107,19 @@ class SshServerTextTest {
                 private ExitCallback callback;
 
                 @Override
-                public void setInputStream(InputStream in) {}
+                public void setInputStream(InputStream in) {
+                    // not needed: test shell exits immediately without reading
+                }
 
                 @Override
-                public void setOutputStream(OutputStream out) {}
+                public void setOutputStream(OutputStream out) {
+                    // not needed: test shell exits immediately without writing
+                }
 
                 @Override
-                public void setErrorStream(OutputStream err) {}
+                public void setErrorStream(OutputStream err) {
+                    // not needed: test shell exits immediately without writing
+                }
 
                 @Override
                 public void setExitCallback(ExitCallback callback) {
@@ -126,7 +132,9 @@ class SshServerTextTest {
                 }
 
                 @Override
-                public void destroy(ChannelSession channel) {}
+                public void destroy(ChannelSession channel) {
+                    // nothing to clean up in the test stub
+                }
             };
         }
     }


### PR DESCRIPTION
Bytes an unpatched client wrote to its terminal after connecting to a server whose welcome banner carries escape sequences:

    Authorized access only<CR><LF><ESC>]0;pwned<BEL><ESC>[2J<ESC>[1;1HPassword:<CR><LF>

`JLineUserInteraction.welcome` hands `SSH_MSG_USERAUTH_BANNER` to `terminal.writer().println` untouched, and `serverVersionInfo` does the same with the extra identification lines a peer may send ahead of its version string. Nothing on that path goes through `fromAnsi`, so a peer that has not authenticated yet picks the window title (OSC 0/2), writes the clipboard (OSC 52), or wipes the screen and repaints its own password prompt. The keyboard-interactive and password-change prompts are server-chosen strings on the same footing.

All four sites now run through a `printable` helper that drops ISO control characters, which covers ESC, BEL and the 8-bit C1 introducers, and keeps newline and tab so multi-line banners render as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sanitized server-provided SSH messages, banners, and prompts to prevent terminal control sequences from affecting the local terminal.
  * Preserved readable formatting such as newlines and tabs in authentication-related text.

* **Tests**
  * Added coverage confirming that hostile welcome banners are displayed as safe, visible text without terminal control characters.
  * Verified the SSH client remains responsive while processing sanitized server messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->