### PR TITLE
fix: lower native library candidate log level from WARNING to DEBUG (fixes #2185)

### DIFF
--- a/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
+++ b/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
@@ -411,7 +411,7 @@ public class JLineNativeLoader {
      * The method handles the following cases:
      * <ul>
      *   <li>If the file doesn't exist, it returns false without attempting to load</li>
-     *   <li>If loading fails with an {@link UnsatisfiedLinkError}, it logs the error and returns false</li>
+     *   <li>If loading fails with an {@link UnsatisfiedLinkError}, it logs the error at DEBUG level and returns false</li>
      *   <li>If loading succeeds, it sets the path and returns true</li>
      * </ul>
      *
@@ -428,7 +428,7 @@ public class JLineNativeLoader {
                 return true;
             } catch (UnsatisfiedLinkError e) {
                 log(
-                        Level.WARNING,
+                        Level.DEBUG,
                         "Failed to load native library:" + libPath.getName() + ". osinfo: "
                                 + OSInfo.getNativeLibFolderPathForCurrentOS(),
                         e);


### PR DESCRIPTION
## Summary

- Lower log level in `loadNativeLibrary()` from `WARNING` to `DEBUG` for failed native library candidates that the fallback chain recovers from
- The unrecoverable case (all candidates fail) already throws from `loadJLineNativeLibrary()` with full `triedPaths`, so no diagnostic information is lost
- Eliminates a deadlock path where the WARNING log re-enters `static synchronized initialize()` through application logging bridges that render to the terminal being built

## Context

When `library.jline.path` is set (e.g. Maven sets it to `${maven.home}/lib/jline-native`), a failure of the first candidate warns even though the next step succeeds. The `System.Logger` WARNING is bridged by applications into their own logging, and if that logging renders through the terminal currently being constructed, the thread parks inside the `static synchronized initialize()` lock — blocking every other terminal build in the JVM.

Reported in #2185, observed in Maven ([apache/maven#12814](https://github.com/apache/maven/pull/12814), [apache/maven-executor#38](https://github.com/apache/maven-executor/issues/38)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the visibility of expected native library load-failure messages to avoid unnecessary warning notifications.
  * Updated related documentation to reflect the revised logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->