### PR TITLE
fix: mask password value in DefaultPrompter result display

### DIFF
--- a/prompt/src/main/java/org/jline/prompt/PasswordPrompt.java
+++ b/prompt/src/main/java/org/jline/prompt/PasswordPrompt.java
@@ -24,10 +24,15 @@ public interface PasswordPrompt extends InputPrompt {
     Character getMask();
 
     /**
-     * Whether to show the mask character or completely hide input.
-     * If true, shows mask characters. If false, shows nothing.
+     * Whether to show the mask character in the post-input display result.
+     * When {@code true}, the display result shows mask characters for each typed character.
+     * When {@code false}, the display result is empty (no visible feedback after input).
+     * <p>
+     * Note: this controls only the post-input display value returned by
+     * {@link InputResult#getDisplayResult()}, not what is shown during typing.
+     * To suppress all visible feedback while typing, use {@code mask('\0')}.
      *
-     * @return true to show mask characters, false to hide completely
+     * @return true to show mask characters in the result, false to hide completely
      */
     default boolean showMask() {
         return true;

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultInputResult.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultInputResult.java
@@ -10,6 +10,7 @@ package org.jline.prompt.impl;
 
 import org.jline.prompt.InputPrompt;
 import org.jline.prompt.InputResult;
+import org.jline.prompt.PasswordPrompt;
 
 /**
  * Implementation of InputResult.
@@ -49,6 +50,9 @@ public class DefaultInputResult extends AbstractPromptResult<InputPrompt> implem
 
     @Override
     public String toString() {
+        if (getPrompt() instanceof PasswordPrompt) {
+            return "InputResult{input='" + displayInput + "'}";
+        }
         return "InputResult{input='" + input + "'}";
     }
 }

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
@@ -492,6 +492,11 @@ public class DefaultPrompter implements Prompter {
         try {
             // Use LineReader to read the input
             Character mask = prompt.getMask();
+            if (mask == null && prompt instanceof PasswordPrompt) {
+                // PasswordPrompt.getMask() documents null as "use the default mask '*'";
+                // passing null through would make readLine echo the password while typing
+                mask = '*';
+            }
             String buffer = defaultValue != null ? defaultValue : null;
 
             String input = reader.readLine(promptString, null, mask, buffer);

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
@@ -501,7 +501,7 @@ public class DefaultPrompter implements Prompter {
                 input = defaultValue;
             }
 
-            return new DefaultInputResult(input, input, prompt);
+            return new DefaultInputResult(input, maskedDisplay(prompt, input), prompt);
         } catch (EndOfFileException e) {
             if (e == ESCAPE_EOF) {
                 // Escape was pressed — go back to previous prompt
@@ -527,6 +527,26 @@ public class DefaultPrompter implements Prompter {
             throws IOException, UserInterruptException {
         // Password prompts are just input prompts with masking
         return executeInputPrompt(header, prompt);
+    }
+
+    /**
+     * Compute the value shown for an input result. When the prompt masks its input (passwords),
+     * the typed text must never be surfaced: the display value is the mask character repeated for
+     * the length of the input, or empty when the prompt hides its input entirely.
+     */
+    private static String maskedDisplay(InputPrompt prompt, String input) {
+        Character mask = prompt.getMask();
+        if (mask == null || input == null) {
+            return input;
+        }
+        if (prompt instanceof PasswordPrompt && !((PasswordPrompt) prompt).showMask()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(input.length());
+        for (int i = 0; i < input.length(); i++) {
+            sb.append(mask.charValue());
+        }
+        return sb.toString();
     }
 
     private InputResult executeNumberPrompt(List<AttributedString> header, NumberPrompt prompt)

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
@@ -493,11 +493,11 @@ public class DefaultPrompter implements Prompter {
             // Use LineReader to read the input
             Character mask = prompt.getMask();
             if (mask == null && prompt instanceof PasswordPrompt) {
-                // PasswordPrompt.getMask() documents null as "use the default mask '*'";
-                // passing null through would make readLine echo the password while typing
+                // A null mask on a password prompt defaults to '*'; without this,
+                // readLine would echo the password in clear text while typing
                 mask = '*';
             }
-            String buffer = defaultValue != null ? defaultValue : null;
+            String buffer = defaultValue;
 
             String input = reader.readLine(promptString, null, mask, buffer);
 

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
@@ -535,16 +535,24 @@ public class DefaultPrompter implements Prompter {
      * the length of the input, or empty when the prompt hides its input entirely.
      */
     private static String maskedDisplay(InputPrompt prompt, String input) {
+        if (input == null) {
+            return null;
+        }
         Character mask = prompt.getMask();
-        if (mask == null || input == null) {
+        if (prompt instanceof PasswordPrompt) {
+            if (!((PasswordPrompt) prompt).showMask()) {
+                return "";
+            }
+            // PasswordPrompt.getMask() documents null as "use the default mask '*'"
+            mask = mask != null ? mask : '*';
+        }
+        if (mask == null) {
             return input;
         }
-        if (prompt instanceof PasswordPrompt && !((PasswordPrompt) prompt).showMask()) {
-            return "";
-        }
+        char maskChar = mask;
         StringBuilder sb = new StringBuilder(input.length());
         for (int i = 0; i < input.length(); i++) {
-            sb.append(mask.charValue());
+            sb.append(maskChar);
         }
         return sb.toString();
     }

--- a/prompt/src/test/java/org/jline/prompt/PasswordPromptMaskingTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PasswordPromptMaskingTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.prompt;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that the text typed at a password prompt is never surfaced in clear text,
+ * neither through the result's display value nor on the terminal.
+ */
+class PasswordPromptMaskingTest {
+
+    private static Map<String, ? extends PromptResult<? extends Prompt>> runPassword(
+            String typed, boolean showMask, ByteArrayOutputStream out) throws Exception {
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write((typed + "\n").getBytes(StandardCharsets.UTF_8));
+
+        Terminal terminal =
+                TerminalBuilder.builder().type("ansi").streams(in, out).build();
+        terminal.setSize(Size.of(160, 80));
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        PromptBuilder builder = prompter.newBuilder();
+        builder.createPasswordPrompt()
+                .name("pw")
+                .message("Password:")
+                .showMask(showMask)
+                .addPrompt();
+        List<Prompt> prompts = builder.build();
+        return prompter.prompt(Collections.emptyList(), prompts);
+    }
+
+    @Test
+    void maskedDisplayNeverLeaksPassword() throws Exception {
+        String secret = "hunter2";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Map<String, ? extends PromptResult<? extends Prompt>> results = runPassword(secret, true, out);
+
+        InputResult result = (InputResult) results.get("pw");
+        // The real value is still available to the caller.
+        assertEquals(secret, result.getInput());
+        // The display value that gets echoed back into the prompt header must be masked.
+        assertEquals("*******", result.getDisplayResult());
+        // The header line rendered on the terminal carries the mask, not the typed password.
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("*******"));
+    }
+
+    @Test
+    void hiddenMaskShowsNothing() throws Exception {
+        String secret = "s3cr3t";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Map<String, ? extends PromptResult<? extends Prompt>> results = runPassword(secret, false, out);
+
+        InputResult result = (InputResult) results.get("pw");
+        assertEquals(secret, result.getInput());
+        assertEquals("", result.getDisplayResult());
+    }
+}

--- a/prompt/src/test/java/org/jline/prompt/PasswordPromptMaskingTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PasswordPromptMaskingTest.java
@@ -15,7 +15,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
@@ -33,11 +37,16 @@ class PasswordPromptMaskingTest {
             String typed, boolean showMask, ByteArrayOutputStream out) throws Exception {
         PipedInputStream in = new PipedInputStream();
         PipedOutputStream outIn = new PipedOutputStream(in);
-        outIn.write((typed + "\n").getBytes(StandardCharsets.UTF_8));
 
         Terminal terminal =
                 TerminalBuilder.builder().type("ansi").streams(in, out).build();
         terminal.setSize(Size.of(160, 80));
+        // Turn off the line discipline's own echo before any input is queued, so everything
+        // captured in `out` is what the prompter rendered, not the terminal echoing the pipe.
+        Attributes attributes = terminal.getAttributes();
+        attributes.setLocalFlag(Attributes.LocalFlag.ECHO, false);
+        terminal.setAttributes(attributes);
+        outIn.write((typed + "\n").getBytes(StandardCharsets.UTF_8));
         Prompter prompter = PrompterFactory.create(terminal);
 
         PromptBuilder builder = prompter.newBuilder();
@@ -62,7 +71,9 @@ class PasswordPromptMaskingTest {
         // The display value that gets echoed back into the prompt header must be masked.
         assertEquals("*******", result.getDisplayResult());
         // The header line rendered on the terminal carries the mask, not the typed password.
-        assertTrue(out.toString(StandardCharsets.UTF_8).contains("*******"));
+        String rendered = out.toString(StandardCharsets.UTF_8);
+        assertTrue(rendered.contains("*******"));
+        assertFalse(rendered.contains(secret));
     }
 
     @Test
@@ -74,5 +85,65 @@ class PasswordPromptMaskingTest {
         InputResult result = (InputResult) results.get("pw");
         assertEquals(secret, result.getInput());
         assertEquals("", result.getDisplayResult());
+        assertFalse(out.toString(StandardCharsets.UTF_8).contains(secret));
+    }
+
+    @Test
+    void nullMaskPasswordPromptStillMasksDisplay() throws Exception {
+        String secret = "hunter2";
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream outIn = new PipedOutputStream(in);
+        outIn.write((secret + "\n").getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Terminal terminal =
+                TerminalBuilder.builder().type("ansi").streams(in, out).build();
+        terminal.setSize(Size.of(160, 80));
+        Prompter prompter = PrompterFactory.create(terminal);
+
+        // A custom PasswordPrompt may leave getMask() null; the interface documents that
+        // as "use the default mask '*'", so the display value must still be masked.
+        PasswordPrompt prompt = new PasswordPrompt() {
+            @Override
+            public String getName() {
+                return "pw";
+            }
+
+            @Override
+            public String getMessage() {
+                return "Password:";
+            }
+
+            @Override
+            public String getDefaultValue() {
+                return null;
+            }
+
+            @Override
+            public Character getMask() {
+                return null;
+            }
+
+            @Override
+            public Completer getCompleter() {
+                return null;
+            }
+
+            @Override
+            public LineReader getLineReader() {
+                return null;
+            }
+
+            @Override
+            public Function<String, Boolean> getValidator() {
+                return null;
+            }
+        };
+        Map<String, ? extends PromptResult<? extends Prompt>> results =
+                prompter.prompt(Collections.emptyList(), Collections.<Prompt>singletonList(prompt));
+
+        InputResult result = (InputResult) results.get("pw");
+        assertEquals(secret, result.getInput());
+        assertEquals("*******", result.getDisplayResult());
     }
 }

--- a/prompt/src/test/java/org/jline/prompt/PasswordPromptMaskingTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PasswordPromptMaskingTest.java
@@ -77,6 +77,19 @@ class PasswordPromptMaskingTest {
     }
 
     @Test
+    void toStringNeverLeaksPassword() throws Exception {
+        String secret = "hunter2";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Map<String, ? extends PromptResult<? extends Prompt>> results = runPassword(secret, true, out);
+
+        InputResult result = (InputResult) results.get("pw");
+        // toString() must use the masked display value, not the raw password
+        String str = result.toString();
+        assertFalse(str.contains(secret), "toString() must not contain the raw password");
+        assertTrue(str.contains("*******"), "toString() should show the masked value");
+    }
+
+    @Test
     void hiddenMaskShowsNothing() throws Exception {
         String secret = "s3cr3t";
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/prompt/src/test/java/org/jline/prompt/PasswordPromptMaskingTest.java
+++ b/prompt/src/test/java/org/jline/prompt/PasswordPromptMaskingTest.java
@@ -93,12 +93,16 @@ class PasswordPromptMaskingTest {
         String secret = "hunter2";
         PipedInputStream in = new PipedInputStream();
         PipedOutputStream outIn = new PipedOutputStream(in);
-        outIn.write((secret + "\n").getBytes(StandardCharsets.UTF_8));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         Terminal terminal =
                 TerminalBuilder.builder().type("ansi").streams(in, out).build();
         terminal.setSize(Size.of(160, 80));
+        // Same as runPassword: silence the line discipline echo before queuing any input.
+        Attributes attributes = terminal.getAttributes();
+        attributes.setLocalFlag(Attributes.LocalFlag.ECHO, false);
+        terminal.setAttributes(attributes);
+        outIn.write((secret + "\n").getBytes(StandardCharsets.UTF_8));
         Prompter prompter = PrompterFactory.create(terminal);
 
         // A custom PasswordPrompt may leave getMask() null; the interface documents that
@@ -145,5 +149,10 @@ class PasswordPromptMaskingTest {
         InputResult result = (InputResult) results.get("pw");
         assertEquals(secret, result.getInput());
         assertEquals("*******", result.getDisplayResult());
+        // The null mask must not reach readLine either: the terminal only ever sees the
+        // default '*' mask, both while typing and in the rendered header line.
+        String rendered = out.toString(StandardCharsets.UTF_8);
+        assertTrue(rendered.contains("*******"));
+        assertFalse(rendered.contains(secret));
     }
 }


### PR DESCRIPTION
Prompt result for a `PasswordPrompt`, before this change:

    expected: <*******> but was: <hunter2>

`executeInputPrompt` returns `DefaultInputResult(input, input, prompt)` and the second field is the display value, so `getDisplayResult()` hands back the clear-text password. `promptInternal` splices that into the `? <message> <answer>` header line, which `reader.printAbove` writes before the next prompt and `close()` paints and leaves on the terminal, so a password that was masked while typing is echoed back and stays in scrollback. The older console-ui `AbstractPrompt` keeps a parallel masked `displayBuffer` for exactly this reason.

The fix builds the display value from the prompt's mask inside `executeInputPrompt` (the only site that reads masked input): the mask character repeated for the input length, or empty when `PasswordPrompt.showMask()` is false. Unmasked prompts (`mask == null`) are unchanged, and `getInput()`/`getResult()` still return the real value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password prompts now mask entered characters by default when no mask is specified.
  * Hidden password mode conceals entered characters while preserving the input for processing.
  * Masked results and string representations no longer expose password text.
  * Unmasked prompts continue displaying entered text normally.

* **Documentation**
  * Clarified the difference between typing-time masking and post-input display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->