### PR TITLE
fix: preserve termios baud rate when setting attributes (#2170)

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -477,7 +477,12 @@ class CLibrary {
         try (Arena arena = Arena.ofConfined()) {
             winsize ws = new winsize(arena);
             int res = (int) ioctl.invoke(fd, (long) TIOCGWINSZ, ws.segment());
+            if (res != 0) {
+                throw new UncheckedIOException(new IOException("ioctl(TIOCGWINSZ) failed with return code " + res));
+            }
             return Size.of(ws.ws_col(), ws.ws_row());
+        } catch (UncheckedIOException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call ioctl(TIOCGWINSZ)", e);
         }
@@ -489,6 +494,11 @@ class CLibrary {
             ws.ws_row((short) size.getRows());
             ws.ws_col((short) size.getColumns());
             int res = (int) ioctl.invoke(fd, TIOCSWINSZ, ws.segment());
+            if (res != 0) {
+                throw new UncheckedIOException(new IOException("ioctl(TIOCSWINSZ) failed with return code " + res));
+            }
+        } catch (UncheckedIOException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call ioctl(TIOCSWINSZ)", e);
         }
@@ -498,7 +508,12 @@ class CLibrary {
         try (Arena arena = Arena.ofConfined()) {
             termios t = new termios(arena);
             int res = (int) tcgetattr.invoke(fd, t.segment());
+            if (res != 0) {
+                throw new UncheckedIOException(new IOException("tcgetattr() failed with return code " + res));
+            }
             return t.asAttributes();
+        } catch (UncheckedIOException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call tcgetattr()", e);
         }
@@ -508,8 +523,18 @@ class CLibrary {
         try (Arena arena = Arena.ofConfined()) {
             termios t = new termios(arena);
             int res = (int) tcgetattr.invoke(fd, t.segment());
+            if (res != 0) {
+                // Best-effort: tcgetattr may fail when the fd is no longer a
+                // valid terminal (e.g. during close).  Log and return early
+                // rather than applying attributes onto uninitialised data.
+                logger.log(Level.DEBUG, "tcgetattr() returned " + res + " for fd " + fd);
+                return;
+            }
             t.apply(attr);
             res = (int) tcsetattr.invoke(fd, TermiosData.TCSANOW, t.segment());
+            if (res != 0) {
+                logger.log(Level.DEBUG, "tcsetattr() returned " + res + " for fd " + fd);
+            }
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call tcsetattr()", e);
         }
@@ -527,12 +552,17 @@ class CLibrary {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment buf = arena.allocate(64);
             int res = (int) ttyname_r.invoke(fd, buf, buf.byteSize());
+            if (res != 0) {
+                throw new UncheckedIOException(new IOException("ttyname_r() failed with return code " + res));
+            }
             byte[] data = buf.toArray(ValueLayout.JAVA_BYTE);
             int len = 0;
             while (data[len] != 0) {
                 len++;
             }
             return new String(data, 0, len);
+        } catch (UncheckedIOException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call ttyname_r()", e);
         }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -180,11 +180,30 @@ class CLibrary {
 
         termios(Arena arena, Attributes t) {
             this(arena);
-            TermiosData data = TermiosMapping.forCurrentPlatform().toTermios(t);
+            apply(t);
+        }
+
+        TermiosData toTermiosData() {
+            TermiosData data = new TermiosData();
+            data.iflag(c_iflag());
+            data.oflag(c_oflag());
+            data.cflag(c_cflag());
+            data.lflag(c_lflag());
+            data.ispeed(c_ispeed());
+            data.ospeed(c_ospeed());
+            byte[] cc = c_cc().toArray(ValueLayout.JAVA_BYTE);
+            System.arraycopy(cc, 0, data.cc(), 0, cc.length);
+            return data;
+        }
+
+        void apply(Attributes t) {
+            TermiosData data = TermiosMapping.forCurrentPlatform().toTermios(t, toTermiosData());
             c_iflag(data.iflag());
             c_oflag(data.oflag());
             c_cflag(data.cflag());
             c_lflag(data.lflag());
+            c_ispeed(data.ispeed());
+            c_ospeed(data.ospeed());
             c_cc().copyFrom(MemorySegment.ofArray(data.cc()).asSlice(0, c_cc_used));
         }
 
@@ -251,14 +270,7 @@ class CLibrary {
          * @return a new {@link Attributes} instance reflecting the current terminal settings
          */
         public Attributes asAttributes() {
-            TermiosData data = new TermiosData();
-            data.iflag(c_iflag());
-            data.oflag(c_oflag());
-            data.cflag(c_cflag());
-            data.lflag(c_lflag());
-            byte[] cc = c_cc().toArray(ValueLayout.JAVA_BYTE);
-            System.arraycopy(cc, 0, data.cc(), 0, cc.length);
-            return TermiosMapping.forCurrentPlatform().toAttributes(data);
+            return TermiosMapping.forCurrentPlatform().toAttributes(toTermiosData());
         }
     }
 
@@ -494,8 +506,10 @@ class CLibrary {
 
     static void setAttributes(int fd, Attributes attr) {
         try (Arena arena = Arena.ofConfined()) {
-            termios t = new termios(arena, attr);
-            int res = (int) tcsetattr.invoke(fd, TermiosData.TCSANOW, t.segment());
+            termios t = new termios(arena);
+            int res = (int) tcgetattr.invoke(fd, t.segment());
+            t.apply(attr);
+            res = (int) tcsetattr.invoke(fd, TermiosData.TCSANOW, t.segment());
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call tcsetattr()", e);
         }

--- a/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
+++ b/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
@@ -15,15 +15,20 @@ import java.lang.foreign.Arena;
 import java.nio.charset.Charset;
 
 import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.ControlFlag;
+import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.TermiosMapping;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FfmTest {
 
@@ -77,6 +82,45 @@ class FfmTest {
             CLibrary.winsize ws = new CLibrary.winsize(arena, cols, rows);
             assertEquals(cols, ws.ws_col());
             assertEquals(rows, ws.ws_row());
+        }
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void applyAttributesPreservesBaudAndSpeed() {
+        try (Arena arena = Arena.ofConfined()) {
+            CLibrary.termios t = new CLibrary.termios(arena);
+            Attributes seed = new Attributes();
+            seed.setControlFlag(ControlFlag.CS8, true);
+            seed.setControlFlag(ControlFlag.CREAD, true);
+            seed.setLocalFlag(LocalFlag.ECHO, true);
+            t.apply(seed);
+
+            TermiosMapping mapping = TermiosMapping.forCurrentPlatform();
+            Attributes allControl = new Attributes();
+            for (ControlFlag flag : ControlFlag.values()) {
+                allControl.setControlFlag(flag, true);
+            }
+            long mappedCflag = mapping.toTermios(allControl).cflag();
+            long baudBits = 0x000DL & ~mappedCflag;
+            if (baudBits == 0) {
+                baudBits = Long.lowestOneBit(~mappedCflag);
+            }
+            t.c_cflag(t.c_cflag() | baudBits);
+            t.c_ispeed(9600);
+            t.c_ospeed(9600);
+
+            Attributes attr = t.asAttributes();
+            attr.setLocalFlag(LocalFlag.ECHO, false);
+            t.apply(attr);
+
+            assertEquals(baudBits, t.c_cflag() & baudBits);
+            assertEquals(9600, t.c_ispeed());
+            assertEquals(9600, t.c_ospeed());
+            Attributes applied = t.asAttributes();
+            assertFalse(applied.getLocalFlag(LocalFlag.ECHO));
+            assertTrue(applied.getControlFlag(ControlFlag.CS8));
+            assertTrue(applied.getControlFlag(ControlFlag.CREAD));
         }
     }
 

--- a/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
+++ b/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
@@ -20,6 +20,7 @@ import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.TermiosMapping;
+import org.jline.utils.OSUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -107,16 +108,24 @@ class FfmTest {
                 baudBits = Long.lowestOneBit(~mappedCflag);
             }
             t.c_cflag(t.c_cflag() | baudBits);
-            t.c_ispeed(9600);
-            t.c_ospeed(9600);
+
+            // Speed fields only exist on non-AIX platforms (macOS, Linux).
+            // On AIX the c_ispeed/c_ospeed VarHandles are null and the
+            // getters return 0 regardless of what is written.
+            if (!OSUtils.IS_AIX) {
+                t.c_ispeed(9600);
+                t.c_ospeed(9600);
+            }
 
             Attributes attr = t.asAttributes();
             attr.setLocalFlag(LocalFlag.ECHO, false);
             t.apply(attr);
 
             assertEquals(baudBits, t.c_cflag() & baudBits);
-            assertEquals(9600, t.c_ispeed());
-            assertEquals(9600, t.c_ospeed());
+            if (!OSUtils.IS_AIX) {
+                assertEquals(9600, t.c_ispeed());
+                assertEquals(9600, t.c_ospeed());
+            }
             Attributes applied = t.asAttributes();
             assertFalse(applied.getLocalFlag(LocalFlag.ECHO));
             assertTrue(applied.getControlFlag(ControlFlag.CS8));

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniNativePty.java
@@ -146,7 +146,9 @@ public abstract class JniNativePty extends AbstractPty implements Pty {
 
     @Override
     protected void doSetAttr(Attributes attr) throws IOException {
-        CLibrary.Termios tios = toNativeTermios(attr);
+        CLibrary.Termios tios = new CLibrary.Termios();
+        CLibrary.tcgetattr(slave, tios);
+        applyAttributes(tios, attr);
         CLibrary.tcsetattr(slave, TCSANOW, tios);
     }
 
@@ -175,18 +177,31 @@ public abstract class JniNativePty extends AbstractPty implements Pty {
         data.oflag(tios.c_oflag);
         data.cflag(tios.c_cflag);
         data.lflag(tios.c_lflag);
+        data.ispeed(tios.c_ispeed);
+        data.ospeed(tios.c_ospeed);
         System.arraycopy(tios.c_cc, 0, data.cc(), 0, Math.min(tios.c_cc.length, data.cc().length));
         return data;
     }
 
-    static CLibrary.Termios toNativeTermiosData(TermiosData data) {
-        CLibrary.Termios tio = new CLibrary.Termios();
+    static void copyTermiosDataToNative(TermiosData data, CLibrary.Termios tio) {
         tio.c_iflag = data.iflag();
         tio.c_oflag = data.oflag();
         tio.c_cflag = data.cflag();
         tio.c_lflag = data.lflag();
+        tio.c_ispeed = data.ispeed();
+        tio.c_ospeed = data.ospeed();
         System.arraycopy(data.cc(), 0, tio.c_cc, 0, Math.min(data.cc().length, tio.c_cc.length));
+    }
+
+    static CLibrary.Termios toNativeTermiosData(TermiosData data) {
+        CLibrary.Termios tio = new CLibrary.Termios();
+        copyTermiosDataToNative(data, tio);
         return tio;
+    }
+
+    static void applyAttributes(CLibrary.Termios tios, Attributes attr) {
+        TermiosData updated = TermiosMapping.forCurrentPlatform().toTermios(attr, fromNativeTermios(tios));
+        copyTermiosDataToNative(updated, tios);
     }
 
     protected static CLibrary.Termios toNativeTermios(Attributes t) {

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
@@ -80,7 +80,10 @@ public class JniUnixSysTerminal extends AbstractUnixSysTerminal {
 
     @Override
     protected void doSetAttributes(Attributes attr) {
-        CLibrary.tcsetattr(STDIN_FD, TCSANOW, JniNativePty.toNativeTermiosData(mapping.toTermios(attr)));
+        CLibrary.Termios tios = new CLibrary.Termios();
+        CLibrary.tcgetattr(STDIN_FD, tios);
+        JniNativePty.applyAttributes(tios, attr);
+        CLibrary.tcsetattr(STDIN_FD, TCSANOW, tios);
     }
 
     @Override

--- a/terminal-jni/src/test/java/org/jline/terminal/impl/jni/JniNativePtyTest.java
+++ b/terminal-jni/src/test/java/org/jline/terminal/impl/jni/JniNativePtyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl.jni;
+
+import org.jline.nativ.CLibrary;
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.ControlFlag;
+import org.jline.terminal.Attributes.LocalFlag;
+import org.jline.terminal.impl.TermiosMapping;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JniNativePtyTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void applyAttributesPreservesBaudAndSpeed() {
+        CLibrary.Termios tios = new CLibrary.Termios();
+        Attributes seed = new Attributes();
+        seed.setControlFlag(ControlFlag.CS8, true);
+        seed.setControlFlag(ControlFlag.CREAD, true);
+        seed.setLocalFlag(LocalFlag.ECHO, true);
+        JniNativePty.applyAttributes(tios, seed);
+
+        TermiosMapping mapping = TermiosMapping.forCurrentPlatform();
+        Attributes allControl = new Attributes();
+        for (ControlFlag flag : ControlFlag.values()) {
+            allControl.setControlFlag(flag, true);
+        }
+        long mappedCflag = mapping.toTermios(allControl).cflag();
+        long baudBits = 0x000DL & ~mappedCflag;
+        if (baudBits == 0) {
+            baudBits = Long.lowestOneBit(~mappedCflag);
+        }
+        tios.c_cflag |= baudBits;
+        tios.c_ispeed = 9600;
+        tios.c_ospeed = 9600;
+        tios.c_cc[31] = 0x5A;
+
+        Attributes attr = mapping.toAttributes(JniNativePty.fromNativeTermios(tios));
+        attr.setLocalFlag(LocalFlag.ECHO, false);
+        JniNativePty.applyAttributes(tios, attr);
+
+        assertEquals(baudBits, tios.c_cflag & baudBits);
+        assertEquals(9600, tios.c_ispeed);
+        assertEquals(9600, tios.c_ospeed);
+        assertEquals((byte) 0x5A, tios.c_cc[31]);
+        Attributes applied = mapping.toAttributes(JniNativePty.fromNativeTermios(tios));
+        assertFalse(applied.getLocalFlag(LocalFlag.ECHO));
+        assertTrue(applied.getControlFlag(ControlFlag.CS8));
+        assertTrue(applied.getControlFlag(ControlFlag.CREAD));
+    }
+}

--- a/terminal/src/main/java/org/jline/terminal/impl/TermiosData.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/TermiosData.java
@@ -11,13 +11,13 @@ package org.jline.terminal.impl;
 /**
  * Platform-independent holder for POSIX termios fields.
  *
- * <p>Mirrors the native {@code struct termios} layout: four flag words and a control-character
- * array. Used as an intermediate representation between JLine {@link org.jline.terminal.Attributes}
- * and the actual native structure provided by JNI or FFM.</p>
+ * <p>Mirrors the native {@code struct termios} layout: four flag words, input/output speeds,
+ * and a control-character array. Used as an intermediate representation between JLine
+ * {@link org.jline.terminal.Attributes} and the actual native structure provided by JNI or FFM.</p>
  */
 public class TermiosData {
 
-    /** Creates a new instance with all flags zeroed and all control characters set to 0. */
+    /** Creates a new instance with all flags and speeds zeroed and all control characters set to 0. */
     public TermiosData() {}
 
     /** Maximum {@code c_cc} array size across supported platforms (Linux NCCS=32, macOS/FreeBSD NCCS=20). */
@@ -30,6 +30,8 @@ public class TermiosData {
     private long oflag;
     private long cflag;
     private long lflag;
+    private long ispeed;
+    private long ospeed;
     private final byte[] cc = new byte[NCCS];
 
     /** Returns the input mode flags. */
@@ -70,6 +72,26 @@ public class TermiosData {
     /** Sets the local mode flags. */
     public void lflag(long value) {
         this.lflag = value;
+    }
+
+    /** Returns the input speed ({@code c_ispeed}). */
+    public long ispeed() {
+        return ispeed;
+    }
+
+    /** Sets the input speed ({@code c_ispeed}). */
+    public void ispeed(long value) {
+        this.ispeed = value;
+    }
+
+    /** Returns the output speed ({@code c_ospeed}). */
+    public long ospeed() {
+        return ospeed;
+    }
+
+    /** Sets the output speed ({@code c_ospeed}). */
+    public void ospeed(long value) {
+        this.ospeed = value;
     }
 
     /** Returns the control characters array. */

--- a/terminal/src/main/java/org/jline/terminal/impl/TermiosMapping.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/TermiosMapping.java
@@ -9,6 +9,7 @@
 package org.jline.terminal.impl;
 
 import java.util.EnumMap;
+import java.util.function.Predicate;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Attributes.*;
@@ -18,7 +19,7 @@ import org.jline.terminal.Attributes.*;
  *
  * <p>Each platform subclass provides EnumMap tables that map JLine flag/control-char enums
  * to their native bitmask or c_cc index values. The base class iterates those tables in
- * {@link #toTermios(Attributes)} and {@link #toAttributes(TermiosData)}, so subclasses
+ * {@link #toTermios(Attributes, TermiosData)} and {@link #toAttributes(TermiosData)}, so subclasses
  * are pure data declarations with no conversion logic.</p>
  *
  * @see AixTermiosMapping
@@ -86,35 +87,61 @@ public abstract class TermiosMapping {
     /**
      * Converts JLine {@link Attributes} to native termios data.
      *
+     * <p>Unmapped bits such as baud-rate flags and {@code c_ispeed}/{@code c_ospeed} are zero
+     * in the returned structure. Prefer {@link #toTermios(Attributes, TermiosData)} when applying
+     * attributes onto an existing terminal so those fields are preserved.</p>
+     *
      * @param attr the JLine attributes
      * @return the corresponding native termios data
      */
     public final TermiosData toTermios(Attributes attr) {
+        return toTermios(attr, null);
+    }
+
+    /**
+     * Converts JLine {@link Attributes} onto an existing native termios snapshot.
+     *
+     * <p>Mapped flags and control characters are replaced from {@code attr}. Unmapped bits
+     * (including baud-rate flags such as {@code CBAUD}/{@code CBAUDEX}), input/output speeds,
+     * and unmapped {@code c_cc} entries from {@code existing} are preserved. When
+     * {@code existing} is {@code null}, this is equivalent to {@link #toTermios(Attributes)}.</p>
+     *
+     * @param attr the JLine attributes
+     * @param existing the current native termios data, or {@code null}
+     * @return native termios data with JLine flags applied
+     */
+    public final TermiosData toTermios(Attributes attr, TermiosData existing) {
         TermiosData tio = new TermiosData();
-        for (var e : inputFlagMap.entrySet()) {
-            if (attr.getInputFlag(e.getKey())) {
-                tio.iflag(tio.iflag() | e.getValue());
-            }
+        if (existing != null) {
+            tio.iflag(existing.iflag());
+            tio.oflag(existing.oflag());
+            tio.cflag(existing.cflag());
+            tio.lflag(existing.lflag());
+            tio.ispeed(existing.ispeed());
+            tio.ospeed(existing.ospeed());
+            System.arraycopy(existing.cc(), 0, tio.cc(), 0, tio.cc().length);
         }
-        for (var e : outputFlagMap.entrySet()) {
-            if (attr.getOutputFlag(e.getKey())) {
-                tio.oflag(tio.oflag() | e.getValue());
-            }
-        }
-        for (var e : controlFlagMap.entrySet()) {
-            if (attr.getControlFlag(e.getKey())) {
-                tio.cflag(tio.cflag() | e.getValue());
-            }
-        }
-        for (var e : localFlagMap.entrySet()) {
-            if (attr.getLocalFlag(e.getKey())) {
-                tio.lflag(tio.lflag() | e.getValue());
-            }
-        }
+        tio.iflag(applyMappedFlags(inputFlagMap, attr::getInputFlag, tio.iflag()));
+        tio.oflag(applyMappedFlags(outputFlagMap, attr::getOutputFlag, tio.oflag()));
+        tio.cflag(applyMappedFlags(controlFlagMap, attr::getControlFlag, tio.cflag()));
+        tio.lflag(applyMappedFlags(localFlagMap, attr::getLocalFlag, tio.lflag()));
         for (var e : controlCharMap.entrySet()) {
             tio.cc()[e.getValue()] = (byte) attr.getControlChar(e.getKey());
         }
         return tio;
+    }
+
+    private static <E extends Enum<E>> long applyMappedFlags(
+            EnumMap<E, Long> map, Predicate<E> enabled, long existing) {
+        long mapped = 0;
+        long value = 0;
+        for (var e : map.entrySet()) {
+            mapped |= e.getValue();
+            if (enabled.test(e.getKey())) {
+                value |= e.getValue();
+            }
+        }
+        return (existing & ~mapped) | value;
     }
 
     /**

--- a/terminal/src/test/java/org/jline/terminal/impl/TermiosMappingRoundtripTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/TermiosMappingRoundtripTest.java
@@ -13,6 +13,7 @@ import org.jline.terminal.Attributes.*;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TermiosMappingRoundtripTest {
@@ -35,6 +36,26 @@ class TermiosMappingRoundtripTest {
     @Test
     void testSolarisRoundtrip() {
         verifyRoundtrip("Solaris", SolarisTermiosMapping.INSTANCE);
+    }
+
+    @Test
+    void testLinuxPreservesBaudWhenApplyingAttributes() {
+        verifyPreservesUnmappedBaudAndSpeed("Linux", LinuxTermiosMapping.INSTANCE, 0x000DL);
+    }
+
+    @Test
+    void testOsXPreservesBaudWhenApplyingAttributes() {
+        verifyPreservesUnmappedBaudAndSpeed("OsX", OsXTermiosMapping.INSTANCE, 0x000DL);
+    }
+
+    @Test
+    void testFreeBsdPreservesBaudWhenApplyingAttributes() {
+        verifyPreservesUnmappedBaudAndSpeed("FreeBsd", FreeBsdTermiosMapping.INSTANCE, 0x000DL);
+    }
+
+    @Test
+    void testSolarisPreservesBaudWhenApplyingAttributes() {
+        verifyPreservesUnmappedBaudAndSpeed("Solaris", SolarisTermiosMapping.INSTANCE, 0x000DL);
     }
 
     private void verifyRoundtrip(String platform, TermiosMapping mapping) {
@@ -124,5 +145,40 @@ class TermiosMappingRoundtripTest {
         assertEquals(tio2.oflag(), tio3.oflag(), platform + ": c_oflag stable after double roundtrip");
         assertEquals(tio2.cflag(), tio3.cflag(), platform + ": c_cflag stable after double roundtrip");
         assertEquals(tio2.lflag(), tio3.lflag(), platform + ": c_lflag stable after double roundtrip");
+    }
+
+    private void verifyPreservesUnmappedBaudAndSpeed(String platform, TermiosMapping mapping, long preferredBaud) {
+        Attributes mapped = new Attributes();
+        for (ControlFlag flag : ControlFlag.values()) {
+            mapped.setControlFlag(flag, true);
+        }
+        long mappedCflag = mapping.toTermios(mapped).cflag();
+        long baudBits = preferredBaud & ~mappedCflag;
+        if (baudBits == 0) {
+            baudBits = Long.lowestOneBit(~mappedCflag);
+        }
+
+        Attributes seed = new Attributes();
+        seed.setControlFlag(ControlFlag.CS8, true);
+        seed.setControlFlag(ControlFlag.CREAD, true);
+        seed.setLocalFlag(LocalFlag.ECHO, true);
+        TermiosData existing = mapping.toTermios(seed);
+        existing.cflag(existing.cflag() | baudBits);
+        existing.ispeed(9600);
+        existing.ospeed(9600);
+        existing.cc()[31] = 0x5A;
+
+        Attributes attr = mapping.toAttributes(existing);
+        attr.setLocalFlag(LocalFlag.ECHO, false);
+
+        TermiosData result = mapping.toTermios(attr, existing);
+        assertEquals(baudBits, result.cflag() & baudBits, platform + ": unmapped baud bits preserved");
+        assertEquals(9600, result.ispeed(), platform + ": c_ispeed preserved");
+        assertEquals(9600, result.ospeed(), platform + ": c_ospeed preserved");
+        assertEquals((byte) 0x5A, result.cc()[31], platform + ": unmapped c_cc bytes preserved");
+        Attributes applied = mapping.toAttributes(result);
+        assertFalse(applied.getLocalFlag(LocalFlag.ECHO), platform + ": mapped ECHO cleared");
+        assertTrue(applied.getControlFlag(ControlFlag.CS8), platform + ": mapped CS8 kept");
+        assertTrue(applied.getControlFlag(ControlFlag.CREAD), platform + ": mapped CREAD kept");
     }
 }


### PR DESCRIPTION
## Problem

On serial terminals (`/dev/ttyS*`), JNI `doSetAttr` and FFM `setAttributes` built a fresh empty `struct termios`, copied only JLine-mapped flags, and called `tcsetattr`. That cleared OS-hidden fields including `CBAUD`/`CBAUDEX` and `c_ispeed`/`c_ospeed`, so the baud rate became 0 and the port stayed dead until getty was restarted.

## Fix

- `TermiosMapping.toTermios(Attributes, TermiosData)` now overlays mapped flags onto an existing snapshot. Unmapped bits, input/output speeds, and unmapped `c_cc` entries are preserved.
- JNI `JniNativePty.doSetAttr` and `JniUnixSysTerminal.doSetAttributes` call `tcgetattr`, apply JLine attributes onto that struct, then `tcsetattr`.
- FFM `CLibrary.setAttributes` does the same: `tcgetattr`, overlay, `tcsetattr`.
- `TermiosData` carries `c_ispeed`/`c_ospeed` so those fields survive the Java mapping.

`toTermios(Attributes)` (no existing snapshot) is unchanged and still used when creating a new pty.

## Tests

- `TermiosMappingRoundtripTest` asserts unmapped baud bits and speeds survive applying JLine attributes on Linux, macOS, FreeBSD, and Solaris mappings.
- `JniNativePtyTest` and `FfmTest` overlay a filled native termios in memory (no physical serial port).

```
./mvx mvn test -pl terminal,terminal-jni,terminal-ffm -am \
  -Dtest=TermiosMappingRoundtripTest,JniNativePtyTest,JniTerminalProviderTest,FfmTest \
  -Dsurefire.failIfNoSpecifiedTests=false
```

TermiosMappingRoundtripTest 8/8, JniNativePtyTest 1/1, JniTerminalProviderTest 2/2, FfmTest 4 pass / 1 skip (Windows-only layout test). JDK 25 (Temurin).

Fixes #2170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal attribute updates across supported backends by preserving existing baud rates, input/output speeds, control characters, and unrelated terminal settings.
  - Ensured requested flag changes are applied without unintentionally resetting other native terminal configuration.
  - Improved consistency when reading, modifying, and writing terminal settings.

- **API Enhancements**
  - Added accessors for terminal input and output speeds in the terminal data representation.
  - Added support for applying attribute changes to existing terminal configuration while retaining unmapped values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->