### PR TITLE
fix: append suffix to buffer when not part of candidate value (fixes #2208)

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4970,6 +4970,11 @@ public class LineReaderImpl implements LineReader, Flushable {
                     buf.backspace(line.rawWordLength());
                 }
                 buf.write(line.escape(completion.value(), completion.complete()));
+                // If the suffix is not already part of the value, append it so that
+                // the suffix-removal backspace (below) does not eat into the value.
+                if (completion.suffix() != null && !completion.value().endsWith(completion.suffix())) {
+                    buf.write(completion.suffix());
+                }
                 if (completion.complete()) {
                     if (buf.currChar() != ' ') {
                         buf.write(" ");
@@ -5410,6 +5415,11 @@ public class LineReaderImpl implements LineReader, Flushable {
         private void update() {
             buf.backspace(word.length());
             word = escaper.apply(completion().value(), true).toString();
+            // Append suffix if not already part of the value
+            Candidate c = completion();
+            if (c.suffix() != null && !c.value().endsWith(c.suffix())) {
+                word = word + c.suffix();
+            }
             buf.write(word);
 
             // Compute displayed prompt

--- a/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4975,13 +4975,6 @@ public class LineReaderImpl implements LineReader, Flushable {
                 if (completion.suffix() != null && !completion.value().endsWith(completion.suffix())) {
                     buf.write(completion.suffix());
                 }
-                if (completion.complete()) {
-                    if (buf.currChar() != ' ') {
-                        buf.write(" ");
-                    } else {
-                        buf.move(1);
-                    }
-                }
                 if (completion.suffix() != null) {
                     if (autosuggestion == SuggestionType.COMPLETER) {
                         listChoices(true);
@@ -4999,7 +4992,17 @@ public class LineReaderImpl implements LineReader, Flushable {
                                 buf.write(' ');
                             }
                         }
-                        pushBackBinding(true);
+                        // Don't replay the typed character when it matches the
+                        // suffix — the suffix is already in the buffer.
+                        if (!(SELF_INSERT.equals(ref) && completion.suffix().startsWith(getLastBinding()))) {
+                            pushBackBinding(true);
+                        }
+                    }
+                } else if (completion.complete()) {
+                    if (buf.currChar() != ' ') {
+                        buf.write(" ");
+                    } else {
+                        buf.move(1);
                     }
                 }
                 return true;

--- a/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
@@ -190,6 +190,8 @@ class CompletionTest extends ReaderTestSupport {
         assertLine("range(1", new TestBuffer("r\t1\n"));
         assertLine("strange ", new TestBuffer("s\t\n"));
         assertLine("strangeTests", new TestBuffer("s\ts\n"));
+        // Typing the suffix character should not duplicate it
+        assertLine("range(x", new TestBuffer("r\t(x\n"));
     }
 
     @Test
@@ -212,6 +214,31 @@ class CompletionTest extends ReaderTestSupport {
         // ";" is a REMOVE_SUFFIX_CHARS char, removes suffix and adds space, then ";" is inserted
         assertLine("test ;", new TestBuffer("t\t;\n"));
         // "x" is NOT a REMOVE_SUFFIX_CHARS char, suffix stays
+        assertLine("test/x", new TestBuffer("t\tx\n"));
+        // Typing the suffix char itself should not duplicate it
+        assertLine("test/y", new TestBuffer("t\t/y\n"));
+    }
+
+    @Test
+    void testSuffixWithComplete() {
+        // Suffix with complete=true: the separator space must be added after
+        // suffix removal so the backspace targets the suffix, not the space.
+        reader.setCompleter((reader, line, candidates) -> {
+            candidates.add(new Candidate(
+                    /* value    = */ "test",
+                    /* displ    = */ "test",
+                    /* group    = */ null,
+                    /* descr    = */ null,
+                    /* suffix   = */ "/",
+                    /* key      = */ null,
+                    /* complete = */ true));
+        });
+
+        // Enter removes the suffix; complete=true adds a separator space
+        assertLine("test ", new TestBuffer("t\t\n"));
+        // ";" removes the suffix and adds a space, then ";" is inserted
+        assertLine("test ;", new TestBuffer("t\t;\n"));
+        // "x" keeps the suffix; no separator space because the word is being extended
         assertLine("test/x", new TestBuffer("t\tx\n"));
     }
 

--- a/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/CompletionTest.java
@@ -193,6 +193,29 @@ class CompletionTest extends ReaderTestSupport {
     }
 
     @Test
+    void testSuffixNotInValue() {
+        // Suffix NOT included in value (follows the Candidate javadoc literally).
+        // Before the fix, the last character(s) of the value were dropped on Enter.
+        reader.setCompleter((reader, line, candidates) -> {
+            candidates.add(new Candidate(
+                    /* value    = */ "test",
+                    /* displ    = */ "test",
+                    /* group    = */ null,
+                    /* descr    = */ "a test command",
+                    /* suffix   = */ "/",
+                    /* key      = */ "test",
+                    /* complete = */ false));
+        });
+
+        // Tab completes "test/" (suffix appended), Enter removes suffix and adds space
+        assertLine("test ", new TestBuffer("t\t\n"));
+        // ";" is a REMOVE_SUFFIX_CHARS char, removes suffix and adds space, then ";" is inserted
+        assertLine("test ;", new TestBuffer("t\t;\n"));
+        // "x" is NOT a REMOVE_SUFFIX_CHARS char, suffix stays
+        assertLine("test/x", new TestBuffer("t\tx\n"));
+    }
+
+    @Test
     void testMenuOrder() {
         reader.setCompleter(new StringsCompleter(List.of(
                 "ae_helloWorld1", "ad_helloWorld12", "ac_helloWorld1234", "ab_helloWorld123", "aa_helloWorld12345")));


### PR DESCRIPTION
## Summary

Fixes #2208 — when a custom `Completer` provides a `Candidate` with a non-empty `suffix` that is **not** already included in its `value`, the completion drops the last character(s) of the completed word on Enter.

**Root cause:** The completion logic writes only `completion.value()` to the buffer, then on Enter (or `REMOVE_SUFFIX_CHARS`) calls `buf.backspace(completion.suffix().length())`. When the suffix isn't part of the value, the backspace eats into the actual value instead of the suffix.

**Fix:** After writing the value, check whether it already ends with the suffix. If not, append the suffix to the buffer so the backspace targets the correct characters. Applied to both the single-match path (`doComplete`) and the menu-completion path (`doMenu`).

- Built-in completers (e.g., `FilesCompleter`) that include the suffix in the value are unaffected — the `endsWith` check skips the extra write.
- Added `testSuffixNotInValue` to `CompletionTest` covering Enter, `REMOVE_SUFFIX_CHARS`, and regular character after completion.

## Test plan

- [x] New `testSuffixNotInValue` test verifies: Tab + Enter yields `"test "` (not `"tes "`), Tab + `;` yields `"test ;"`, Tab + `x` yields `"test/x"`
- [x] Existing `testSuffix` still passes (suffix included in value — no behavior change)
- [x] Full reader module test suite: 260 tests, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion behavior when a candidate’s suffix is not included in its value.
  * Prevented suffix characters from being duplicated when typed after completion.
  * Updated direct and menu-based completion to handle suffixes consistently.
  * Confirmed expected behavior for Enter, suffix-removing characters, and regular typed characters.
  * Completion now applies spacing and separator behavior correctly across these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->