### PR TITLE
fix: use SGR mouse encoding on Windows to avoid corruption at column >= 96

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
@@ -314,8 +314,6 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
         }
     }
 
-    private int lastButtonState;
-
     private void processMouseEvent(MOUSE_EVENT_RECORD mouseEvent) throws IOException {
         int dwEventFlags = mouseEvent.eventFlags();
         int dwButtonState = mouseEvent.buttonState();
@@ -353,22 +351,8 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
             }
         }
         lastButtonState = dwButtonState;
-        int cx = mouseEvent.mousePosition().x();
-        int cy = mouseEvent.mousePosition().y();
-        // Use SGR format: ESC [ < cb ; cx ; cy M/m
-        // SGR uses decimal coordinates (1-based) separated by semicolons,
-        // avoiding the X10 format's single-char encoding that breaks at column >= 96
-        // when readMouse() misinterprets high char values as UTF-8 lead bytes.
-        // 'M' = press, 'm' = release (SGR explicit release).
-        StringBuilder sb = new StringBuilder(16);
-        sb.append("\033[<");
-        sb.append(cb);
-        sb.append(';');
-        sb.append(cx + 1);
-        sb.append(';');
-        sb.append(cy + 1);
-        sb.append(isRelease ? 'm' : 'M');
-        slaveInputPipe.write(sb.toString());
+        writeMouseEvent(
+                cb, mouseEvent.mousePosition().x(), mouseEvent.mousePosition().y(), isRelease);
     }
 
     @Override

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
@@ -314,8 +314,6 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
         }
     }
 
-    private final char[] mouse = new char[] {'\033', '[', 'M', ' ', ' ', ' '};
-
     private void processMouseEvent(MOUSE_EVENT_RECORD mouseEvent) throws IOException {
         int dwEventFlags = mouseEvent.eventFlags();
         int dwButtonState = mouseEvent.buttonState();
@@ -344,10 +342,19 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
         }
         int cx = mouseEvent.mousePosition().x();
         int cy = mouseEvent.mousePosition().y();
-        mouse[3] = (char) (' ' + cb);
-        mouse[4] = (char) (' ' + cx + 1);
-        mouse[5] = (char) (' ' + cy + 1);
-        slaveInputPipe.write(mouse);
+        // Use SGR format: ESC [ < cb ; cx ; cy M
+        // SGR uses decimal coordinates (1-based) separated by semicolons,
+        // avoiding the X10 format's single-char encoding that breaks at column >= 96
+        // when readMouse() misinterprets high char values as UTF-8 lead bytes.
+        StringBuilder sb = new StringBuilder(16);
+        sb.append("\033[<");
+        sb.append(cb);
+        sb.append(';');
+        sb.append(cx + 1);
+        sb.append(';');
+        sb.append(cy + 1);
+        sb.append('M');
+        slaveInputPipe.write(sb.toString());
     }
 
     @Override

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
@@ -314,6 +314,8 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
         }
     }
 
+    private int lastButtonState;
+
     private void processMouseEvent(MOUSE_EVENT_RECORD mouseEvent) throws IOException {
         int dwEventFlags = mouseEvent.eventFlags();
         int dwButtonState = mouseEvent.buttonState();
@@ -323,6 +325,7 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
             return;
         }
         int cb = 0;
+        boolean isRelease = false;
         dwEventFlags &= ~DOUBLE_CLICK; // Treat double-clicks as normal
         if (dwEventFlags == MOUSE_WHEELED) {
             cb |= 64;
@@ -338,14 +341,25 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
         } else if ((dwButtonState & FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
             cb |= 0x02;
         } else {
-            cb |= 0x03;
+            // No button is currently pressed — this is a release event.
+            // Determine which button was released from lastButtonState.
+            isRelease = true;
+            if ((lastButtonState & FROM_LEFT_1ST_BUTTON_PRESSED) != 0) {
+                cb = 0;
+            } else if ((lastButtonState & RIGHTMOST_BUTTON_PRESSED) != 0) {
+                cb = 1;
+            } else if ((lastButtonState & FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
+                cb = 2;
+            }
         }
+        lastButtonState = dwButtonState;
         int cx = mouseEvent.mousePosition().x();
         int cy = mouseEvent.mousePosition().y();
-        // Use SGR format: ESC [ < cb ; cx ; cy M
+        // Use SGR format: ESC [ < cb ; cx ; cy M/m
         // SGR uses decimal coordinates (1-based) separated by semicolons,
         // avoiding the X10 format's single-char encoding that breaks at column >= 96
         // when readMouse() misinterprets high char values as UTF-8 lead bytes.
+        // 'M' = press, 'm' = release (SGR explicit release).
         StringBuilder sb = new StringBuilder(16);
         sb.append("\033[<");
         sb.append(cb);
@@ -353,7 +367,7 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
         sb.append(cx + 1);
         sb.append(';');
         sb.append(cy + 1);
-        sb.append('M');
+        sb.append(isRelease ? 'm' : 'M');
         slaveInputPipe.write(sb.toString());
     }
 

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
@@ -315,44 +315,11 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<MemorySegment>
     }
 
     private void processMouseEvent(MOUSE_EVENT_RECORD mouseEvent) throws IOException {
-        int dwEventFlags = mouseEvent.eventFlags();
-        int dwButtonState = mouseEvent.buttonState();
-        if (tracking == MouseTracking.Off
-                || tracking == MouseTracking.Normal && dwEventFlags == MOUSE_MOVED
-                || tracking == MouseTracking.Button && dwEventFlags == MOUSE_MOVED && dwButtonState == 0) {
-            return;
-        }
-        int cb = 0;
-        boolean isRelease = false;
-        dwEventFlags &= ~DOUBLE_CLICK; // Treat double-clicks as normal
-        if (dwEventFlags == MOUSE_WHEELED) {
-            cb |= 64;
-            if ((dwButtonState >> 16) < 0) {
-                cb |= 1;
-            }
-        } else if (dwEventFlags == MOUSE_HWHEELED) {
-            return;
-        } else if ((dwButtonState & FROM_LEFT_1ST_BUTTON_PRESSED) != 0) {
-            // cb is already 0 for left button
-        } else if ((dwButtonState & RIGHTMOST_BUTTON_PRESSED) != 0) {
-            cb |= 0x01;
-        } else if ((dwButtonState & FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
-            cb |= 0x02;
-        } else {
-            // No button is currently pressed — this is a release event.
-            // Determine which button was released from lastButtonState.
-            isRelease = true;
-            if ((lastButtonState & FROM_LEFT_1ST_BUTTON_PRESSED) != 0) {
-                cb = 0;
-            } else if ((lastButtonState & RIGHTMOST_BUTTON_PRESSED) != 0) {
-                cb = 1;
-            } else if ((lastButtonState & FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
-                cb = 2;
-            }
-        }
-        lastButtonState = dwButtonState;
-        writeMouseEvent(
-                cb, mouseEvent.mousePosition().x(), mouseEvent.mousePosition().y(), isRelease);
+        processMouseEvent(
+                mouseEvent.eventFlags(),
+                mouseEvent.buttonState(),
+                mouseEvent.mousePosition().x(),
+                mouseEvent.mousePosition().y());
     }
 
     @Override

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
@@ -309,8 +309,6 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
         }
     }
 
-    private char[] mouse = new char[] {'\033', '[', 'M', ' ', ' ', ' '};
-
     private void processMouseEvent(Kernel32.MOUSE_EVENT_RECORD mouseEvent) throws IOException {
         int dwEventFlags = mouseEvent.eventFlags;
         int dwButtonState = mouseEvent.buttonState;
@@ -341,10 +339,19 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
         }
         int cx = mouseEvent.mousePosition.x;
         int cy = mouseEvent.mousePosition.y;
-        mouse[3] = (char) (' ' + cb);
-        mouse[4] = (char) (' ' + cx + 1);
-        mouse[5] = (char) (' ' + cy + 1);
-        slaveInputPipe.write(mouse);
+        // Use SGR format: ESC [ < cb ; cx ; cy M
+        // SGR uses decimal coordinates (1-based) separated by semicolons,
+        // avoiding the X10 format's single-char encoding that breaks at column >= 96
+        // when readMouse() misinterprets high char values as UTF-8 lead bytes.
+        StringBuilder sb = new StringBuilder(16);
+        sb.append("\033[<");
+        sb.append(cb);
+        sb.append(';');
+        sb.append(cx + 1);
+        sb.append(';');
+        sb.append(cy + 1);
+        sb.append('M');
+        slaveInputPipe.write(sb.toString());
     }
 
     @Override

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
@@ -309,6 +309,8 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
         }
     }
 
+    private int lastButtonState;
+
     private void processMouseEvent(Kernel32.MOUSE_EVENT_RECORD mouseEvent) throws IOException {
         int dwEventFlags = mouseEvent.eventFlags;
         int dwButtonState = mouseEvent.buttonState;
@@ -320,6 +322,7 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
             return;
         }
         int cb = 0;
+        boolean isRelease = false;
         dwEventFlags &= ~Kernel32.MOUSE_EVENT_RECORD.DOUBLE_CLICK; // Treat double-clicks as normal
         if (dwEventFlags == Kernel32.MOUSE_EVENT_RECORD.MOUSE_WHEELED) {
             cb |= 64;
@@ -335,14 +338,25 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
         } else if ((dwButtonState & Kernel32.MOUSE_EVENT_RECORD.FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
             cb |= 0x02;
         } else {
-            cb |= 0x03;
+            // No button is currently pressed — this is a release event.
+            // Determine which button was released from lastButtonState.
+            isRelease = true;
+            if ((lastButtonState & Kernel32.MOUSE_EVENT_RECORD.FROM_LEFT_1ST_BUTTON_PRESSED) != 0) {
+                cb = 0;
+            } else if ((lastButtonState & Kernel32.MOUSE_EVENT_RECORD.RIGHTMOST_BUTTON_PRESSED) != 0) {
+                cb = 1;
+            } else if ((lastButtonState & Kernel32.MOUSE_EVENT_RECORD.FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
+                cb = 2;
+            }
         }
+        lastButtonState = dwButtonState;
         int cx = mouseEvent.mousePosition.x;
         int cy = mouseEvent.mousePosition.y;
-        // Use SGR format: ESC [ < cb ; cx ; cy M
+        // Use SGR format: ESC [ < cb ; cx ; cy M/m
         // SGR uses decimal coordinates (1-based) separated by semicolons,
         // avoiding the X10 format's single-char encoding that breaks at column >= 96
         // when readMouse() misinterprets high char values as UTF-8 lead bytes.
+        // 'M' = press, 'm' = release (SGR explicit release).
         StringBuilder sb = new StringBuilder(16);
         sb.append("\033[<");
         sb.append(cb);
@@ -350,7 +364,7 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
         sb.append(cx + 1);
         sb.append(';');
         sb.append(cy + 1);
-        sb.append('M');
+        sb.append(isRelease ? 'm' : 'M');
         slaveInputPipe.write(sb.toString());
     }
 

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
@@ -310,45 +310,8 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
     }
 
     private void processMouseEvent(Kernel32.MOUSE_EVENT_RECORD mouseEvent) throws IOException {
-        int dwEventFlags = mouseEvent.eventFlags;
-        int dwButtonState = mouseEvent.buttonState;
-        if (tracking == MouseTracking.Off
-                || tracking == MouseTracking.Normal && dwEventFlags == Kernel32.MOUSE_EVENT_RECORD.MOUSE_MOVED
-                || tracking == MouseTracking.Button
-                        && dwEventFlags == Kernel32.MOUSE_EVENT_RECORD.MOUSE_MOVED
-                        && dwButtonState == 0) {
-            return;
-        }
-        int cb = 0;
-        boolean isRelease = false;
-        dwEventFlags &= ~Kernel32.MOUSE_EVENT_RECORD.DOUBLE_CLICK; // Treat double-clicks as normal
-        if (dwEventFlags == Kernel32.MOUSE_EVENT_RECORD.MOUSE_WHEELED) {
-            cb |= 64;
-            if ((dwButtonState >> 16) < 0) {
-                cb |= 1;
-            }
-        } else if (dwEventFlags == Kernel32.MOUSE_EVENT_RECORD.MOUSE_HWHEELED) {
-            return;
-        } else if ((dwButtonState & Kernel32.MOUSE_EVENT_RECORD.FROM_LEFT_1ST_BUTTON_PRESSED) != 0) {
-            // cb is already 0 for left button
-        } else if ((dwButtonState & Kernel32.MOUSE_EVENT_RECORD.RIGHTMOST_BUTTON_PRESSED) != 0) {
-            cb |= 0x01;
-        } else if ((dwButtonState & Kernel32.MOUSE_EVENT_RECORD.FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
-            cb |= 0x02;
-        } else {
-            // No button is currently pressed — this is a release event.
-            // Determine which button was released from lastButtonState.
-            isRelease = true;
-            if ((lastButtonState & Kernel32.MOUSE_EVENT_RECORD.FROM_LEFT_1ST_BUTTON_PRESSED) != 0) {
-                cb = 0;
-            } else if ((lastButtonState & Kernel32.MOUSE_EVENT_RECORD.RIGHTMOST_BUTTON_PRESSED) != 0) {
-                cb = 1;
-            } else if ((lastButtonState & Kernel32.MOUSE_EVENT_RECORD.FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
-                cb = 2;
-            }
-        }
-        lastButtonState = dwButtonState;
-        writeMouseEvent(cb, mouseEvent.mousePosition.x, mouseEvent.mousePosition.y, isRelease);
+        processMouseEvent(
+                mouseEvent.eventFlags, mouseEvent.buttonState, mouseEvent.mousePosition.x, mouseEvent.mousePosition.y);
     }
 
     @Override

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/win/NativeWinSysTerminal.java
@@ -309,8 +309,6 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
         }
     }
 
-    private int lastButtonState;
-
     private void processMouseEvent(Kernel32.MOUSE_EVENT_RECORD mouseEvent) throws IOException {
         int dwEventFlags = mouseEvent.eventFlags;
         int dwButtonState = mouseEvent.buttonState;
@@ -350,22 +348,7 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<Long> {
             }
         }
         lastButtonState = dwButtonState;
-        int cx = mouseEvent.mousePosition.x;
-        int cy = mouseEvent.mousePosition.y;
-        // Use SGR format: ESC [ < cb ; cx ; cy M/m
-        // SGR uses decimal coordinates (1-based) separated by semicolons,
-        // avoiding the X10 format's single-char encoding that breaks at column >= 96
-        // when readMouse() misinterprets high char values as UTF-8 lead bytes.
-        // 'M' = press, 'm' = release (SGR explicit release).
-        StringBuilder sb = new StringBuilder(16);
-        sb.append("\033[<");
-        sb.append(cb);
-        sb.append(';');
-        sb.append(cx + 1);
-        sb.append(';');
-        sb.append(cy + 1);
-        sb.append(isRelease ? 'm' : 'M');
-        slaveInputPipe.write(sb.toString());
+        writeMouseEvent(cb, mouseEvent.mousePosition.x, mouseEvent.mousePosition.y, isRelease);
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -720,18 +720,69 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
         return true;
     }
 
+    // Windows mouse event flag constants (dwEventFlags)
+    private static final int MOUSE_FLAG_MOVED = 0x0001;
+    private static final int MOUSE_FLAG_DOUBLE_CLICK = 0x0002;
+    private static final int MOUSE_FLAG_WHEELED = 0x0004;
+    private static final int MOUSE_FLAG_HWHEELED = 0x0008;
+
+    // Windows mouse button state constants (dwButtonState)
+    private static final int BUTTON_LEFT = 0x0001; // FROM_LEFT_1ST_BUTTON_PRESSED
+    private static final int BUTTON_RIGHT = 0x0002; // RIGHTMOST_BUTTON_PRESSED
+    private static final int BUTTON_MIDDLE = 0x0004; // FROM_LEFT_2ND_BUTTON_PRESSED
+    private static final int BUTTON_MASK = BUTTON_LEFT | BUTTON_RIGHT | BUTTON_MIDDLE;
+
     /**
-     * Writes a mouse event in SGR format to the slave input pipe.
-     * SGR format uses decimal coordinates separated by semicolons, avoiding the X10 format's
-     * single-char encoding that corrupts events at column &gt;= 96.
+     * Processes a Windows mouse event and writes the corresponding SGR escape sequence.
+     * SGR format ({@code ESC [ < cb ; cx ; cy M/m}) uses decimal coordinates, avoiding the
+     * X10 format's single-char encoding that corrupts events at column &ge; 96.
      *
-     * @param cb the button code
+     * <p>Button transitions are detected by comparing the current button state with
+     * {@link #lastButtonState}, so overlapping button presses and releases (e.g. left
+     * released while right is still held) are reported correctly.</p>
+     *
+     * @param dwEventFlags the Windows mouse event flags
+     * @param dwButtonState the Windows mouse button state
      * @param cx the 0-based column coordinate
      * @param cy the 0-based row coordinate
-     * @param isRelease true to emit 'm' (release), false to emit 'M' (press)
      * @throws IOException if the write fails
      */
-    protected void writeMouseEvent(int cb, int cx, int cy, boolean isRelease) throws IOException {
+    protected void processMouseEvent(int dwEventFlags, int dwButtonState, int cx, int cy) throws IOException {
+        if (tracking == MouseTracking.Off
+                || tracking == MouseTracking.Normal && dwEventFlags == MOUSE_FLAG_MOVED
+                || tracking == MouseTracking.Button && dwEventFlags == MOUSE_FLAG_MOVED && dwButtonState == 0) {
+            return;
+        }
+        int cb = 0;
+        boolean isRelease = false;
+        dwEventFlags &= ~MOUSE_FLAG_DOUBLE_CLICK; // Treat double-clicks as normal
+        if (dwEventFlags == MOUSE_FLAG_WHEELED) {
+            cb |= 64;
+            if ((dwButtonState >> 16) < 0) {
+                cb |= 1;
+            }
+        } else if (dwEventFlags == MOUSE_FLAG_HWHEELED) {
+            return;
+        } else if (dwEventFlags == 0) {
+            // Button state change — detect which button transitioned
+            int released = (lastButtonState & ~dwButtonState) & BUTTON_MASK;
+            int pressed = (dwButtonState & ~lastButtonState) & BUTTON_MASK;
+            if (released != 0) {
+                isRelease = true;
+                cb = buttonBitToCode(released);
+            } else if (pressed != 0) {
+                cb = buttonBitToCode(pressed);
+            } else {
+                // No transition detected; report current state
+                cb = buttonBitToCode(dwButtonState & BUTTON_MASK);
+            }
+        } else {
+            // Motion — report currently held button
+            int buttons = dwButtonState & BUTTON_MASK;
+            cb = buttons != 0 ? buttonBitToCode(buttons) : 3;
+        }
+        lastButtonState = dwButtonState;
+        // Write SGR format: ESC [ < cb ; cx ; cy M/m
         StringBuilder sb = new StringBuilder(16);
         sb.append("\033[<");
         sb.append(cb);
@@ -741,6 +792,13 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
         sb.append(cy + 1);
         sb.append(isRelease ? 'm' : 'M');
         slaveInputPipe.write(sb.toString());
+    }
+
+    private static int buttonBitToCode(int buttonBit) {
+        if ((buttonBit & BUTTON_LEFT) != 0) return 0;
+        if ((buttonBit & BUTTON_RIGHT) != 0) return 1;
+        if ((buttonBit & BUTTON_MIDDLE) != 0) return 2;
+        return 0;
     }
 
     protected abstract int getConsoleMode(Console console);

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -716,6 +716,9 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
     @Override
     public boolean trackMouse(MouseTracking tracking) {
         this.tracking = tracking;
+        if (tracking == MouseTracking.Off) {
+            lastButtonState = 0;
+        }
         updateConsoleMode();
         return true;
     }
@@ -771,8 +774,9 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
             } else if (pressed != 0) {
                 cb = buttonBitToCode(pressed);
             } else {
-                // No transition detected; report current state
-                cb = buttonBitToCode(dwButtonState & BUTTON_MASK);
+                // No supported button transitioned (e.g. 4th/5th button); update state and skip
+                lastButtonState = dwButtonState;
+                return;
             }
         } else {
             // Motion — report currently held button

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -131,6 +131,7 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
 
     protected MouseTracking tracking = MouseTracking.Off;
     protected boolean focusTracking = false;
+    protected int lastButtonState;
     private final boolean softwareSignals;
     private volatile boolean closing;
     protected boolean skipNextLf;
@@ -717,6 +718,29 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
         this.tracking = tracking;
         updateConsoleMode();
         return true;
+    }
+
+    /**
+     * Writes a mouse event in SGR format to the slave input pipe.
+     * SGR format uses decimal coordinates separated by semicolons, avoiding the X10 format's
+     * single-char encoding that corrupts events at column &gt;= 96.
+     *
+     * @param cb the button code
+     * @param cx the 0-based column coordinate
+     * @param cy the 0-based row coordinate
+     * @param isRelease true to emit 'm' (release), false to emit 'M' (press)
+     * @throws IOException if the write fails
+     */
+    protected void writeMouseEvent(int cb, int cx, int cy, boolean isRelease) throws IOException {
+        StringBuilder sb = new StringBuilder(16);
+        sb.append("\033[<");
+        sb.append(cb);
+        sb.append(';');
+        sb.append(cx + 1);
+        sb.append(';');
+        sb.append(cy + 1);
+        sb.append(isRelease ? 'm' : 'M');
+        slaveInputPipe.write(sb.toString());
     }
 
     protected abstract int getConsoleMode(Console console);

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractWindowsTerminal.java
@@ -748,9 +748,7 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
      * @throws IOException if the write fails
      */
     protected void processMouseEvent(int dwEventFlags, int dwButtonState, int cx, int cy) throws IOException {
-        if (tracking == MouseTracking.Off
-                || tracking == MouseTracking.Normal && dwEventFlags == MOUSE_FLAG_MOVED
-                || tracking == MouseTracking.Button && dwEventFlags == MOUSE_FLAG_MOVED && dwButtonState == 0) {
+        if (shouldIgnoreMouseEvent(dwEventFlags, dwButtonState)) {
             return;
         }
         int cb = 0;
@@ -799,6 +797,12 @@ public abstract class AbstractWindowsTerminal<Console> extends AbstractTerminal 
         if ((buttonBit & BUTTON_RIGHT) != 0) return 1;
         if ((buttonBit & BUTTON_MIDDLE) != 0) return 2;
         return 0;
+    }
+
+    private boolean shouldIgnoreMouseEvent(int dwEventFlags, int dwButtonState) {
+        return tracking == MouseTracking.Off
+                || tracking == MouseTracking.Normal && dwEventFlags == MOUSE_FLAG_MOVED
+                || tracking == MouseTracking.Button && dwEventFlags == MOUSE_FLAG_MOVED && dwButtonState == 0;
     }
 
     protected abstract int getConsoleMode(Console console);

--- a/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
@@ -211,6 +211,35 @@ class MouseSupportTest {
         assertEquals(20, event.getY()); // 0-based, so 21-1
     }
 
+    @Test
+    void testReadMouseSGRHighColumnDoesNotCorrupt() {
+        // Regression test for #2220: X10 format corrupts events at column >= 96
+        // because (32 + 96 + 1) = 129 = 0x81 which readMouse() misinterprets as
+        // a UTF-8 lead byte. SGR format uses decimal coordinates and is immune.
+        // SGR format: ESC [ < 0;200;50 M  (left press at column 200, row 50)
+        int[] input = {'<', '0', ';', '2', '0', '0', ';', '5', '0', 'M'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Pressed, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+        assertEquals(199, event.getX()); // 0-based: 200 - 1
+        assertEquals(49, event.getY()); // 0-based: 50 - 1
+    }
+
+    @Test
+    void testReadMouseSGRColumnExactly96() {
+        // The exact boundary where X10 format breaks: column 96
+        // X10 would encode this as (32 + 96 + 1) = 129 = 0x81, a UTF-8 lead byte.
+        // SGR format: ESC [ < 0;97;1 M  (left press at column 96, row 0, both 1-based)
+        int[] input = {'<', '0', ';', '9', '7', ';', '1', 'M'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Pressed, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+        assertEquals(96, event.getX()); // 0-based: 97 - 1
+        assertEquals(0, event.getY()); // 0-based: 1 - 1
+    }
+
     private IntSupplier createReader(int[] input) {
         return new IntSupplier() {
             private int index = 0;

--- a/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
@@ -266,6 +266,36 @@ class MouseSupportTest {
         assertEquals(20, event.getY());
     }
 
+    @Test
+    void testReadMouseSGROverlappingButtonTransitions() {
+        // Regression test for overlapping button transitions:
+        // Left pressed, then right pressed while left held, then left released while right held.
+        // Each event is a separate SGR sequence as processMouseEvent would emit.
+
+        // 1. Left press at (10, 20): ESC [ < 0;11;21 M
+        int[] input1 = {'<', '0', ';', '1', '1', ';', '2', '1', 'M'};
+        MouseEvent last = createDummyEvent();
+        MouseEvent event = MouseSupport.readMouse(createReader(input1), last);
+        assertEquals(MouseEvent.Type.Pressed, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+
+        // 2. Right press while left held at (10, 20): ESC [ < 1;11;21 M
+        int[] input2 = {'<', '1', ';', '1', '1', ';', '2', '1', 'M'};
+        last = event;
+        event = MouseSupport.readMouse(createReader(input2), last);
+        assertEquals(MouseEvent.Type.Pressed, event.getType());
+        assertEquals(MouseEvent.Button.Button2, event.getButton());
+
+        // 3. Left released while right still held at (10, 20): ESC [ < 0;11;21 m
+        int[] input3 = {'<', '0', ';', '1', '1', ';', '2', '1', 'm'};
+        last = event;
+        event = MouseSupport.readMouse(createReader(input3), last);
+        assertEquals(MouseEvent.Type.Released, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+        assertEquals(10, event.getX());
+        assertEquals(20, event.getY());
+    }
+
     private IntSupplier createReader(int[] input) {
         return new IntSupplier() {
             private int index = 0;

--- a/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/MouseSupportTest.java
@@ -240,6 +240,32 @@ class MouseSupportTest {
         assertEquals(0, event.getY()); // 0-based: 1 - 1
     }
 
+    @Test
+    void testReadMouseSGRReleaseAtHighColumn() {
+        // SGR release at high column: ESC [ < 0;200;50 m
+        // Lowercase 'm' signals an explicit release event with the released button code.
+        int[] input = {'<', '0', ';', '2', '0', '0', ';', '5', '0', 'm'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Released, event.getType());
+        assertEquals(MouseEvent.Button.Button1, event.getButton());
+        assertEquals(199, event.getX()); // 0-based: 200 - 1
+        assertEquals(49, event.getY()); // 0-based: 50 - 1
+    }
+
+    @Test
+    void testReadMouseSGRRightButtonRelease() {
+        // SGR right button release: ESC [ < 2;11;21 m
+        // cb=2 maps to Button3 (right button in SGR encoding)
+        int[] input = {'<', '2', ';', '1', '1', ';', '2', '1', 'm'};
+        MouseEvent event = MouseSupport.readMouse(createReader(input), createDummyEvent());
+
+        assertEquals(MouseEvent.Type.Released, event.getType());
+        assertEquals(MouseEvent.Button.Button3, event.getButton());
+        assertEquals(10, event.getX());
+        assertEquals(20, event.getY());
+    }
+
     private IntSupplier createReader(int[] input) {
         return new IntSupplier() {
             private int index = 0;


### PR DESCRIPTION
## Summary

Fixes #2220.

The X10 mouse format encodes coordinates as single characters offset by 32 (space). At column ≥ 96, this produces char values ≥ 129 (0x81), which `MouseSupport.readMouse()` misinterprets as UTF-8 lead bytes, corrupting the mouse event and potentially consuming subsequent input bytes.

This PR switches both `NativeWinSysTerminal` implementations (JNI and FFM) from X10 format (`ESC [ M cb cx cy` with raw char values) to SGR format (`ESC [ < cb;cx;cy M` with semicolon-separated decimal coordinates). SGR uses explicit decimal numbers for all parameters and an `M`/`m` terminator for press/release, so coordinates of any magnitude are encoded correctly.

### Changes
- **terminal-jni**: `NativeWinSysTerminal.processMouseEvent()` — replaced X10 char-array encoding with SGR string builder
- **terminal-ffm**: `NativeWinSysTerminal.processMouseEvent()` — same change
- **terminal (tests)**: Added two regression tests to `MouseSupportTest` verifying SGR parsing at column 96 (the exact breakpoint) and column 200 (well beyond)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows terminal mouse-event reporting for larger screen coordinates.
  * Corrected mouse-release events, including overlapping left- and right-button interactions.
  * Improved handling of wheel and motion events, including unsupported horizontal scrolling.
  * Standardized SGR mouse-event sequences across supported Windows terminal implementations.

* **Tests**
  * Added coverage for high-column coordinates, boundary positions, release events, and overlapping-button scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->