### PR TITLE
fix: escape control chars in oversized line-buffer display

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4494,7 +4494,27 @@ public class LineReaderImpl implements LineReader, Flushable {
                 && buffer.length() < getInt(FEATURES_MAX_BUFFER_SIZE, DEFAULT_FEATURES_MAX_BUFFER_SIZE)) {
             return highlighter.highlight(this, buffer);
         }
-        return new AttributedString(buffer);
+        // Fallback when the highlighter is absent, disabled, or skipped for an oversized
+        // buffer. DefaultHighlighter neutralizes control characters; do the same here so a
+        // large pasted or history-replayed line cannot emit raw escape sequences to the
+        // terminal (bracketed paste is meant to make pasted bytes inert).
+        return escapeControlChars(buffer);
+    }
+
+    private static AttributedString escapeControlChars(String buffer) {
+        AttributedStringBuilder sb = new AttributedStringBuilder(buffer.length());
+        for (int i = 0; i < buffer.length(); ) {
+            int cp = buffer.codePointAt(i);
+            if (cp == '\t' || cp == '\n') {
+                sb.append((char) cp);
+            } else if (cp < 32) {
+                sb.append('^').append((char) (cp + '@'));
+            } else if (WCWidth.wcwidth(cp) >= 0) {
+                sb.appendCodePoint(cp);
+            }
+            i += Character.charCount(cp);
+        }
+        return sb.toAttributedString();
     }
 
     AttributedString expandPromptPattern(String pattern, int padToWidth, String message, int line) {

--- a/reader/src/test/java/org/jline/reader/impl/HighlightedBufferEscapeTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/HighlightedBufferEscapeTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader.impl;
+
+import java.util.Collections;
+
+import org.jline.utils.AttributedString;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The line-editor display renders control characters as caret notation via the
+ * highlighter, but that path is skipped for buffers at or above
+ * {@code FEATURES_MAX_BUFFER_SIZE}. This checks that the oversized-buffer
+ * fallback still neutralizes control bytes so a large pasted or replayed line
+ * cannot emit escape sequences to the terminal.
+ */
+class HighlightedBufferEscapeTest extends ReaderTestSupport {
+
+    private static final char ESC = 0x1b;
+    private static final char BEL = 0x07;
+
+    @Test
+    void oversizedBufferDoesNotEmitRawEscapes() {
+        // OSC "set window title" then enough text to exceed FEATURES_MAX_BUFFER_SIZE.
+        StringBuilder payload =
+                new StringBuilder().append(ESC).append("]0;pwned").append(BEL);
+        while (payload.length() < 2000) {
+            payload.append('a');
+        }
+        reader.getBuffer().write(payload.toString());
+
+        AttributedString displayed = reader.getDisplayedBufferWithPrompts(Collections.emptyList());
+        String plain = displayed.toString();
+
+        assertFalse(plain.indexOf(ESC) >= 0, "raw ESC reached the display");
+        assertFalse(plain.indexOf(BEL) >= 0, "raw BEL reached the display");
+        assertTrue(plain.contains("^["), "ESC should render as caret notation");
+        assertTrue(plain.contains("aaaa"), "printable text should be preserved");
+    }
+
+    @Test
+    void oversizedBufferKeepsPrintableUnicode() {
+        char eacute = 0x00e9;
+        StringBuilder payload = new StringBuilder();
+        while (payload.length() < 1500) {
+            payload.append(eacute);
+        }
+        reader.getBuffer().write(payload.toString());
+
+        AttributedString displayed = reader.getDisplayedBufferWithPrompts(Collections.emptyList());
+        String threeEacute = new String(new char[] {eacute, eacute, eacute});
+        assertTrue(displayed.toString().contains(threeEacute), "printable non-ASCII should survive");
+    }
+}


### PR DESCRIPTION
HighlightedBufferEscapeTest against the current fallback:

    raw ESC reached the display ==> expected: <false> but was: <true>

DefaultHighlighter renders C0 controls as caret notation (^[) and drops non-printable DEL/C1, so control bytes never reach the terminal on redisplay. getHighlightedBuffer skips the highlighter once the buffer reaches features-max-buffer-size (default 1000), or when it is disabled, and returned `new AttributedString(buffer)` raw; toAnsi then emits ESC and friends verbatim. Bracketed paste is on by default and up-arrow history replay both fill the buffer without keystrokes, so a >=1000-char pasted or replayed line carrying `ESC ] 0 ; ... BEL` (window title) or `ESC ] 52` (clipboard) is written straight to the terminal.

The fallback now neutralizes control chars the same way DefaultHighlighter does, in one linear pass so the oversized-buffer path stays cheap. Printable text, tabs and newlines are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback text rendering by safely displaying control characters as caret notation.
  * Preserved tabs, newlines, printable ASCII, and Unicode characters.
  * Omitted characters that cannot be displayed with a valid width, preventing raw escape sequences from appearing.

* **Tests**
  * Added coverage for oversized-buffer rendering and control-character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->