### PR TITLE
strip control characters from file names in posix builtins

### DIFF
--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -1111,14 +1111,8 @@ public class PosixCommands {
                 if (!lastNl.get()) {
                     lines.incrementAndGet();
                 }
-                context.out()
-                        .printf(
-                                format,
-                                lines.get(),
-                                words.get(),
-                                chars.get(),
-                                bytes.get(),
-                                stripControlChars(source.getName()));
+                String name = stripControlChars(source.getName());
+                context.out().printf(format, lines.get(), words.get(), chars.get(), bytes.get(), name);
                 totalBytes += bytes.get();
                 totalChars += chars.get();
                 totalWords += words.get();

--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -1969,7 +1969,7 @@ public class PosixCommands {
             space = true;
             Path path = currentDir.resolve(entry.path);
             if (expanded.size() > 1) {
-                out.println(currentDir.relativize(path).toString() + ":");
+                out.println(stripControlChars(currentDir.relativize(path).toString()) + ":");
             }
             try (Stream<Path> pathStream = Files.list(path)) {
                 display.accept(Stream.concat(Stream.of(".", "..").map(path::resolve), pathStream)
@@ -2191,7 +2191,7 @@ public class PosixCommands {
      * Removes ISO control characters (ESC, BEL, CR, LF, the C1 introducers, ...)
      * from a file name or other filesystem-derived string before it is written to
      * the terminal. The name is chosen by whoever created the file, so without this
-     * an entry such as {@code report]0;pwned.txt} would drive the
+     * an entry such as {@code report<ESC>]0;pwned<BEL>.txt} would drive the
      * terminal (set the window title, write the clipboard via OSC 52, ...) when it
      * is listed. Printable Unicode is kept so ordinary names render unchanged.
      */

--- a/builtins/src/main/java/org/jline/builtins/PosixCommands.java
+++ b/builtins/src/main/java/org/jline/builtins/PosixCommands.java
@@ -1111,7 +1111,14 @@ public class PosixCommands {
                 if (!lastNl.get()) {
                     lines.incrementAndGet();
                 }
-                context.out().printf(format, lines.get(), words.get(), chars.get(), bytes.get(), source.getName());
+                context.out()
+                        .printf(
+                                format,
+                                lines.get(),
+                                words.get(),
+                                chars.get(),
+                                bytes.get(),
+                                stripControlChars(source.getName()));
                 totalBytes += bytes.get();
                 totalChars += chars.get();
                 totalWords += words.get();
@@ -1157,7 +1164,7 @@ public class PosixCommands {
                 if (src != sources.get(0)) {
                     context.out().println();
                 }
-                context.out().println("==> " + src.getName() + " <==");
+                context.out().println("==> " + stripControlChars(src.getName()) + " <==");
             }
             try (InputStream is = src.read()) {
                 byte[] buf = new byte[DEFAULT_BUFFER_SIZE];
@@ -1347,7 +1354,7 @@ public class PosixCommands {
             private void print(String toPrint) {
                 if (lastPrinted.get() != this && opt.args().size() > 1 && !opt.isSet("quiet")) {
                     context.out().println();
-                    context.out().println("==> " + source.getName() + " <==");
+                    context.out().println("==> " + stripControlChars(source.getName()) + " <==");
                 }
                 context.out().print(toPrint);
                 lastPrinted.set(this);
@@ -1498,7 +1505,7 @@ public class PosixCommands {
                                     if (colored) {
                                         applyStyle(sbl, colors, "fn");
                                     }
-                                    sbl.append(src.getName());
+                                    sbl.append(stripControlChars(src.getName()));
                                     if (colored) {
                                         applyStyle(sbl, colors, "se");
                                     }
@@ -1546,7 +1553,7 @@ public class PosixCommands {
                                 if (colored) {
                                     applyStyle(sbl, colors, "fn");
                                 }
-                                sbl.append(src.getName());
+                                sbl.append(stripControlChars(src.getName()));
                                 if (colored) {
                                     applyStyle(sbl, colors, "se");
                                 }
@@ -1571,7 +1578,7 @@ public class PosixCommands {
                                 if (colored) {
                                     applyStyle(sbl, colors, "fn");
                                 }
-                                sbl.append(src.getName());
+                                sbl.append(stripControlChars(src.getName()));
                                 if (colored) {
                                     applyStyle(sbl, colors, "se");
                                 }
@@ -1624,7 +1631,7 @@ public class PosixCommands {
                                 if (colored) {
                                     applyStyle(sbl, colors, "fn");
                                 }
-                                sbl.append(src.getName());
+                                sbl.append(stripControlChars(src.getName()));
                                 if (colored) {
                                     applyStyle(sbl, colors, "se");
                                 }
@@ -1805,7 +1812,7 @@ public class PosixCommands {
                     suffix = "@";
                     try {
                         Path l = Files.readSymbolicLink(abs);
-                        link = " -> " + l.toString();
+                        link = " -> " + stripControlChars(l.toString());
                     } catch (IOException e) {
                         // ignore
                     }
@@ -1823,7 +1830,7 @@ public class PosixCommands {
                     suffix = "";
                 }
                 boolean addSuffix = opt.isSet("F");
-                return applyStyle(path.toString(), colors, type) + (addSuffix ? suffix : "") + link;
+                return applyStyle(stripControlChars(path.toString()), colors, type) + (addSuffix ? suffix : "") + link;
             }
 
             String longDisplay() {
@@ -2184,6 +2191,27 @@ public class PosixCommands {
         String sep = COLOR_FORMAT_PATTERN.matcher(str).matches() ? ":" : " ";
         return Arrays.stream(str.split(sep))
                 .collect(Collectors.toMap(s -> s.substring(0, s.indexOf('=')), s -> s.substring(s.indexOf('=') + 1)));
+    }
+
+    /**
+     * Removes ISO control characters (ESC, BEL, CR, LF, the C1 introducers, ...)
+     * from a file name or other filesystem-derived string before it is written to
+     * the terminal. The name is chosen by whoever created the file, so without this
+     * an entry such as {@code report]0;pwned.txt} would drive the
+     * terminal (set the window title, write the clipboard via OSC 52, ...) when it
+     * is listed. Printable Unicode is kept so ordinary names render unchanged.
+     */
+    private static String stripControlChars(String s) {
+        if (s == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder(s.length());
+        s.codePoints().forEach(cp -> {
+            if (!Character.isISOControl(cp)) {
+                sb.appendCodePoint(cp);
+            }
+        });
+        return sb.toString();
     }
 
     /**

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsControlCharTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsControlCharTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.DumbTerminal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The POSIX listing/output builtins print filesystem-derived names (the file
+ * name, a symlink target, the {@code ==> name <==} header, the grep filename
+ * prefix). The name is chosen by whoever created the file, so an entry whose
+ * name carries an OSC or CSI sequence must not reach the terminal verbatim.
+ *
+ * <p>The commands are driven with {@code --color=never} where they support it so
+ * that legitimate SGR (which is itself ESC-based) stays out of the output; any
+ * ESC/BEL that remains can only have come from an unescaped name.
+ */
+class PosixCommandsControlCharTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Terminal terminal;
+    private ByteArrayOutputStream out;
+    private PosixCommands.Context context;
+
+    // OSC 0 (set window title) framed by ESC ] ... BEL, embedded in a file name.
+    private static final String EVIL = "a\u001b]0;pwned\u0007b.txt";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        out = new ByteArrayOutputStream();
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        Map<String, Object> vars = new HashMap<>();
+        terminal = new DumbTerminal(in, out);
+        context = new PosixCommands.Context(
+                in, new PrintStream(out), new PrintStream(new ByteArrayOutputStream()), tempDir, terminal, vars::get);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (terminal != null) {
+            terminal.close();
+        }
+    }
+
+    private String output() {
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    private static void assertNoControlBytes(String s) {
+        assertFalse(s.indexOf('\u001b') >= 0, "ESC must not reach the terminal");
+        assertFalse(s.indexOf('\u0007') >= 0, "BEL must not reach the terminal");
+    }
+
+    @Test
+    void lsStripsControlCharsInFileName() throws Exception {
+        Path evil = tempDir.resolve(EVIL);
+        Files.createFile(evil);
+        // -1 prints each name straight to the terminal (no column re-rendering).
+        PosixCommands.ls(context, new String[] {"ls", "-1", "--color=never", evil.toString()});
+        String o = output();
+        assertNoControlBytes(o);
+        assertTrue(o.contains("a]0;pwnedb.txt"), "the printable part of the name should still render: " + o);
+    }
+
+    @Test
+    void lsLongStripsControlCharsInFileName() throws Exception {
+        Path evil = tempDir.resolve(EVIL);
+        Files.createFile(evil);
+        PosixCommands.ls(context, new String[] {"ls", "-l", "--color=never", evil.toString()});
+        assertNoControlBytes(output());
+    }
+
+    @Test
+    void lsStripsControlCharsInSymlinkTarget() throws Exception {
+        // A link whose target name carries the control sequence; ls prints "link -> <target>".
+        Path target = tempDir.resolve(EVIL);
+        Files.createFile(target);
+        Path link = tempDir.resolve("link");
+        try {
+            Files.createSymbolicLink(link, target.getFileName());
+        } catch (UnsupportedOperationException | IOException e) {
+            return; // symlinks unavailable on this platform/filesystem
+        }
+        PosixCommands.ls(context, new String[] {"ls", "-l", "--color=never", link.toString()});
+        assertNoControlBytes(output());
+    }
+
+    @Test
+    void headStripsControlCharsInFileHeader() throws Exception {
+        Path evil = tempDir.resolve(EVIL);
+        Files.write(evil, "hello\n".getBytes(StandardCharsets.UTF_8));
+        Path plain = tempDir.resolve("plain.txt");
+        Files.write(plain, "world\n".getBytes(StandardCharsets.UTF_8));
+        // More than one source makes head emit the "==> name <==" headers.
+        PosixCommands.head(context, new String[] {"head", evil.toString(), plain.toString()});
+        assertNoControlBytes(output());
+    }
+
+    @Test
+    void grepStripsControlCharsInFileHeader() throws Exception {
+        Path evil = tempDir.resolve(EVIL);
+        Files.write(evil, "match\n".getBytes(StandardCharsets.UTF_8));
+        Path plain = tempDir.resolve("plain.txt");
+        Files.write(plain, "match\n".getBytes(StandardCharsets.UTF_8));
+        // More than one source makes grep prefix each match with the file name.
+        PosixCommands.grep(context, new String[] {"grep", "--color=never", "match", evil.toString(), plain.toString()});
+        assertNoControlBytes(output());
+    }
+}

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsControlCharTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsControlCharTest.java
@@ -23,6 +23,8 @@ import org.jline.terminal.impl.DumbTerminal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,7 +39,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>The commands are driven with {@code --color=never} where they support it so
  * that legitimate SGR (which is itself ESC-based) stays out of the output; any
  * ESC/BEL that remains can only have come from an unescaped name.
+ *
+ * <p>Windows NTFS forbids control characters (0x00–0x1F) in file names,
+ * so these tests are skipped on Windows — the attack surface they validate
+ * only exists on Unix-like filesystems.
  */
+@DisabledOnOs(OS.WINDOWS)
 class PosixCommandsControlCharTest {
 
     @TempDir

--- a/builtins/src/test/java/org/jline/builtins/PosixCommandsControlCharTest.java
+++ b/builtins/src/test/java/org/jline/builtins/PosixCommandsControlCharTest.java
@@ -10,7 +10,6 @@ package org.jline.builtins;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -110,7 +109,7 @@ class PosixCommandsControlCharTest {
         Path link = tempDir.resolve("link");
         try {
             Files.createSymbolicLink(link, target.getFileName());
-        } catch (UnsupportedOperationException | IOException e) {
+        } catch (UnsupportedOperationException e) {
             return; // symlinks unavailable on this platform/filesystem
         }
         PosixCommands.ls(context, new String[] {"ls", "-l", "--color=never", link.toString()});
@@ -125,6 +124,21 @@ class PosixCommandsControlCharTest {
         Files.write(plain, "world\n".getBytes(StandardCharsets.UTF_8));
         // More than one source makes head emit the "==> name <==" headers.
         PosixCommands.head(context, new String[] {"head", evil.toString(), plain.toString()});
+        assertNoControlBytes(output());
+    }
+
+    @Test
+    void lsMultiDirStripsControlCharsInHeader() throws Exception {
+        // When ls lists multiple directories it emits a "dirname:" header for each.
+        // A directory whose name contains control chars must not leak them.
+        String evilDir = "d\u001b]0;pwned\u0007ir";
+        Path dir1 = tempDir.resolve(evilDir);
+        Files.createDirectory(dir1);
+        Files.createFile(dir1.resolve("file.txt"));
+        Path dir2 = tempDir.resolve("safe");
+        Files.createDirectory(dir2);
+        Files.createFile(dir2.resolve("file.txt"));
+        PosixCommands.ls(context, new String[] {"ls", "-1", "--color=never", dir1.toString(), dir2.toString()});
         assertNoControlBytes(output());
     }
 


### PR DESCRIPTION
`ls -1` (also `-l`/`-m`, and `head`/`tail`/`wc`/`grep`) on a file whose name carries an OSC sequence, the bytes reaching the terminal:

    a\e]0;pwned\ab.txt

The name is filesystem-derived, so a file planted by another user or unpacked from an archive drives the terminal (window title, OSC 52 clipboard write) when the directory is listed or grepped. `PathEntry.display()` emits `path.toString()` and the `readSymbolicLink` target, the `==> name <==` headers and the grep filename prefix emit `src.getName()`, all with no filtering; `ls`'s column path is only spared because `toColumn` re-parses through `fromAnsi`, while `-1`, `-l`, `-m` and non-tty output print the name straight to the terminal.

Strip ISO control characters at each name site, the same thing `Less` already does for its status line (#2156). GNU `ls` quotes non-printable file names by default for this reason. File content printed by `grep`/`cat` is unchanged.

Test drives each command against an attacker-named file and asserts no ESC/BEL reaches the output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized file names, symbolic-link targets, and directory headers displayed by POSIX commands, including listing, preview, counting, and search commands.
  * Prevented terminal control sequences in file names from affecting terminal output while preserving printable Unicode content.

* **Tests**
  * Added cross-platform coverage for safe output from supported POSIX commands, including files, symbolic links, and directory headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->