### PR TITLE
chore: migrate Release Drafter configs to new when syntax

### DIFF
--- a/.github/release-drafter-3x.yml
+++ b/.github/release-drafter-3x.yml
@@ -25,60 +25,71 @@ filter-by-commitish: true
 
 # Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
+  - type: pre-exclude
+    when:
+      labels:
+        - reverted
+        - no-changelog
+        - skip-changelog
+        - invalid
   - title: ":boom: Breaking changes"
-    labels:
-      - breaking
+    when:
+      label: breaking
   - title: 🚨 Removed
-    label: removed
+    when:
+      label: removed
   - title: ":tada: Major features and improvements"
-    labels:
-      - major-enhancement
-      - major-rfe
+    when:
+      labels:
+        - major-enhancement
+        - major-rfe
   - title: 🐛 Major bug fixes
-    labels:
-      - major-bug
+    when:
+      label: major-bug
   - title: ⚠️ Deprecated
-    label: deprecated
+    when:
+      label: deprecated
   - title: 🚀 New features and improvements
-    labels:
-      - enhancement
-      - feature
-      - rfe
+    when:
+      labels:
+        - enhancement
+        - feature
+        - rfe
   - title: 🐛 Bug Fixes
-    labels:
-      - bug
-      - fix
-      - bugfix
-      - regression
-      - backport
+    when:
+      labels:
+        - bug
+        - fix
+        - bugfix
+        - regression
+        - backport
   - title: ":construction_worker: Changes for developers"
-    labels:
-      - developer
+    when:
+      label: developer
   # Default label used by Dependabot
   - title: 📦 Dependency updates
-    label: dependencies
+    when:
+      label: dependencies
   - title: 📝 Documentation updates
-    label: documentation
+    when:
+      label: documentation
   - title: 👻 Maintenance
-    labels:
-      - chore
-      - internal
-      - maintenance
+    when:
+      labels:
+        - chore
+        - internal
+        - maintenance
   - title: 🔧 Build
-    label: build
+    when:
+      label: build
   - title: 🚦 Tests
-    labels:
-      - test
-      - tests
-exclude-labels:
-  - reverted
-  - no-changelog
-  - skip-changelog
-  - invalid
+    when:
+      labels:
+        - test
+        - tests
 
 change-template: '- $TITLE ([#$NUMBER]($URL)) @$AUTHOR'
 
 template: |
   <!-- Optional: add a release summary here -->
   $CHANGES
-

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
 name-template: JLine $NEXT_MINOR_VERSION
 tag-template: $NEXT_MINOR_VERSION
 version-template: $MAJOR.$MINOR.$PATCH
@@ -24,59 +24,70 @@ filter-by-commitish: true
 
 # Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
+  - type: pre-exclude
+    when:
+      labels:
+        - reverted
+        - no-changelog
+        - skip-changelog
+        - invalid
   - title: ":boom: Breaking changes"
-    labels:
-      - breaking
+    when:
+      label: breaking
   - title: 🚨 Removed
-    label: removed
+    when:
+      label: removed
   - title: ":tada: Major features and improvements"
-    labels:
-      - major-enhancement
-      - major-rfe
+    when:
+      labels:
+        - major-enhancement
+        - major-rfe
   - title: 🐛 Major bug fixes
-    labels:
-      - major-bug
+    when:
+      label: major-bug
   - title: ⚠️ Deprecated
-    label: deprecated
+    when:
+      label: deprecated
   - title: 🚀 New features and improvements
-    labels:
-      - enhancement
-      - feature
-      - rfe
+    when:
+      labels:
+        - enhancement
+        - feature
+        - rfe
   - title: 🐛 Bug Fixes
-    labels:
-      - bug
-      - fix
-      - bugfix
-      - regression
+    when:
+      labels:
+        - bug
+        - fix
+        - bugfix
+        - regression
   - title: ":construction_worker: Changes for developers"
-    labels:
-      - developer
+    when:
+      label: developer
   # Default label used by Dependabot
   - title: 📦 Dependency updates
-    label: dependencies
+    when:
+      label: dependencies
   - title: 📝 Documentation updates
-    label: documentation
+    when:
+      label: documentation
   - title: 👻 Maintenance
-    labels:
-      - chore
-      - internal
-      - maintenance
+    when:
+      labels:
+        - chore
+        - internal
+        - maintenance
   - title: 🔧 Build
-    label: build
+    when:
+      label: build
   - title: 🚦 Tests
-    labels:
-      - test
-      - tests
-exclude-labels:
-  - reverted
-  - no-changelog
-  - skip-changelog
-  - invalid
+    when:
+      labels:
+        - test
+        - tests
 
 change-template: '- $TITLE ([#$NUMBER]($URL)) @$AUTHOR'
 
 template: |
   <!-- Optional: add a release summary here -->
   $CHANGES
-


### PR DESCRIPTION
## Summary

- Migrate both `release-drafter.yml` (master) and `release-drafter-3x.yml` (jline-3.x) from the deprecated `label`/`labels`/`exclude-labels` fields to the new `when`-based category format
- Removes all deprecation warnings from release-drafter v7.6.0

### Before
```yaml
categories:
  - title: 📝 Documentation updates
    label: documentation
exclude-labels:
  - reverted
```

### After
```yaml
categories:
  - type: pre-exclude
    when:
      labels:
        - reverted
  - title: 📝 Documentation updates
    when:
      label: documentation
```

See [release-drafter#1558](https://github.com/release-drafter/release-drafter/pull/1558) for the migration docs.

## Test plan

- [ ] Release Drafter run on this merge produces no deprecation warnings
- [ ] Draft release notes still categorize PRs correctly by label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Management**
  - Improved automatic release note categorization by applying label-based inclusion and exclusion rules more consistently.
  - Added safeguards to prevent reverted, skipped, invalid, or explicitly excluded changes from appearing in generated release notes.
  - Preserved existing release naming and formatting behavior.

- **Documentation**
  - Updated the Release Drafter documentation link to point to the current repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->