### PR TITLE
chore: use nisse 0.9.5 with .mvn/nisse.properties for source-archive builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.dll binary
 *.so binary
 
+.mvn/nisse.properties export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto
 *.dll binary
 *.so binary
-.mvn/maven-user.properties export-subst
 

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -8,6 +8,6 @@
   <extension>
     <groupId>eu.maveniverse.maven.nisse</groupId>
     <artifactId>extension</artifactId>
-    <version>0.9.3</version>
+    <version>0.9.5</version>
   </extension>
 </extensions>

--- a/.mvn/maven-user.properties
+++ b/.mvn/maven-user.properties
@@ -1,5 +1,2 @@
 # Enable GIT dynamic version
 nisse.source.jgit.dynamicVersion=true
-# Fallback values for source archives (expanded by git archive via export-subst)
-nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
-nisse.jgit.date=$Format:%aI$

--- a/.mvn/nisse.properties
+++ b/.mvn/nisse.properties
@@ -1,0 +1,3 @@
+# Fallback values for source archives (expanded by git archive via export-subst)
+nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
+nisse.jgit.date=$Format:%aI$


### PR DESCRIPTION
## Summary

Replaces the `maven-user.properties` approach from #2151 with nisse's new
`.mvn/nisse.properties` low-priority fallback (maveniverse/nisse#182, shipped
in nisse 0.9.5).

**Changes:**
- Upgrade nisse extension from 0.9.3 → 0.9.5
- Add `.mvn/nisse.properties` with `export-subst` placeholders
- Remove the `maven-user.properties` fallback lines added in #2151 (the `nisse.source.jgit.dynamicVersion=true` config line remains)
- Update `.gitattributes` to target `nisse.properties` instead of `maven-user.properties`

**Why:** `.mvn/maven-user.properties` is a Maven 4-only feature. The previous
approach silently broke source-archive builds on Maven 3. Nisse 0.9.5 reads
`.mvn/nisse.properties` directly — independent of Maven version.

## Verified locally

- ✅ Git checkout build: `./mvx mvn clean install -B -DskipTests -T1C` → BUILD SUCCESS (version from JGit)
- ✅ Source archive build: `git archive | tar -x && cd archive && ./mvx mvn install` → BUILD SUCCESS (version from `nisse.properties` fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling to a newer Maven extension version.
  * Improved source archive metadata handling, including reliable fallback version and date values.
  * Removed obsolete archive substitution settings and streamlined related configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->