### PR TITLE
fix: keep image options inside the kitty and iterm2 sequences

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/ITerm2Graphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/ITerm2Graphics.java
@@ -203,6 +203,7 @@ public class ITerm2Graphics implements TerminalGraphics {
      * @param position position specification for non-inline images
      * @return the complete iTerm2 graphics protocol sequence
      * @throws IOException if an I/O error occurs
+     * @throws IllegalArgumentException if size or position holds a control character or a separator
      */
     public String convertImageWithExtendedOptions(
             BufferedImage image, ImageOptions options, String size, String position) throws IOException {
@@ -224,7 +225,7 @@ public class ITerm2Graphics implements TerminalGraphics {
 
         // Add size if specified
         if (size != null) {
-            parameters.append("size=").append(size).append(";");
+            parameters.append("size=").append(checkParameterValue(size, "size")).append(";");
         } else {
             // Add dimensions if specified
             if (options.getWidth() != null) {
@@ -245,7 +246,10 @@ public class ITerm2Graphics implements TerminalGraphics {
             parameters.append("inline=0;");
             // Add position for non-inline images
             if (position != null) {
-                parameters.append("position=").append(position).append(";");
+                parameters
+                        .append("position=")
+                        .append(checkParameterValue(position, "position"))
+                        .append(";");
             }
         } else {
             parameters.append("inline=1;");
@@ -290,6 +294,7 @@ public class ITerm2Graphics implements TerminalGraphics {
      * @param image the image to display
      * @param position position specification (e.g., "center", "top-left")
      * @throws IOException if an I/O error occurs
+     * @throws IllegalArgumentException if the position holds a control character or an iTerm2 parameter separator
      */
     public void displayBackgroundImage(Terminal terminal, BufferedImage image, String position) throws IOException {
         ImageOptions options = new ImageOptions().inline(false);
@@ -306,5 +311,29 @@ public class ITerm2Graphics implements TerminalGraphics {
      */
     private String base64Encode(String input) {
         return Base64.getEncoder().encodeToString(input.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Checks a parameter value that is emitted literally rather than base64 encoded.
+     *
+     * <p>The parameters sit inside the {@code <ESC>]1337;File= ... <BEL>} frame as a {@code ;}
+     * separated list closed by a {@code :}, so a value holding a control character can close the
+     * sequence and have the rest of it read as terminal input, and a value holding either
+     * separator can append parameters or start the payload early.</p>
+     *
+     * @param value the value to check
+     * @param name the parameter name, for the error message
+     * @return the value
+     * @throws IllegalArgumentException if the value holds a control character or a separator
+     */
+    private String checkParameterValue(String value, String name) {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (Character.isISOControl(c) || c == ';' || c == ':') {
+                throw new IllegalArgumentException(
+                        "iTerm2 " + name + " parameter contains a control character or a separator");
+            }
+        }
+        return value;
     }
 }

--- a/terminal/src/main/java/org/jline/terminal/impl/KittyGraphics.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/KittyGraphics.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.imageio.ImageIO;
@@ -212,7 +213,7 @@ public class KittyGraphics implements TerminalGraphics {
 
         // Add name if specified
         if (options.getName() != null) {
-            controlData.append(",n=").append(options.getName());
+            controlData.append(",n=").append(base64Encode(options.getName()));
         }
 
         // For large images, we might need to chunk the data
@@ -286,7 +287,7 @@ public class KittyGraphics implements TerminalGraphics {
 
                 // Add name if specified
                 if (options.getName() != null) {
-                    controlData.append(",n=").append(options.getName());
+                    controlData.append(",n=").append(base64Encode(options.getName()));
                 }
             } else {
                 // Subsequent chunks: only image ID and more flag
@@ -334,5 +335,19 @@ public class KittyGraphics implements TerminalGraphics {
         String clearSequence = KITTY_GRAPHICS_START + "a=d,q=2" + KITTY_GRAPHICS_END;
         terminal.writer().print(clearSequence);
         terminal.writer().flush();
+    }
+
+    /**
+     * Base64 encodes a string value for use in the control data.
+     *
+     * <p>Control data is a comma separated list of {@code key=value} pairs sitting inside the
+     * {@code <ESC>_G ... <ESC>\} frame, so a value must not carry the separators or the string
+     * terminator.</p>
+     *
+     * @param input the string to encode
+     * @return the base64-encoded string
+     */
+    private String base64Encode(String input) {
+        return Base64.getEncoder().encodeToString(input.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/terminal/src/test/java/org/jline/terminal/impl/TerminalGraphicsTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/TerminalGraphicsTest.java
@@ -29,6 +29,9 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class TerminalGraphicsTest {
 
+    /** A name that closes the enclosing sequence, then follows it with an OSC that sets the window title. */
+    private static final String ESCAPING_NAME = "photo\033\\\033]0;pwned\007";
+
     private BufferedImage testImage;
 
     @BeforeEach
@@ -335,5 +338,77 @@ class TerminalGraphicsTest {
             // Clean up: reset forced protocol
             TerminalGraphicsManager.forceProtocol(null);
         }
+    }
+
+    @Test
+    void testKittyImageNameStaysInsideControlData() throws IOException {
+        KittyGraphics kitty = new KittyGraphics();
+        TerminalGraphics.ImageOptions options = new TerminalGraphics.ImageOptions().name(ESCAPING_NAME);
+
+        String sequence = kitty.convertImage(testImage, options);
+
+        assertFalse(sequence.contains("\033]0;"), "image name must not inject an OSC into the emitted sequence");
+        assertEquals(
+                sequence.length() - 2,
+                sequence.indexOf("\033\\"),
+                "the only string terminator must be the one closing the APC frame");
+    }
+
+    @Test
+    void testKittyChunkedImageNameStaysInsideControlData() throws IOException {
+        KittyGraphics kitty = new KittyGraphics();
+        TerminalGraphics.ImageOptions options = new TerminalGraphics.ImageOptions().name(ESCAPING_NAME);
+
+        String sequence = kitty.convertImageChunked(testImage, options, 512);
+
+        assertFalse(sequence.contains("\033]0;"), "image name must not inject an OSC into the emitted sequence");
+    }
+
+    @Test
+    void testITerm2RejectsSizeThatLeavesTheSequence() {
+        ITerm2Graphics iterm2 = new ITerm2Graphics();
+        TerminalGraphics.ImageOptions options = new TerminalGraphics.ImageOptions();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> iterm2.convertImageWithExtendedOptions(testImage, options, "50%\007\033]0;pwned\007", null));
+        assertDoesNotThrow(() -> iterm2.convertImageWithExtendedOptions(testImage, options, "50%", null));
+    }
+
+    @Test
+    void testITerm2RejectsPositionThatLeavesTheSequence() {
+        ITerm2Graphics iterm2 = new ITerm2Graphics();
+        TerminalGraphics.ImageOptions options = new TerminalGraphics.ImageOptions().inline(false);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> iterm2.convertImageWithExtendedOptions(testImage, options, null, "center\007\033]0;pwned\007"));
+        assertDoesNotThrow(() -> iterm2.convertImageWithExtendedOptions(testImage, options, null, "center"));
+    }
+
+    @Test
+    void testITerm2RejectsSizeThatLeavesTheParameter() {
+        ITerm2Graphics iterm2 = new ITerm2Graphics();
+        TerminalGraphics.ImageOptions options = new TerminalGraphics.ImageOptions();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> iterm2.convertImageWithExtendedOptions(testImage, options, "50%;inline=0", null));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> iterm2.convertImageWithExtendedOptions(testImage, options, "50%:payload", null));
+    }
+
+    @Test
+    void testITerm2RejectsPositionThatLeavesTheParameter() {
+        ITerm2Graphics iterm2 = new ITerm2Graphics();
+        TerminalGraphics.ImageOptions options = new TerminalGraphics.ImageOptions().inline(false);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> iterm2.convertImageWithExtendedOptions(testImage, options, null, "center;inline=1"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> iterm2.convertImageWithExtendedOptions(testImage, options, null, "center:payload"));
     }
 }


### PR DESCRIPTION
`KittyGraphics.convertImage` for an image name of `photo<ESC>\<ESC>]0;pwned<BEL>`:

    before:  ESC_Ga=T,f=100,i=1,q=2,n=photoESC\ESC]0;pwnedBEL,m=0;iVBORw0KGgo...
    after:   ESC_Ga=T,f=100,i=1,q=2,n=cGhvdG8bXBtdMDtwd25lZAc=,m=0;iVBORw0KGgo...

The name lands in the control data untouched, so an `ESC \` inside it closes the APC
string and the terminal reads what follows as fresh input, here an OSC 0 that repaints
the window title; OSC 52 writes the clipboard the same way. The `,` and `;` separators
walk out of the frame for the same reason. `ITerm2Graphics.convertImage` already base64
encodes this option, so both Kitty sites now do the same, including the chunked path.

`convertImageWithExtendedOptions` has the sibling problem in `size` and `position`. Those
go literally into `ESC ]1337;File= ... BEL` and cannot be encoded, so a `BEL` in either one
ends the OSC early; both are now rejected when they carry a control character. `SixelGraphics`
interpolates no caller strings, which makes these four the only such sites in the tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved terminal graphics handling to prevent control-sequence injection through image metadata and positioning options.
* **Compatibility**
  * Image names containing non-ASCII characters are now encoded correctly for Kitty terminal graphics.
  * Valid iTerm2 size and position values continue to work as expected.
* **Bug Fixes**
  * Invalid image parameters containing control characters or protocol separators are now rejected safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->