### PR TITLE
fix: backport security fixes from master (#2156, #2164, #2175)

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -1041,7 +1041,7 @@ public class Less {
                 if (displayMessage) {
                     AttributedStringBuilder asb = new AttributedStringBuilder();
                     asb.style(AttributedStyle.INVERSE);
-                    asb.append(source.getName()).append(" (press RETURN)");
+                    asb.append(stripControlChars(source.getName())).append(" (press RETURN)");
                     asb.toAttributedString().println(terminal);
                     terminal.writer().flush();
                     terminal.reader().read();
@@ -1055,7 +1055,7 @@ public class Less {
                     throw exp;
                 } else {
                     AttributedStringBuilder asb = new AttributedStringBuilder();
-                    asb.append(source.getName()).append(" not found!");
+                    asb.append(stripControlChars(source.getName())).append(" not found!");
                     asb.toAttributedString().println(terminal);
                     terminal.writer().flush();
                     open = false;
@@ -1177,6 +1177,19 @@ public class Less {
                 sb.append('\\').append(String.format("%03o", (int) c));
             }
         }
+        return sb.toString();
+    }
+
+    // Drops ESC, BEL, the 8-bit C1 introducers and other ISO control characters while keeping
+    // printable (including non-ASCII) text, so a file name shown on the status line cannot carry
+    // an escape sequence into the terminal.
+    private static String stripControlChars(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        s.codePoints().forEach(cp -> {
+            if (!Character.isISOControl(cp)) {
+                sb.appendCodePoint(cp);
+            }
+        });
         return sb.toString();
     }
 
@@ -1402,7 +1415,7 @@ public class Less {
             msg.append(" ").append(printable(bindingReader.getCurrentBuffer()));
         } else if (message != null) {
             msg.style(AttributedStyle.INVERSE);
-            msg.append(message);
+            msg.append(stripControlChars(message));
             msg.style(AttributedStyle.INVERSE.inverseOff());
         } else if (displayPattern != null) {
             msg.append("&");

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) the original author(s).
+ * Copyright (c) 2026, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.regex.Pattern;
@@ -44,7 +44,7 @@ class LessTest {
 
     private LineDisciplineTerminal newTerminal(ByteArrayOutputStream output) throws IOException {
         LineDisciplineTerminal terminal = new LineDisciplineTerminal("less", "xterm", output, StandardCharsets.UTF_8);
-        terminal.setSize(Size.of(80, 24));
+        terminal.setSize(new Size(80, 24));
         return terminal;
     }
 
@@ -55,8 +55,8 @@ class LessTest {
      * file/source and an interactive read loop).
      */
     private Less newDisplayableLess(LineDisciplineTerminal terminal) {
-        Less less = new Less(terminal, Path.of("."));
-        less.size = terminal.getSize();
+        Less less = new Less(terminal, Paths.get("."));
+        less.size.copy(terminal.getSize());
         less.reader = new BufferedReader(new StringReader(""));
         less.syntaxHighlighter = SyntaxHighlighter.build(new ArrayList<>(), null, "none");
         return less;
@@ -72,7 +72,7 @@ class LessTest {
 
             less.display(false);
 
-            String rendered = output.toString(StandardCharsets.UTF_8);
+            String rendered = output.toString(StandardCharsets.UTF_8.name());
             assertFalse(rendered.contains("\u001b]0;"), "OSC introducer must not reach the terminal");
             assertFalse(rendered.contains("\u0007"), "BEL must not reach the terminal");
             String plainText = stripAnsi(rendered);
@@ -86,8 +86,8 @@ class LessTest {
     void openSourceStripsControlCharactersFromFileNames() throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         try (LineDisciplineTerminal terminal = newTerminal(output)) {
-            Less less = new Less(terminal, Path.of("."));
-            less.size = terminal.getSize();
+            Less less = new Less(terminal, Paths.get("."));
+            less.size.copy(terminal.getSize());
             String name = "réport\u001b]0;pwned\u0007.txt";
             Source missing = new Source() {
                 @Override
@@ -113,7 +113,7 @@ class LessTest {
 
             less.openSource();
 
-            String rendered = output.toString(StandardCharsets.UTF_8);
+            String rendered = output.toString(StandardCharsets.UTF_8.name());
             assertFalse(rendered.contains("\u001b]0;"), "OSC introducer must not reach the terminal");
             assertFalse(rendered.contains("\u0007"), "BEL must not reach the terminal");
             String plainText = stripAnsi(rendered);

--- a/builtins/src/test/java/org/jline/builtins/LessTest.java
+++ b/builtins/src/test/java/org/jline/builtins/LessTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import org.jline.builtins.Source.InputStreamSource;
+import org.jline.terminal.Size;
+import org.jline.terminal.impl.LineDisciplineTerminal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the control-character stripping security fix in {@link Less}.
+ */
+class LessTest {
+
+    private static final Pattern ANSI_ESCAPE = Pattern.compile("\033\\[[0-9;]*[A-Za-z]");
+
+    /** Strip ANSI escape sequences to get plain visible text. */
+    private static String stripAnsi(String s) {
+        return ANSI_ESCAPE.matcher(s).replaceAll("");
+    }
+
+    private LineDisciplineTerminal newTerminal(ByteArrayOutputStream output) throws IOException {
+        LineDisciplineTerminal terminal = new LineDisciplineTerminal("less", "xterm", output, StandardCharsets.UTF_8);
+        terminal.setSize(Size.of(80, 24));
+        return terminal;
+    }
+
+    /**
+     * Builds a {@link Less} instance with the minimal internal state required to safely
+     * invoke the package-private {@code display(boolean)} method directly, without going
+     * through the full {@code run()}/{@code openSource()} machinery (which requires a real
+     * file/source and an interactive read loop).
+     */
+    private Less newDisplayableLess(LineDisciplineTerminal terminal) {
+        Less less = new Less(terminal, Path.of("."));
+        less.size = terminal.getSize();
+        less.reader = new BufferedReader(new StringReader(""));
+        less.syntaxHighlighter = SyntaxHighlighter.build(new ArrayList<>(), null, "none");
+        return less;
+    }
+
+    @Test
+    @Timeout(5)
+    void displayStripsControlCharactersFromMessage() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = newDisplayableLess(terminal);
+            less.message = "réport\u001b]0;pwned\u0007.txt";
+
+            less.display(false);
+
+            String rendered = output.toString(StandardCharsets.UTF_8);
+            assertFalse(rendered.contains("\u001b]0;"), "OSC introducer must not reach the terminal");
+            assertFalse(rendered.contains("\u0007"), "BEL must not reach the terminal");
+            String plainText = stripAnsi(rendered);
+            assertTrue(plainText.contains("réport"), "non-ASCII file name text should be preserved");
+            assertTrue(plainText.contains("pwned.txt"), "surrounding file name text should be preserved");
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void openSourceStripsControlCharactersFromFileNames() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LineDisciplineTerminal terminal = newTerminal(output)) {
+            Less less = new Less(terminal, Path.of("."));
+            less.size = terminal.getSize();
+            String name = "réport\u001b]0;pwned\u0007.txt";
+            Source missing = new Source() {
+                @Override
+                public String getName() {
+                    return name;
+                }
+
+                @Override
+                public InputStream read() throws IOException {
+                    throw new FileNotFoundException(name);
+                }
+
+                @Override
+                public Long lines() {
+                    return null;
+                }
+            };
+            Source next = new InputStreamSource(new ByteArrayInputStream(new byte[0]), true, name);
+            less.sources = new ArrayList<>(Arrays.asList(
+                    new InputStreamSource(new ByteArrayInputStream(new byte[0]), true, "help"), missing, next));
+            less.sourceIdx = 1;
+            terminal.processInputByte('\n');
+
+            less.openSource();
+
+            String rendered = output.toString(StandardCharsets.UTF_8);
+            assertFalse(rendered.contains("\u001b]0;"), "OSC introducer must not reach the terminal");
+            assertFalse(rendered.contains("\u0007"), "BEL must not reach the terminal");
+            String plainText = stripAnsi(rendered);
+            assertTrue(plainText.contains("réport"), "non-ASCII file name text should be preserved");
+            assertTrue(plainText.contains("pwned.txt not found!"), "not-found line should keep printable text");
+            assertTrue(plainText.contains("pwned.txt (press RETURN)"), "press-RETURN line should keep printable text");
+        }
+    }
+}

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4233,7 +4233,7 @@ public class LineReaderImpl implements LineReader, Flushable {
             } else if (cp < 32) {
                 sb.append('^').append((char) (cp + '@'));
             } else if (WCWidth.wcwidth(cp) >= 0) {
-                sb.appendCodePoint(cp);
+                sb.append(new String(Character.toChars(cp)));
             }
             i += Character.charCount(cp);
         }

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4217,7 +4217,27 @@ public class LineReaderImpl implements LineReader, Flushable {
                 && buffer.length() < getInt(FEATURES_MAX_BUFFER_SIZE, DEFAULT_FEATURES_MAX_BUFFER_SIZE)) {
             return highlighter.highlight(this, buffer);
         }
-        return new AttributedString(buffer);
+        // Fallback when the highlighter is absent, disabled, or skipped for an oversized
+        // buffer. DefaultHighlighter neutralizes control characters; do the same here so a
+        // large pasted or history-replayed line cannot emit raw escape sequences to the
+        // terminal (bracketed paste is meant to make pasted bytes inert).
+        return escapeControlChars(buffer);
+    }
+
+    private static AttributedString escapeControlChars(String buffer) {
+        AttributedStringBuilder sb = new AttributedStringBuilder(buffer.length());
+        for (int i = 0; i < buffer.length(); ) {
+            int cp = buffer.codePointAt(i);
+            if (cp == '\t' || cp == '\n') {
+                sb.append((char) cp);
+            } else if (cp < 32) {
+                sb.append('^').append((char) (cp + '@'));
+            } else if (WCWidth.wcwidth(cp) >= 0) {
+                sb.appendCodePoint(cp);
+            }
+            i += Character.charCount(cp);
+        }
+        return sb.toAttributedString();
     }
 
     private AttributedString expandPromptPattern(String pattern, int padToWidth, String message, int line) {

--- a/reader/src/test/java/org/jline/reader/impl/HighlightedBufferEscapeTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/HighlightedBufferEscapeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) the original author(s).
+ * Copyright (c) 2026, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/reader/src/test/java/org/jline/reader/impl/HighlightedBufferEscapeTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/HighlightedBufferEscapeTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.reader.impl;
+
+import java.util.Collections;
+
+import org.jline.utils.AttributedString;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The line-editor display renders control characters as caret notation via the
+ * highlighter, but that path is skipped for buffers at or above
+ * {@code FEATURES_MAX_BUFFER_SIZE}. This checks that the oversized-buffer
+ * fallback still neutralizes control bytes so a large pasted or replayed line
+ * cannot emit escape sequences to the terminal.
+ */
+class HighlightedBufferEscapeTest extends ReaderTestSupport {
+
+    private static final char ESC = 0x1b;
+    private static final char BEL = 0x07;
+
+    @Test
+    void oversizedBufferDoesNotEmitRawEscapes() {
+        // OSC "set window title" then enough text to exceed FEATURES_MAX_BUFFER_SIZE.
+        StringBuilder payload =
+                new StringBuilder().append(ESC).append("]0;pwned").append(BEL);
+        while (payload.length() < 2000) {
+            payload.append('a');
+        }
+        reader.getBuffer().write(payload.toString());
+
+        AttributedString displayed = reader.getDisplayedBufferWithPrompts(Collections.emptyList());
+        String plain = displayed.toString();
+
+        assertFalse(plain.indexOf(ESC) >= 0, "raw ESC reached the display");
+        assertFalse(plain.indexOf(BEL) >= 0, "raw BEL reached the display");
+        assertTrue(plain.contains("^["), "ESC should render as caret notation");
+        assertTrue(plain.contains("aaaa"), "printable text should be preserved");
+    }
+
+    @Test
+    void oversizedBufferKeepsPrintableUnicode() {
+        char eacute = 0x00e9;
+        StringBuilder payload = new StringBuilder();
+        while (payload.length() < 1500) {
+            payload.append(eacute);
+        }
+        reader.getBuffer().write(payload.toString());
+
+        AttributedString displayed = reader.getDisplayedBufferWithPrompts(Collections.emptyList());
+        String threeEacute = new String(new char[] {eacute, eacute, eacute});
+        assertTrue(displayed.toString().contains(threeEacute), "printable non-ASCII should survive");
+    }
+}

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/TelnetIO.java
@@ -353,6 +353,13 @@ public class TelnetIO {
 
         out.write(b);
 
+        // a data byte 255 (IAC) must be doubled, otherwise the peer reads it as
+        // the start of a telnet command (RFC 854). read() already collapses the
+        // doubled form back to a single 255 on input.
+        if (b == (byte) IAC) {
+            out.write(IAC);
+        }
+
         if (b == 13) {
             crFlag = true;
         } else {
@@ -431,10 +438,11 @@ public class TelnetIO {
     public void closeOutput() {
 
         try {
-            // sends telnetprotocol logout acknowledgement
-            write(IAC);
-            write(DO);
-            write(LOGOUT);
+            // sends telnetprotocol logout acknowledgement; this is a command
+            // sequence and must bypass the IAC-doubling done by write(byte).
+            rawWrite(IAC);
+            rawWrite(DO);
+            rawWrite(LOGOUT);
             // and now close underlying outputstream
 
             out.close();

--- a/remote-telnet/src/test/java/org/jline/builtins/telnet/TelnetIOEscapeTest.java
+++ b/remote-telnet/src/test/java/org/jline/builtins/telnet/TelnetIOEscapeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) the original author(s).
+ * Copyright (c) 2026, the original author(s).
  *
  * This software is distributable under the BSD license. See the terms of the
  * BSD license in the documentation provided with this software.

--- a/remote-telnet/src/test/java/org/jline/builtins/telnet/TelnetIOEscapeTest.java
+++ b/remote-telnet/src/test/java/org/jline/builtins/telnet/TelnetIOEscapeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins.telnet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class TelnetIOEscapeTest {
+
+    private static final int IAC = 255;
+    private static final int DO = 253;
+    private static final int LOGOUT = 18;
+
+    private static ByteArrayOutputStream wire(TelnetIO io) throws Exception {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        Field out = TelnetIO.class.getDeclaredField("out");
+        out.setAccessible(true);
+        out.set(io, new DataOutputStream(sink));
+        return sink;
+    }
+
+    @Test
+    public void dataByteIacIsDoubled() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write(IAC); // a 0xFF byte emitted by the hosted application
+        io.flush();
+
+        // The peer un-escapes 255 255 back to a single 255; a lone 255 would be
+        // read as the IAC command introducer instead.
+        assertArrayEquals(new byte[] {(byte) 255, (byte) 255}, sink.toByteArray());
+    }
+
+    @Test
+    public void iacInsideDataStreamIsEscapedInPlace() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write(new byte[] {(byte) 'a', (byte) 0xFF, (byte) 'b'});
+        io.flush();
+
+        assertArrayEquals(new byte[] {(byte) 'a', (byte) 255, (byte) 255, (byte) 'b'}, sink.toByteArray());
+    }
+
+    @Test
+    public void consecutiveIacBytesAreEachDoubled() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write(new byte[] {(byte) 0xFF, (byte) 0xFF});
+        io.flush();
+
+        // Two 0xFF data bytes are escaped independently, so four reach the wire.
+        assertArrayEquals(new byte[] {(byte) 255, (byte) 255, (byte) 255, (byte) 255}, sink.toByteArray());
+    }
+
+    @Test
+    public void iacFollowedByLfKeepsCrLfConversion() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write(new byte[] {(byte) 0xFF, (byte) '\n'});
+        io.flush();
+
+        // IAC doubling and the LF -> CRLF conversion do not interfere.
+        assertArrayEquals(new byte[] {(byte) 255, (byte) 255, (byte) 13, (byte) 10}, sink.toByteArray());
+    }
+
+    @Test
+    public void ordinaryBytesPassThroughUnchanged() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.write((byte) 'A');
+        io.flush();
+
+        assertArrayEquals(new byte[] {(byte) 'A'}, sink.toByteArray());
+    }
+
+    @Test
+    public void logoutCommandIsNotDoubled() throws Exception {
+        TelnetIO io = new TelnetIO();
+        ByteArrayOutputStream sink = wire(io);
+
+        io.closeOutput();
+
+        // IAC DO LOGOUT is a command sequence, so its leading 255 stays single.
+        assertArrayEquals(new byte[] {(byte) IAC, (byte) DO, (byte) LOGOUT}, sink.toByteArray());
+    }
+}


### PR DESCRIPTION
Backport of three security fixes from master to the 3.x maintenance branch.

## Cherry-picked commits

1. **fix: strip control characters from Less status messages (#2156)** — sanitizes the Less pager's status line output to prevent terminal escape injection via crafted filenames (OSC 0 window title, OSC 52 clipboard writes).

2. **fix: escape IAC byte in the telnet data output stream (#2164)** — doubles the IAC byte (0xFF) in the telnet data write path per RFC 854, preventing telnet command injection. The read side already un-escapes the doubled form; this makes the protocol handling symmetric.

3. **fix: escape control chars in oversized line-buffer display (#2175)** — neutralizes C0 control characters in `getHighlightedBuffer()`'s oversized-buffer fallback path (when the buffer exceeds `features-max-buffer-size`), consistent with how `DefaultHighlighter` handles them.

## Adaptations for 3.x

- Replaced `Path.of()` with `Paths.get()` (Java 8 compatibility)
- Replaced `ByteArrayOutputStream.toString(Charset)` with `toString(String)` (Java 8)
- Replaced `Size.of()` with `new Size()` (API not present in 3.x)
- Replaced `less.size =` with `less.size.copy()` (`size` field is `final` in 3.x)
- Replaced `appendCodePoint()` with `append(new String(Character.toChars()))` (not available on `AttributedStringBuilder` in 3.x)
- Removed `defaultPrompt`-related tests (feature not present in 3.x)
- Resolved conflict in Less.java `display()` method (no `defaultPrompt` branch in 3.x)

All tests pass locally: LessTest (2), TelnetIOEscapeTest (6), HighlightedBufferEscapeTest (2).