### PR TITLE
fix: emit full code points when rendering tmux panes

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -1192,7 +1192,7 @@ public class Tmux {
                     sb.style(bold ? sb.style().bold() : sb.style().boldOff());
                     prevBold = bold;
                 }
-                sb.append((char) c);
+                sb.append(new String(Character.toChars(c)));
             }
             lines.add(sb.toAttributedString());
         }

--- a/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
+++ b/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
@@ -139,23 +139,25 @@ class TmuxEncodingTest {
         tmuxThread.setDaemon(true);
         tmuxThread.start();
 
-        assertTrue(textWritten.await(5, TimeUnit.SECONDS), "Text should be written within timeout");
-
-        long deadline = System.currentTimeMillis() + 3000;
         String output = "";
-        while (System.currentTimeMillis() < deadline) {
-            output = masterOut.toString(StandardCharsets.UTF_8);
-            if (output.contains("INJECTED")) {
-                break;
-            }
-            synchronized (masterOut) {
-                masterOut.wait(100);
-            }
-        }
+        try {
+            assertTrue(textWritten.await(5, TimeUnit.SECONDS), "Text should be written within timeout");
 
-        testDone.countDown();
-        terminal.close();
-        tmuxThread.join(5000);
+            long deadline = System.currentTimeMillis() + 3000;
+            while (System.currentTimeMillis() < deadline) {
+                output = masterOut.toString(StandardCharsets.UTF_8);
+                if (output.contains("INJECTED")) {
+                    break;
+                }
+                synchronized (masterOut) {
+                    masterOut.wait(100);
+                }
+            }
+        } finally {
+            testDone.countDown();
+            terminal.close();
+            tmuxThread.join(5000);
+        }
 
         // The outer terminal only ever receives CSI (ESC [ ...) from the Display, never the
         // OSC the pane tried to synthesize; its presence means the code point was truncated.

--- a/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
+++ b/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
@@ -93,4 +93,76 @@ class TmuxEncodingTest {
         assertTrue(plain.contains("界"), "Should contain second CJK character");
         assertTrue(plain.contains("café"), "Should contain accented characters");
     }
+
+    @Test
+    void paneCannotInjectControlBytesViaSupplementaryCodePoints() throws Exception {
+        // U+1001B is a supplementary-plane code point whose low 16 bits are 0x1B (ESC).
+        // The pane emulator stores full code points and never keeps C0/C1 controls in a
+        // cell, so narrowing the cell to a Java char is the only way ESC reaches the outer
+        // terminal.  A pane must not be able to smuggle a control sequence out this way.
+        String smp = new String(Character.toChars(0x1001B));
+        String paneText = "A" + smp + "]0;INJECTED";
+
+        ByteArrayOutputStream masterOut = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "screen-256color", masterOut, StandardCharsets.UTF_8);
+        terminal.setSize(Size.of(80, 24));
+
+        CountDownLatch textWritten = new CountDownLatch(1);
+        CountDownLatch testDone = new CountDownLatch(1);
+
+        Tmux tmux = new Tmux(terminal, new PrintStream(OutputStream.nullOutputStream()), paneTerminal -> {
+            new Thread(
+                            () -> {
+                                try {
+                                    paneTerminal.writer().print(paneText);
+                                    paneTerminal.writer().flush();
+                                    textWritten.countDown();
+                                    testDone.await(5, TimeUnit.SECONDS);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                            },
+                            "test-pane")
+                    .start();
+        });
+
+        Thread tmuxThread = new Thread(
+                () -> {
+                    try {
+                        tmux.run();
+                    } catch (IOException e) {
+                        // expected when terminal closes
+                    }
+                },
+                "tmux-main");
+        tmuxThread.setDaemon(true);
+        tmuxThread.start();
+
+        assertTrue(textWritten.await(5, TimeUnit.SECONDS), "Text should be written within timeout");
+
+        long deadline = System.currentTimeMillis() + 3000;
+        String output = "";
+        while (System.currentTimeMillis() < deadline) {
+            output = masterOut.toString(StandardCharsets.UTF_8);
+            if (output.contains("INJECTED")) {
+                break;
+            }
+            synchronized (masterOut) {
+                masterOut.wait(100);
+            }
+        }
+
+        testDone.countDown();
+        terminal.close();
+        tmuxThread.join(5000);
+
+        // The outer terminal only ever receives CSI (ESC [ ...) from the Display, never the
+        // OSC the pane tried to synthesize; its presence means the code point was truncated.
+        assertFalse(
+                output.contains("\u001b]0;INJECTED"), "pane must not inject an OSC sequence into the outer terminal");
+        // and the supplementary character is rendered instead of a stray control byte
+        String plain = output.replaceAll("\\[[^@-~]*[@-~]", "");
+        assertTrue(plain.contains(smp), "supplementary code point should be rendered, not narrowed");
+    }
 }


### PR DESCRIPTION
A program in a pane can drive the outer terminal by printing a
supplementary code point whose low 16 bits are a control byte:

    (char) 0x1001B == 0x001B   // ESC

redraw() renders each pane cell with `sb.append((char) c)`. ScreenTerminal
stores full code points and never keeps a C0/C1 control in a cell, so this
narrowing is the only path a control byte has to the real terminal:
U+1001B becomes ESC and the printable `]0;...` bytes after it are read by the
outer terminal as an OSC (clipboard write via OSC 52, window title, RIS), so
pane output breaks out of the multiplexer. Supplementary characters (emoji,
CJK Ext-B) are also rendered as the wrong glyph.

Emit the full code point, as `ScreenTerminal.dump()` and
`SwingTerminal.paintCell` already do; they are the only other cell renderers
and neither narrows to `char`.

The added test drives a pane through `LineDisciplineTerminal` and asserts the
synthesized OSC never reaches the outer stream (it does on the unpatched tree).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of supplementary Unicode characters in tmux panes, including characters outside the basic multilingual plane.
  * Prevented certain Unicode characters from being misinterpreted as terminal control sequences, improving output safety.

* **Tests**
  * Added regression coverage confirming correct rendering and ensuring pane content cannot inject unintended terminal control sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->