### PR TITLE
fix: escape IAC byte in the telnet data output stream

### DIFF
--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
@@ -353,6 +353,13 @@ public class TelnetIO {
 
         out.write(b);
 
+        // a data byte 255 (IAC) must be doubled, otherwise the peer reads it as
+        // the start of a telnet command (RFC 854). read() already collapses the
+        // doubled form back to a single 255 on input.
+        if (b == (byte) IAC) {
+            out.write(IAC);
+        }
+
         if (b == 13) {
             crFlag = true;
         } else {
@@ -431,10 +438,11 @@ public class TelnetIO {
     public void closeOutput() {
 
         try {
-            // sends telnetprotocol logout acknowledgement
-            write(IAC);
-            write(DO);
-            write(LOGOUT);
+            // sends telnetprotocol logout acknowledgement; this is a command
+            // sequence and must bypass the IAC-doubling done by write(byte).
+            rawWrite(IAC);
+            rawWrite(DO);
+            rawWrite(LOGOUT);
             // and now close underlying outputstream
 
             out.close();

--- a/remote-telnet/src/test/java/org/jline/builtins/telnet/TelnetIOEscapeTest.java
+++ b/remote-telnet/src/test/java/org/jline/builtins/telnet/TelnetIOEscapeTest.java
@@ -55,6 +55,30 @@ public class TelnetIOEscapeTest {
     }
 
     @Test
+    public void consecutiveIacBytesAreEachDoubled() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write(new byte[] {(byte) 0xFF, (byte) 0xFF});
+        io.flush();
+
+        // Two 0xFF data bytes are escaped independently, so four reach the wire.
+        assertArrayEquals(new byte[] {(byte) 255, (byte) 255, (byte) 255, (byte) 255}, sink.toByteArray());
+    }
+
+    @Test
+    public void iacFollowedByLfKeepsCrLfConversion() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write(new byte[] {(byte) 0xFF, (byte) '\n'});
+        io.flush();
+
+        // IAC doubling and the LF -> CRLF conversion do not interfere.
+        assertArrayEquals(new byte[] {(byte) 255, (byte) 255, (byte) 13, (byte) 10}, sink.toByteArray());
+    }
+
+    @Test
     public void ordinaryBytesPassThroughUnchanged() throws Exception {
         TelnetIO io = new TelnetIO();
         ByteArrayOutputStream sink = wire(io);

--- a/remote-telnet/src/test/java/org/jline/builtins/telnet/TelnetIOEscapeTest.java
+++ b/remote-telnet/src/test/java/org/jline/builtins/telnet/TelnetIOEscapeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins.telnet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class TelnetIOEscapeTest {
+
+    private static final int IAC = 255;
+    private static final int DO = 253;
+    private static final int LOGOUT = 18;
+
+    private static ByteArrayOutputStream wire(TelnetIO io) throws Exception {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        Field out = TelnetIO.class.getDeclaredField("out");
+        out.setAccessible(true);
+        out.set(io, new DataOutputStream(sink));
+        return sink;
+    }
+
+    @Test
+    public void dataByteIacIsDoubled() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write(IAC); // a 0xFF byte emitted by the hosted application
+        io.flush();
+
+        // The peer un-escapes 255 255 back to a single 255; a lone 255 would be
+        // read as the IAC command introducer instead.
+        assertArrayEquals(new byte[] {(byte) 255, (byte) 255}, sink.toByteArray());
+    }
+
+    @Test
+    public void iacInsideDataStreamIsEscapedInPlace() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write(new byte[] {(byte) 'a', (byte) 0xFF, (byte) 'b'});
+        io.flush();
+
+        assertArrayEquals(new byte[] {(byte) 'a', (byte) 255, (byte) 255, (byte) 'b'}, sink.toByteArray());
+    }
+
+    @Test
+    public void ordinaryBytesPassThroughUnchanged() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write((byte) 'A');
+        io.flush();
+
+        assertArrayEquals(new byte[] {(byte) 'A'}, sink.toByteArray());
+    }
+
+    @Test
+    public void logoutCommandIsNotDoubled() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.closeOutput();
+
+        // IAC DO LOGOUT is a command sequence, so its leading 255 stays single.
+        assertArrayEquals(new byte[] {(byte) IAC, (byte) DO, (byte) LOGOUT}, sink.toByteArray());
+    }
+}


### PR DESCRIPTION
Data output goes through TelnetIO.write(byte). It doubles CR to CRLF but never doubles a data byte 255 (IAC), while read() already un-escapes the doubled form:

    app prints:   61 FF 62      "a", 0xFF, "b"
    on the wire:  61 FF 62      the lone 0xFF is read by the client as IAC
    client sees:  IAC <next byte> ...   a telnet command it never asked for

Any 0xFF a hosted application emits (a binary file shown via cat, another user's text in a multi-user shell, an attacker-influenced filename) becomes a command introducer on the peer: IAC WILL ECHO turns off local echo before a password prompt, IAC DO LOGOUT drops the session, IAC SB desyncs later output.

write(byte) now doubles IAC to match the read-side un-escaping. closeOutput()'s IAC DO LOGOUT is a genuine command sequence, so it moves to rawWrite; every other protocol write in the class already uses rawWrite, so the data path carries only application bytes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telnet output handling by correctly escaping protocol bytes within transmitted data.
  * Preserved line-ending conversion and ordinary-byte transmission.
  * Corrected logout negotiation so protocol commands are sent without unintended escaping.

* **Tests**
  * Added coverage for standalone, embedded, and consecutive escaped bytes, line endings, regular output, and logout sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->