### PR TITLE
Enable reproducible builds from source archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
 *.dll binary
 *.so binary
+.mvn/maven-user.properties export-subst
 

--- a/.mvn/maven-user.properties
+++ b/.mvn/maven-user.properties
@@ -1,2 +1,5 @@
 # Enable GIT dynamic version
 nisse.source.jgit.dynamicVersion=true
+# Fallback values for source archives (expanded by git archive via export-subst)
+nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
+nisse.jgit.date=$Format:%aI$


### PR DESCRIPTION
## Summary

GitHub tag tarballs (and any `git archive` output) lack a `.git` directory, so nisse
can't derive the version or commit timestamp. This makes it impossible to rebuild
from a source archive — or to verify that published artifacts match their source.

This PR uses git's `export-subst` mechanism to solve both problems with zero ongoing
maintenance:

- `.gitattributes` marks `.mvn/maven-user.properties` for `export-subst`
- `.mvn/maven-user.properties` gains two `$Format:...$` placeholders for version and timestamp

**In a git checkout**: nisse resolves both properties from git history, overwriting the
literal `$Format:...$` strings. No behavior change.

**In a source archive** (GitHub tarball, `git archive`): git expands the placeholders
at archive time. Maven reads the pre-expanded values from `maven-user.properties`
directly. `./mvx mvn install` just works — no `-D` flags needed.

### Verification

Downloaded the 4.3.1 tag tarball, rebuilt with the correct version and timestamp,
and confirmed byte-identical SHA-256 against the Maven Central artifact:

```
Central: 272927363471fdbf2f38710befbfe866acc1ed3472062a8ced02b16686f27bcc
Local:   272927363471fdbf2f38710befbfe866acc1ed3472062a8ced02b16686f27bcc
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved source archive metadata by including the version tag and commit date.
  * Added fallback values to ensure metadata remains available when Git details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->