### PR TITLE
fix: strip control characters from Less status messages

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -1477,7 +1477,7 @@ public class Less {
             msg.append("&");
         } else if (defaultPrompt != null) {
             msg.style(AttributedStyle.INVERSE);
-            msg.append(defaultPrompt);
+            msg.append(stripControlChars(defaultPrompt));
             msg.style(AttributedStyle.INVERSE.inverseOff());
         } else {
             msg.append(":");

--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -1225,6 +1225,19 @@ public class Less {
         return sb.toString();
     }
 
+    // Drops ESC, BEL, the 8-bit C1 introducers and other ISO control characters while keeping
+    // printable (including non-ASCII) text, so a file name shown on the status line cannot carry
+    // an escape sequence into the terminal.
+    private static String stripControlChars(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        s.codePoints().forEach(cp -> {
+            if (!Character.isISOControl(cp)) {
+                sb.appendCodePoint(cp);
+            }
+        });
+        return sb.toString();
+    }
+
     void moveForward(int lines) throws IOException {
         Pattern dpCompiled = getPattern(true);
         int width = size.getColumns() - (printLineNumbers ? 8 : 0);
@@ -1458,7 +1471,7 @@ public class Less {
             msg.append(" ").append(printable(bindingReader.getCurrentBuffer()));
         } else if (message != null) {
             msg.style(AttributedStyle.INVERSE);
-            msg.append(message);
+            msg.append(stripControlChars(message));
             msg.style(AttributedStyle.INVERSE.inverseOff());
         } else if (displayPattern != null) {
             msg.append("&");

--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -1086,7 +1086,7 @@ public class Less {
                 if (displayMessage) {
                     AttributedStringBuilder asb = new AttributedStringBuilder();
                     asb.style(AttributedStyle.INVERSE);
-                    asb.append(source.getName()).append(" (press RETURN)");
+                    asb.append(stripControlChars(source.getName())).append(" (press RETURN)");
                     asb.toAttributedString().println(terminal);
                     terminal.writer().flush();
                     terminal.reader().read();
@@ -1100,7 +1100,7 @@ public class Less {
                     throw exp;
                 } else {
                     AttributedStringBuilder asb = new AttributedStringBuilder();
-                    asb.append(source.getName()).append(" not found!");
+                    asb.append(stripControlChars(source.getName())).append(" not found!");
                     asb.toAttributedString().println(terminal);
                     terminal.writer().flush();
                     open = false;

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -9,8 +9,11 @@
 package org.jline.builtins;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -225,6 +228,50 @@ class LessTest {
             String plainText = stripAnsi(rendered);
             assertTrue(plainText.contains("prompt"), "prompt text should be preserved");
             assertTrue(plainText.contains("pwned>"), "surrounding prompt text should be preserved");
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void openSourceStripsControlCharactersFromFileNames() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = new Less(terminal, Path.of("."));
+            less.size = terminal.getSize();
+            String name = "réport\u001b]0;pwned\u0007.txt";
+            // A source whose read() fails exercises the "not found!" branch; the next
+            // source then opens with displayMessage set, exercising "(press RETURN)".
+            Source missing = new Source() {
+                @Override
+                public String getName() {
+                    return name;
+                }
+
+                @Override
+                public InputStream read() throws IOException {
+                    throw new FileNotFoundException(name);
+                }
+
+                @Override
+                public Long lines() {
+                    return null;
+                }
+            };
+            Source next = new InputStreamSource(new ByteArrayInputStream(new byte[0]), true, name);
+            less.sources = new ArrayList<>(Arrays.asList(
+                    new InputStreamSource(new ByteArrayInputStream(new byte[0]), true, "help"), missing, next));
+            less.sourceIdx = 1;
+            terminal.processInputByte('\n'); // satisfies the "(press RETURN)" read
+
+            less.openSource();
+
+            String rendered = output.toString(StandardCharsets.UTF_8);
+            assertFalse(rendered.contains("\u001b]0;"), "OSC introducer must not reach the terminal");
+            assertFalse(rendered.contains("\u0007"), "BEL must not reach the terminal");
+            String plainText = stripAnsi(rendered);
+            assertTrue(plainText.contains("réport"), "non-ASCII file name text should be preserved");
+            assertTrue(plainText.contains("pwned.txt not found!"), "not-found line should keep printable text");
+            assertTrue(plainText.contains("pwned.txt (press RETURN)"), "press-RETURN line should keep printable text");
         }
     }
 

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -189,6 +189,28 @@ class LessTest {
 
     @Test
     @Timeout(5)
+    void displayStripsControlCharactersFromMessage() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = newDisplayableLess(terminal);
+            // The status line is set to source.getName() at startup, so a file name coming
+            // from a glob of an attacker-writable directory reaches it verbatim.
+            less.message = "réport\u001b]0;pwned\u0007.txt";
+
+            less.display(false);
+
+            String rendered = output.toString(StandardCharsets.UTF_8);
+            assertFalse(rendered.contains("\u001b]0;"), "OSC introducer must not reach the terminal");
+            assertFalse(rendered.contains("\u0007"), "BEL must not reach the terminal");
+            // Printable text, including non-ASCII, is kept.
+            String plainText = stripAnsi(rendered);
+            assertTrue(plainText.contains("réport"), "non-ASCII file name text should be preserved");
+            assertTrue(plainText.contains("pwned.txt"), "surrounding file name text should be preserved");
+        }
+    }
+
+    @Test
+    @Timeout(5)
     void displayPatternTakesPrecedenceOverDefaultPrompt() throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         try (LineDisciplineTerminal terminal = newTerminal(output)) {

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -211,6 +211,25 @@ class LessTest {
 
     @Test
     @Timeout(5)
+    void displayStripsControlCharactersFromDefaultPrompt() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = newDisplayableLess(terminal);
+            less.defaultPrompt("prompt\u001b]0;pwned\u0007>");
+
+            less.display(false);
+
+            String rendered = output.toString(StandardCharsets.UTF_8);
+            assertFalse(rendered.contains("\u001b]0;"), "OSC introducer must not reach the terminal");
+            assertFalse(rendered.contains("\u0007"), "BEL must not reach the terminal");
+            String plainText = stripAnsi(rendered);
+            assertTrue(plainText.contains("prompt"), "prompt text should be preserved");
+            assertTrue(plainText.contains("pwned>"), "surrounding prompt text should be preserved");
+        }
+    }
+
+    @Test
+    @Timeout(5)
     void displayPatternTakesPrecedenceOverDefaultPrompt() throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         try (LineDisciplineTerminal terminal = newTerminal(output)) {


### PR DESCRIPTION
`less *` in a directory holding `report\e]0;pwned\a.txt`, the status-line bytes:

    \e[7mréport\e]0;pwned\a.txt\e[27m

`message` is set to `source.getName()` in `openSource()`, so it lands before any keystroke. `display()` appends it with a plain `AttributedStringBuilder.append()`, which writes to the terminal byte for byte, so the OSC 0 in the file name sets the window title (OSC 52 writes the clipboard the same way). The pager body already routes through `fromAnsi` and the input buffer through `printable()`; only the `message` branch was raw. Filtered it there, dropping ISO control characters while keeping non-ASCII text so real file names still render.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized terminal viewer messages, prompts, and filenames to remove control characters.
  * Preserved printable ASCII and Unicode text during display.
  * Prevented escape sequences and alert characters from affecting terminal output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->