### PR TITLE
fix: prevent first-line scroll on non-xenl terminals (fixes #2206)

### DIFF
--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -463,6 +463,19 @@ public class Display implements Sized {
                 puts(Capability.clear_screen);
                 puts(Capability.cursor_address, 0, 0);
                 oldLines.clear();
+                // After clear_screen the terminal shows blank spaces at every position.
+                // Seed oldLines with rows of spaces so the diff engine knows these
+                // positions are already blank.  Without this, every blank row looks
+                // "new" and gets rewritten — including the last row.  On terminals
+                // without eat_newline_glitch (e.g. windows-vtp) writing the last
+                // character of the last row triggers an immediate scroll that pushes
+                // the first line off-screen (see #2206).
+                if (fullScreen && columns > 0 && rows > 0) {
+                    AttributedString blankRow = blankRow(columns);
+                    for (int i = 0; i < rows; i++) {
+                        oldLines.add(blankRow);
+                    }
+                }
                 cursorPos = 0;
                 reset = false;
             }
@@ -556,6 +569,18 @@ public class Display implements Sized {
                 }
                 if (newNL) {
                     nEnd--;
+                }
+                // Prevent bottom-right-corner scroll on non-xenl terminals (#2206).
+                // On terminals with auto_right_margin but without eat_newline_glitch,
+                // writing the last column of the last row triggers an immediate
+                // wrap + scroll that pushes the first line off-screen.  Truncate
+                // the effective line length by one column for both old and new lines
+                // so the diff never emits output past column (columns - 2).
+                if (fullScreen && wrapAtEol && !delayedWrapAtEol && lineIndex == rows - 1) {
+                    int maxN = nStart + columns - 1;
+                    if (nEnd > maxN) nEnd = maxN;
+                    int maxO = oStart + columns - 1;
+                    if (oEnd > maxO) oEnd = maxO;
                 }
                 if (wrapNeeded && lineIndex == (cursorPos + 1) / columns1 && lineIndex < newLines.size()) {
                     // move from right margin to next line's left margin
@@ -1140,6 +1165,17 @@ public class Display implements Sized {
             byteBuilder.csi().appendAscii("0m");
             ansiColorState[0] = 0;
         }
+    }
+
+    /**
+     * Build an {@link AttributedString} of {@code width} plain space characters.
+     * Used to seed {@code oldLines} after a {@code clear_screen} so the diff
+     * engine knows blank rows are already rendered.
+     */
+    private static AttributedString blankRow(int width) {
+        char[] buf = new char[width];
+        java.util.Arrays.fill(buf, ' ');
+        return new AttributedString(new String(buf));
     }
 
     private static final Object[] EMPTY_PARAMS = new Object[0];

--- a/terminal/src/main/java/org/jline/utils/Display.java
+++ b/terminal/src/main/java/org/jline/utils/Display.java
@@ -573,13 +573,17 @@ public class Display implements Sized {
                 // Prevent bottom-right-corner scroll on non-xenl terminals (#2206).
                 // On terminals with auto_right_margin but without eat_newline_glitch,
                 // writing the last column of the last row triggers an immediate
-                // wrap + scroll that pushes the first line off-screen.  Truncate
-                // the effective line length by one column for both old and new lines
-                // so the diff never emits output past column (columns - 2).
+                // wrap + scroll that pushes the first line off-screen.  Cap both
+                // old and new line bounds to the character length that fits within
+                // (columns - 1) display columns so the diff never writes into the
+                // bottom-right cell.  columnSubSequence is used instead of raw char
+                // offsets to handle double-width (CJK) characters correctly.
                 if (fullScreen && wrapAtEol && !delayedWrapAtEol && lineIndex == rows - 1) {
-                    int maxN = nStart + columns - 1;
+                    int maxN =
+                            newLine.columnSubSequence(terminal, 0, columns - 1).length();
                     if (nEnd > maxN) nEnd = maxN;
-                    int maxO = oStart + columns - 1;
+                    int maxO =
+                            oldLine.columnSubSequence(terminal, 0, columns - 1).length();
                     if (oEnd > maxO) oEnd = maxO;
                 }
                 if (wrapNeeded && lineIndex == (cursorPos + 1) / columns1 && lineIndex < newLines.size()) {
@@ -1174,7 +1178,7 @@ public class Display implements Sized {
      */
     private static AttributedString blankRow(int width) {
         char[] buf = new char[width];
-        java.util.Arrays.fill(buf, ' ');
+        Arrays.fill(buf, ' ');
         return new AttributedString(new String(buf));
     }
 

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -1083,7 +1083,7 @@ class DisplayTest {
             terminal.puts(enter_ca_mode);
 
             Display display = new Display(terminal, true);
-            display.reset();
+            display.clear();
             display.resize(Size.of(cols, rows));
 
             // Every line is exactly cols characters wide, no trailing newline.
@@ -1126,7 +1126,7 @@ class DisplayTest {
             terminal.puts(enter_ca_mode);
 
             Display display = new Display(terminal, true);
-            display.reset();
+            display.clear();
             display.resize(Size.of(cols, rows));
 
             // Build lines the same way the reproducer does: first 3 rows have
@@ -1181,7 +1181,7 @@ class DisplayTest {
             terminal.puts(enter_ca_mode);
 
             Display display = new Display(terminal, true);
-            display.reset();
+            display.clear();
             display.resize(Size.of(cols, rows));
 
             List<AttributedString> newLines = new ArrayList<>();
@@ -1206,6 +1206,50 @@ class DisplayTest {
                             expected, (char) screen[r * cols + c], "Row " + r + " col " + c + " wrong.\n" + screenStr);
                 }
             }
+        }
+    }
+
+    /**
+     * Double-width (CJK) characters on the last row of a non-xenl terminal.
+     * Without column-aware truncation, the five double-width chars would
+     * occupy all 10 columns and trigger a bottom-right corner scroll.
+     */
+    @Test
+    void fullScreenDoubleWidthLastRowOnWindowsVtp() throws IOException {
+        int cols = 10;
+        int rows = 3;
+        try (VirtualTerminal terminal =
+                new VirtualTerminal("test", "windows-vtp", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.clear();
+            display.resize(Size.of(cols, rows));
+
+            List<AttributedString> newLines = new ArrayList<>();
+            newLines.add(new AttributedString("AAAAAAAAAA")); // 10 chars, 10 cols
+            newLines.add(new AttributedString("BBBBBBBBBB")); // 10 chars, 10 cols
+            // 5 double-width chars = 10 columns, but must be truncated to 9 cols
+            newLines.add(new AttributedString("世世世世世"));
+
+            display.update(newLines, 0);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            String screenStr = dumpScreen(screen, cols, rows);
+
+            // Row 0 must survive — no scroll
+            assertEquals('A', (char) screen[0], "Row 0 scrolled away.\n" + screenStr);
+            assertEquals('B', (char) screen[cols], "Row 1 missing.\n" + screenStr);
+            // Last row: first CJK char must be present
+            assertEquals('世', (char) screen[2 * cols], "Row 2 should have CJK content.\n" + screenStr);
+            // The 5th double-width char must NOT be written (would cause scroll)
+            // so columns 8-9 must be blank (space or continuation)
+            char lastCol = (char) screen[2 * cols + cols - 1];
+            assertTrue(
+                    lastCol == ' ' || lastCol == 0,
+                    "Last column should be blank to prevent scroll, was: '" + lastCol + "'\n" + screenStr);
         }
     }
 

--- a/terminal/src/test/java/org/jline/utils/DisplayTest.java
+++ b/terminal/src/test/java/org/jline/utils/DisplayTest.java
@@ -1064,6 +1064,163 @@ class DisplayTest {
         }
     }
 
+    /**
+     * Issue #2206: On windows-vtp (no eat_newline_glitch), writing the last column
+     * of the last row causes an immediate wrap + scroll, pushing the first line
+     * off-screen.
+     *
+     * <p>This test fills ALL rows with exactly cols-wide content (no trailing
+     * newline). With the fix, the last row is truncated by one column to avoid
+     * the scroll, and every other row is rendered intact.
+     */
+    @Test
+    void fullScreenFirstRowMissingOnWindowsVtp() throws IOException {
+        int cols = 10;
+        int rows = 5;
+        try (VirtualTerminal terminal =
+                new VirtualTerminal("test", "windows-vtp", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.reset();
+            display.resize(Size.of(cols, rows));
+
+            // Every line is exactly cols characters wide, no trailing newline.
+            List<AttributedString> newLines = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                StringBuilder sb = new StringBuilder();
+                char ch = (char) ('A' + r);
+                for (int c = 0; c < cols; c++) sb.append(ch);
+                newLines.add(new AttributedString(sb.toString()));
+            }
+
+            display.update(newLines, 0);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            String screenStr = dumpScreen(screen, cols, rows);
+
+            // Row 0 must survive — the scroll must not happen
+            assertEquals('A', (char) screen[0], "First row scrolled away.\n" + screenStr);
+            // Rows 1 .. rows-2 must be intact
+            for (int r = 1; r < rows - 1; r++) {
+                char expected = (char) ('A' + r);
+                assertEquals(expected, (char) screen[r * cols], "Row " + r + " wrong.\n" + screenStr);
+            }
+        }
+    }
+
+    /**
+     * Issue #2206 reproduction scenario: 3 content rows + blank padding rows.
+     * After clear_screen, blank rows must not be rewritten because they already
+     * match the cleared screen state.
+     */
+    @Test
+    void fullScreenFirstRowWithBlankPaddingOnWindowsVtp() throws IOException {
+        int cols = 20;
+        int rows = 10;
+        try (VirtualTerminal terminal =
+                new VirtualTerminal("test", "windows-vtp", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.reset();
+            display.resize(Size.of(cols, rows));
+
+            // Build lines the same way the reproducer does: first 3 rows have
+            // content, remaining rows are full-width spaces.
+            List<AttributedString> newLines = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                AttributedStringBuilder sb = new AttributedStringBuilder(cols);
+                for (int c = 0; c < cols; c++) {
+                    if (r < 3) {
+                        sb.append((char) ('0' + (c % 10)));
+                    } else {
+                        sb.append(' ');
+                    }
+                }
+                newLines.add(sb.toAttributedString());
+            }
+
+            display.update(newLines, 0);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            String screenStr = dumpScreen(screen, cols, rows);
+
+            // All 3 content rows must be visible
+            assertEquals('0', (char) screen[0], "Row 0 missing.\n" + screenStr);
+            assertEquals('0', (char) screen[cols], "Row 1 missing.\n" + screenStr);
+            assertEquals('0', (char) screen[2 * cols], "Row 2 missing.\n" + screenStr);
+            // Row 3 must be blank
+            assertEquals(' ', (char) screen[3 * cols], "Row 3 should be blank.\n" + screenStr);
+
+            // Second update with the same content must not corrupt the screen
+            display.update(newLines, 0);
+            terminal.flush();
+
+            screen = terminal.dump();
+            screenStr = dumpScreen(screen, cols, rows);
+            assertEquals('0', (char) screen[0], "Row 0 missing after second update.\n" + screenStr);
+        }
+    }
+
+    /**
+     * On xterm (am + xenl), the bottom-right corner can be written safely
+     * because the cursor enters delayed-wrap state instead of scrolling.
+     * Verify the last character of the last row is NOT truncated.
+     */
+    @Test
+    void fullScreenLastRowNotTruncatedOnXterm() throws IOException {
+        int cols = 10;
+        int rows = 5;
+        try (VirtualTerminal terminal = new VirtualTerminal("test", "xterm", StandardCharsets.UTF_8, cols, rows)) {
+            terminal.enterRawMode();
+            terminal.puts(enter_ca_mode);
+
+            Display display = new Display(terminal, true);
+            display.reset();
+            display.resize(Size.of(cols, rows));
+
+            List<AttributedString> newLines = new ArrayList<>();
+            for (int r = 0; r < rows; r++) {
+                StringBuilder sb = new StringBuilder();
+                char ch = (char) ('A' + r);
+                for (int c = 0; c < cols; c++) sb.append(ch);
+                newLines.add(new AttributedString(sb.toString()));
+            }
+
+            display.update(newLines, 0);
+            terminal.flush();
+
+            long[] screen = terminal.dump();
+            String screenStr = dumpScreen(screen, cols, rows);
+
+            // Every row must be fully rendered, including the last column
+            for (int r = 0; r < rows; r++) {
+                char expected = (char) ('A' + r);
+                for (int c = 0; c < cols; c++) {
+                    assertEquals(
+                            expected, (char) screen[r * cols + c], "Row " + r + " col " + c + " wrong.\n" + screenStr);
+                }
+            }
+        }
+    }
+
+    private static String dumpScreen(long[] screen, int cols, int rows) {
+        StringBuilder sb = new StringBuilder("Screen dump:\n");
+        for (int r = 0; r < rows; r++) {
+            sb.append("Row ").append(r).append(": ");
+            for (int c = 0; c < cols; c++) {
+                sb.append((char) screen[r * cols + c]);
+            }
+            sb.append("|\n");
+        }
+        return sb.toString();
+    }
+
     public static void main(String[] args) throws InterruptedException, IOException {
 
         try (Terminal terminal = TerminalBuilder.builder().build()) {


### PR DESCRIPTION
## Summary

Fixes the regression reported in #2206 where the first line of a `List<AttributedString>` is not rendered on Windows 11 (JLine 4.3.0+).

**Root cause:** On terminals with `auto_right_margin` but without `eat_newline_glitch` (e.g. `windows-vtp`), writing the last character of the last row triggers an immediate wrap + scroll that pushes the first line off-screen. This existed before 4.3.0 but became visible after synchronized output (mode 2026) was added — the terminal now renders everything atomically, so the user never sees the first line before the scroll erases it.

**Fix (two parts):**

1. **Seed `oldLines` after `clear_screen`** — populate with blank rows matching terminal dimensions so the diff engine knows blank positions are already rendered. Without this, every blank row looks "new" and gets rewritten — including the last row, which triggers the scroll.

2. **Truncate last row on non-xenl terminals** — on the last row, limit the effective line length to `columns - 1` so the diff engine never writes past the second-to-last column. This prevents the bottom-right corner scroll for all content (not just blank padding).

## Test plan

- [x] `fullScreenFirstRowMissingOnWindowsVtp` — all rows filled with content on `windows-vtp`; verifies first row survives
- [x] `fullScreenFirstRowWithBlankPaddingOnWindowsVtp` — exact reproduction scenario (3 content rows + blank padding); also verifies idempotent re-render
- [x] `fullScreenLastRowNotTruncatedOnXterm` — `xterm` (with xenl) gets full last-row content with no truncation; confirms the fix doesn't affect xenl terminals
- [x] All 32 DisplayTest tests pass
- [x] Full project build succeeds (`./mvx mvn install -DskipTests`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-screen rendering to prevent the first row from disappearing or the screen from scrolling unexpectedly.
  * Preserved the last column of the final row during terminal rendering, including with double-width characters.
  * Ensured blank padding rows remain correctly displayed across repeated updates.
  * Improved compatibility across Windows VTP and xterm terminals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->