### PR TITLE
fix: handle IOError in BindingReader gracefully instead of crashing (fixes #2155)

### DIFF
--- a/reader/src/main/java/org/jline/keymap/BindingReader.java
+++ b/reader/src/main/java/org/jline/keymap/BindingReader.java
@@ -10,6 +10,7 @@ package org.jline.keymap;
 
 import java.io.IOError;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -199,8 +200,10 @@ public class BindingReader {
             }
         } catch (ClosedException e) {
             throw new EndOfFileException(e);
-        } catch (IOException e) {
+        } catch (InterruptedIOException e) {
             throw new IOError(e);
+        } catch (IOException e) {
+            throw new EndOfFileException(e);
         }
     }
 
@@ -212,8 +215,7 @@ public class BindingReader {
      * outside the BMP (Basic Multilingual Plane).
      *
      * @return the character read, or -1 if the end of the stream is reached
-     * @throws EndOfFileException if the stream is closed while reading
-     * @throws IOError if an I/O error occurs
+     * @throws EndOfFileException if the stream is closed or an I/O error occurs while reading
      */
     public int readCharacter() {
         if (!pushBackChar.isEmpty()) {
@@ -232,8 +234,10 @@ public class BindingReader {
             return s != 0 ? Character.toCodePoint((char) s, (char) c) : c;
         } catch (ClosedException e) {
             throw new EndOfFileException(e);
-        } catch (IOException e) {
+        } catch (InterruptedIOException e) {
             throw new IOError(e);
+        } catch (IOException e) {
+            throw new EndOfFileException(e);
         }
     }
 
@@ -245,8 +249,7 @@ public class BindingReader {
      * Unicode characters outside the BMP (Basic Multilingual Plane).
      *
      * @return the character read, or -1 if the end of the stream is reached
-     * @throws EndOfFileException if the stream is closed while reading
-     * @throws IOError if an I/O error occurs
+     * @throws EndOfFileException if the stream is closed or an I/O error occurs while reading
      */
     public int readCharacterBuffered() {
         try {
@@ -284,8 +287,10 @@ public class BindingReader {
             return pushBackChar.pop();
         } catch (ClosedException e) {
             throw new EndOfFileException(e);
-        } catch (IOException e) {
+        } catch (InterruptedIOException e) {
             throw new IOError(e);
+        } catch (IOException e) {
+            throw new EndOfFileException(e);
         }
     }
 
@@ -298,7 +303,7 @@ public class BindingReader {
      *
      * @param timeout the maximum time to wait in milliseconds
      * @return the next character, -1 if the end of the stream is reached, or -2 if the timeout expires
-     * @throws IOError if an I/O error occurs
+     * @throws EndOfFileException if an I/O error occurs while peeking
      */
     public int peekCharacter(long timeout) {
         if (!pushBackChar.isEmpty()) {
@@ -306,8 +311,12 @@ public class BindingReader {
         }
         try {
             return reader.peek(timeout);
-        } catch (IOException e) {
+        } catch (ClosedException e) {
+            throw new EndOfFileException(e);
+        } catch (InterruptedIOException e) {
             throw new IOError(e);
+        } catch (IOException e) {
+            throw new EndOfFileException(e);
         }
     }
 

--- a/reader/src/main/java/org/jline/keymap/BindingReader.java
+++ b/reader/src/main/java/org/jline/keymap/BindingReader.java
@@ -175,8 +175,9 @@ public class BindingReader {
      * </p>
      *
      * @param sequence the terminating sequence to look for
-     * @return the string read up to but not including the terminating sequence,
-     *         or null if the end of the stream is reached before the sequence is found
+     * @return the string read up to but not including the terminating sequence
+     * @throws EndOfFileException if the stream is closed or an I/O error occurs before the sequence is found
+     * @throws IOError if the read is interrupted ({@link InterruptedIOException})
      */
     public String readStringUntil(String sequence) {
         StringBuilder sb = new StringBuilder();
@@ -216,6 +217,7 @@ public class BindingReader {
      *
      * @return the character read, or -1 if the end of the stream is reached
      * @throws EndOfFileException if the stream is closed or an I/O error occurs while reading
+     * @throws IOError if the read is interrupted ({@link InterruptedIOException})
      */
     public int readCharacter() {
         if (!pushBackChar.isEmpty()) {
@@ -250,6 +252,7 @@ public class BindingReader {
      *
      * @return the character read, or -1 if the end of the stream is reached
      * @throws EndOfFileException if the stream is closed or an I/O error occurs while reading
+     * @throws IOError if the read is interrupted ({@link InterruptedIOException})
      */
     public int readCharacterBuffered() {
         try {
@@ -303,7 +306,8 @@ public class BindingReader {
      *
      * @param timeout the maximum time to wait in milliseconds
      * @return the next character, -1 if the end of the stream is reached, or -2 if the timeout expires
-     * @throws EndOfFileException if an I/O error occurs while peeking
+     * @throws EndOfFileException if the stream is closed or an I/O error occurs while peeking
+     * @throws IOError if the read is interrupted ({@link InterruptedIOException})
      */
     public int peekCharacter(long timeout) {
         if (!pushBackChar.isEmpty()) {


### PR DESCRIPTION
## Summary

When the terminal's PTY input stream encounters an I/O error (e.g., EIO on Linux with Java 25), `BindingReader` previously wrapped the `IOException` in an `IOError` (which extends `Error`). Since most applications don't catch `Error`, this caused unrecoverable crashes — notably PaperMC server shutdowns as reported in #2155.

An I/O error on the terminal input effectively means the terminal connection is lost, which is semantically equivalent to EOF. This change:

- Converts `IOException` → `EndOfFileException` (a `RuntimeException` that applications already handle gracefully) in all `BindingReader` methods: `readCharacter()`, `readCharacterBuffered()`, `readStringUntil()`, and `peekCharacter()`
- Preserves the existing `InterruptedIOException` → `IOError` → `UserInterruptException` path used for Ctrl-C / interrupt handling
- Adds `ClosedException` handling to `peekCharacter()` for consistency with the other methods

The result: instead of an `IOError` propagating up and crashing the application, an `EndOfFileException` signals the terminal is gone, allowing the application's existing read-loop to terminate gracefully.

## Test plan

- [x] All 220 reader module tests pass (including `LineReaderInterruptTest` which validates interrupt handling still works)
- [x] Full project build succeeds
- [x] Verified `InterruptedIOException` still properly produces `UserInterruptException` (not `EndOfFileException`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted and failed input operations.
  * Interruptions now report an input error, while other I/O failures are treated as end-of-file conditions.
* **Documentation**
  * Updated API documentation to clarify input-related exception behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->