### PR TITLE
docs: document macOS native library signing process

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -176,6 +176,73 @@ make native-all
 
 This requires Docker for cross-compilation.
 
+### Signing macOS Native Libraries
+
+macOS requires native libraries to be signed with an Apple Developer ID for
+applications to pass [notarization](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution).
+The CI build verifies that the macOS `.jnilib` binaries are properly signed on
+every push and pull request.
+
+**Prerequisites:**
+
+* An [Apple Developer Program](https://developer.apple.com/programs/) membership ($99/year)
+* A "Developer ID Application" certificate installed in your Keychain
+
+**Setting up the certificate (one-time):**
+
+1. Enroll in the Apple Developer Program at https://developer.apple.com/programs/
+2. Create a "Developer ID Application" certificate (choose **G2 Sub-CA**) via
+   Xcode → Settings → Accounts → Manage Certificates, or through the
+   [Apple Developer portal](https://developer.apple.com/account/resources/certificates/list)
+3. Verify the certificate is installed:
+
+```sh
+security find-identity -v -p codesigning
+# Should show: "Developer ID Application: Your Name (TEAMID)"
+```
+
+**Signing the binaries:**
+
+After rebuilding native libraries with `make native-all`, sign them on your Mac:
+
+```sh
+cd native
+make sign
+```
+
+This signs all three macOS architectures (x86, x86\_64, arm64) with the
+Developer ID certificate. The signing identity defaults to the one configured
+in the Makefile and can be overridden:
+
+```sh
+make sign APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+```
+
+**Verifying signatures:**
+
+```sh
+cd native
+make verify-sign
+```
+
+This checks that each binary has a valid signature from a Developer ID
+Application certificate (not ad-hoc or other certificate types).
+
+**Workflow:**
+
+```sh
+cd native
+make native-all    # cross-compile all platforms
+make sign          # sign macOS binaries
+make verify-sign   # verify signatures
+cd ..
+git add native/src/main/resources/org/jline/nativ/Mac/
+git commit -m "chore: rebuild and sign native libraries"
+```
+
+The signed binaries are committed to git so that release builds are
+reproducible — the release workflow publishes exactly what is in the repository.
+
 ## Maven Profiles
 
 JLine's build includes several Maven profiles:


### PR DESCRIPTION
## Summary

Documents the macOS native library signing process in `BUILDING.md`, right after the existing "Building Native Libraries" section.

Covers:
- Prerequisites (Apple Developer Program, Developer ID certificate)
- One-time certificate setup
- `make sign` / `make verify-sign` usage
- Full workflow (build → sign → verify → commit)

Follows up on #2173 and #1033.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to sign and verify macOS native libraries across x86, x86_64, and arm64 architectures.
  * Signing uses Apple Developer ID certificates, hardened runtime, and timestamps.

* **Bug Fixes**
  * Builds now fail when macOS libraries are missing, unsigned, or signed with an invalid certificate.

* **Documentation**
  * Added setup instructions, prerequisites, and a complete signing workflow for macOS release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->