### PR TITLE
fix: add software signal interception to Windows terminals (fixes #2127)

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -33,6 +33,8 @@ import org.jline.utils.ShutdownHooks;
 import org.jline.utils.Signals;
 import org.jline.utils.WriterOutputStream;
 
+import static org.jline.terminal.TerminalBuilder.PROP_SOFTWARE_SIGNALS;
+
 /**
  * Base implementation for terminals on Windows systems.
  *
@@ -129,6 +131,7 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
 
     protected MouseTracking tracking = MouseTracking.Off;
     protected boolean focusTracking = false;
+    private final boolean softwareSignals;
     private volatile boolean closing;
     protected boolean skipNextLf;
 
@@ -184,6 +187,7 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
         super(name, type, encoding, inputEncoding, outputEncoding, signalHandler);
         this.provider = provider;
         this.systemStream = systemStream;
+        this.softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "true"));
         NonBlockingPumpReader reader = NonBlocking.nonBlockingPumpReader();
         this.slaveInputPipe = reader.getWriter();
         this.reader = reader;
@@ -656,6 +660,20 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
             } else if (c == attributes.getControlChar(Attributes.ControlChar.VSUSP)) {
                 raise(Signal.TSTP);
                 return;
+            } else if (c == attributes.getControlChar(Attributes.ControlChar.VSTATUS)) {
+                raise(Signal.INFO);
+            }
+        } else if (softwareSignals) {
+            // Software signal interception: raise the signal even in raw mode
+            // (ISIG cleared), but pass the character through so the LineReader's
+            // keymap can also handle it (e.g. the INTERRUPT widget).
+            // This mirrors SignalInterceptingInputStream used on POSIX terminals.
+            if (c == attributes.getControlChar(Attributes.ControlChar.VINTR)) {
+                raise(Signal.INT);
+            } else if (c == attributes.getControlChar(Attributes.ControlChar.VQUIT)) {
+                raise(Signal.QUIT);
+            } else if (c == attributes.getControlChar(Attributes.ControlChar.VSUSP)) {
+                raise(Signal.TSTP);
             } else if (c == attributes.getControlChar(Attributes.ControlChar.VSTATUS)) {
                 raise(Signal.INFO);
             }

--- a/terminal/src/test/java/org/jline/terminal/impl/WindowsSoftwareSignalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/WindowsSoftwareSignalTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.BufferedWriter;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.LocalFlag;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal.Signal;
+import org.jline.terminal.Terminal.SignalHandler;
+import org.jline.utils.AnsiWriter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.jline.terminal.TerminalBuilder.PROP_SOFTWARE_SIGNALS;
+import static org.jline.terminal.impl.AbstractWindowsTerminal.TYPE_WINDOWS;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for software signal interception in {@link AbstractWindowsTerminal}
+ * when ISIG is cleared (raw mode).
+ *
+ * <p>Verifies that signal control characters (VINTR, VQUIT, VSUSP) raise the
+ * corresponding signal even in raw mode when {@code softwareSignals} is enabled,
+ * mirroring the behavior of {@link SignalInterceptingInputStream} on POSIX
+ * terminals (fixes #2127).
+ */
+class WindowsSoftwareSignalTest {
+
+    private String originalSoftwareSignals;
+
+    @BeforeEach
+    void setUp() {
+        originalSoftwareSignals = System.getProperty(PROP_SOFTWARE_SIGNALS);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (originalSoftwareSignals != null) {
+            System.setProperty(PROP_SOFTWARE_SIGNALS, originalSoftwareSignals);
+        } else {
+            System.clearProperty(PROP_SOFTWARE_SIGNALS);
+        }
+    }
+
+    private AbstractWindowsTerminal<?> createTestTerminal(boolean nativeSignals) throws Exception {
+        System.setProperty("org.jline.terminal.conemu.disable-activate", "true");
+        StringWriter sw = new StringWriter();
+        return new AbstractWindowsTerminal<>(
+                null,
+                null,
+                new AnsiWriter(new BufferedWriter(sw)),
+                "test",
+                TYPE_WINDOWS,
+                Charset.defaultCharset(),
+                nativeSignals,
+                SignalHandler.SIG_DFL,
+                null,
+                0,
+                null,
+                0) {
+            @Override
+            protected int getConsoleMode(Object console) {
+                return 0;
+            }
+
+            @Override
+            protected void setConsoleMode(Object console, int mode) {}
+
+            @Override
+            public int getDefaultForegroundColor() {
+                return -1;
+            }
+
+            @Override
+            public int getDefaultBackgroundColor() {
+                return -1;
+            }
+
+            @Override
+            protected boolean processConsoleInput() {
+                return false;
+            }
+
+            @Override
+            public Size getSize() {
+                return Size.of(80, 25);
+            }
+        };
+    }
+
+    @Test
+    void testCtrlCRaisesSignalWhenIsigEnabled() throws Exception {
+        try (AbstractWindowsTerminal<?> terminal = createTestTerminal(false)) {
+            // ISIG is on by default
+            Attributes attr = terminal.getAttributes();
+            assertTrue(attr.getLocalFlag(LocalFlag.ISIG));
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            terminal.processInputChar('\3'); // Ctrl-C
+
+            assertEquals(Signal.INT, received.get());
+        }
+    }
+
+    @Test
+    void testCtrlCRaisesSignalInRawModeWithSoftwareSignals() throws Exception {
+        System.setProperty(PROP_SOFTWARE_SIGNALS, "true");
+        try (AbstractWindowsTerminal<?> terminal = createTestTerminal(false)) {
+            // Enter raw mode — clears ISIG
+            Attributes attr = terminal.getAttributes();
+            attr.setLocalFlag(LocalFlag.ISIG, false);
+            terminal.setAttributes(attr);
+            assertFalse(terminal.getAttributes().getLocalFlag(LocalFlag.ISIG));
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            terminal.processInputChar('\3'); // Ctrl-C
+
+            // Signal should be raised even with ISIG cleared
+            assertEquals(Signal.INT, received.get());
+        }
+    }
+
+    @Test
+    void testCtrlCPassesThroughInRawModeWithSoftwareSignals() throws Exception {
+        System.setProperty(PROP_SOFTWARE_SIGNALS, "true");
+        try (AbstractWindowsTerminal<?> terminal = createTestTerminal(false)) {
+            // Enter raw mode
+            Attributes attr = terminal.getAttributes();
+            attr.setLocalFlag(LocalFlag.ISIG, false);
+            terminal.setAttributes(attr);
+
+            terminal.handle(Signal.INT, s -> {});
+
+            terminal.processInputChar('\3');
+
+            // Character should also be written to the reader (passed through)
+            int ch = terminal.reader().read(100);
+            assertEquals('\3', ch);
+        }
+    }
+
+    @Test
+    void testCtrlCNotRaisedInRawModeWhenSoftwareSignalsDisabled() throws Exception {
+        System.setProperty(PROP_SOFTWARE_SIGNALS, "false");
+        try (AbstractWindowsTerminal<?> terminal = createTestTerminal(false)) {
+            // Enter raw mode
+            Attributes attr = terminal.getAttributes();
+            attr.setLocalFlag(LocalFlag.ISIG, false);
+            terminal.setAttributes(attr);
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            terminal.processInputChar('\3');
+
+            // Signal should NOT be raised when softwareSignals is disabled
+            assertNull(received.get());
+
+            // But character should still be written to the pipe
+            int ch = terminal.reader().read(100);
+            assertEquals('\3', ch);
+        }
+    }
+
+    @Test
+    void testCtrlZRaisesSignalInRawModeWithSoftwareSignals() throws Exception {
+        System.setProperty(PROP_SOFTWARE_SIGNALS, "true");
+        try (AbstractWindowsTerminal<?> terminal = createTestTerminal(false)) {
+            // Enter raw mode
+            Attributes attr = terminal.getAttributes();
+            attr.setLocalFlag(LocalFlag.ISIG, false);
+            terminal.setAttributes(attr);
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.TSTP, received::set);
+
+            terminal.processInputChar('\032'); // Ctrl-Z (VSUSP)
+
+            assertEquals(Signal.TSTP, received.get());
+        }
+    }
+
+    @Test
+    void testCtrlCConsumedWhenIsigEnabled() throws Exception {
+        try (AbstractWindowsTerminal<?> terminal = createTestTerminal(false)) {
+            // ISIG is on — signal chars should be consumed (not passed through)
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            terminal.processInputChar('\3');
+
+            assertEquals(Signal.INT, received.get());
+
+            // Character should NOT be in the reader (consumed by signal handling)
+            int ch = terminal.reader().read(100);
+            assertEquals(-2, ch); // -2 = no data available (timeout)
+        }
+    }
+
+    @Test
+    void testSoftwareSignalsDefaultsToTrue() throws Exception {
+        // Clear the property to test the default
+        System.clearProperty(PROP_SOFTWARE_SIGNALS);
+        try (AbstractWindowsTerminal<?> terminal = createTestTerminal(false)) {
+            // Enter raw mode
+            Attributes attr = terminal.getAttributes();
+            attr.setLocalFlag(LocalFlag.ISIG, false);
+            terminal.setAttributes(attr);
+
+            AtomicReference<Signal> received = new AtomicReference<>();
+            terminal.handle(Signal.INT, received::set);
+
+            terminal.processInputChar('\3');
+
+            // Default should be true, so signal should be raised
+            assertEquals(Signal.INT, received.get());
+        }
+    }
+}

--- a/terminal/src/test/java/org/jline/terminal/impl/WindowsSoftwareSignalTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/WindowsSoftwareSignalTest.java
@@ -55,7 +55,6 @@ class WindowsSoftwareSignalTest {
     }
 
     private AbstractWindowsTerminal<?> createTestTerminal(boolean nativeSignals) throws Exception {
-        System.setProperty("org.jline.terminal.conemu.disable-activate", "true");
         StringWriter sw = new StringWriter();
         return new AbstractWindowsTerminal<>(
                 null,
@@ -76,7 +75,9 @@ class WindowsSoftwareSignalTest {
             }
 
             @Override
-            protected void setConsoleMode(Object console, int mode) {}
+            protected void setConsoleMode(Object console, int mode) {
+                // No-op: test stub — no real console to configure
+            }
 
             @Override
             public int getDefaultForegroundColor() {


### PR DESCRIPTION
## Summary

- Adds software signal interception to `AbstractWindowsTerminal.processInputChar()` so that signal control characters (Ctrl-C, Ctrl-\, Ctrl-Z) raise the corresponding `Signal` even when ISIG is cleared (raw mode)
- This mirrors the `SignalInterceptingInputStream` fix applied to POSIX terminals in #1982
- The signal is raised AND the character is passed through to the pipe, so the LineReader's keymap can also handle it (e.g. the INTERRUPT widget)
- Controlled by the same `org.jline.terminal.softwareSignals` system property (defaults to `true`)

## Root Cause

When `LineReader.readLine()` calls `enterRawMode()`, ISIG is cleared. On Windows, `updateConsoleMode()` then removes `ENABLE_PROCESSED_INPUT`, causing Windows to deliver Ctrl-C as a `KEY_EVENT` with `ch='\3'` instead of handling it at the console level. Without software signal interception, `processInputChar()` skipped the signal check (because ISIG was false) and wrote the raw `\3` to the pipe — the user's `Signal.INT` handler was never called.

The POSIX fix in #1982 added `SignalInterceptingInputStream` to wrap the terminal's input stream. Since Windows terminals use a pump thread with `processConsoleInput()` → `processKeyEvent()` → `processInputChar()` instead of an input stream, the equivalent interception is added directly in `processInputChar()`.

## Test plan

- [x] New `WindowsSoftwareSignalTest` with 7 test cases covering:
  - Signal raised when ISIG is enabled (existing behavior preserved)
  - Signal raised in raw mode (ISIG cleared) when `softwareSignals=true`
  - Character passes through to reader in raw mode (for keymap binding)
  - Signal NOT raised in raw mode when `softwareSignals=false`
  - Ctrl-Z (VSUSP) raises TSTP signal in raw mode
  - Signal character consumed (not passed through) when ISIG is enabled
  - Default behavior (property not set) raises signal in raw mode
- [x] All 464 terminal module tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable software signal handling for Windows terminals.
  * Control characters such as Ctrl-C and Ctrl-Z can trigger signals even when input signaling is disabled.
  * Software signal handling is enabled by default and can be disabled through configuration.

* **Tests**
  * Added coverage for raw-mode signal handling, pass-through behavior, signal consumption, and default configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->