### PR TITLE
feat: add AttributedStringBuilder.appendCodePoint(int)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -1192,7 +1192,7 @@ public class Tmux {
                     sb.style(bold ? sb.style().bold() : sb.style().boldOff());
                     prevBold = bold;
                 }
-                sb.append((char) c);
+                sb.append(new String(Character.toChars(c)));
             }
             lines.add(sb.toAttributedString());
         }

--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -1192,7 +1192,7 @@ public class Tmux {
                     sb.style(bold ? sb.style().bold() : sb.style().boldOff());
                     prevBold = bold;
                 }
-                sb.append(new String(Character.toChars(c)));
+                sb.appendCodePoint(c);
             }
             lines.add(sb.toAttributedString());
         }

--- a/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
+++ b/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
@@ -139,23 +139,25 @@ class TmuxEncodingTest {
         tmuxThread.setDaemon(true);
         tmuxThread.start();
 
-        assertTrue(textWritten.await(5, TimeUnit.SECONDS), "Text should be written within timeout");
-
-        long deadline = System.currentTimeMillis() + 3000;
         String output = "";
-        while (System.currentTimeMillis() < deadline) {
-            output = masterOut.toString(StandardCharsets.UTF_8);
-            if (output.contains("INJECTED")) {
-                break;
-            }
-            synchronized (masterOut) {
-                masterOut.wait(100);
-            }
-        }
+        try {
+            assertTrue(textWritten.await(5, TimeUnit.SECONDS), "Text should be written within timeout");
 
-        testDone.countDown();
-        terminal.close();
-        tmuxThread.join(5000);
+            long deadline = System.currentTimeMillis() + 3000;
+            while (System.currentTimeMillis() < deadline) {
+                output = masterOut.toString(StandardCharsets.UTF_8);
+                if (output.contains("INJECTED")) {
+                    break;
+                }
+                synchronized (masterOut) {
+                    masterOut.wait(100);
+                }
+            }
+        } finally {
+            testDone.countDown();
+            terminal.close();
+            tmuxThread.join(5000);
+        }
 
         // The outer terminal only ever receives CSI (ESC [ ...) from the Display, never the
         // OSC the pane tried to synthesize; its presence means the code point was truncated.

--- a/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
+++ b/builtins/src/test/java/org/jline/builtins/TmuxEncodingTest.java
@@ -93,4 +93,76 @@ class TmuxEncodingTest {
         assertTrue(plain.contains("界"), "Should contain second CJK character");
         assertTrue(plain.contains("café"), "Should contain accented characters");
     }
+
+    @Test
+    void paneCannotInjectControlBytesViaSupplementaryCodePoints() throws Exception {
+        // U+1001B is a supplementary-plane code point whose low 16 bits are 0x1B (ESC).
+        // The pane emulator stores full code points and never keeps C0/C1 controls in a
+        // cell, so narrowing the cell to a Java char is the only way ESC reaches the outer
+        // terminal.  A pane must not be able to smuggle a control sequence out this way.
+        String smp = new String(Character.toChars(0x1001B));
+        String paneText = "A" + smp + "]0;INJECTED";
+
+        ByteArrayOutputStream masterOut = new ByteArrayOutputStream();
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("test", "screen-256color", masterOut, StandardCharsets.UTF_8);
+        terminal.setSize(Size.of(80, 24));
+
+        CountDownLatch textWritten = new CountDownLatch(1);
+        CountDownLatch testDone = new CountDownLatch(1);
+
+        Tmux tmux = new Tmux(terminal, new PrintStream(OutputStream.nullOutputStream()), paneTerminal -> {
+            new Thread(
+                            () -> {
+                                try {
+                                    paneTerminal.writer().print(paneText);
+                                    paneTerminal.writer().flush();
+                                    textWritten.countDown();
+                                    testDone.await(5, TimeUnit.SECONDS);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                            },
+                            "test-pane")
+                    .start();
+        });
+
+        Thread tmuxThread = new Thread(
+                () -> {
+                    try {
+                        tmux.run();
+                    } catch (IOException e) {
+                        // expected when terminal closes
+                    }
+                },
+                "tmux-main");
+        tmuxThread.setDaemon(true);
+        tmuxThread.start();
+
+        assertTrue(textWritten.await(5, TimeUnit.SECONDS), "Text should be written within timeout");
+
+        long deadline = System.currentTimeMillis() + 3000;
+        String output = "";
+        while (System.currentTimeMillis() < deadline) {
+            output = masterOut.toString(StandardCharsets.UTF_8);
+            if (output.contains("INJECTED")) {
+                break;
+            }
+            synchronized (masterOut) {
+                masterOut.wait(100);
+            }
+        }
+
+        testDone.countDown();
+        terminal.close();
+        tmuxThread.join(5000);
+
+        // The outer terminal only ever receives CSI (ESC [ ...) from the Display, never the
+        // OSC the pane tried to synthesize; its presence means the code point was truncated.
+        assertFalse(
+                output.contains("\u001b]0;INJECTED"), "pane must not inject an OSC sequence into the outer terminal");
+        // and the supplementary character is rendered instead of a stray control byte
+        String plain = output.replaceAll("\\[[^@-~]*[@-~]", "");
+        assertTrue(plain.contains(smp), "supplementary code point should be rendered, not narrowed");
+    }
 }

--- a/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
+++ b/terminal/src/main/java/org/jline/utils/AttributedStringBuilder.java
@@ -296,6 +296,42 @@ public class AttributedStringBuilder extends AttributedCharSequence implements A
     }
 
     /**
+     * Appends the specified Unicode code point to this builder.
+     *
+     * <p>
+     * This method appends the specified code point to this builder,
+     * applying the current style. For supplementary code points (above U+FFFF),
+     * the high and low surrogate chars are both appended with the same style.
+     * This avoids the temporary {@code String} and {@code char[]} allocation
+     * that {@code append(new String(Character.toChars(cp)))} would require.
+     * </p>
+     *
+     * @param codePoint the Unicode code point to append
+     * @return this builder
+     * @throws IllegalArgumentException if codePoint is not a valid Unicode code point
+     */
+    public AttributedStringBuilder appendCodePoint(int codePoint) {
+        if (Character.isBmpCodePoint(codePoint)) {
+            return append((char) codePoint);
+        }
+        if (!Character.isValidCodePoint(codePoint)) {
+            throw new IllegalArgumentException("Not a valid Unicode code point: 0x" + Integer.toHexString(codePoint));
+        }
+        // Supplementary code point: append the surrogate pair directly
+        long s = current.getStyle();
+        ensureCapacity(length + 2);
+        buffer[length] = Character.highSurrogate(codePoint);
+        style[length] = s;
+        length++;
+        lastLineLength++;
+        buffer[length] = Character.lowSurrogate(codePoint);
+        style[length] = s;
+        length++;
+        lastLineLength++;
+        return this;
+    }
+
+    /**
      * Appends the specified character to this builder multiple times.
      *
      * <p>

--- a/terminal/src/test/java/org/jline/utils/AttributedStringBuilderTest.java
+++ b/terminal/src/test/java/org/jline/utils/AttributedStringBuilderTest.java
@@ -154,6 +154,61 @@ class AttributedStringBuilderTest {
     }
 
     @Test
+    void testAppendCodePointBmp() {
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        sb.appendCodePoint('A');
+        sb.appendCodePoint(0x00E9); // é
+        sb.appendCodePoint('Z');
+        assertEquals("AéZ", sb.toString());
+    }
+
+    @Test
+    void testAppendCodePointSupplementary() {
+        // U+1F600 = 😀 (GRINNING FACE) — a supplementary code point
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        sb.append("hi ");
+        sb.appendCodePoint(0x1F600);
+        sb.append(" bye");
+        String result = sb.toString();
+        assertEquals("hi 😀 bye", result);
+        // Verify the code point round-trips correctly
+        assertEquals(0x1F600, result.codePointAt(3));
+    }
+
+    @Test
+    void testAppendCodePointPreservesStyle() {
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        sb.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
+        sb.appendCodePoint(0x1F600); // supplementary
+        sb.style(AttributedStyle.DEFAULT);
+        sb.appendCodePoint('!');
+        AttributedString str = sb.toAttributedString();
+        // Both surrogate chars of the supplementary code point should carry the red style
+        long style0 = str.styleCodeAt(0);
+        long style1 = str.styleCodeAt(1);
+        long styleExcl = str.styleCodeAt(2);
+        assertEquals(style0, style1, "Both surrogates of a supplementary code point should have the same style");
+        assertNotEquals(style0, styleExcl, "Style should change after the supplementary code point");
+    }
+
+    @Test
+    void testAppendCodePointInvalidThrows() {
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        assertThrows(IllegalArgumentException.class, () -> sb.appendCodePoint(0x110000));
+        assertThrows(IllegalArgumentException.class, () -> sb.appendCodePoint(-1));
+    }
+
+    @Test
+    void testAppendCodePointTab() {
+        // BMP tab character should still be expanded when tab stops are set
+        AttributedStringBuilder sb = new AttributedStringBuilder().tabs(4);
+        sb.append("ab");
+        sb.appendCodePoint('\t');
+        sb.append("c");
+        assertEquals("ab  c", sb.toString());
+    }
+
+    @Test
     void styleMatchesGuardsAgainstCatastrophicBacktracking() {
         // (.*a){30} over a run of 'a's forces exponential backtracking in
         // java.util.regex (still true on current JVMs). styleMatches feeds


### PR DESCRIPTION
## Summary

Follow-up to #2157 — adds `AttributedStringBuilder.appendCodePoint(int)` so callers can append a full Unicode code point without allocating a temporary `String` and `char[]` each time.

- For BMP code points, delegates to the existing `append(char)` path (tab expansion, newline tracking preserved).
- For supplementary code points, writes the surrogate pair directly into the backing `char[]` buffer with the current style — no intermediate objects.
- Updates `Tmux.redraw()` to use the new method, replacing `sb.append(new String(Character.toChars(c)))`.
- Adds unit tests covering BMP, supplementary, style preservation, invalid code point rejection, and tab expansion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for appending Unicode code points directly while preserving text styling.
  * Improved rendering of supplementary Unicode characters.

* **Bug Fixes**
  * Prevented supplementary characters from being misinterpreted as terminal control sequences.
  * Added validation for invalid Unicode code points.

* **Tests**
  * Added coverage for Unicode rendering, styling, tab expansion, and terminal escape-sequence safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->