### PR TITLE
fix: reduce ambiguous binding timeout from 1000ms to 100ms

### DIFF
--- a/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/AbstractPrompt.java
@@ -46,8 +46,6 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
     private Display display;
     private ListRange range = null;
 
-    public static final long DEFAULT_TIMEOUT_WITH_ESC = 150L;
-
     public AbstractPrompt(
             Terminal terminal,
             Display display,
@@ -400,7 +398,6 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
             map.bind(Operation.INTERRUPT, ctrl('C'));
-            map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
         public ExpandableChoiceResult execute() {
@@ -517,7 +514,6 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
             map.bind(Operation.INTERRUPT, ctrl('C'));
-            map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
         public ConfirmResult execute() {
@@ -635,7 +631,6 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.SELECT_CANDIDATE, "\t");
             map.bind(Operation.CANCEL, KeyMap.esc());
             map.bind(Operation.INTERRUPT, ctrl('C'));
-            map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
         private void bindSelectKeys(KeyMap<SelectOp> map) {
@@ -644,7 +639,6 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(SelectOp.EXIT, "\r");
             map.bind(SelectOp.CANCEL, KeyMap.esc());
             map.bind(SelectOp.INTERRUPT, ctrl('C'));
-            map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
         public InputResult execute() {
@@ -922,7 +916,6 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
             map.bind(Operation.INTERRUPT, ctrl('C'));
-            map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
         public ListResult execute() {
@@ -1009,7 +1002,6 @@ public abstract class AbstractPrompt<T extends ConsoleUIItemIF> {
             map.bind(Operation.EXIT, "\r", "\n");
             map.bind(Operation.CANCEL, KeyMap.esc());
             map.bind(Operation.INTERRUPT, ctrl('C'));
-            map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
         }
 
         public CheckboxResult execute() {

--- a/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
+++ b/prompt/src/main/java/org/jline/prompt/impl/DefaultPrompter.java
@@ -64,9 +64,6 @@ public class DefaultPrompter implements Prompter {
     private Attributes attributes;
     private List<AttributedString> header = new ArrayList<>();
 
-    // Default timeout for escape sequences
-    public static final long DEFAULT_TIMEOUT_WITH_ESC = 150L;
-
     // Default page size for lists
     private static final int DEFAULT_PAGE_SIZE = 10;
 
@@ -754,7 +751,6 @@ public class DefaultPrompter implements Prompter {
         keyMap.bind(InputOperation.EXIT, "\r", "\n");
         keyMap.bind(InputOperation.ESCAPE, esc());
         keyMap.bind(InputOperation.CANCEL, ctrl('C'));
-        keyMap.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
 
         InputOperation op = bindingReader.readBinding(keyMap);
         switch (op) {
@@ -1074,7 +1070,6 @@ public class DefaultPrompter implements Prompter {
         keyMap.bind(InputOperation.BEGINNING_OF_LINE, ctrl('A'));
         keyMap.bind(InputOperation.END_OF_LINE, ctrl('E'));
         keyMap.bind(InputOperation.SELECT_CANDIDATE, "\t"); // Tab for completion
-        keyMap.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
     }
 
     /**
@@ -1086,7 +1081,6 @@ public class DefaultPrompter implements Prompter {
         keyMap.bind(ConfirmOperation.EXIT, "\r", "\n");
         keyMap.bind(ConfirmOperation.CANCEL, ctrl('C'));
         keyMap.bind(ConfirmOperation.ESCAPE, esc());
-        keyMap.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
     }
 
     private ListResult executeListPrompt(List<AttributedString> header, ListPrompt prompt)
@@ -1671,7 +1665,6 @@ public class DefaultPrompter implements Prompter {
         keyMap.bind(ConfirmOperation.EXIT, "\r", "\n");
         keyMap.bind(ConfirmOperation.ESCAPE, esc());
         keyMap.bind(ConfirmOperation.CANCEL, ctrl('C'));
-        keyMap.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
 
         while (true) {
             List<AttributedString> out = new ArrayList<>();
@@ -1753,7 +1746,6 @@ public class DefaultPrompter implements Prompter {
         keyMap.bind("RIGHT", key(terminal, key_right));
         keyMap.bind("CANCEL", ctrl('C'));
         keyMap.bind("ESCAPE", esc());
-        keyMap.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
 
         String result = bindingReader.readBinding(keyMap);
         if ("CANCEL".equals(result)) {
@@ -1832,7 +1824,6 @@ public class DefaultPrompter implements Prompter {
 
         // Set up fallback for unmatched keys (like console-ui behavior)
         map.setNomatch(ListOperation.IGNORE);
-        map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
     }
 
     /**
@@ -1989,7 +1980,6 @@ public class DefaultPrompter implements Prompter {
 
         // Set up fallback for unmatched keys (like console-ui behavior)
         map.setNomatch(CheckboxOperation.IGNORE);
-        map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
     }
 
     /**
@@ -2145,7 +2135,6 @@ public class DefaultPrompter implements Prompter {
         map.bind(ChoiceOperation.EXIT, "\r", "\n");
         map.bind(ChoiceOperation.ESCAPE, esc());
         map.bind(ChoiceOperation.CANCEL, ctrl('C'));
-        map.setAmbiguousTimeout(DEFAULT_TIMEOUT_WITH_ESC);
     }
 
     /**

--- a/reader/src/main/java/org/jline/keymap/KeyMap.java
+++ b/reader/src/main/java/org/jline/keymap/KeyMap.java
@@ -54,8 +54,13 @@ public class KeyMap<T> {
      * For example, if both Escape and Escape+[A are bound, the reader will wait this
      * amount of time after receiving Escape to determine if it's a standalone Escape
      * or the beginning of the Escape+[A sequence.
+     * <p>
+     * 100ms matches Vim's {@code defaults.vim} setting for {@code ttimeoutlen} and is
+     * comfortably above the inter-character delay of terminal escape sequences, even
+     * over SSH connections.  The previous value of 1000ms caused a perceptible lag
+     * every time the Escape key was pressed in vi mode.
      */
-    public static final long DEFAULT_AMBIGUOUS_TIMEOUT = 1000L;
+    public static final long DEFAULT_AMBIGUOUS_TIMEOUT = 100L;
 
     private Object[] mapping = new Object[KEYMAP_LENGTH];
     private T anotherKey = null;

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -105,7 +105,7 @@ public class LineReaderImpl implements LineReader, Flushable {
     public static final int DEFAULT_MENU_LIST_MAX = Integer.MAX_VALUE;
     public static final int DEFAULT_ERRORS = 2;
     public static final long DEFAULT_BLINK_MATCHING_PAREN = 500L;
-    public static final long DEFAULT_AMBIGUOUS_BINDING = 1000L;
+    public static final long DEFAULT_AMBIGUOUS_BINDING = 100L;
     public static final String DEFAULT_SECONDARY_PROMPT_PATTERN = "%M> ";
     public static final String DEFAULT_OTHERS_GROUP_NAME = "others";
     public static final String DEFAULT_ORIGINAL_GROUP_NAME = "original";


### PR DESCRIPTION
## Summary

- Lower the default ambiguous-binding timeout from **1000ms → 100ms**, eliminating the 1-second lag on every bare ESC keypress in vi mode
- Remove the now-unnecessary 150ms overrides in `console-ui` and `prompt` modules (14 call sites, 2 constants — pure deletion)
- Aligns with Vim's `defaults.vim` (`ttimeoutlen=100`) and industry consensus (tmux recommends 10–50ms, ZSH defaults to 10ms)

## ⚠️ Breaking change

The default value of `KeyMap.DEFAULT_AMBIGUOUS_TIMEOUT` and `LineReaderImpl.DEFAULT_AMBIGUOUS_BINDING` changes from **1000ms to 100ms**. Additionally, `AbstractPrompt.DEFAULT_TIMEOUT_WITH_ESC` and `DefaultPrompter.DEFAULT_TIMEOUT_WITH_ESC` (both `public static final`) are removed entirely.

**Who is affected:** applications that rely on the 1000ms default without setting the `ambiguous-binding` variable explicitly, or that reference the removed `DEFAULT_TIMEOUT_WITH_ESC` constants.

**Migration:** if an application needs a longer timeout (e.g. very high-latency connections), set it explicitly:
```java
reader.setVariable(LineReader.AMBIGUOUS_BINDING, 500L);
```

## Context

When ESC is both a standalone binding (vi insert→command mode) **and** a prefix of multi-character sequences (arrow keys `ESC[A`, Alt-keys `ESCb`, function keys), `BindingReader.readBinding()` waits the full ambiguous timeout to decide which one was intended. At 1000ms this is the same class of problem as [ncurses' `ESCDELAY`](https://invisible-island.net/ncurses/man/curs_inopts.3x.html) — perceptible lag that every vi-mode user feels on every mode switch.

100ms is safe even over SSH — terminal escape sequences arrive as a burst within microseconds to single-digit milliseconds. The value remains user-configurable via the `ambiguous-binding` LineReader variable.

## Test plan

- [x] `./mvx mvn test -pl reader` — 213 tests pass
- [x] `./mvx mvn test -pl terminal` — 466 tests pass
- [x] `./mvx mvn test -pl console-ui,prompt` — 72 tests pass
- [x] Spotless formatting clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Reduced the delay when entering ambiguous key sequences, making keyboard interactions feel more responsive.
  - Standardized prompts and command-line input to use the shorter default timeout.
  - ESC-key handling no longer waits for an extended timeout in interactive prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->