### PR TITLE
fix: backport security fixes to 3.x (path traversal + DSR plain text)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Commands.java
+++ b/builtins/src/main/java/org/jline/builtins/Commands.java
@@ -1974,6 +1974,11 @@ public class Commands {
      * @return the path with the file name replaced
      */
     private static String replaceFileName(Path path, String name) {
+        // name is a theme file name inside path's directory; a separator or ".." segment
+        // would let it point elsewhere (e.g. "../../etc/passwd"), so reject those.
+        if (name.indexOf('/') >= 0 || name.indexOf('\\') >= 0 || name.equals("..") || name.equals(".")) {
+            throw new IllegalArgumentException("Invalid theme name: " + name);
+        }
         int nameLength = path.getFileName().toString().length();
         int pathLength = path.toString().length();
         return (path.toString().substring(0, pathLength - nameLength) + name).replace("\\", "\\\\");

--- a/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
+++ b/builtins/src/main/java/org/jline/builtins/ScreenTerminal.java
@@ -1041,10 +1041,6 @@ public class ScreenTerminal {
             vt100_out = "\u001b[0n";
         } else if ("6".equals(ps[0])) {
             vt100_out = "\u001b[" + (cy + 1) + ";" + (cx + 1) + "R";
-        } else if ("7".equals(ps[0])) {
-            vt100_out = "gogo-term";
-        } else if ("8".equals(ps[0])) {
-            vt100_out = "1.0-SNAPSHOT";
         } else if ("?6".equals(ps[0])) {
             vt100_out = "\u001b[" + (cy + 1) + ";" + (cx + 1) + ";0R";
         } else if ("?15".equals(ps[0])) {
@@ -1056,6 +1052,9 @@ public class ScreenTerminal {
         } else if ("?53".equals(ps[0])) {
             vt100_out = "\u001b[?53n";
         }
+        // Replies are fed back as terminal input, so only control sequences are
+        // sent: 7 (terminal name) and 8 (firmware version) are not ECMA-48 DSR
+        // requests and answering them typed plain text into the application.
         // ?75 : Data Integrity report
         // ?62 : Macro Space report
         // ?63 : Memory Checksum report

--- a/builtins/src/test/java/org/jline/builtins/CommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CommandsTest.java
@@ -13,7 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
+import java.util.Collections;
 
 import org.jline.reader.History;
 import org.jline.reader.LineReader;
@@ -73,10 +73,10 @@ public class CommandsTest {
     @Test
     void highlighterViewRejectsThemePathTraversal(@TempDir Path tmp) throws Exception {
         Path configDir = Files.createDirectory(tmp.resolve("config"));
-        Files.write(configDir.resolve("jnanorc"), List.of("theme dark.nanorctheme"));
-        Files.write(configDir.resolve("dark.nanorctheme"), List.of("DEFAULT white"));
+        Files.write(configDir.resolve("jnanorc"), Collections.singletonList("theme dark.nanorctheme"));
+        Files.write(configDir.resolve("dark.nanorctheme"), Collections.singletonList("DEFAULT white"));
         // sits one level above the theme directory; the viewer must not reach it
-        Files.write(tmp.resolve("outside.nanorctheme"), List.of("SECRET_TOKEN white"));
+        Files.write(tmp.resolve("outside.nanorctheme"), Collections.singletonList("SECRET_TOKEN white"));
 
         for (String name : new String[] {"../outside.nanorctheme", "..\\outside.nanorctheme"}) {
             ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
@@ -109,8 +109,8 @@ public class CommandsTest {
     @Test
     void highlighterViewReadsThemeInConfigDir(@TempDir Path tmp) throws Exception {
         Path configDir = Files.createDirectory(tmp.resolve("config"));
-        Files.write(configDir.resolve("jnanorc"), List.of("theme dark.nanorctheme"));
-        Files.write(configDir.resolve("dark.nanorctheme"), List.of("DEFAULT white"));
+        Files.write(configDir.resolve("jnanorc"), Collections.singletonList("theme dark.nanorctheme"));
+        Files.write(configDir.resolve("dark.nanorctheme"), Collections.singletonList("DEFAULT white"));
 
         ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
         ByteArrayOutputStream errBytes = new ByteArrayOutputStream();

--- a/builtins/src/test/java/org/jline/builtins/CommandsTest.java
+++ b/builtins/src/test/java/org/jline/builtins/CommandsTest.java
@@ -9,8 +9,11 @@
 package org.jline.builtins;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.jline.reader.History;
 import org.jline.reader.LineReader;
@@ -20,8 +23,11 @@ import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CommandsTest {
     @Test
@@ -62,5 +68,69 @@ public class CommandsTest {
         } catch (Exception e) {
             throw new RuntimeException("Test failed", e);
         }
+    }
+
+    @Test
+    void highlighterViewRejectsThemePathTraversal(@TempDir Path tmp) throws Exception {
+        Path configDir = Files.createDirectory(tmp.resolve("config"));
+        Files.write(configDir.resolve("jnanorc"), List.of("theme dark.nanorctheme"));
+        Files.write(configDir.resolve("dark.nanorctheme"), List.of("DEFAULT white"));
+        // sits one level above the theme directory; the viewer must not reach it
+        Files.write(tmp.resolve("outside.nanorctheme"), List.of("SECRET_TOKEN white"));
+
+        for (String name : new String[] {"../outside.nanorctheme", "..\\outside.nanorctheme"}) {
+            ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+            ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+            ByteArrayOutputStream termBytes = new ByteArrayOutputStream();
+            try (Terminal terminal = TerminalBuilder.builder()
+                    .dumb(true)
+                    .streams(new ByteArrayInputStream(new byte[0]), termBytes)
+                    .build()) {
+                LineReader reader =
+                        LineReaderBuilder.builder().terminal(terminal).build();
+                ConfigurationPath configPath = new ConfigurationPath(configDir, configDir);
+                Commands.highlighter(
+                        reader,
+                        terminal,
+                        new PrintStream(outBytes),
+                        new PrintStream(errBytes),
+                        new String[] {"--view", name},
+                        configPath);
+            }
+            String out = outBytes.toString(StandardCharsets.UTF_8.name());
+            String err = errBytes.toString(StandardCharsets.UTF_8.name());
+            String term = termBytes.toString(StandardCharsets.UTF_8.name());
+            assertTrue(err.contains("Invalid theme name"), name + " should be rejected, err=" + err);
+            assertFalse(out.contains("outside"), name + " must not be resolved, out=" + out);
+            assertFalse(term.contains("SECRET_TOKEN"), "content outside the theme dir must not leak");
+        }
+    }
+
+    @Test
+    void highlighterViewReadsThemeInConfigDir(@TempDir Path tmp) throws Exception {
+        Path configDir = Files.createDirectory(tmp.resolve("config"));
+        Files.write(configDir.resolve("jnanorc"), List.of("theme dark.nanorctheme"));
+        Files.write(configDir.resolve("dark.nanorctheme"), List.of("DEFAULT white"));
+
+        ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+        ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .dumb(true)
+                .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream())
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+            ConfigurationPath configPath = new ConfigurationPath(configDir, configDir);
+            Commands.highlighter(
+                    reader,
+                    terminal,
+                    new PrintStream(outBytes),
+                    new PrintStream(errBytes),
+                    new String[] {"--view", "dark.nanorctheme"},
+                    configPath);
+        }
+        String out = outBytes.toString(StandardCharsets.UTF_8.name());
+        String err = errBytes.toString(StandardCharsets.UTF_8.name());
+        assertFalse(err.contains("Invalid theme name"), "valid theme name must be accepted, err=" + err);
+        assertTrue(out.contains("dark.nanorctheme"), "theme path should be printed, out=" + out);
     }
 }

--- a/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
+++ b/builtins/src/test/java/org/jline/builtins/ScreenTerminalTest.java
@@ -157,4 +157,25 @@ public class ScreenTerminalTest {
             assertNotEquals('\0', content.charAt(i), "Found null character at position " + i);
         }
     }
+
+    /**
+     * DSR replies are fed back as terminal input, so every reply must be a
+     * control sequence the application consumes as a report. Requests outside
+     * the ECMA-48 set are left unanswered.
+     */
+    @Test
+    void testDsrDoesNotReplyWithPlainText() {
+        ScreenTerminal screen = new ScreenTerminal(80, 24);
+
+        screen.write("\033[7n");
+        assertEquals("", screen.read(), "DSR 7 must not reply");
+        screen.write("\033[8n");
+        assertEquals("", screen.read(), "DSR 8 must not reply");
+
+        // The standard reports still answer
+        screen.write("\033[5n");
+        assertEquals("\033[0n", screen.read());
+        screen.write("\033[6n");
+        assertEquals("\033[1;1R", screen.read());
+    }
 }


### PR DESCRIPTION
Backport of #2112 and #2128 to the `jline-3.x` maintenance branch.

**#2112 — reject theme path traversal in highlighter command**
The `highlighter --view` command accepted theme names containing `../`, allowing reads outside the config directory. Now validates that the resolved path stays within the config dir.

**#2128 — stop answering DSR 7/8 with plain text in ScreenTerminal**
`csi_DSR` responded to DSR 7 and 8 with plain text strings (`gogo-term`, `1.0-SNAPSHOT`) that were fed back as terminal input, effectively typing into the application. These non-standard requests are now left unanswered.

Adaptation for 3.x: test relocated from `terminal/` to `builtins/` module (where `ScreenTerminal` lives on 3.x), and `toString(Charset)` → `toString(Charset.name())` for Java 8 compatibility.