### PR TITLE
fix: bound !# history expansion to prevent exponential blowup

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/DefaultExpander.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultExpander.java
@@ -36,6 +36,14 @@ import org.jline.reader.History.Entry;
 public class DefaultExpander implements Expander {
 
     /**
+     * Upper bound on the length of a history expansion. The {@code !#} event
+     * designator expands to the command line built so far, so each occurrence
+     * doubles the accumulated result; this bounds that growth so a short
+     * crafted line cannot exhaust the heap.
+     */
+    private static final int MAX_EXPANSION_SIZE = 1 << 20;
+
+    /**
      * Creates a new DefaultExpander.
      */
     public DefaultExpander() {
@@ -95,6 +103,11 @@ public class DefaultExpander implements Expander {
                                     rep = history.get(history.index() - 1);
                                     break;
                                 case '#':
+                                    // "!#" doubles the result built so far, so a line that repeats it
+                                    // grows exponentially; reject the expansion before it can exhaust the heap
+                                    if ((long) sb.length() * 2 > MAX_EXPANSION_SIZE) {
+                                        throw new IllegalArgumentException("!#: expansion too large");
+                                    }
                                     sb.append(sb.toString());
                                     break;
                                 case '?':

--- a/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
@@ -114,6 +114,31 @@ class TerminalReaderTest extends ReaderTestSupport {
     }
 
     @Test
+    void testExpansionBombIsRejected() {
+        DefaultHistory history = new DefaultHistory(reader);
+        reader.setVariable(LineReader.HISTORY_SIZE, 3);
+        history.add("mkdir monkey");
+
+        Expander expander = new DefaultExpander();
+
+        // a single "!#" still doubles the line built so far
+        assertEquals("echo echo a", expander.expandHistory(history, "echo !#a"));
+
+        // repeating "!#" doubles the accumulator each time; without a bound this
+        // grows to 2^40 chars from a 81-byte line and exhausts the heap
+        StringBuilder bomb = new StringBuilder("a");
+        for (int i = 0; i < 40; i++) {
+            bomb.append("!#");
+        }
+        try {
+            expander.expandHistory(history, bomb.toString());
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("!#: expansion too large", e.getMessage());
+        }
+    }
+
+    @Test
     void testNumericExpansions() {
         DefaultHistory history = new DefaultHistory(reader);
         reader.setVariable(LineReader.HISTORY_SIZE, 3);

--- a/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -130,12 +131,10 @@ class TerminalReaderTest extends ReaderTestSupport {
         for (int i = 0; i < 40; i++) {
             bomb.append("!#");
         }
-        try {
-            expander.expandHistory(history, bomb.toString());
-            fail("expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertEquals("!#: expansion too large", e.getMessage());
-        }
+        String bombLine = bomb.toString();
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> expander.expandHistory(history, bombLine));
+        assertEquals("!#: expansion too large", e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Repeating the `!#` event designator in a submitted line:

    java.lang.OutOfMemoryError: Java heap space
        at java.base/java.lang.StringBuilder.toString(StringBuilder.java:454)
        at org.jline.reader.impl.DefaultExpander.expandHistory(DefaultExpander.java:98)

`!#` expands to the line built so far via `sb.append(sb.toString())`, so every occurrence doubles the accumulator. `a` followed by 40 `!#` is 81 bytes and grows toward 2^40 chars. Event expansion is on by default (`DISABLE_EVENT_EXPANSION` has no default), and `LineReaderImpl.acceptLine` runs it on the submitted line while catching only `IllegalArgumentException`, so the `OutOfMemoryError` escapes `readLine` and takes the JVM down instead of the session.

The line is attacker-controlled wherever the reader is driven from an untrusted byte stream (remote-telnet, remote-ssh, WebTerminal), and bracketed paste (on by default) delivers it without keystrokes.

`!#` is the only self-referential designator; every other one appends bounded history text. The fix caps the doubling inside `expandHistory` and throws the same `IllegalArgumentException` the method already raises for bad events. A single `!#` (`echo !#a` -> `echo echo a`) is unchanged. Regression test added in `TerminalReaderTest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against excessively large history expansions caused by repeated `!#` sequences.
  * Such expansions are now rejected with a clear error instead of risking excessive memory usage.

* **Tests**
  * Added coverage verifying normal `!#` expansion remains supported and oversized expansions are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->