### PR TITLE
fix: use poll(2) in pump thread to prevent tty keystroke theft (fixes #2219)

### DIFF
--- a/native/src/main/java/org/jline/nativ/CLibrary.java
+++ b/native/src/main/java/org/jline/nativ/CLibrary.java
@@ -57,6 +57,16 @@ public class CLibrary {
      */
     public static native int isatty(int fd);
 
+    /**
+     * Polls a single file descriptor for input readability using {@code poll(2)}.
+     * Retries automatically on {@code EINTR} (signal interruption).
+     *
+     * @param fd        file descriptor to poll (e.g. {@code 0} for stdin)
+     * @param timeoutMs timeout in milliseconds; 0 = immediate, −1 = infinite
+     * @return positive if data is ready, 0 on timeout, −1 on permanent error
+     */
+    public static native int pollIn(int fd, int timeoutMs);
+
     public static native String ttyname(int filedes);
 
     /**

--- a/native/src/main/java/org/jline/nativ/CLibrary.java
+++ b/native/src/main/java/org/jline/nativ/CLibrary.java
@@ -65,7 +65,7 @@ public class CLibrary {
      * @param timeoutMs timeout in milliseconds; 0 = immediate, −1 = infinite
      * @return positive if data is ready, 0 on timeout, −1 on permanent error
      */
-    public static native int pollIn(int fd, int timeoutMs);
+    public static native int pollForInput(int fd, int timeoutMs);
 
     public static native String ttyname(int filedes);
 

--- a/native/src/main/native/clibrary.c
+++ b/native/src/main/native/clibrary.c
@@ -256,11 +256,32 @@ JNIEXPORT jint JNICALL CLibrary_NATIVE(pollForInput)
 	pfd.events = POLLIN;
 	pfd.revents = 0;
 
-	do {
-		rc = (jint)poll(&pfd, 1, timeoutMs);
-	} while (rc < 0 && errno == EINTR);
+	if (timeoutMs <= 0) {
+		/* Immediate (0) or infinite (-1): no deadline to track */
+		do {
+			rc = (jint)poll(&pfd, 1, timeoutMs);
+		} while (rc < 0 && errno == EINTR);
+		return rc;
+	}
 
-	return rc;
+	/* Finite timeout: preserve deadline across EINTR retries */
+	struct timespec deadline, now;
+	clock_gettime(CLOCK_MONOTONIC, &deadline);
+	deadline.tv_nsec += (long)(timeoutMs % 1000) * 1000000L;
+	deadline.tv_sec  += timeoutMs / 1000 + deadline.tv_nsec / 1000000000L;
+	deadline.tv_nsec %= 1000000000L;
+
+	int remaining = timeoutMs;
+	do {
+		rc = (jint)poll(&pfd, 1, remaining);
+		if (rc >= 0 || errno != EINTR) {
+			return rc;
+		}
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		remaining = (int)((deadline.tv_sec - now.tv_sec) * 1000
+		               + (deadline.tv_nsec - now.tv_nsec) / 1000000);
+	} while (remaining > 0);
+	return 0; /* deadline expired → timeout */
 }
 
 #endif

--- a/native/src/main/native/clibrary.c
+++ b/native/src/main/native/clibrary.c
@@ -246,7 +246,7 @@ JNIEXPORT jstring JNICALL CLibrary_NATIVE(ttyname)
  * @param timeoutMs timeout in milliseconds; 0 = immediate, -1 = infinite
  * @return positive if data is ready, 0 on timeout, -1 on permanent error
  */
-JNIEXPORT jint JNICALL CLibrary_NATIVE(pollIn)
+JNIEXPORT jint JNICALL CLibrary_NATIVE(pollForInput)
 	(JNIEnv *env, jclass that, jint fd, jint timeoutMs)
 {
 	struct pollfd pfd;

--- a/native/src/main/native/clibrary.c
+++ b/native/src/main/native/clibrary.c
@@ -238,4 +238,29 @@ JNIEXPORT jstring JNICALL CLibrary_NATIVE(ttyname)
 	return rc;
 }
 
+/**
+ * Polls a single file descriptor for input readability using poll(2).
+ * Retries automatically on EINTR (signal interruption).
+ *
+ * @param fd        file descriptor to poll
+ * @param timeoutMs timeout in milliseconds; 0 = immediate, -1 = infinite
+ * @return positive if data is ready, 0 on timeout, -1 on permanent error
+ */
+JNIEXPORT jint JNICALL CLibrary_NATIVE(pollIn)
+	(JNIEnv *env, jclass that, jint fd, jint timeoutMs)
+{
+	struct pollfd pfd;
+	jint rc;
+
+	pfd.fd = fd;
+	pfd.events = POLLIN;
+	pfd.revents = 0;
+
+	do {
+		rc = (jint)poll(&pfd, 1, timeoutMs);
+	} while (rc < 0 && errno == EINTR);
+
+	return rc;
+}
+
 #endif

--- a/native/src/main/native/jlinenative.h
+++ b/native/src/main/native/jlinenative.h
@@ -16,6 +16,8 @@
     #include <pty.h>
     #include <unistd.h>
     #include <stdlib.h>
+    #include <poll.h>
+    #include <errno.h>
 
     #include "jni.h"
 #endif
@@ -30,6 +32,8 @@
     #include <libutil.h>
     #include <termios.h>
     #include <sys/ioctl.h>
+    #include <poll.h>
+    #include <errno.h>
 
     #include "jni.h"
 #endif
@@ -53,6 +57,8 @@
     #include <termios.h>
     #include <sys/ioctl.h>
     #include <unistd.h>
+    #include <poll.h>
+    #include <errno.h>
 
     #include "jni.h"
 #endif

--- a/native/src/main/native/jlinenative.h
+++ b/native/src/main/native/jlinenative.h
@@ -18,6 +18,7 @@
     #include <stdlib.h>
     #include <poll.h>
     #include <errno.h>
+    #include <time.h>
 
     #include "jni.h"
 #endif
@@ -34,6 +35,7 @@
     #include <sys/ioctl.h>
     #include <poll.h>
     #include <errno.h>
+    #include <time.h>
 
     #include "jni.h"
 #endif
@@ -59,6 +61,7 @@
     #include <unistd.h>
     #include <poll.h>
     #include <errno.h>
+    #include <time.h>
 
     #include "jni.h"
 #endif

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -302,6 +302,13 @@ class CLibrary {
     /** POSIX POLLIN constant (0x0001 on all supported platforms). */
     static final short POLLIN = 0x0001;
 
+    /** POSIX EINTR constant (4 on all supported UNIX platforms). */
+    private static final int EINTR = 4;
+
+    private static final StructLayout CAPTURED_STATE_LAYOUT = Linker.Option.captureStateLayout();
+    private static final VarHandle ERRNO_HANDLE =
+            CAPTURED_STATE_LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("errno"));
+
     static final MethodHandle pollHandle;
 
     static final MethodHandle ioctl;
@@ -321,7 +328,8 @@ class CLibrary {
         ValueLayout nfdsLayout = (OSUtils.IS_LINUX || OSUtils.IS_AIX) ? ValueLayout.JAVA_LONG : ValueLayout.JAVA_INT;
         pollHandle = linker.downcallHandle(
                 lookup.find("poll").get(),
-                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, nfdsLayout, ValueLayout.JAVA_INT));
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, nfdsLayout, ValueLayout.JAVA_INT),
+                Linker.Option.captureCallState("errno"));
         // https://man7.org/linux/man-pages/man2/ioctl.2.html
         ioctl = linker.downcallHandle(
                 lookup.find("ioctl").get(),
@@ -512,7 +520,8 @@ class CLibrary {
     /**
      * Polls a single file descriptor for input readability.
      *
-     * <p>Retries automatically on transient errors (EINTR) up to a fixed limit.</p>
+     * <p>Uses {@link Linker.Option#captureCallState(String...)} to read
+     * {@code errno} after each call, retrying only on {@code EINTR}.</p>
      *
      * @param fd        file descriptor to poll (e.g. {@code STDIN_FILENO})
      * @param timeoutMs timeout in milliseconds; 0 = immediate, −1 = infinite
@@ -524,49 +533,59 @@ class CLibrary {
             PollFd.FD.set(pfd, fd);
             PollFd.EVENTS.set(pfd, POLLIN);
 
+            MemorySegment capturedState = arena.allocate(CAPTURED_STATE_LAYOUT);
+
             if (timeoutMs <= 0) {
                 // Immediate (0) or infinite (-1): no deadline to track.
-                // Retry on error up to a limit (cannot check errno via FFM
-                // without captureCallState, so a bounded retry is the safest
-                // fallback for transient EINTR).
                 int rc;
-                int retries = 0;
                 do {
                     PollFd.REVENTS.set(pfd, (short) 0);
-                    rc = platformPoll(pfd, timeoutMs);
-                } while (rc < 0 && ++retries < 10);
+                    rc = platformPoll(capturedState, pfd, timeoutMs);
+                } while (rc < 0 && capturedErrno(capturedState) == EINTR);
                 return rc;
             }
 
             // Finite timeout: preserve deadline across EINTR retries.
-            // Without captureCallState("errno") we cannot distinguish EINTR
-            // from permanent errors, but permanent errors return instantly so
-            // the deadline expires quickly (≤ timeoutMs of wall time).
             long deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000L;
             int remaining = timeoutMs;
             int rc;
             do {
                 PollFd.REVENTS.set(pfd, (short) 0);
-                rc = platformPoll(pfd, remaining);
+                rc = platformPoll(capturedState, pfd, remaining);
                 if (rc >= 0) {
                     return rc;
                 }
+                if (capturedErrno(capturedState) != EINTR) {
+                    return rc; // permanent error
+                }
                 remaining = (int) ((deadlineNanos - System.nanoTime()) / 1_000_000L);
             } while (remaining > 0);
-            return rc; // last error, or 0 is never reached since remaining <= 0
+            return 0; // deadline expired → timeout
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call poll()", e);
         }
     }
 
     /**
-     * Invokes the platform-specific {@code poll()} downcall.
+     * Reads the captured {@code errno} value from the call-state segment.
      */
-    private static int platformPoll(MemorySegment pfd, int timeoutMs) throws Throwable {
+    private static int capturedErrno(MemorySegment capturedState) {
+        return (int) ERRNO_HANDLE.get(capturedState, 0L);
+    }
+
+    /**
+     * Invokes the platform-specific {@code poll()} downcall.
+     *
+     * <p>The leading {@code capturedState} segment is required by the
+     * {@link Linker.Option#captureCallState(String...)} option used when
+     * linking the handle — the JVM writes {@code errno} into it immediately
+     * after the native call returns.</p>
+     */
+    private static int platformPoll(MemorySegment capturedState, MemorySegment pfd, int timeoutMs) throws Throwable {
         if (OSUtils.IS_LINUX || OSUtils.IS_AIX) {
-            return (int) pollHandle.invoke(pfd, 1L, timeoutMs);
+            return (int) pollHandle.invoke(capturedState, pfd, 1L, timeoutMs);
         } else {
-            return (int) pollHandle.invoke(pfd, 1, timeoutMs);
+            return (int) pollHandle.invoke(capturedState, pfd, 1, timeoutMs);
         }
     }
 

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -524,19 +524,49 @@ class CLibrary {
             PollFd.FD.set(pfd, fd);
             PollFd.EVENTS.set(pfd, POLLIN);
 
+            if (timeoutMs <= 0) {
+                // Immediate (0) or infinite (-1): no deadline to track.
+                // Retry on error up to a limit (cannot check errno via FFM
+                // without captureCallState, so a bounded retry is the safest
+                // fallback for transient EINTR).
+                int rc;
+                int retries = 0;
+                do {
+                    PollFd.REVENTS.set(pfd, (short) 0);
+                    rc = platformPoll(pfd, timeoutMs);
+                } while (rc < 0 && ++retries < 10);
+                return rc;
+            }
+
+            // Finite timeout: preserve deadline across EINTR retries.
+            // Without captureCallState("errno") we cannot distinguish EINTR
+            // from permanent errors, but permanent errors return instantly so
+            // the deadline expires quickly (≤ timeoutMs of wall time).
+            long deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000L;
+            int remaining = timeoutMs;
             int rc;
-            int retries = 0;
             do {
                 PollFd.REVENTS.set(pfd, (short) 0);
-                if (OSUtils.IS_LINUX || OSUtils.IS_AIX) {
-                    rc = (int) pollHandle.invoke(pfd, 1L, timeoutMs);
-                } else {
-                    rc = (int) pollHandle.invoke(pfd, 1, timeoutMs);
+                rc = platformPoll(pfd, remaining);
+                if (rc >= 0) {
+                    return rc;
                 }
-            } while (rc < 0 && ++retries < 10);
-            return rc;
+                remaining = (int) ((deadlineNanos - System.nanoTime()) / 1_000_000L);
+            } while (remaining > 0);
+            return rc; // last error, or 0 is never reached since remaining <= 0
         } catch (Throwable e) {
             throw new RuntimeException("Unable to call poll()", e);
+        }
+    }
+
+    /**
+     * Invokes the platform-specific {@code poll()} downcall.
+     */
+    private static int platformPoll(MemorySegment pfd, int timeoutMs) throws Throwable {
+        if (OSUtils.IS_LINUX || OSUtils.IS_AIX) {
+            return (int) pollHandle.invoke(pfd, 1L, timeoutMs);
+        } else {
+            return (int) pollHandle.invoke(pfd, 1, timeoutMs);
         }
     }
 

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -284,17 +284,19 @@ class CLibrary {
      *   short revents;  // returned events
      * </pre>
      */
-    static class pollfd {
+    static class PollFd {
         static final GroupLayout LAYOUT = MemoryLayout.structLayout(
                 ValueLayout.JAVA_INT.withName("fd"),
                 ValueLayout.JAVA_SHORT.withName("events"),
                 ValueLayout.JAVA_SHORT.withName("revents"));
-        private static final VarHandle fd =
+        private static final VarHandle FD =
                 FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("fd"));
-        private static final VarHandle events =
+        private static final VarHandle EVENTS =
                 FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("events"));
-        private static final VarHandle revents =
+        private static final VarHandle REVENTS =
                 FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("revents"));
+
+        private PollFd() {}
     }
 
     /** POSIX POLLIN constant (0x0001 on all supported platforms). */
@@ -516,16 +518,16 @@ class CLibrary {
      * @param timeoutMs timeout in milliseconds; 0 = immediate, −1 = infinite
      * @return positive if data is ready, 0 on timeout, −1 on permanent error
      */
-    static int pollIn(int fd, int timeoutMs) {
+    static int pollForInput(int fd, int timeoutMs) {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment pfd = arena.allocate(pollfd.LAYOUT);
-            pollfd.fd.set(pfd, fd);
-            pollfd.events.set(pfd, POLLIN);
+            MemorySegment pfd = arena.allocate(PollFd.LAYOUT);
+            PollFd.FD.set(pfd, fd);
+            PollFd.EVENTS.set(pfd, POLLIN);
 
             int rc;
             int retries = 0;
             do {
-                pollfd.revents.set(pfd, (short) 0);
+                PollFd.REVENTS.set(pfd, (short) 0);
                 if (OSUtils.IS_LINUX || OSUtils.IS_AIX) {
                     rc = (int) pollHandle.invoke(pfd, 1L, timeoutMs);
                 } else {

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/CLibrary.java
@@ -274,6 +274,34 @@ class CLibrary {
         }
     }
 
+    // ── poll(2) support ──────────────────────────────────────────────────
+
+    /**
+     * {@code struct pollfd} layout (POSIX).
+     * <pre>
+     *   int   fd;       // file descriptor
+     *   short events;   // requested events
+     *   short revents;  // returned events
+     * </pre>
+     */
+    static class pollfd {
+        static final GroupLayout LAYOUT = MemoryLayout.structLayout(
+                ValueLayout.JAVA_INT.withName("fd"),
+                ValueLayout.JAVA_SHORT.withName("events"),
+                ValueLayout.JAVA_SHORT.withName("revents"));
+        private static final VarHandle fd =
+                FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("fd"));
+        private static final VarHandle events =
+                FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("events"));
+        private static final VarHandle revents =
+                FfmTerminalProvider.lookupVarHandle(LAYOUT, MemoryLayout.PathElement.groupElement("revents"));
+    }
+
+    /** POSIX POLLIN constant (0x0001 on all supported platforms). */
+    static final short POLLIN = 0x0001;
+
+    static final MethodHandle pollHandle;
+
     static final MethodHandle ioctl;
     static final MethodHandle isatty;
     static final MethodHandle openptyHandle;
@@ -286,6 +314,12 @@ class CLibrary {
         // methods
         Linker linker = Linker.nativeLinker();
         SymbolLookup lookup = SymbolLookup.loaderLookup().or(linker.defaultLookup());
+        // https://man7.org/linux/man-pages/man2/poll.2.html
+        // nfds_t is unsigned long on Linux/AIX, unsigned int on macOS/FreeBSD
+        ValueLayout nfdsLayout = (OSUtils.IS_LINUX || OSUtils.IS_AIX) ? ValueLayout.JAVA_LONG : ValueLayout.JAVA_INT;
+        pollHandle = linker.downcallHandle(
+                lookup.find("poll").get(),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, nfdsLayout, ValueLayout.JAVA_INT));
         // https://man7.org/linux/man-pages/man2/ioctl.2.html
         ioctl = linker.downcallHandle(
                 lookup.find("ioctl").get(),
@@ -471,6 +505,37 @@ class CLibrary {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Polls a single file descriptor for input readability.
+     *
+     * <p>Retries automatically on transient errors (EINTR) up to a fixed limit.</p>
+     *
+     * @param fd        file descriptor to poll (e.g. {@code STDIN_FILENO})
+     * @param timeoutMs timeout in milliseconds; 0 = immediate, −1 = infinite
+     * @return positive if data is ready, 0 on timeout, −1 on permanent error
+     */
+    static int pollIn(int fd, int timeoutMs) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment pfd = arena.allocate(pollfd.LAYOUT);
+            pollfd.fd.set(pfd, fd);
+            pollfd.events.set(pfd, POLLIN);
+
+            int rc;
+            int retries = 0;
+            do {
+                pollfd.revents.set(pfd, (short) 0);
+                if (OSUtils.IS_LINUX || OSUtils.IS_AIX) {
+                    rc = (int) pollHandle.invoke(pfd, 1L, timeoutMs);
+                } else {
+                    rc = (int) pollHandle.invoke(pfd, 1, timeoutMs);
+                }
+            } while (rc < 0 && ++retries < 10);
+            return rc;
+        } catch (Throwable e) {
+            throw new RuntimeException("Unable to call poll()", e);
+        }
     }
 
     static Size getTerminalSize(int fd) {

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmUnixSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmUnixSysTerminal.java
@@ -9,6 +9,7 @@
 package org.jline.terminal.impl.ffm;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 
 import org.jline.terminal.Attributes;
@@ -17,6 +18,8 @@ import org.jline.terminal.Sized;
 import org.jline.terminal.impl.AbstractUnixSysTerminal;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
+import org.jline.utils.NonBlockingInputStream;
+import org.jline.utils.NonBlockingInputStream.TimedReader;
 
 /**
  * FFM-based POSIX system terminal that calls {@link CLibrary} directly.
@@ -55,6 +58,20 @@ public class FfmUnixSysTerminal extends AbstractUnixSysTerminal {
                 signalHandler,
                 CLibrary.getAttributes(STDIN_FD));
         this.outputFd = (systemStream == SystemStream.Output) ? STDOUT_FD : STDERR_FD;
+    }
+
+    @Override
+    protected TimedReader createTimedStdinReader(InputStream stdin) {
+        return (timeoutMs) -> {
+            int ret = CLibrary.pollIn(STDIN_FD, timeoutMs);
+            if (ret > 0) {
+                return stdin.read();
+            } else if (ret == 0) {
+                return NonBlockingInputStream.READ_EXPIRED;
+            } else {
+                throw new IOException("poll() failed on stdin");
+            }
+        };
     }
 
     @Override

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmUnixSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmUnixSysTerminal.java
@@ -60,7 +60,7 @@ public class FfmUnixSysTerminal extends AbstractUnixSysTerminal {
 
     @Override
     protected IntUnaryOperator createPollFunction() {
-        return timeoutMs -> CLibrary.pollIn(STDIN_FD, timeoutMs);
+        return timeoutMs -> CLibrary.pollForInput(STDIN_FD, timeoutMs);
     }
 
     @Override

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmUnixSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmUnixSysTerminal.java
@@ -9,8 +9,8 @@
 package org.jline.terminal.impl.ffm;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.function.IntUnaryOperator;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
@@ -18,7 +18,6 @@ import org.jline.terminal.Sized;
 import org.jline.terminal.impl.AbstractUnixSysTerminal;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
-import org.jline.utils.NonBlockingInputStream.TimedReader;
 
 /**
  * FFM-based POSIX system terminal that calls {@link CLibrary} directly.
@@ -60,8 +59,8 @@ public class FfmUnixSysTerminal extends AbstractUnixSysTerminal {
     }
 
     @Override
-    protected TimedReader createTimedStdinReader(InputStream stdin) {
-        return newPollTimedReader(stdin, CLibrary::pollIn);
+    protected IntUnaryOperator createPollFunction() {
+        return timeoutMs -> CLibrary.pollIn(STDIN_FD, timeoutMs);
     }
 
     @Override

--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmUnixSysTerminal.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmUnixSysTerminal.java
@@ -18,7 +18,6 @@ import org.jline.terminal.Sized;
 import org.jline.terminal.impl.AbstractUnixSysTerminal;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
-import org.jline.utils.NonBlockingInputStream;
 import org.jline.utils.NonBlockingInputStream.TimedReader;
 
 /**
@@ -62,16 +61,7 @@ public class FfmUnixSysTerminal extends AbstractUnixSysTerminal {
 
     @Override
     protected TimedReader createTimedStdinReader(InputStream stdin) {
-        return (timeoutMs) -> {
-            int ret = CLibrary.pollIn(STDIN_FD, timeoutMs);
-            if (ret > 0) {
-                return stdin.read();
-            } else if (ret == 0) {
-                return NonBlockingInputStream.READ_EXPIRED;
-            } else {
-                throw new IOException("poll() failed on stdin");
-            }
-        };
+        return newPollTimedReader(stdin, CLibrary::pollIn);
     }
 
     @Override

--- a/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
+++ b/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
@@ -106,7 +106,7 @@
         "returnType": "int",
         "parameterTypes": ["void*", "int", "int"],
         "options": {
-          "captureCallState": ["errno"]
+          "captureCallState": true
         }
       }
     ]

--- a/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
+++ b/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
@@ -104,7 +104,10 @@
       },
       {
         "returnType": "int",
-        "parameterTypes": ["void*", "int", "int"]
+        "parameterTypes": ["void*", "int", "int"],
+        "options": {
+          "captureCallState": ["errno"]
+        }
       }
     ]
   }

--- a/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
+++ b/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
@@ -101,6 +101,10 @@
         "options": {
           "firstVariadicArg": 2
         }
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "int", "int"]
       }
     ]
   }

--- a/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
+++ b/terminal-ffm/src/main/resources/META-INF/native-image/org.jline/jline-terminal-ffm/reachability-metadata.json
@@ -108,6 +108,13 @@
         "options": {
           "captureCallState": true
         }
+      },
+      {
+        "returnType": "int",
+        "parameterTypes": ["void*", "long long", "int"],
+        "options": {
+          "captureCallState": true
+        }
       }
     ]
   }

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
@@ -76,7 +76,7 @@ public class JniUnixSysTerminal extends AbstractUnixSysTerminal {
 
     @Override
     protected IntUnaryOperator createPollFunction() {
-        return timeoutMs -> CLibrary.pollIn(STDIN_FD, timeoutMs);
+        return timeoutMs -> CLibrary.pollForInput(STDIN_FD, timeoutMs);
     }
 
     @Override

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
@@ -20,7 +20,6 @@ import org.jline.terminal.impl.AbstractUnixSysTerminal;
 import org.jline.terminal.impl.TermiosMapping;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
-import org.jline.utils.NonBlockingInputStream;
 import org.jline.utils.NonBlockingInputStream.TimedReader;
 
 import static org.jline.terminal.impl.TermiosData.TCSANOW;
@@ -78,16 +77,7 @@ public class JniUnixSysTerminal extends AbstractUnixSysTerminal {
 
     @Override
     protected TimedReader createTimedStdinReader(InputStream stdin) {
-        return (timeoutMs) -> {
-            int ret = CLibrary.pollIn(STDIN_FD, timeoutMs);
-            if (ret > 0) {
-                return stdin.read();
-            } else if (ret == 0) {
-                return NonBlockingInputStream.READ_EXPIRED;
-            } else {
-                throw new IOException("poll() failed on stdin");
-            }
-        };
+        return newPollTimedReader(stdin, CLibrary::pollIn);
     }
 
     @Override

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
@@ -9,6 +9,7 @@
 package org.jline.terminal.impl.jni;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 
 import org.jline.nativ.CLibrary;
@@ -19,6 +20,8 @@ import org.jline.terminal.impl.AbstractUnixSysTerminal;
 import org.jline.terminal.impl.TermiosMapping;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
+import org.jline.utils.NonBlockingInputStream;
+import org.jline.utils.NonBlockingInputStream.TimedReader;
 
 import static org.jline.terminal.impl.TermiosData.TCSANOW;
 
@@ -71,6 +74,20 @@ public class JniUnixSysTerminal extends AbstractUnixSysTerminal {
         CLibrary.Termios tios = new CLibrary.Termios();
         CLibrary.tcgetattr(STDIN_FD, tios);
         return mapping.toAttributes(JniNativePty.fromNativeTermios(tios));
+    }
+
+    @Override
+    protected TimedReader createTimedStdinReader(InputStream stdin) {
+        return (timeoutMs) -> {
+            int ret = CLibrary.pollIn(STDIN_FD, timeoutMs);
+            if (ret > 0) {
+                return stdin.read();
+            } else if (ret == 0) {
+                return NonBlockingInputStream.READ_EXPIRED;
+            } else {
+                throw new IOException("poll() failed on stdin");
+            }
+        };
     }
 
     @Override

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
@@ -9,8 +9,8 @@
 package org.jline.terminal.impl.jni;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.function.IntUnaryOperator;
 
 import org.jline.nativ.CLibrary;
 import org.jline.terminal.Attributes;
@@ -20,7 +20,6 @@ import org.jline.terminal.impl.AbstractUnixSysTerminal;
 import org.jline.terminal.impl.TermiosMapping;
 import org.jline.terminal.spi.SystemStream;
 import org.jline.terminal.spi.TerminalProvider;
-import org.jline.utils.NonBlockingInputStream.TimedReader;
 
 import static org.jline.terminal.impl.TermiosData.TCSANOW;
 
@@ -76,8 +75,8 @@ public class JniUnixSysTerminal extends AbstractUnixSysTerminal {
     }
 
     @Override
-    protected TimedReader createTimedStdinReader(InputStream stdin) {
-        return newPollTimedReader(stdin, CLibrary::pollIn);
+    protected IntUnaryOperator createPollFunction() {
+        return timeoutMs -> CLibrary.pollIn(STDIN_FD, timeoutMs);
     }
 
     @Override

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniUnixSysTerminal.java
@@ -76,6 +76,13 @@ public class JniUnixSysTerminal extends AbstractUnixSysTerminal {
 
     @Override
     protected IntUnaryOperator createPollFunction() {
+        try {
+            // Verify the native method is available in the loaded library.
+            // Older pre-compiled binaries may not contain pollForInput yet.
+            CLibrary.pollForInput(STDIN_FD, 0);
+        } catch (UnsatisfiedLinkError e) {
+            return null; // fall back to blocking reads
+        }
         return timeoutMs -> CLibrary.pollForInput(STDIN_FD, timeoutMs);
     }
 

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -30,6 +30,7 @@ import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.FastBufferedOutputStream;
 import org.jline.utils.NonBlocking;
 import org.jline.utils.NonBlockingInputStream;
+import org.jline.utils.NonBlockingInputStream.TimedReader;
 import org.jline.utils.NonBlockingReader;
 import org.jline.utils.NonCloseableInputStream;
 import org.jline.utils.NonCloseableOutputStream;
@@ -100,11 +101,9 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
         boolean softwareSignals = Boolean.parseBoolean(System.getProperty(PROP_SOFTWARE_SIGNALS, "true"));
 
         InputStream stdin = new NonCloseableInputStream(new FileInputStream(FileDescriptor.in));
-        this.input = NonBlocking.nonBlocking(
-                getName(),
-                softwareSignals
-                        ? new SignalInterceptingInputStream(stdin, () -> cachedAttributes, this::raise)
-                        : stdin);
+        InputStream wrappedStdin =
+                softwareSignals ? new SignalInterceptingInputStream(stdin, () -> cachedAttributes, this::raise) : stdin;
+        this.input = NonBlocking.nonBlocking(getName(), wrappedStdin, createTimedStdinReader(wrappedStdin));
         cachedAttributes = new Attributes(originalAttributes);
         FileDescriptor outFd;
         if (systemStream == SystemStream.Output) {
@@ -168,6 +167,22 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
     protected abstract Size doGetSize();
 
     protected abstract void doSetSize(Sized size);
+
+    /**
+     * Creates a timed reader that uses {@code poll(2)} on the stdin fd to avoid
+     * parking the pump thread in an indefinite blocking read.
+     *
+     * <p>Subclasses should override this to provide a platform-specific
+     * implementation (FFM or JNI).  The default returns {@code null}, which
+     * falls back to blocking reads and preserves backward compatibility.</p>
+     *
+     * @param stdin the wrapped stdin input stream (may be a
+     *              {@link SignalInterceptingInputStream})
+     * @return a timed reader, or {@code null} if poll-based reads are not available
+     */
+    protected TimedReader createTimedStdinReader(InputStream stdin) {
+        return null;
+    }
 
     @Override
     public Attributes getAttributes() {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -19,8 +19,8 @@ import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.IntBinaryOperator;
 import java.util.function.IntConsumer;
+import java.util.function.IntUnaryOperator;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Cursor;
@@ -31,7 +31,6 @@ import org.jline.terminal.spi.TerminalProvider;
 import org.jline.utils.FastBufferedOutputStream;
 import org.jline.utils.NonBlocking;
 import org.jline.utils.NonBlockingInputStream;
-import org.jline.utils.NonBlockingInputStream.TimedReader;
 import org.jline.utils.NonBlockingReader;
 import org.jline.utils.NonCloseableInputStream;
 import org.jline.utils.NonCloseableOutputStream;
@@ -104,7 +103,11 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
         InputStream stdin = new NonCloseableInputStream(new FileInputStream(FileDescriptor.in));
         InputStream wrappedStdin =
                 softwareSignals ? new SignalInterceptingInputStream(stdin, () -> cachedAttributes, this::raise) : stdin;
-        this.input = NonBlocking.nonBlocking(getName(), wrappedStdin, createTimedStdinReader(wrappedStdin));
+        this.input = NonBlocking.nonBlocking(getName(), wrappedStdin);
+        IntUnaryOperator pollFn = createPollFunction();
+        if (pollFn != null) {
+            this.input.setPollFunction(pollFn);
+        }
         cachedAttributes = new Attributes(originalAttributes);
         FileDescriptor outFd;
         if (systemStream == SystemStream.Output) {
@@ -170,50 +173,26 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
     protected abstract void doSetSize(Sized size);
 
     /**
-     * Creates a timed reader that uses {@code poll(2)} on the stdin fd to avoid
-     * parking the pump thread in an indefinite blocking read.
+     * Creates a poll function that checks stdin for input readiness using
+     * {@code poll(2)}.
      *
-     * <p>Subclasses should override this to provide a platform-specific
-     * implementation (FFM or JNI).  The default returns {@code null}, which
-     * falls back to blocking reads and preserves backward compatibility.</p>
+     * <p>When non-null, the returned function is passed to
+     * {@link NonBlockingInputStream#setPollFunction(IntUnaryOperator)} so the
+     * pump thread can use short-timeout polls instead of an indefinite blocking
+     * read.  This prevents the pump from stealing keystrokes from subprocesses
+     * that share the same tty fd
+     * (see <a href="https://github.com/jline/jline3/issues/2219">#2219</a>).</p>
      *
-     * <p>Subclasses that have a {@code poll(2)} binding can delegate to
-     * {@link #newPollTimedReader(InputStream, IntBinaryOperator)} to avoid
-     * duplicating the poll-result → TimedReader conversion logic.</p>
+     * <p>Subclasses should override to provide a platform-specific binding
+     * (FFM or JNI).  The default returns {@code null}, which falls back to
+     * blocking reads and preserves backward compatibility.</p>
      *
-     * @param stdin the wrapped stdin input stream (may be a
-     *              {@link SignalInterceptingInputStream})
-     * @return a timed reader, or {@code null} if poll-based reads are not available
+     * @return {@code (timeoutMs) → poll result}: positive if data is ready,
+     *         0 on timeout, negative on error; or {@code null} if poll is
+     *         not available
      */
-    protected TimedReader createTimedStdinReader(InputStream stdin) {
+    protected IntUnaryOperator createPollFunction() {
         return null;
-    }
-
-    /**
-     * Builds a {@link TimedReader} from a raw {@code poll(2)} function,
-     * converting poll results into the TimedReader contract.
-     *
-     * <p>This helper eliminates duplication across FFM and JNI subclasses.
-     * Subclasses override {@link #createTimedStdinReader(InputStream)} and
-     * delegate here, passing their platform-specific {@code pollIn} binding
-     * as a method reference (e.g. {@code CLibrary::pollIn}).</p>
-     *
-     * @param stdin  the wrapped stdin stream
-     * @param pollFn {@code (fd, timeoutMs) → poll result}: positive if data is
-     *               ready, 0 on timeout, negative on error
-     * @return a timed reader that polls then reads
-     */
-    protected TimedReader newPollTimedReader(InputStream stdin, IntBinaryOperator pollFn) {
-        return (timeoutMs) -> {
-            int ret = pollFn.applyAsInt(STDIN_FD, timeoutMs);
-            if (ret > 0) {
-                return stdin.read();
-            } else if (ret == 0) {
-                return NonBlockingInputStream.READ_EXPIRED;
-            } else {
-                throw new IOException("poll() failed on stdin");
-            }
-        };
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -19,6 +19,7 @@ import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntBinaryOperator;
 import java.util.function.IntConsumer;
 
 import org.jline.terminal.Attributes;
@@ -176,12 +177,43 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
      * implementation (FFM or JNI).  The default returns {@code null}, which
      * falls back to blocking reads and preserves backward compatibility.</p>
      *
+     * <p>Subclasses that have a {@code poll(2)} binding can delegate to
+     * {@link #newPollTimedReader(InputStream, IntBinaryOperator)} to avoid
+     * duplicating the poll-result → TimedReader conversion logic.</p>
+     *
      * @param stdin the wrapped stdin input stream (may be a
      *              {@link SignalInterceptingInputStream})
      * @return a timed reader, or {@code null} if poll-based reads are not available
      */
     protected TimedReader createTimedStdinReader(InputStream stdin) {
         return null;
+    }
+
+    /**
+     * Builds a {@link TimedReader} from a raw {@code poll(2)} function,
+     * converting poll results into the TimedReader contract.
+     *
+     * <p>This helper eliminates duplication across FFM and JNI subclasses.
+     * Subclasses override {@link #createTimedStdinReader(InputStream)} and
+     * delegate here, passing their platform-specific {@code pollIn} binding
+     * as a method reference (e.g. {@code CLibrary::pollIn}).</p>
+     *
+     * @param stdin  the wrapped stdin stream
+     * @param pollFn {@code (fd, timeoutMs) → poll result}: positive if data is
+     *               ready, 0 on timeout, negative on error
+     * @return a timed reader that polls then reads
+     */
+    protected TimedReader newPollTimedReader(InputStream stdin, IntBinaryOperator pollFn) {
+        return (timeoutMs) -> {
+            int ret = pollFn.applyAsInt(STDIN_FD, timeoutMs);
+            if (ret > 0) {
+                return stdin.read();
+            } else if (ret == 0) {
+                return NonBlockingInputStream.READ_EXPIRED;
+            } else {
+                throw new IOException("poll() failed on stdin");
+            }
+        };
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/utils/NonBlocking.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlocking.java
@@ -80,27 +80,6 @@ public class NonBlocking {
         return new NonBlockingInputStreamImpl(name, inputStream);
     }
 
-    /**
-     * Creates a non-blocking input stream backed by an optional timed reader.
-     *
-     * <p>When {@code timedReader} is non-null, the pump thread uses short-timeout
-     * reads (e.g. {@code poll(2)}-based) so that it can be cancelled promptly
-     * when a consumer's timed read expires.  This prevents the pump from stealing
-     * keystrokes from subprocesses that share the same tty fd.</p>
-     *
-     * @param name        stream name (used for the pump thread name)
-     * @param inputStream the underlying blocking input stream
-     * @param timedReader optional timed reader; {@code null} falls back to blocking reads
-     * @return a non-blocking input stream
-     */
-    public static NonBlockingInputStream nonBlocking(
-            String name, InputStream inputStream, NonBlockingInputStream.TimedReader timedReader) {
-        if (inputStream instanceof NonBlockingInputStream) {
-            return (NonBlockingInputStream) inputStream;
-        }
-        return new NonBlockingInputStreamImpl(name, inputStream, timedReader);
-    }
-
     public static NonBlockingReader nonBlocking(String name, Reader reader) {
         if (reader instanceof NonBlockingReader) {
             return (NonBlockingReader) reader;

--- a/terminal/src/main/java/org/jline/utils/NonBlocking.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlocking.java
@@ -80,6 +80,27 @@ public class NonBlocking {
         return new NonBlockingInputStreamImpl(name, inputStream);
     }
 
+    /**
+     * Creates a non-blocking input stream backed by an optional timed reader.
+     *
+     * <p>When {@code timedReader} is non-null, the pump thread uses short-timeout
+     * reads (e.g. {@code poll(2)}-based) so that it can be cancelled promptly
+     * when a consumer's timed read expires.  This prevents the pump from stealing
+     * keystrokes from subprocesses that share the same tty fd.</p>
+     *
+     * @param name        stream name (used for the pump thread name)
+     * @param inputStream the underlying blocking input stream
+     * @param timedReader optional timed reader; {@code null} falls back to blocking reads
+     * @return a non-blocking input stream
+     */
+    public static NonBlockingInputStream nonBlocking(
+            String name, InputStream inputStream, NonBlockingInputStream.TimedReader timedReader) {
+        if (inputStream instanceof NonBlockingInputStream) {
+            return (NonBlockingInputStream) inputStream;
+        }
+        return new NonBlockingInputStreamImpl(name, inputStream, timedReader);
+    }
+
     public static NonBlockingReader nonBlocking(String name, Reader reader) {
         if (reader instanceof NonBlockingReader) {
             return (NonBlockingReader) reader;

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.util.function.IntUnaryOperator;
 
 import static org.jline.terminal.TerminalBuilder.PROP_CLOSE_MODE;
 
@@ -48,33 +49,32 @@ import static org.jline.terminal.TerminalBuilder.PROP_CLOSE_MODE;
 public abstract class NonBlockingInputStream extends InputStream {
 
     /**
-     * A reader that supports timed reads using an OS-level mechanism such as
-     * {@code poll(2)}.
-     *
-     * <p>Implementations must return within the specified timeout, allowing the
-     * pump thread to be cancelled promptly when a consumer's timed read expires.
-     * This prevents the pump from stealing keystrokes from subprocesses that
-     * share the same tty (see <a href="https://github.com/jline/jline3/issues/2219">#2219</a>).</p>
-     */
-    @FunctionalInterface
-    public interface TimedReader {
-        /**
-         * Reads one byte, blocking for at most {@code timeoutMs} milliseconds.
-         *
-         * @param timeoutMs maximum time to wait; 0 returns immediately, &lt;0 waits forever
-         * @return 0–255 for data, {@link #EOF} (−1) on end-of-stream,
-         *         or {@link #READ_EXPIRED} (−2) if the timeout elapsed with no input
-         * @throws IOException on I/O error
-         */
-        int read(int timeoutMs) throws IOException;
-    }
-
-    /**
      * Default constructor.
      * Initializes close mode based on the current value of the system property.
      */
     public NonBlockingInputStream() {
         this.closeMode = parseCloseMode();
+    }
+
+    /**
+     * Sets a poll function that checks the underlying file descriptor for
+     * input readiness using an OS-level mechanism such as {@code poll(2)}.
+     *
+     * <p>When set, the pump thread uses short-timeout polls instead of an
+     * indefinite blocking read, allowing it to be cancelled promptly when a
+     * consumer's timed read expires.  This prevents the pump from stealing
+     * keystrokes from subprocesses that share the same tty fd
+     * (see <a href="https://github.com/jline/jline3/issues/2219">#2219</a>).</p>
+     *
+     * <p>Must be called before the first read.  The default implementation
+     * is a no-op; subclasses that support poll-based reads should override.</p>
+     *
+     * @param pollFn {@code (timeoutMs) → poll result}: positive if data is
+     *               ready, 0 on timeout, negative on error.  The fd must be
+     *               captured by the caller.  Pass {@code null} to disable.
+     */
+    public void setPollFunction(IntUnaryOperator pollFn) {
+        // Override in subclasses
     }
 
     /**

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStream.java
@@ -48,6 +48,28 @@ import static org.jline.terminal.TerminalBuilder.PROP_CLOSE_MODE;
 public abstract class NonBlockingInputStream extends InputStream {
 
     /**
+     * A reader that supports timed reads using an OS-level mechanism such as
+     * {@code poll(2)}.
+     *
+     * <p>Implementations must return within the specified timeout, allowing the
+     * pump thread to be cancelled promptly when a consumer's timed read expires.
+     * This prevents the pump from stealing keystrokes from subprocesses that
+     * share the same tty (see <a href="https://github.com/jline/jline3/issues/2219">#2219</a>).</p>
+     */
+    @FunctionalInterface
+    public interface TimedReader {
+        /**
+         * Reads one byte, blocking for at most {@code timeoutMs} milliseconds.
+         *
+         * @param timeoutMs maximum time to wait; 0 returns immediately, &lt;0 waits forever
+         * @return 0–255 for data, {@link #EOF} (−1) on end-of-stream,
+         *         or {@link #READ_EXPIRED} (−2) if the timeout elapsed with no input
+         * @throws IOException on I/O error
+         */
+        int read(int timeoutMs) throws IOException;
+    }
+
+    /**
      * Default constructor.
      * Initializes close mode based on the current value of the system property.
      */

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -11,6 +11,7 @@ package org.jline.utils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
+import java.util.function.IntUnaryOperator;
 
 /**
  * This class wraps a regular input stream and allows it to appear as if it
@@ -32,7 +33,7 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
     private static final int POLL_INTERVAL_MS = 100;
 
     private InputStream in; // The actual input stream
-    private TimedReader timedReader; // Optional poll-based reader (non-null on POSIX sys terminals)
+    private IntUnaryOperator pollFn; // Optional poll function (non-null on POSIX sys terminals)
     private int b = READ_EXPIRED; // Recently read byte
 
     private String name;
@@ -49,27 +50,14 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
      */
     @SuppressWarnings("this-escape")
     public NonBlockingInputStreamImpl(String name, InputStream in) {
-        this(name, in, null);
-    }
-
-    /**
-     * Creates a <code>NonBlockingInputStream</code> with an optional timed reader.
-     *
-     * <p>When a {@code timedReader} is provided (typically backed by {@code poll(2)}
-     * on a tty fd), the pump thread uses short-timeout reads and can be cancelled
-     * promptly when the consumer's timed read expires.  This prevents the pump from
-     * stealing keystrokes from subprocesses that share the same tty.</p>
-     *
-     * @param name        stream name
-     * @param in          the stream to wrap
-     * @param timedReader optional timed reader; {@code null} falls back to blocking reads
-     */
-    @SuppressWarnings("this-escape")
-    public NonBlockingInputStreamImpl(String name, InputStream in, TimedReader timedReader) {
         this.in = in;
         this.name = name;
-        this.timedReader = timedReader;
         this.pump = new PumpThread(this, 60_000);
+    }
+
+    @Override
+    public void setPollFunction(IntUnaryOperator pollFn) {
+        this.pollFn = pollFn;
     }
 
     public void shutdown() {
@@ -167,7 +155,7 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
          * The pump will see reading==false at its next poll timeout (≤100 ms)
          * and return to the idle wait state without consuming a byte.
          */
-        if (b == READ_EXPIRED && pump.isReading() && timedReader != null) {
+        if (b == READ_EXPIRED && pump.isReading() && pollFn != null) {
             pump.setReading(false);
         }
 
@@ -189,8 +177,21 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
             exception = failure;
             b = value;
         };
-        if (timedReader != null) {
-            pump.runLoop(timedReader, POLL_INTERVAL_MS, handler, "NonBlockingInputStream");
+        if (pollFn != null) {
+            pump.runLoop(
+                    timeoutMs -> {
+                        int ret = pollFn.applyAsInt(timeoutMs);
+                        if (ret > 0) {
+                            return in.read();
+                        } else if (ret == 0) {
+                            return READ_EXPIRED;
+                        } else {
+                            throw new IOException("poll() failed on stdin");
+                        }
+                    },
+                    POLL_INTERVAL_MS,
+                    handler,
+                    "NonBlockingInputStream");
         } else {
             pump.runLoop(in::read, handler, "NonBlockingInputStream");
         }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -27,7 +27,12 @@ import java.io.InterruptedIOException;
  * </ul>
  */
 public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
+
+    /** Per-poll timeout used by the timed pump loop (ms). */
+    private static final int POLL_INTERVAL_MS = 100;
+
     private InputStream in; // The actual input stream
+    private TimedReader timedReader; // Optional poll-based reader (non-null on POSIX sys terminals)
     private int b = READ_EXPIRED; // Recently read byte
 
     private String name;
@@ -35,17 +40,35 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
     private final PumpThread pump;
 
     /**
-     * Creates a <code>NonBlockingReader</code> out of a normal blocking
-     * reader. Note that this call also spawn a separate thread to perform the
+     * Creates a <code>NonBlockingInputStream</code> out of a normal blocking
+     * stream. Note that this call also spawns a separate thread to perform the
      * blocking I/O on behalf of the thread that is using this class. The
      * {@link #shutdown()} method must be called in order to shut this thread down.
      * @param name The stream name
-     * @param in The reader to wrap
+     * @param in The stream to wrap
      */
     @SuppressWarnings("this-escape")
     public NonBlockingInputStreamImpl(String name, InputStream in) {
+        this(name, in, null);
+    }
+
+    /**
+     * Creates a <code>NonBlockingInputStream</code> with an optional timed reader.
+     *
+     * <p>When a {@code timedReader} is provided (typically backed by {@code poll(2)}
+     * on a tty fd), the pump thread uses short-timeout reads and can be cancelled
+     * promptly when the consumer's timed read expires.  This prevents the pump from
+     * stealing keystrokes from subprocesses that share the same tty.</p>
+     *
+     * @param name        stream name
+     * @param in          the stream to wrap
+     * @param timedReader optional timed reader; {@code null} falls back to blocking reads
+     */
+    @SuppressWarnings("this-escape")
+    public NonBlockingInputStreamImpl(String name, InputStream in, TimedReader timedReader) {
         this.in = in;
         this.name = name;
+        this.timedReader = timedReader;
         this.pump = new PumpThread(this, 60_000);
     }
 
@@ -136,6 +159,19 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
         }
 
         /*
+         * If the pump is still reading and we have a timed reader, cancel the
+         * pump's outstanding read so it stops polling the tty fd.  This prevents
+         * the pump from stealing keystrokes from a subprocess that the caller
+         * is about to spawn (see #2219).
+         *
+         * The pump will see reading==false at its next poll timeout (≤100 ms)
+         * and return to the idle wait state without consuming a byte.
+         */
+        if (b == READ_EXPIRED && pump.isReading() && timedReader != null) {
+            pump.setReading(false);
+        }
+
+        /*
          * b is the character that was just read. Either we set it because
          * a local read was performed or the read thread set it (or failed to
          * change it).  We will return it's value, but if this was a peek
@@ -149,12 +185,14 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
     }
 
     private void run() {
-        pump.runLoop(
-                in::read,
-                (value, failure) -> {
-                    exception = failure;
-                    b = value;
-                },
-                "NonBlockingInputStream");
+        PumpThread.ResultHandler handler = (value, failure) -> {
+            exception = failure;
+            b = value;
+        };
+        if (timedReader != null) {
+            pump.runLoop(timedReader, POLL_INTERVAL_MS, handler, "NonBlockingInputStream");
+        } else {
+            pump.runLoop(in::read, handler, "NonBlockingInputStream");
+        }
     }
 }

--- a/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
+++ b/terminal/src/main/java/org/jline/utils/NonBlockingInputStreamImpl.java
@@ -180,7 +180,12 @@ public class NonBlockingInputStreamImpl extends NonBlockingInputStream {
         if (pollFn != null) {
             pump.runLoop(
                     timeoutMs -> {
-                        int ret = pollFn.applyAsInt(timeoutMs);
+                        int ret;
+                        try {
+                            ret = pollFn.applyAsInt(timeoutMs);
+                        } catch (RuntimeException e) {
+                            throw new IOException("poll() failed on stdin", e);
+                        }
                         if (ret > 0) {
                             return in.read();
                         } else if (ret == 0) {

--- a/terminal/src/main/java/org/jline/utils/PumpThread.java
+++ b/terminal/src/main/java/org/jline/utils/PumpThread.java
@@ -102,55 +102,13 @@ final class PumpThread {
      */
     void runLoop(TimedIoReader reader, int pollIntervalMs, ResultHandler handler, String logName) {
         Log.debug(logName + " start");
-        boolean needToRead;
 
         try {
             while (true) {
-                // ── idle wait ──────────────────────────────────────────
-                synchronized (lock) {
-                    needToRead = reading;
-                    try {
-                        if (!needToRead) {
-                            lock.wait(idleTimeout);
-                        }
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        return;
-                    }
-                    needToRead = reading;
-                    if (!needToRead) {
-                        return;
-                    }
+                if (!awaitReadRequest()) {
+                    return;
                 }
-
-                // ── timed read loop ────────────────────────────────────
-                // Poll in short intervals; between polls, check whether
-                // the consumer cancelled this read request.
-                int value = NonBlockingInputStream.READ_EXPIRED;
-                IOException failure = null;
-                try {
-                    while (true) {
-                        value = reader.read(pollIntervalMs);
-                        if (value != NonBlockingInputStream.READ_EXPIRED) {
-                            break; // data, EOF, or error
-                        }
-                        synchronized (lock) {
-                            if (!reading) {
-                                break; // consumer cancelled
-                            }
-                        }
-                    }
-                } catch (IOException e) {
-                    failure = e;
-                }
-
-                synchronized (lock) {
-                    if (value != NonBlockingInputStream.READ_EXPIRED || failure != null) {
-                        handler.accept(value, failure);
-                    }
-                    reading = false;
-                    lock.notifyAll();
-                }
+                readAndDispatch(reader, pollIntervalMs, handler);
             }
         } catch (Throwable t) {
             Log.warn("Error in " + logName + " thread", t);
@@ -158,6 +116,67 @@ final class PumpThread {
             Log.debug(logName + " shutdown");
             synchronized (lock) {
                 clearThread();
+            }
+        }
+    }
+
+    /**
+     * Blocks until the consumer requests a read, or the idle timeout expires.
+     *
+     * @return {@code true} if a read was requested, {@code false} if the thread
+     *         should exit (idle timeout or interruption)
+     */
+    private boolean awaitReadRequest() {
+        synchronized (lock) {
+            if (!reading) {
+                try {
+                    lock.wait(idleTimeout);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
+            }
+            return reading;
+        }
+    }
+
+    /**
+     * Performs a single timed read and dispatches the result to the handler.
+     */
+    private void readAndDispatch(TimedIoReader reader, int pollIntervalMs, ResultHandler handler) {
+        int value = NonBlockingInputStream.READ_EXPIRED;
+        IOException failure = null;
+        try {
+            value = timedRead(reader, pollIntervalMs);
+        } catch (IOException e) {
+            failure = e;
+        }
+
+        synchronized (lock) {
+            if (value != NonBlockingInputStream.READ_EXPIRED || failure != null) {
+                handler.accept(value, failure);
+            }
+            reading = false;
+            lock.notifyAll();
+        }
+    }
+
+    /**
+     * Polls in short intervals until data arrives or the consumer cancels.
+     *
+     * @return the byte/char read, {@link NonBlockingInputStream#EOF EOF}, or
+     *         {@link NonBlockingInputStream#READ_EXPIRED READ_EXPIRED} if cancelled
+     */
+    private int timedRead(TimedIoReader reader, int pollIntervalMs) throws IOException {
+        while (true) {
+            int value = reader.read(pollIntervalMs);
+            if (value != NonBlockingInputStream.READ_EXPIRED) {
+                return value;
+            }
+            synchronized (lock) {
+                if (!reading) {
+                    return NonBlockingInputStream.READ_EXPIRED;
+                }
             }
         }
     }

--- a/terminal/src/main/java/org/jline/utils/PumpThread.java
+++ b/terminal/src/main/java/org/jline/utils/PumpThread.java
@@ -78,49 +78,10 @@ final class PumpThread {
     }
 
     void runLoop(IoReader reader, ResultHandler handler, String logName) {
-        Log.debug(logName + " start");
-        boolean needToRead;
-
-        try {
-            while (true) {
-                synchronized (lock) {
-                    needToRead = reading;
-                    try {
-                        if (!needToRead) {
-                            lock.wait(idleTimeout);
-                        }
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        return;
-                    }
-                    needToRead = reading;
-                    if (!needToRead) {
-                        return;
-                    }
-                }
-
-                int value = NonBlockingInputStream.READ_EXPIRED;
-                IOException failure = null;
-                try {
-                    value = reader.read();
-                } catch (IOException e) {
-                    failure = e;
-                }
-
-                synchronized (lock) {
-                    handler.accept(value, failure);
-                    reading = false;
-                    lock.notifyAll();
-                }
-            }
-        } catch (Throwable t) {
-            Log.warn("Error in " + logName + " thread", t);
-        } finally {
-            Log.debug(logName + " shutdown");
-            synchronized (lock) {
-                clearThread();
-            }
-        }
+        // A blocking reader never returns READ_EXPIRED, so the timed
+        // loop behaves identically: the inner poll loop breaks on the
+        // first iteration and the READ_EXPIRED guard is a no-op.
+        runLoop(timeoutMs -> reader.read(), 0, handler, logName);
     }
 
     /**
@@ -140,7 +101,7 @@ final class PumpThread {
      * @param logName        label for debug logging
      */
     void runLoop(TimedIoReader reader, int pollIntervalMs, ResultHandler handler, String logName) {
-        Log.debug(logName + " start (timed)");
+        Log.debug(logName + " start");
         boolean needToRead;
 
         try {
@@ -184,7 +145,7 @@ final class PumpThread {
                 }
 
                 synchronized (lock) {
-                    if (value != NonBlockingInputStream.READ_EXPIRED) {
+                    if (value != NonBlockingInputStream.READ_EXPIRED || failure != null) {
                         handler.accept(value, failure);
                     }
                     reading = false;

--- a/terminal/src/main/java/org/jline/utils/PumpThread.java
+++ b/terminal/src/main/java/org/jline/utils/PumpThread.java
@@ -118,6 +118,84 @@ final class PumpThread {
         }
     }
 
+    /**
+     * Runs the pump loop using a timed reader that returns periodically,
+     * allowing the loop to check whether the consumer still needs data.
+     *
+     * <p>Unlike the blocking {@link #runLoop(IoReader, ResultHandler, String)}
+     * variant, this loop calls the timed reader with short poll intervals so
+     * that a cancelled read request (consumer set {@code reading = false}) is
+     * detected within one poll period — rather than blocking until a byte
+     * arrives on the underlying stream.  This prevents the pump from stealing
+     * keystrokes from subprocesses that share the same tty fd.</p>
+     *
+     * @param reader         timed reader (e.g. poll-then-read on a tty fd)
+     * @param pollIntervalMs per-iteration poll timeout in milliseconds
+     * @param handler        callback that receives the result
+     * @param logName        label for debug logging
+     */
+    void runLoop(NonBlockingInputStream.TimedReader reader, int pollIntervalMs, ResultHandler handler, String logName) {
+        Log.debug(logName + " start (timed)");
+        boolean needToRead;
+
+        try {
+            while (true) {
+                // ── idle wait ──────────────────────────────────────────
+                synchronized (lock) {
+                    needToRead = reading;
+                    try {
+                        if (!needToRead) {
+                            lock.wait(idleTimeout);
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    needToRead = reading;
+                    if (!needToRead) {
+                        return;
+                    }
+                }
+
+                // ── timed read loop ────────────────────────────────────
+                // Poll in short intervals; between polls, check whether
+                // the consumer cancelled this read request.
+                int value = NonBlockingInputStream.READ_EXPIRED;
+                IOException failure = null;
+                try {
+                    while (true) {
+                        value = reader.read(pollIntervalMs);
+                        if (value != NonBlockingInputStream.READ_EXPIRED) {
+                            break; // data, EOF, or error
+                        }
+                        synchronized (lock) {
+                            if (!reading) {
+                                break; // consumer cancelled
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                    failure = e;
+                }
+
+                synchronized (lock) {
+                    if (value != NonBlockingInputStream.READ_EXPIRED) {
+                        handler.accept(value, failure);
+                    }
+                    reading = false;
+                    lock.notifyAll();
+                }
+            }
+        } catch (Throwable t) {
+            Log.warn("Error in " + logName + " thread", t);
+        } finally {
+            Log.debug(logName + " shutdown");
+            synchronized (lock) {
+                clearThread();
+            }
+        }
+    }
+
     boolean isReading() {
         return reading;
     }

--- a/terminal/src/main/java/org/jline/utils/PumpThread.java
+++ b/terminal/src/main/java/org/jline/utils/PumpThread.java
@@ -27,6 +27,11 @@ final class PumpThread {
     }
 
     @FunctionalInterface
+    interface TimedIoReader {
+        int read(int timeoutMs) throws IOException;
+    }
+
+    @FunctionalInterface
     interface ResultHandler {
         void accept(int value, IOException failure);
     }
@@ -134,7 +139,7 @@ final class PumpThread {
      * @param handler        callback that receives the result
      * @param logName        label for debug logging
      */
-    void runLoop(NonBlockingInputStream.TimedReader reader, int pollIntervalMs, ResultHandler handler, String logName) {
+    void runLoop(TimedIoReader reader, int pollIntervalMs, ResultHandler handler, String logName) {
         Log.debug(logName + " start (timed)");
         boolean needToRead;
 

--- a/terminal/src/main/java/org/jline/utils/PumpThread.java
+++ b/terminal/src/main/java/org/jline/utils/PumpThread.java
@@ -128,15 +128,20 @@ final class PumpThread {
      */
     private boolean awaitReadRequest() {
         synchronized (lock) {
-            if (!reading) {
+            long deadlineNanos = System.nanoTime() + idleTimeout * 1_000_000L;
+            while (!reading) {
+                long remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000L;
+                if (remainingMs <= 0) {
+                    return false;
+                }
                 try {
-                    lock.wait(idleTimeout);
+                    lock.wait(remainingMs);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return false;
                 }
             }
-            return reading;
+            return true;
         }
     }
 

--- a/terminal/src/test/java/org/jline/utils/PumpThreadTimedLoopTest.java
+++ b/terminal/src/test/java/org/jline/utils/PumpThreadTimedLoopTest.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the poll-based timed pump loop introduced in #2219.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>{@code PumpThread.runLoop(TimedIoReader, ...)} — the timed loop variant</li>
+ *   <li>{@code NonBlockingInputStreamImpl} with a poll function set</li>
+ *   <li>Cancellation of the pump when the consumer's timed read expires</li>
+ *   <li>Poll error → IOException conversion</li>
+ *   <li>Idle timeout expiry in {@code awaitReadRequest()}</li>
+ * </ul>
+ */
+@Timeout(10)
+class PumpThreadTimedLoopTest {
+
+    // ────────────────── Poll-based NonBlockingInputStreamImpl tests ──────────────────
+
+    /**
+     * When a poll function is set and data is available, a timed read returns the byte.
+     */
+    @Test
+    void testPollBasedReadReturnsDataWhenReady() throws Exception {
+        byte[] data = {42, 99, 0x7F};
+        InputStream in = new ByteArrayInputStream(data);
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("poll-data-ready", in);
+        try {
+            // Poll function: always says data is ready (returns > 0)
+            nbis.setPollFunction(timeoutMs -> 1);
+
+            assertEquals(42, nbis.read(500));
+            assertEquals(99, nbis.read(500));
+            assertEquals(0x7F, nbis.read(500));
+            assertEquals(NonBlockingInputStream.EOF, nbis.read(500));
+        } finally {
+            nbis.close();
+        }
+    }
+
+    /**
+     * When the poll function returns 0 (timeout, no data) and the consumer's read
+     * timeout expires, the result should be READ_EXPIRED, and the pump should be
+     * cancelled (reading == false).
+     */
+    @Test
+    void testPollTimeoutCancelsPump() throws Exception {
+        // An input stream that blocks indefinitely (never provides data)
+        InputStream in = new NeverReadyInputStream();
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("poll-timeout", in);
+        try {
+            // Poll function always says "no data" (returns 0)
+            nbis.setPollFunction(timeoutMs -> 0);
+
+            long t0 = System.currentTimeMillis();
+            int result = nbis.read(300);
+            long elapsed = System.currentTimeMillis() - t0;
+
+            assertEquals(
+                    NonBlockingInputStream.READ_EXPIRED,
+                    result,
+                    "Should return READ_EXPIRED when poll keeps timing out");
+            // The read should respect the consumer timeout (~300ms)
+            assertTrue(elapsed >= 250, "Should wait approximately the requested timeout");
+            assertTrue(elapsed < 3000, "Should not wait excessively long");
+        } finally {
+            nbis.close();
+        }
+    }
+
+    /**
+     * When the poll function signals an error (returns negative), the pump should
+     * convert it to an IOException that propagates to the consumer.
+     */
+    @Test
+    void testPollErrorThrowsIOException() throws Exception {
+        InputStream in = new NeverReadyInputStream();
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("poll-error", in);
+        try {
+            // Poll function always returns error (negative)
+            nbis.setPollFunction(timeoutMs -> -1);
+
+            assertThrows(
+                    IOException.class, () -> nbis.read(1000), "Negative poll result should surface as IOException");
+        } finally {
+            nbis.close();
+        }
+    }
+
+    /**
+     * When the poll function throws a RuntimeException, it should be wrapped
+     * in an IOException (the fix from commit a9e1dd1).
+     */
+    @Test
+    void testPollRuntimeExceptionWrappedAsIOException() throws Exception {
+        InputStream in = new NeverReadyInputStream();
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("poll-rte", in);
+        try {
+            nbis.setPollFunction(timeoutMs -> {
+                throw new RuntimeException("simulated native failure");
+            });
+
+            IOException thrown = assertThrows(IOException.class, () -> nbis.read(1000));
+            assertTrue(
+                    thrown.getMessage().contains("poll() failed"),
+                    "Should mention poll failure: " + thrown.getMessage());
+            assertNotNull(thrown.getCause(), "Should preserve the original RuntimeException as cause");
+            assertTrue(thrown.getCause() instanceof RuntimeException);
+        } finally {
+            nbis.close();
+        }
+    }
+
+    /**
+     * When data arrives after a short poll delay, the timed reader should pick it up
+     * within one poll interval.
+     */
+    @Test
+    void testPollBasedReadWithDelayedData() throws Exception {
+        // InputStream that returns data after being signalled
+        CountDownLatch dataReady = new CountDownLatch(1);
+        InputStream in = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                return 'X';
+            }
+        };
+        AtomicInteger pollCount = new AtomicInteger(0);
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("poll-delayed", in);
+        try {
+            // Poll function: first 3 calls return 0 (no data), then returns 1 (data ready)
+            nbis.setPollFunction(timeoutMs -> {
+                int n = pollCount.incrementAndGet();
+                if (n <= 3) {
+                    // Simulate short poll sleep
+                    try {
+                        Thread.sleep(Math.min(timeoutMs, 50));
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return 0; // no data yet
+                }
+                return 1; // data ready
+            });
+
+            int result = nbis.read(5000);
+            assertEquals('X', result, "Should eventually read the byte after poll becomes ready");
+            assertTrue(pollCount.get() >= 4, "Poll should have been called at least 4 times");
+        } finally {
+            nbis.close();
+        }
+    }
+
+    /**
+     * Without a poll function (pollFn == null), NonBlockingInputStreamImpl falls
+     * back to the blocking IoReader path — the behavior should be identical to
+     * the pre-#2219 code.
+     */
+    @Test
+    void testBlockingFallbackWhenNoPollFunction() throws Exception {
+        byte[] data = {65, 66, 67};
+        InputStream in = new ByteArrayInputStream(data);
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("no-poll", in);
+        try {
+            // No setPollFunction call — should use blocking path
+            assertEquals(65, nbis.read(500));
+            assertEquals(66, nbis.read(500));
+            assertEquals(67, nbis.read(500));
+            assertEquals(NonBlockingInputStream.EOF, nbis.read(500));
+        } finally {
+            nbis.close();
+        }
+    }
+
+    /**
+     * Verifies that a peek operation with a poll function does not consume the byte.
+     */
+    @Test
+    void testPeekWithPollFunction() throws Exception {
+        byte[] data = {77};
+        InputStream in = new ByteArrayInputStream(data);
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("poll-peek", in);
+        try {
+            nbis.setPollFunction(timeoutMs -> 1);
+
+            // Peek should see the byte but not consume it
+            assertEquals(77, nbis.peek(500));
+            // Regular read should still see it
+            assertEquals(77, nbis.read(500));
+            // Now it's consumed
+            assertEquals(NonBlockingInputStream.EOF, nbis.read(500));
+        } finally {
+            nbis.close();
+        }
+    }
+
+    /**
+     * After calling close(), subsequent reads should throw ClosedException even
+     * when a poll function is set.
+     */
+    @Test
+    void testCloseWithPollFunction() throws Exception {
+        InputStream in = new NeverReadyInputStream();
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("poll-close", in);
+        nbis.setPollFunction(timeoutMs -> 0);
+
+        nbis.close();
+        assertThrows(ClosedException.class, () -> nbis.read(100));
+    }
+
+    /**
+     * The pump thread should exit within a reasonable time after the consumer's read
+     * timeout expires when using the poll-based path (i.e., it doesn't hold the tty
+     * fd with a blocking read).
+     */
+    @Test
+    void testPumpThreadExitsAfterTimedReadExpires() throws Exception {
+        InputStream in = new NeverReadyInputStream();
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("pump-exit", in);
+        try {
+            // Poll function simulates poll() with actual timeout sleep
+            nbis.setPollFunction(timeoutMs -> {
+                try {
+                    Thread.sleep(Math.min(timeoutMs, 50));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return 0;
+            });
+
+            // Trigger a timed read that will expire
+            int result = nbis.read(200);
+            assertEquals(NonBlockingInputStream.READ_EXPIRED, result);
+
+            // Give the pump thread a moment to notice cancellation and park
+            Thread.sleep(300);
+
+            // The pump thread should exist but NOT be in a blocking read state.
+            // Do another read — if the pump was stuck in a blocking read,
+            // this would hang or steal data.
+            result = nbis.read(200);
+            assertEquals(NonBlockingInputStream.READ_EXPIRED, result);
+        } finally {
+            nbis.close();
+        }
+    }
+
+    /**
+     * Multiple consecutive timed reads with a poll function should all work correctly,
+     * with the pump restarting between reads.
+     */
+    @Test
+    void testConsecutiveTimedReadsWithPoll() throws Exception {
+        AtomicInteger readCount = new AtomicInteger(0);
+        InputStream in = new InputStream() {
+            @Override
+            public int read() {
+                return 'A' + readCount.getAndIncrement();
+            }
+        };
+        AtomicInteger pollCycle = new AtomicInteger(0);
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("consecutive-poll", in);
+        try {
+            // Poll function alternates: first call per cycle returns 0, second returns 1
+            nbis.setPollFunction(timeoutMs -> {
+                int n = pollCycle.incrementAndGet();
+                if (n % 2 == 1) {
+                    try {
+                        Thread.sleep(Math.min(timeoutMs, 30));
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return 0;
+                }
+                return 1;
+            });
+
+            assertEquals('A', nbis.read(2000));
+            assertEquals('B', nbis.read(2000));
+            assertEquals('C', nbis.read(2000));
+        } finally {
+            nbis.close();
+        }
+    }
+
+    /**
+     * Test that when the consumer's read expires and the pump is cancelled,
+     * the pump doesn't consume a byte from the underlying stream. The next read
+     * should still get the next available byte.
+     */
+    @Test
+    void testCancelledPumpDoesNotConsumeBytes() throws Exception {
+        AtomicInteger nextByte = new AtomicInteger('A');
+        InputStream in = new InputStream() {
+            @Override
+            public int read() {
+                return nextByte.getAndIncrement();
+            }
+        };
+        AtomicInteger pollCallCount = new AtomicInteger(0);
+        NonBlockingInputStreamImpl nbis = new NonBlockingInputStreamImpl("no-steal", in);
+        try {
+            // Poll function: always times out (returns 0), simulates no data
+            nbis.setPollFunction(timeoutMs -> {
+                pollCallCount.incrementAndGet();
+                try {
+                    Thread.sleep(Math.min(timeoutMs, 30));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return 0;
+            });
+
+            // First read times out — pump should be cancelled without consuming
+            int result = nbis.read(150);
+            assertEquals(NonBlockingInputStream.READ_EXPIRED, result);
+
+            // Now set poll to return data ready
+            nbis.setPollFunction(timeoutMs -> 1);
+
+            // The next byte from the stream should be 'A' (none stolen)
+            result = nbis.read(2000);
+            assertEquals('A', result, "Pump should not have consumed a byte during cancelled poll");
+        } finally {
+            nbis.close();
+        }
+    }
+
+    // ────────────────── Helper classes ──────────────────
+
+    /**
+     * An InputStream whose read() blocks indefinitely (useful for testing
+     * that the poll path prevents blocking).
+     */
+    private static class NeverReadyInputStream extends InputStream {
+        @Override
+        public int read() throws IOException {
+            try {
+                Thread.sleep(Long.MAX_VALUE);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return -1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When a timed read expires on a POSIX system terminal, the pump thread in `NonBlockingInputStreamImpl` previously remained parked in a blocking `read()` on the tty fd. If a subprocess (e.g. `less`) was then spawned to read the same tty, the parked read raced the subprocess for keyboard input, stealing exactly one keystroke (see #2219 for full analysis).

This PR replaces the indefinite blocking read with `poll(2)`-based timed reads on both the FFM and JNI providers:

- **`NonBlockingInputStream.TimedReader`** — new public functional interface for readers that support a timeout, returning `READ_EXPIRED` when no data arrives within the specified time
- **`PumpThread.runLoop(TimedReader, ...)`** — new overload that polls in short intervals (100 ms) and checks a cancellation flag between polls; when the consumer's timed read expires, it cancels the pump, which stops within one poll period
- **FFM `CLibrary.pollIn()`** — FFM binding for `poll(2)` with `struct pollfd` layout, handling platform-specific `nfds_t` sizes (Linux/AIX `unsigned long` vs macOS `unsigned int`)
- **JNI `CLibrary.pollIn()`** — native JNI implementation with `EINTR` retry
- **`AbstractUnixSysTerminal.createTimedStdinReader()`** — protected hook overridden by `FfmUnixSysTerminal` and `JniUnixSysTerminal` to provide platform-specific poll-based readers

After this change, the pump thread never holds a blocking read on the tty for longer than 100 ms. When a consumer's timed read (or peek) expires, the pump is cancelled and returns to idle within one poll period — leaving the tty fd uncontested for any subprocess the application may spawn.

## Test plan

- [x] All 589 terminal module tests pass
- [x] FFM and JNI module tests pass
- [x] Full 22-module build succeeds
- [ ] Manual verification with the reproducer from the issue (timed read → spawn `less` → single `q` exits cleanly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added platform-specific input readiness polling for Unix terminals using JNI and FFM providers.
  - Added timed, non-blocking terminal input support to improve responsiveness.
  - Terminal input handling now coordinates more reliably with subprocesses sharing the same terminal.

- **Bug Fixes**
  - Reduced the risk of terminal keystrokes being consumed by subprocesses.
  - Preserved finite input wait durations when waits are interrupted.
  - Improved handling of poll timeouts, interrupted waits, and input errors across supported Unix platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->