### PR TITLE
fix: check return codes from native calls in FFM CLibrary

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -465,7 +465,12 @@ class CLibrary {
         try (Arena arena = Arena.ofConfined()) {
             winsize ws = new winsize(arena);
             int res = (int) ioctl.invoke(fd, (long) TIOCGWINSZ, ws.segment());
+            if (res != 0) {
+                throw new RuntimeException("ioctl(TIOCGWINSZ) failed with return code " + res);
+            }
             return Size.of(ws.ws_col(), ws.ws_row());
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call ioctl(TIOCGWINSZ)", e);
         }
@@ -477,6 +482,11 @@ class CLibrary {
             ws.ws_row((short) size.getRows());
             ws.ws_col((short) size.getColumns());
             int res = (int) ioctl.invoke(fd, TIOCSWINSZ, ws.segment());
+            if (res != 0) {
+                throw new RuntimeException("ioctl(TIOCSWINSZ) failed with return code " + res);
+            }
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call ioctl(TIOCSWINSZ)", e);
         }
@@ -486,7 +496,12 @@ class CLibrary {
         try (Arena arena = Arena.ofConfined()) {
             termios t = new termios(arena);
             int res = (int) tcgetattr.invoke(fd, t.segment());
+            if (res != 0) {
+                throw new RuntimeException("tcgetattr() failed with return code " + res);
+            }
             return t.asAttributes();
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call tcgetattr()", e);
         }
@@ -496,6 +511,11 @@ class CLibrary {
         try (Arena arena = Arena.ofConfined()) {
             termios t = new termios(arena, attr);
             int res = (int) tcsetattr.invoke(fd, TermiosData.TCSANOW, t.segment());
+            if (res != 0) {
+                // Best-effort: tcsetattr may legitimately fail when restoring
+                // attributes during close (e.g. the slave fd is already gone).
+                logger.log(Level.DEBUG, "tcsetattr() returned " + res + " for fd " + fd);
+            }
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call tcsetattr()", e);
         }
@@ -513,12 +533,17 @@ class CLibrary {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment buf = arena.allocate(64);
             int res = (int) ttyname_r.invoke(fd, buf, buf.byteSize());
+            if (res != 0) {
+                throw new RuntimeException("ttyname_r() failed with return code " + res);
+            }
             byte[] data = buf.toArray(ValueLayout.JAVA_BYTE);
             int len = 0;
             while (data[len] != 0) {
                 len++;
             }
             return new String(data, 0, len);
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call ttyname_r()", e);
         }

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -466,10 +466,10 @@ class CLibrary {
             winsize ws = new winsize(arena);
             int res = (int) ioctl.invoke(fd, (long) TIOCGWINSZ, ws.segment());
             if (res != 0) {
-                throw new RuntimeException("ioctl(TIOCGWINSZ) failed with return code " + res);
+                throw new UncheckedIOException(new IOException("ioctl(TIOCGWINSZ) failed with return code " + res));
             }
             return Size.of(ws.ws_col(), ws.ws_row());
-        } catch (RuntimeException e) {
+        } catch (UncheckedIOException e) {
             throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call ioctl(TIOCGWINSZ)", e);
@@ -483,9 +483,9 @@ class CLibrary {
             ws.ws_col((short) size.getColumns());
             int res = (int) ioctl.invoke(fd, TIOCSWINSZ, ws.segment());
             if (res != 0) {
-                throw new RuntimeException("ioctl(TIOCSWINSZ) failed with return code " + res);
+                throw new UncheckedIOException(new IOException("ioctl(TIOCSWINSZ) failed with return code " + res));
             }
-        } catch (RuntimeException e) {
+        } catch (UncheckedIOException e) {
             throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call ioctl(TIOCSWINSZ)", e);
@@ -497,10 +497,10 @@ class CLibrary {
             termios t = new termios(arena);
             int res = (int) tcgetattr.invoke(fd, t.segment());
             if (res != 0) {
-                throw new RuntimeException("tcgetattr() failed with return code " + res);
+                throw new UncheckedIOException(new IOException("tcgetattr() failed with return code " + res));
             }
             return t.asAttributes();
-        } catch (RuntimeException e) {
+        } catch (UncheckedIOException e) {
             throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call tcgetattr()", e);
@@ -534,7 +534,7 @@ class CLibrary {
             MemorySegment buf = arena.allocate(64);
             int res = (int) ttyname_r.invoke(fd, buf, buf.byteSize());
             if (res != 0) {
-                throw new RuntimeException("ttyname_r() failed with return code " + res);
+                throw new UncheckedIOException(new IOException("ttyname_r() failed with return code " + res));
             }
             byte[] data = buf.toArray(ValueLayout.JAVA_BYTE);
             int len = 0;
@@ -542,7 +542,7 @@ class CLibrary {
                 len++;
             }
             return new String(data, 0, len);
-        } catch (RuntimeException e) {
+        } catch (UncheckedIOException e) {
             throw e;
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call ttyname_r()", e);

--- a/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
+++ b/terminal-ffm/src/test/java/org/jline/terminal/impl/ffm/FfmTest.java
@@ -15,8 +15,11 @@ import java.lang.foreign.Arena;
 import java.nio.charset.Charset;
 
 import org.jline.terminal.Attributes;
+import org.jline.terminal.Attributes.InputFlag;
+import org.jline.terminal.Attributes.LocalFlag;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
+import org.jline.utils.OSUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -77,6 +80,45 @@ class FfmTest {
             CLibrary.winsize ws = new CLibrary.winsize(arena, cols, rows);
             assertEquals(cols, ws.ws_col());
             assertEquals(rows, ws.ws_row());
+        }
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void applyAttributesPreservesFlagsAndSpeed() {
+        try (Arena arena = Arena.ofConfined()) {
+            // Set up Attributes with recognisable flags
+            Attributes attr = new Attributes();
+            attr.setInputFlag(InputFlag.ICRNL, true);
+            attr.setLocalFlag(LocalFlag.ECHO, true);
+            attr.setLocalFlag(LocalFlag.ICANON, true);
+
+            // Round-trip: Attributes -> native termios -> Attributes
+            CLibrary.termios t = new CLibrary.termios(arena, attr);
+            Attributes roundTripped = t.asAttributes();
+
+            assertEquals(
+                    attr.getInputFlag(InputFlag.ICRNL),
+                    roundTripped.getInputFlag(InputFlag.ICRNL),
+                    "ICRNL should survive the round-trip");
+            assertEquals(
+                    attr.getLocalFlag(LocalFlag.ECHO),
+                    roundTripped.getLocalFlag(LocalFlag.ECHO),
+                    "ECHO should survive the round-trip");
+            assertEquals(
+                    attr.getLocalFlag(LocalFlag.ICANON),
+                    roundTripped.getLocalFlag(LocalFlag.ICANON),
+                    "ICANON should survive the round-trip");
+
+            // Speed fields exist only on non-AIX platforms (macOS, Linux).
+            // On AIX the c_ispeed/c_ospeed VarHandles are null and the
+            // getters return 0 regardless of what is written.
+            if (!OSUtils.IS_AIX) {
+                t.c_ispeed(9600L);
+                t.c_ospeed(9600L);
+                assertEquals(9600L, t.c_ispeed(), "c_ispeed should be stored");
+                assertEquals(9600L, t.c_ospeed(), "c_ospeed should be stored");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Check return codes from `ioctl`, `tcgetattr`, `tcsetattr`, and `ttyname_r` in the FFM `CLibrary` instead of silently discarding them — fixes the SonarCloud "unused local variable" findings.
- `getTerminalSize`, `setTerminalSize`, `getAttributes`, and `ttyName` now throw `RuntimeException` on nonzero return codes.
- `setAttributes` logs a `DEBUG` warning rather than throwing, because `tcsetattr` may legitimately fail when restoring attributes during terminal close (e.g. the slave fd is already gone).
- Add `applyAttributesPreservesFlagsAndSpeed` test that verifies the `Attributes` → native `termios` → `Attributes` round-trip, with `c_ispeed`/`c_ospeed` assertions conditionally skipped on AIX where those fields do not exist.

## Test plan

- [x] `./mvx mvn test -pl terminal-ffm` passes (5 run, 0 failures, 1 skipped on Linux)
- [ ] CI green on all platforms