### PR TITLE
feat: support in-band resize (mode 2048) in Nano, Less, and Tmux builtins

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -29,6 +29,7 @@ import org.jline.builtins.Nano.PatternHistory;
 import org.jline.builtins.Source.ResourceSource;
 import org.jline.builtins.Source.URLSource;
 import org.jline.keymap.BindingReader;
+import org.jline.keymap.InBandResize;
 import org.jline.keymap.KeyMap;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
@@ -692,6 +693,9 @@ public class Less {
                             case HELP:
                                 help();
                                 break;
+                            case TERMINAL_RESIZE:
+                                InBandResize.handleResize(bindingReader, terminal);
+                                break;
                         }
                         buffer.setLength(0);
                     }
@@ -893,6 +897,7 @@ public class Less {
         fileKeyMap.bind(Operation.DELETE_WORD, alt('X'));
         fileKeyMap.bind(Operation.DELETE_LINE, ctrl('U'));
         fileKeyMap.bind(Operation.ACCEPT, "\r");
+        fileKeyMap.bind(Operation.TERMINAL_RESIZE, InBandResize.RESIZE_SEQ);
 
         SavedSourcePositions ssp = new SavedSourcePositions();
         message = null;
@@ -913,6 +918,8 @@ public class Less {
                     ssp.restore(name);
                 }
                 return;
+            } else if (op == Operation.TERMINAL_RESIZE) {
+                InBandResize.handleResize(bindingReader, terminal);
             } else if (op != null) {
                 curPos = lineEditor.editBuffer(op, curPos);
             }
@@ -944,6 +951,7 @@ public class Less {
         searchKeyMap.bind(Operation.UP, key(terminal, Capability.key_up), alt('k'));
         searchKeyMap.bind(Operation.DOWN, key(terminal, Capability.key_down), alt('j'));
         searchKeyMap.bind(Operation.ACCEPT, "\r");
+        searchKeyMap.bind(Operation.TERMINAL_RESIZE, InBandResize.RESIZE_SEQ);
 
         boolean forward = true;
         message = null;
@@ -1008,6 +1016,9 @@ public class Less {
                         message = null;
                     }
                     return forward;
+                case TERMINAL_RESIZE:
+                    InBandResize.handleResize(bindingReader, terminal);
+                    break;
                 default:
                     curPos = lineEditor.editBuffer(op, curPos);
                     currentBuffer = buffer.toString();
@@ -1040,6 +1051,9 @@ public class Less {
                             break;
                         case BACKWARD_ONE_WINDOW_OR_LINES:
                             moveBackward(getStrictPositiveNumberInBuffer(window));
+                            break;
+                        case TERMINAL_RESIZE:
+                            InBandResize.handleResize(bindingReader, terminal);
                             break;
                     }
                 }
@@ -1583,6 +1597,9 @@ public class Less {
         map.bind(Operation.DELETE_FILE, ":d");
         map.bind(Operation.BACKSPACE, del());
         "-/0123456789?&".chars().forEach(c -> map.bind(Operation.CHAR, Character.toString((char) c)));
+
+        // Bind in-band resize report (mode 2048) prefix
+        map.bind(Operation.TERMINAL_RESIZE, InBandResize.RESIZE_SEQ);
     }
 
     protected enum Operation {
@@ -1644,6 +1661,9 @@ public class Less {
 
         //
         CHAR,
+
+        // In-band resize
+        TERMINAL_RESIZE,
 
         // Edit pattern
         INSERT,

--- a/builtins/src/main/java/org/jline/builtins/Less.java
+++ b/builtins/src/main/java/org/jline/builtins/Less.java
@@ -920,6 +920,8 @@ public class Less {
                 return;
             } else if (op == Operation.TERMINAL_RESIZE) {
                 InBandResize.handleResize(bindingReader, terminal);
+                display(false, curPos);
+                continue;
             } else if (op != null) {
                 curPos = lineEditor.editBuffer(op, curPos);
             }

--- a/builtins/src/main/java/org/jline/builtins/Nano.java
+++ b/builtins/src/main/java/org/jline/builtins/Nano.java
@@ -35,6 +35,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.jline.keymap.BindingReader;
+import org.jline.keymap.InBandResize;
 import org.jline.keymap.KeyMap;
 import org.jline.reader.Editor;
 import org.jline.terminal.Attributes;
@@ -2193,6 +2194,9 @@ public class Nano implements Editor {
                     case MOUSE_EVENT:
                         mouseEvent();
                         break;
+                    case TERMINAL_RESIZE:
+                        InBandResize.handleResize(bindingReader, terminal);
+                        break;
                     case TOGGLE_SUSPENSION:
                         toggleSuspension();
                         break;
@@ -2316,6 +2320,7 @@ public class Nano implements Editor {
         // Bind all possible mouse event prefixes
         // This ensures mouse events are recognized regardless of the terminal's kmous capability
         writeKeyMap.bind(Operation.MOUSE_EVENT, MouseSupport.keys(terminal));
+        writeKeyMap.bind(Operation.TERMINAL_RESIZE, InBandResize.RESIZE_SEQ);
 
         writeKeyMap.bind(Operation.TOGGLE_SUSPENSION, alt('z'));
         writeKeyMap.bind(Operation.RIGHT, key(terminal, Capability.key_right));
@@ -2361,6 +2366,9 @@ public class Nano implements Editor {
                     break;
                 case MOUSE_EVENT:
                     mouseEvent();
+                    break;
+                case TERMINAL_RESIZE:
+                    InBandResize.handleResize(bindingReader, terminal);
                     break;
                 case TOGGLE_SUSPENSION:
                     toggleSuspension();
@@ -2538,6 +2546,7 @@ public class Nano implements Editor {
         // Bind all possible mouse event prefixes
         // This ensures mouse events are recognized regardless of the terminal's kmous capability
         readKeyMap.bind(Operation.MOUSE_EVENT, MouseSupport.keys(terminal));
+        readKeyMap.bind(Operation.TERMINAL_RESIZE, InBandResize.RESIZE_SEQ);
 
         readKeyMap.bind(Operation.RIGHT, key(terminal, Capability.key_right));
         readKeyMap.bind(Operation.LEFT, key(terminal, Capability.key_left));
@@ -2591,6 +2600,9 @@ public class Nano implements Editor {
                 case MOUSE_EVENT:
                     mouseEvent();
                     break;
+                case TERMINAL_RESIZE:
+                    InBandResize.handleResize(bindingReader, terminal);
+                    break;
                 default:
                     curPos = editInputBuffer(op, curPos);
                     break;
@@ -2624,6 +2636,7 @@ public class Nano implements Editor {
         // Bind all possible mouse event prefixes
         // This ensures mouse events are recognized regardless of the terminal's kmous capability
         readKeyMap.bind(Operation.MOUSE_EVENT, MouseSupport.keys(terminal));
+        readKeyMap.bind(Operation.TERMINAL_RESIZE, InBandResize.RESIZE_SEQ);
 
         readKeyMap.bind(Operation.RIGHT, key(terminal, Capability.key_right));
         readKeyMap.bind(Operation.LEFT, key(terminal, Capability.key_left));
@@ -2680,6 +2693,9 @@ public class Nano implements Editor {
                     return;
                 case HELP:
                     help("nano-goto-help.txt");
+                    break;
+                case TERMINAL_RESIZE:
+                    InBandResize.handleResize(bindingReader, terminal);
                     break;
                 default:
                     curPos = editInputBuffer(op, curPos);
@@ -2857,6 +2873,9 @@ public class Nano implements Editor {
                     case MOUSE_EVENT:
                         mouseEvent();
                         break;
+                    case TERMINAL_RESIZE:
+                        InBandResize.handleResize(bindingReader, terminal);
+                        break;
                     case TOGGLE_SUSPENSION:
                         toggleSuspension();
                         break;
@@ -2960,6 +2979,7 @@ public class Nano implements Editor {
         // Bind all possible mouse event prefixes
         // This ensures mouse events are recognized regardless of the terminal's kmous capability
         searchKeyMap.bind(Operation.MOUSE_EVENT, MouseSupport.keys(terminal));
+        searchKeyMap.bind(Operation.TERMINAL_RESIZE, InBandResize.RESIZE_SEQ);
 
         searchKeyMap.bind(Operation.RIGHT, key(terminal, Capability.key_right));
         searchKeyMap.bind(Operation.LEFT, key(terminal, Capability.key_left));
@@ -3028,6 +3048,9 @@ public class Nano implements Editor {
                     case MOUSE_EVENT:
                         mouseEvent();
                         break;
+                    case TERMINAL_RESIZE:
+                        InBandResize.handleResize(bindingReader, terminal);
+                        break;
                     case TOGGLE_REPLACE:
                         searchToReplace = !searchToReplace;
                         this.shortcuts = searchShortcuts();
@@ -3066,6 +3089,7 @@ public class Nano implements Editor {
         // Bind all possible mouse event prefixes
         // This ensures mouse events are recognized regardless of the terminal's kmous capability
         keyMap.bind(Operation.MOUSE_EVENT, MouseSupport.keys(terminal));
+        keyMap.bind(Operation.TERMINAL_RESIZE, InBandResize.RESIZE_SEQ);
 
         keyMap.bind(Operation.RIGHT, key(terminal, Capability.key_right));
         keyMap.bind(Operation.LEFT, key(terminal, Capability.key_left));
@@ -3112,6 +3136,9 @@ public class Nano implements Editor {
                         break;
                     case MOUSE_EVENT:
                         mouseEvent();
+                        break;
+                    case TERMINAL_RESIZE:
+                        InBandResize.handleResize(bindingReader, terminal);
                         break;
                     default:
                         curPos = editInputBuffer(op, curPos);
@@ -3912,6 +3939,9 @@ public class Nano implements Editor {
         // This ensures mouse events are recognized regardless of the terminal's kmous capability
         keys.bind(Operation.MOUSE_EVENT, MouseSupport.keys(terminal));
 
+        // Bind in-band resize report (mode 2048) prefix
+        keys.bind(Operation.TERMINAL_RESIZE, InBandResize.RESIZE_SEQ);
+
         keys.bind(Operation.TOGGLE_SUSPENSION, alt('z'));
         keys.bind(Operation.NEXT_PAGE, key(terminal, Capability.key_npage));
         keys.bind(Operation.PREV_PAGE, key(terminal, Capability.key_ppage));
@@ -4005,6 +4035,8 @@ public class Nano implements Editor {
         UNCUT,
 
         MOUSE_EVENT,
+
+        TERMINAL_RESIZE,
 
         TOGGLE_SUSPENSION
     }

--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -38,6 +38,7 @@ import java.util.stream.IntStream;
 
 import org.jline.builtins.Options.HelpException;
 import org.jline.keymap.BindingReader;
+import org.jline.keymap.InBandResize;
 import org.jline.keymap.KeyMap;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.impl.DefaultParser;
@@ -235,7 +236,8 @@ public class Tmux {
     enum Binding {
         Discard,
         SelfInsert,
-        Mouse
+        Mouse,
+        Resize
     }
 
     private class Window {
@@ -490,6 +492,7 @@ public class Tmux {
             keyMap.bind(Binding.Discard, prefix + (char) (i));
         }
         keyMap.bind(Binding.Mouse, key(terminal, Capability.key_mouse));
+        keyMap.bind(Binding.Resize, InBandResize.RESIZE_SEQ);
         return keyMap;
     }
 
@@ -596,7 +599,9 @@ public class Tmux {
                         active().getMasterInputOutput().flush();
                         first = true;
                     }
-                    if (b == Binding.Mouse) {
+                    if (b == Binding.Resize) {
+                        InBandResize.handleResize(reader, terminal);
+                    } else if (b == Binding.Mouse) {
                         MouseEvent event = terminal.readMouseEvent(reader::readCharacter, reader.getLastBinding());
                         // System.err.println(event.toString());
                     } else if (b instanceof String || b instanceof String[]) {

--- a/builtins/src/main/java/org/jline/builtins/Tmux.java
+++ b/builtins/src/main/java/org/jline/builtins/Tmux.java
@@ -234,10 +234,10 @@ public class Tmux {
     private KeyMap<Object> keyMap;
 
     enum Binding {
-        Discard,
-        SelfInsert,
-        Mouse,
-        Resize
+        DISCARD,
+        SELF_INSERT,
+        MOUSE,
+        RESIZE
     }
 
     private class Window {
@@ -486,13 +486,13 @@ public class Tmux {
 
     protected KeyMap<Object> createEmptyKeyMap(String prefix) {
         KeyMap<Object> keyMap = new KeyMap<>();
-        keyMap.setUnicode(Binding.SelfInsert);
-        keyMap.setNomatch(Binding.SelfInsert);
+        keyMap.setUnicode(Binding.SELF_INSERT);
+        keyMap.setNomatch(Binding.SELF_INSERT);
         for (int i = 0; i < 255; i++) {
-            keyMap.bind(Binding.Discard, prefix + (char) (i));
+            keyMap.bind(Binding.DISCARD, prefix + (char) (i));
         }
-        keyMap.bind(Binding.Mouse, key(terminal, Capability.key_mouse));
-        keyMap.bind(Binding.Resize, InBandResize.RESIZE_SEQ);
+        keyMap.bind(Binding.MOUSE, key(terminal, Capability.key_mouse));
+        keyMap.bind(Binding.RESIZE, InBandResize.RESIZE_SEQ);
         return keyMap;
     }
 
@@ -579,7 +579,7 @@ public class Tmux {
                 } else {
                     b = null;
                 }
-                if (b == Binding.SelfInsert) {
+                if (b == Binding.SELF_INSERT) {
                     if (active().clock) {
                         active().clock = false;
                         if (clockFuture != null && panes().stream().noneMatch(vc -> vc.clock)) {
@@ -599,9 +599,9 @@ public class Tmux {
                         active().getMasterInputOutput().flush();
                         first = true;
                     }
-                    if (b == Binding.Resize) {
+                    if (b == Binding.RESIZE) {
                         InBandResize.handleResize(reader, terminal);
-                    } else if (b == Binding.Mouse) {
+                    } else if (b == Binding.MOUSE) {
                         MouseEvent event = terminal.readMouseEvent(reader::readCharacter, reader.getLastBinding());
                         // System.err.println(event.toString());
                     } else if (b instanceof String || b instanceof String[]) {
@@ -902,7 +902,7 @@ public class Tmux {
         String prefix = serverOptions.get(OPT_PREFIX);
         String key = prefix + KeyMap.translate(vargs.remove(0));
         keyMap.unbind(key);
-        keyMap.bind(Binding.Discard, key);
+        keyMap.bind(Binding.DISCARD, key);
     }
 
     protected void listKeys(PrintStream out, PrintStream err, List<String> args) throws Exception {

--- a/reader/src/main/java/org/jline/keymap/InBandResize.java
+++ b/reader/src/main/java/org/jline/keymap/InBandResize.java
@@ -59,18 +59,22 @@ public final class InBandResize {
             if (c == 't') {
                 return discard ? null : sb.toString();
             }
-            if (!discard) {
-                if ((c >= '0' && c <= '9') || c == ';') {
-                    sb.append((char) c);
-                    if (sb.length() > 50) {
-                        discard = true; // Too long — drain to 't' then discard
-                    }
-                } else {
-                    discard = true; // Invalid character — drain to 't' then discard
-                }
+            if (discard) {
+                continue;
             }
+            if (!isParamChar(c) || sb.length() > MAX_PARAM_LENGTH) {
+                discard = true;
+                continue;
+            }
+            sb.append((char) c);
         }
         return null;
+    }
+
+    private static final int MAX_PARAM_LENGTH = 50;
+
+    private static boolean isParamChar(int c) {
+        return (c >= '0' && c <= '9') || c == ';';
     }
 
     /**

--- a/reader/src/main/java/org/jline/keymap/InBandResize.java
+++ b/reader/src/main/java/org/jline/keymap/InBandResize.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.keymap;
+
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+
+/**
+ * Shared utility for handling DEC private mode 2048 (in-band window resize
+ * notifications).
+ *
+ * <p>When mode 2048 is active, the terminal sends
+ * {@code CSI 48 ; rows ; cols ; pixelHeight ; pixelWidth t} whenever the
+ * window is resized.  The {@link KeyMap} binding consumes the
+ * {@code CSI 48 ;} prefix ({@link #RESIZE_SEQ}); the methods in this class
+ * handle the remainder of the sequence.</p>
+ *
+ * <p>This was originally implemented inside
+ * {@code org.jline.reader.impl.LineReaderImpl} but is extracted here so that
+ * full-screen builtins ({@code Nano}, {@code Less}, {@code Tmux}) — which
+ * bypass {@code LineReader} and read input directly via
+ * {@link BindingReader} — can also handle in-band resize reports.</p>
+ *
+ * @see Terminal#trackInBandResize(boolean)
+ */
+public final class InBandResize {
+
+    /**
+     * The CSI prefix that starts an in-band resize report.
+     * Bind this in a {@link KeyMap} to trigger resize handling.
+     */
+    public static final String RESIZE_SEQ = "\033[48;";
+
+    private InBandResize() {}
+
+    /**
+     * Reads resize parameters from the input until the final {@code t} byte.
+     *
+     * <p>The {@link KeyMap} match has already consumed the {@link #RESIZE_SEQ}
+     * prefix.  This method reads the remaining characters — digits and
+     * semicolons forming {@code rows;cols[;pixelHeight;pixelWidth]} — up to
+     * the terminating {@code t}.</p>
+     *
+     * @param reader the binding reader to read characters from
+     * @return the parameter string (e.g. {@code "24;80"}), or {@code null}
+     *         if the sequence is malformed or too long
+     */
+    public static String readResizeParams(BindingReader reader) {
+        StringBuilder sb = new StringBuilder();
+        boolean discard = false;
+        int c;
+        while ((c = reader.readCharacter()) >= 0) {
+            if (c == 't') {
+                return discard ? null : sb.toString();
+            }
+            if (!discard) {
+                if ((c >= '0' && c <= '9') || c == ';') {
+                    sb.append((char) c);
+                    if (sb.length() > 50) {
+                        discard = true; // Too long — drain to 't' then discard
+                    }
+                } else {
+                    discard = true; // Invalid character — drain to 't' then discard
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parses {@code rows;cols[;pixelHeight;pixelWidth]} and applies the new
+     * terminal size, raising {@link Terminal.Signal#WINCH}.
+     *
+     * <p>The pixel dimensions (if present) are currently ignored — only the
+     * character-cell dimensions are applied.</p>
+     *
+     * @param params the parameter string returned by {@link #readResizeParams}
+     * @param terminal the terminal whose size should be updated
+     */
+    public static void applyResizeParams(String params, Terminal terminal) {
+        String[] parts = params.split(";", -1);
+        if (parts.length < 2) {
+            return;
+        }
+        try {
+            int rows = Integer.parseInt(parts[0]);
+            int cols = Integer.parseInt(parts[1]);
+            if (rows > 0 && cols > 0) {
+                terminal.setSize(Size.of(cols, rows));
+                terminal.raise(Terminal.Signal.WINCH);
+            }
+        } catch (NumberFormatException e) {
+            // Ignore malformed resize reports
+        }
+    }
+
+    /**
+     * Convenience method that reads and applies an in-band resize report
+     * in a single call.
+     *
+     * @param reader the binding reader to read characters from
+     * @param terminal the terminal whose size should be updated
+     */
+    public static void handleResize(BindingReader reader, Terminal terminal) {
+        String params = readResizeParams(reader);
+        if (params != null) {
+            applyResizeParams(params, terminal);
+        }
+    }
+}

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.jline.keymap.BindingReader;
+import org.jline.keymap.InBandResize;
 import org.jline.keymap.KeyMap;
 import org.jline.reader.*;
 import org.jline.reader.Parser.ParseContext;
@@ -135,7 +136,12 @@ public class LineReaderImpl implements LineReader, Flushable {
 
     public static final String FOCUS_IN_SEQ = "\033[I";
     public static final String FOCUS_OUT_SEQ = "\033[O";
-    public static final String RESIZE_SEQ = "\033[48;";
+    /**
+     * @deprecated Use {@link InBandResize#RESIZE_SEQ} instead.
+     */
+    @Deprecated
+    public static final String RESIZE_SEQ = InBandResize.RESIZE_SEQ;
+
     public static final int DEFAULT_MAX_REPEAT_COUNT = 9999;
 
     /**
@@ -6560,62 +6566,11 @@ public class LineReaderImpl implements LineReader, Flushable {
      * {@link Terminal.Signal#WINCH}.</p>
      *
      * @return {@code true} always
+     * @see InBandResize#handleResize(BindingReader, Terminal)
      */
     public boolean terminalResize() {
-        String params = readResizeParams();
-        if (params != null) {
-            applyResizeParams(params);
-        }
+        InBandResize.handleResize(bindingReader, terminal);
         return true;
-    }
-
-    /**
-     * Reads resize parameters from the input until the final {@code t} byte.
-     *
-     * @return the parameter string (e.g. {@code "24;80"}), or {@code null}
-     *         if the sequence is malformed or too long
-     */
-    private String readResizeParams() {
-        StringBuilder sb = new StringBuilder();
-        boolean discard = false;
-        int c;
-        while ((c = bindingReader.readCharacter()) >= 0) {
-            if (c == 't') {
-                return discard ? null : sb.toString();
-            }
-            if (!discard) {
-                if ((c >= '0' && c <= '9') || c == ';') {
-                    sb.append((char) c);
-                    if (sb.length() > 50) {
-                        discard = true; // Too long — drain to 't' then discard
-                    }
-                } else {
-                    discard = true; // Invalid character — drain to 't' then discard
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Parses {@code rows;cols[;pixelHeight;pixelWidth]} and applies
-     * the new terminal size, raising {@link Terminal.Signal#WINCH}.
-     */
-    private void applyResizeParams(String params) {
-        String[] parts = params.split(";", -1);
-        if (parts.length < 2) {
-            return;
-        }
-        try {
-            int rows = Integer.parseInt(parts[0]);
-            int cols = Integer.parseInt(parts[1]);
-            if (rows > 0 && cols > 0) {
-                terminal.setSize(Size.of(cols, rows));
-                terminal.raise(Terminal.Signal.WINCH);
-            }
-        } catch (NumberFormatException e) {
-            // Ignore malformed resize reports
-        }
     }
 
     /**

--- a/reader/src/test/java/org/jline/keymap/InBandResizeTest.java
+++ b/reader/src/test/java/org/jline/keymap/InBandResizeTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.keymap;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jline.reader.impl.ReaderTestSupport.EofPipedInputStream;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.Terminal.Signal;
+import org.jline.terminal.impl.DumbTerminal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link InBandResize} — the shared utility for parsing
+ * DEC private mode 2048 in-band resize reports.
+ *
+ * <p>These tests exercise the static helper methods directly, without
+ * going through {@code LineReaderImpl} or any builtin.  The existing
+ * {@code InBandResizeWidgetTest} covers the integration path through
+ * the {@code terminal-resize} widget.</p>
+ */
+class InBandResizeTest {
+
+    private Terminal terminal;
+    private EofPipedInputStream in;
+    private ByteArrayOutputStream out;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        in = new EofPipedInputStream();
+        out = new ByteArrayOutputStream();
+        terminal = new DumbTerminal("dumb", "dumb", in, out, StandardCharsets.UTF_8);
+        terminal.setSize(Size.of(160, 80));
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (terminal != null) {
+            terminal.close();
+        }
+    }
+
+    private BindingReader readerFor(String input) {
+        in.setIn(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+        return new BindingReader(terminal.reader());
+    }
+
+    // ---- readResizeParams ----
+
+    @Test
+    void readResizeParams_rowsAndCols() {
+        BindingReader reader = readerFor("24;80t");
+        assertEquals("24;80", InBandResize.readResizeParams(reader));
+    }
+
+    @Test
+    void readResizeParams_withPixelDimensions() {
+        BindingReader reader = readerFor("30;120;480;960t");
+        assertEquals("30;120;480;960", InBandResize.readResizeParams(reader));
+    }
+
+    @Test
+    void readResizeParams_malformedCharReturnsNull() {
+        // 'x' is invalid — drained to 't', returns null
+        BindingReader reader = readerFor("10x30;80t");
+        assertNull(InBandResize.readResizeParams(reader));
+    }
+
+    @Test
+    void readResizeParams_tooLongReturnsNull() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 60; i++) {
+            sb.append('1');
+        }
+        sb.append('t');
+        BindingReader reader = readerFor(sb.toString());
+        assertNull(InBandResize.readResizeParams(reader));
+    }
+
+    @Test
+    void readResizeParams_emptyParamsBeforeT() {
+        BindingReader reader = readerFor("t");
+        assertEquals("", InBandResize.readResizeParams(reader));
+    }
+
+    @Test
+    void readResizeParams_eofWithoutT() {
+        // No terminating 't' — EOF reached
+        BindingReader reader = readerFor("24;80");
+        assertNull(InBandResize.readResizeParams(reader));
+    }
+
+    @Test
+    void readResizeParams_consumesExactlyUpToT() {
+        // After reading params up to 't', remaining data should still be readable
+        BindingReader reader = readerFor("24;80tAB");
+        assertEquals("24;80", InBandResize.readResizeParams(reader));
+        // 'A' and 'B' should remain
+        assertEquals('A', reader.readCharacter());
+        assertEquals('B', reader.readCharacter());
+    }
+
+    // ---- applyResizeParams ----
+
+    @Test
+    void applyResizeParams_updatesTerminalSize() {
+        InBandResize.applyResizeParams("30;120", terminal);
+        assertEquals(Size.of(120, 30), terminal.getSize());
+    }
+
+    @Test
+    void applyResizeParams_withPixelDimensions() {
+        // Pixel dimensions are ignored — only rows and cols applied
+        InBandResize.applyResizeParams("50;200;800;1600", terminal);
+        assertEquals(Size.of(200, 50), terminal.getSize());
+    }
+
+    @Test
+    void applyResizeParams_raisesWINCH() {
+        List<Signal> signals = new ArrayList<>();
+        terminal.handle(Signal.WINCH, signals::add);
+
+        InBandResize.applyResizeParams("25;80", terminal);
+
+        assertEquals(1, signals.size());
+        assertEquals(Signal.WINCH, signals.get(0));
+    }
+
+    @Test
+    void applyResizeParams_tooFewPartsIgnored() {
+        Size before = terminal.getSize();
+        InBandResize.applyResizeParams("30", terminal);
+        assertEquals(before, terminal.getSize());
+    }
+
+    @Test
+    void applyResizeParams_emptyStringIgnored() {
+        Size before = terminal.getSize();
+        InBandResize.applyResizeParams("", terminal);
+        assertEquals(before, terminal.getSize());
+    }
+
+    @Test
+    void applyResizeParams_zeroRowsIgnored() {
+        Size before = terminal.getSize();
+        InBandResize.applyResizeParams("0;80", terminal);
+        assertEquals(before, terminal.getSize());
+    }
+
+    @Test
+    void applyResizeParams_zeroColsIgnored() {
+        Size before = terminal.getSize();
+        InBandResize.applyResizeParams("30;0", terminal);
+        assertEquals(before, terminal.getSize());
+    }
+
+    @Test
+    void applyResizeParams_nonNumericIgnored() {
+        Size before = terminal.getSize();
+        InBandResize.applyResizeParams("abc;def", terminal);
+        assertEquals(before, terminal.getSize());
+    }
+
+    // ---- handleResize (end-to-end) ----
+
+    @Test
+    void handleResize_validSequence() {
+        BindingReader reader = readerFor("40;132t");
+        InBandResize.handleResize(reader, terminal);
+        assertEquals(Size.of(132, 40), terminal.getSize());
+    }
+
+    @Test
+    void handleResize_malformedSequenceNoChange() {
+        Size before = terminal.getSize();
+        BindingReader reader = readerFor("bad;datat");
+        InBandResize.handleResize(reader, terminal);
+        assertEquals(before, terminal.getSize());
+    }
+
+    @Test
+    void handleResize_raisesWINCHOnValidSequence() {
+        List<Signal> signals = new ArrayList<>();
+        terminal.handle(Signal.WINCH, signals::add);
+
+        BindingReader reader = readerFor("25;80t");
+        InBandResize.handleResize(reader, terminal);
+
+        assertEquals(1, signals.size());
+    }
+
+    @Test
+    void handleResize_noWINCHOnMalformedSequence() {
+        List<Signal> signals = new ArrayList<>();
+        terminal.handle(Signal.WINCH, signals::add);
+
+        BindingReader reader = readerFor("x;yt");
+        InBandResize.handleResize(reader, terminal);
+
+        assertTrue(signals.isEmpty());
+    }
+
+    // ---- KeyMap integration ----
+
+    @Test
+    void resizeSeqBindsInKeyMap() {
+        in.setIn(new ByteArrayInputStream(("\033[48;25;80t").getBytes(StandardCharsets.UTF_8)));
+        BindingReader reader = new BindingReader(terminal.reader());
+
+        KeyMap<String> keyMap = new KeyMap<>();
+        keyMap.setUnicode("insert");
+        keyMap.bind("resize", InBandResize.RESIZE_SEQ);
+
+        // The KeyMap should match the CSI 48; prefix
+        String binding = reader.readBinding(keyMap);
+        assertEquals("resize", binding);
+        assertEquals(InBandResize.RESIZE_SEQ, reader.getLastBinding());
+
+        // Now read the remaining params + apply
+        InBandResize.handleResize(reader, terminal);
+        assertEquals(Size.of(80, 25), terminal.getSize());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2096.

PR #2021 added DEC private mode 2048 (in-band window resize notifications) support to the `Terminal` API and `LineReader`. However, the built-in full-screen applications — **Nano**, **Less**, and **Tmux** — bypass `LineReader` and read input directly via `BindingReader`, so resize reports arrived as unrecognized sequences.

This PR:

- **Extracts** the resize-report parsing logic (`readResizeParams()` / `applyResizeParams()`) from `LineReaderImpl` into a new shared utility class `InBandResize` in `org.jline.keymap`
- **Refactors** `LineReaderImpl.terminalResize()` to delegate to `InBandResize.handleResize()`
- **Adds** `TERMINAL_RESIZE` bindings for `CSI 48;` in all KeyMaps of each builtin:
  - **Nano**: main keymap + all sub-dialog keymaps (write, read, goto, search, replace, help)
  - **Less**: main keymap + search, file, and help sub-keymaps
  - **Tmux**: base keymap via `createEmptyKeyMap()`
- The existing `Signal.WINCH` handlers in each component already handle redraw, so the resize report just triggers the same code path via `terminal.raise(Signal.WINCH)`

## Design

The `InBandResize` utility provides:
- `RESIZE_SEQ` — the `\033[48;` prefix constant to bind in KeyMaps
- `readResizeParams(BindingReader)` — reads `rows;cols[;pixelH;pixelW]` up to `t`
- `applyResizeParams(String, Terminal)` — parses and applies via `terminal.setSize()` + `terminal.raise(WINCH)`
- `handleResize(BindingReader, Terminal)` — convenience combining both

## Test plan

- [x] `./mvx mvn install -DskipTests` — full build passes
- [x] `./mvx mvn test -pl reader,builtins` — 1085 tests pass, 0 failures
- [x] `./mvx mvn test -pl terminal` — 576 tests pass, 0 failures
- [ ] Manual: enable mode 2048 on a terminal that supports it, run Nano/Less/Tmux builtins, resize the terminal window — verify the display updates correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for in-band terminal resize reports.
  * Terminal dimensions now update automatically while using the pager, editor, multiplexer, search, help, and other interactive input modes.
  * Resize events now trigger the standard terminal window-change notification.

* **Bug Fixes**
  * Malformed, incomplete, or oversized resize reports are safely ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->