### PR TITLE
fix: use poll(2) for probe and PTY reads (fixes #2223)

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmNativePty.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmNativePty.java
@@ -14,6 +14,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.function.IntUnaryOperator;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
@@ -72,6 +73,11 @@ class FfmNativePty extends AbstractPty {
         if (slave > 0) {
             getSlaveInput().close();
         }
+    }
+
+    @Override
+    protected IntUnaryOperator createSlavePollFunction() {
+        return timeoutMs -> CLibrary.pollForInput(slave, timeoutMs);
     }
 
     public int getMaster() {

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniNativePty.java
@@ -14,6 +14,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.function.IntUnaryOperator;
 
 import org.jline.nativ.CLibrary;
 import org.jline.nativ.Kernel32;
@@ -91,6 +92,18 @@ public abstract class JniNativePty extends AbstractPty implements Pty {
         if (slave > 0) {
             getSlaveInput().close();
         }
+    }
+
+    @Override
+    protected IntUnaryOperator createSlavePollFunction() {
+        try {
+            // Verify the native method is available in the loaded library.
+            // Older pre-compiled binaries may not contain pollForInput yet.
+            CLibrary.pollForInput(slave, 0);
+        } catch (UnsatisfiedLinkError e) {
+            return null; // fall back to VMIN/VTIME heuristic
+        }
+        return timeoutMs -> CLibrary.pollForInput(slave, timeoutMs);
     }
 
     public int getMaster() {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -17,7 +17,7 @@ import java.io.InterruptedIOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.function.IntUnaryOperator;
 
 import org.jline.nativ.JLineLibrary;
 import org.jline.nativ.JLineNativeLoader;
@@ -129,12 +129,35 @@ public abstract class AbstractPty implements Pty {
         return systemStream;
     }
 
+    /**
+     * Creates a poll function for the slave file descriptor.
+     *
+     * <p>When non-null, the returned function checks the slave fd for input
+     * readiness using an OS-level mechanism such as {@code poll(2)}.  This
+     * replaces the fragile VMIN/VTIME timing heuristic in {@link PtyInputStream}
+     * with a kernel-enforced timeout that works reliably on PTY file descriptors.</p>
+     *
+     * <p>Subclasses that have access to the slave fd number should override this
+     * to provide a platform-specific binding (FFM or JNI).  The default returns
+     * {@code null}, which falls back to the VMIN/VTIME heuristic for backward
+     * compatibility.</p>
+     *
+     * @return {@code (timeoutMs) → poll result}: positive if data is ready,
+     *         0 on timeout, negative on error; or {@code null} if poll is
+     *         not available
+     */
+    protected IntUnaryOperator createSlavePollFunction() {
+        return null;
+    }
+
     class PtyInputStream extends NonBlockingInputStream {
         final InputStream in;
+        final IntUnaryOperator pollFn;
         int c = 0;
 
         PtyInputStream(InputStream in) {
             this.in = in;
+            this.pollFn = createSlavePollFunction();
         }
 
         @Override
@@ -147,11 +170,31 @@ public abstract class AbstractPty implements Pty {
                     c = 0;
                 }
                 return r;
+            }
+            if (pollFn != null) {
+                return readWithPoll(timeout, isPeek);
             } else {
-                setNonBlocking();
-                long start = System.nanoTime();
-                while (true) {
-                    long readStart = System.nanoTime();
+                return readWithVtime(timeout, isPeek);
+            }
+        }
+
+        /**
+         * Poll-based read: uses {@code poll(2)} to wait for data readiness,
+         * then reads without risk of blocking. No VMIN/VTIME manipulation
+         * needed — poll provides its own kernel-enforced timeout.
+         */
+        private int readWithPoll(long timeout, boolean isPeek) throws IOException {
+            long deadline = timeout > 0 ? System.currentTimeMillis() + timeout : 0;
+            while (true) {
+                int remaining = timeout > 0 ? (int) Math.max(1, deadline - System.currentTimeMillis()) : 100;
+                int pollResult;
+                try {
+                    pollResult = pollFn.applyAsInt(remaining);
+                } catch (RuntimeException e) {
+                    return -1; // poll error → treat as EOF
+                }
+                if (pollResult > 0) {
+                    // Data ready — read() will not block
                     int r = in.read();
                     if (r >= 0) {
                         if (isPeek) {
@@ -159,18 +202,48 @@ public abstract class AbstractPty implements Pty {
                         }
                         return r;
                     }
-                    // r == -1: could be real EOF or VMIN=0/VTIME=1 timeout on a real PTY.
-                    // With VTIME=1 (100ms), a timeout takes ~100ms to return -1.
-                    // Real EOF (pipe closed, PTY slave closed) returns -1 instantly.
-                    long readElapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - readStart);
-                    if (readElapsed < 50) {
-                        return -1;
+                    return -1; // EOF
+                } else if (pollResult < 0) {
+                    return -1; // poll error → EOF
+                }
+                // pollResult == 0: timeout
+                checkInterrupted();
+                if (timeout > 0 && System.currentTimeMillis() >= deadline) {
+                    return NonBlockingInputStream.READ_EXPIRED;
+                }
+                if (timeout == 0) {
+                    return NonBlockingInputStream.READ_EXPIRED;
+                }
+            }
+        }
+
+        /**
+         * Legacy VMIN/VTIME-based read for terminals without poll(2) support.
+         * Uses a timing heuristic: real EOF returns from {@code read()} in
+         * under 50ms, while a VTIME=1 timeout takes ~100ms.
+         */
+        private int readWithVtime(long timeout, boolean isPeek) throws IOException {
+            setNonBlocking();
+            long startMs = System.currentTimeMillis();
+            while (true) {
+                long readStart = System.nanoTime();
+                int r = in.read();
+                if (r >= 0) {
+                    if (isPeek) {
+                        c = r;
                     }
-                    checkInterrupted();
-                    long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-                    if (timeout > 0 && elapsed > timeout) {
-                        return NonBlockingInputStream.READ_EXPIRED;
-                    }
+                    return r;
+                }
+                // r == -1: could be real EOF or VMIN=0/VTIME=1 timeout on a real PTY.
+                // With VTIME=1 (100ms), a timeout takes ~100ms to return -1.
+                // Real EOF (pipe closed, PTY slave closed) returns -1 instantly.
+                long readElapsedMs = (System.nanoTime() - readStart) / 1_000_000L;
+                if (readElapsedMs < 50) {
+                    return -1;
+                }
+                checkInterrupted();
+                if (timeout > 0 && (System.currentTimeMillis() - startMs) > timeout) {
+                    return NonBlockingInputStream.READ_EXPIRED;
                 }
             }
         }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -442,6 +442,23 @@ public abstract class AbstractTerminal implements TerminalExt {
 
     // ---- Terminal mode batch probing ----
 
+    /**
+     * Returns {@code true} if the terminal's input stream uses {@code poll(2)}
+     * or an equivalent mechanism to enforce read timeouts.
+     *
+     * <p>When poll is available, the probe code can run synchronously on the
+     * calling thread because {@code read(timeout)} will reliably return within
+     * the specified time even on PTY file descriptors. When poll is NOT available,
+     * the probe must use a daemon thread with a hard deadline to break out of
+     * potentially blocking reads (see {@link #ensureModesProbed()}).</p>
+     *
+     * <p>The default returns {@code false}. Subclasses that wire poll into
+     * their input streams should override.</p>
+     */
+    protected boolean hasPollSupport() {
+        return false;
+    }
+
     @Override
     public boolean isModeSupported(Mode mode) {
         ensureModesProbed();
@@ -505,13 +522,6 @@ public abstract class AbstractTerminal implements TerminalExt {
 
                 long probeTimeout = getLongProperty(TerminalBuilder.PROP_PROBE_TIMEOUT, 200);
                 long drainTimeout = getLongProperty(TerminalBuilder.PROP_DRAIN_TIMEOUT, 25);
-                // Hard deadline = probe timeout + drain timeout + 500 ms safety margin.
-                // The Java-level timeouts inside readProbeChar/readTerminalResponse should
-                // normally be sufficient, but when the native read() on a PTY fd blocks
-                // despite VMIN=0/VTIME=0 (#2209), the Java timeout is never reached.
-                // The hard deadline breaks out of that state via Thread.join(timeout).
-                // Saturating addition prevents overflow when properties are very large.
-                long hardDeadline = saturatingAdd(probeTimeout, drainTimeout, 500);
 
                 Attributes prev = getAttributes();
                 Attributes probeAttrs = new Attributes(prev);
@@ -520,50 +530,51 @@ public abstract class AbstractTerminal implements TerminalExt {
                 probeAttrs.setControlChar(ControlChar.VTIME, 0);
                 setAttributes(probeAttrs);
 
-                // Track whether the probe completed before the hard deadline.
-                // The probe thread only publishes results and restores attributes
-                // when it finishes cleanly; a timed-out/interrupted probe leaves
-                // cleanup to the calling thread.
-                AtomicBoolean probeCompleted = new AtomicBoolean(false);
-                Thread probeThread = new Thread(
-                        () -> {
-                            try {
-                                probeModes();
-                                // Only mark completed if the calling thread has not
-                                // interrupted us. The interrupt flag signals that the
-                                // caller timed out and has taken over cleanup.
-                                if (!Thread.currentThread().isInterrupted()) {
-                                    probeCompleted.set(true);
+                if (hasPollSupport()) {
+                    // poll(2) guarantees that read timeouts are enforced even on
+                    // PTY fds, so we can probe synchronously without a daemon thread.
+                    try {
+                        probeModes();
+                    } finally {
+                        drainInput(reader(), drainTimeout, -1);
+                        setAttributes(prev);
+                    }
+                } else {
+                    // Without poll, native read() on a PTY fd may block despite
+                    // VMIN=0/VTIME=0 (#2209).  Use a daemon thread with a hard
+                    // deadline to break out of that state.
+                    long hardDeadline = saturatingAdd(probeTimeout, drainTimeout, 500);
+                    AtomicBoolean probeCompleted = new AtomicBoolean(false);
+                    Thread probeThread = new Thread(
+                            () -> {
+                                try {
+                                    probeModes();
+                                    if (!Thread.currentThread().isInterrupted()) {
+                                        probeCompleted.set(true);
+                                    }
+                                } finally {
+                                    if (probeCompleted.get()) {
+                                        drainInput(reader(), drainTimeout, -1);
+                                        setAttributes(prev);
+                                    }
                                 }
-                            } finally {
-                                // Drain and restore only when the probe completed
-                                // before the caller's hard deadline. A timed-out
-                                // probe must not restore stale attributes that the
-                                // calling thread has already corrected.
-                                if (probeCompleted.get()) {
-                                    drainInput(reader(), drainTimeout, -1);
-                                    setAttributes(prev);
-                                }
-                            }
-                        },
-                        getName() + " probe");
-                probeThread.setDaemon(true);
-                probeThread.start();
-                try {
-                    probeThread.join(hardDeadline);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-                if (!probeCompleted.get()) {
-                    // Probe did not complete in time — interrupt the thread
-                    // (best effort), discard any partial results, and restore
-                    // terminal attributes from the calling thread.
-                    probeThread.interrupt();
-                    modeProbeResults.clear();
-                    setAttributes(prev);
-                    if (probeThread.isAlive()) {
-                        Log.debug("Terminal probe timed out on " + getName()
-                                + " — native read may be stuck on a PTY fd (#2209)");
+                            },
+                            getName() + " probe");
+                    probeThread.setDaemon(true);
+                    probeThread.start();
+                    try {
+                        probeThread.join(hardDeadline);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    if (!probeCompleted.get()) {
+                        probeThread.interrupt();
+                        modeProbeResults.clear();
+                        setAttributes(prev);
+                        if (probeThread.isAlive()) {
+                            Log.debug("Terminal probe timed out on " + getName()
+                                    + " — native read may be stuck on a PTY fd (#2209)");
+                        }
                     }
                 }
             } finally {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -79,6 +79,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
     final Map<Signal, Object> nativeHandlers = new ConcurrentHashMap<>();
     private volatile Attributes cachedAttributes;
     private final Task closer;
+    private final boolean pollAvailable;
 
     @SuppressWarnings({"this-escape", "squid:S107"})
     protected AbstractUnixSysTerminal(
@@ -107,6 +108,9 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
         IntUnaryOperator pollFn = createPollFunction();
         if (pollFn != null) {
             this.input.setPollFunction(pollFn);
+            this.pollAvailable = true;
+        } else {
+            this.pollAvailable = false;
         }
         cachedAttributes = new Attributes(originalAttributes);
         FileDescriptor outFd;
@@ -193,6 +197,11 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
      */
     protected IntUnaryOperator createPollFunction() {
         return null;
+    }
+
+    @Override
+    protected boolean hasPollSupport() {
+        return pollAvailable;
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -67,6 +67,7 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
     private Thread inputPumpThread;
     private Thread outputPumpThread;
     private boolean paused = true;
+    private final boolean pollAvailable;
 
     public PosixPtyTerminal(String name, String type, Pty pty, InputStream in, OutputStream out, Charset encoding)
             throws IOException {
@@ -121,6 +122,7 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
         this.output = pty.getSlaveOutput();
         this.reader = NonBlocking.nonBlocking(name, input, inputEncoding());
         this.writer = new PrintWriter(new OutputStreamWriter(output, outputEncoding()));
+        this.pollAvailable = pty instanceof AbstractPty && ((AbstractPty) pty).createSlavePollFunction() != null;
         parseInfoCmp();
         if (!paused) {
             resume();
@@ -145,6 +147,11 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
     public PrintWriter writer() {
         checkClosed();
         return writer;
+    }
+
+    @Override
+    protected boolean hasPollSupport() {
+        return pollAvailable;
     }
 
     @Override

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.function.IntUnaryOperator;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Size;
+import org.jline.terminal.Sized;
+import org.jline.utils.NonBlockingInputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.jline.terminal.TerminalBuilder.PROP_NON_BLOCKING_READS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that {@code PtyInputStream} uses {@code poll(2)} when available,
+ * falling back to the VMIN/VTIME heuristic when not.
+ */
+class PtyInputStreamPollTest {
+
+    private String savedNonBlockingReads;
+
+    @BeforeEach
+    void setUp() {
+        savedNonBlockingReads = System.getProperty(PROP_NON_BLOCKING_READS);
+        System.setProperty(PROP_NON_BLOCKING_READS, "true");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedNonBlockingReads != null) {
+            System.setProperty(PROP_NON_BLOCKING_READS, savedNonBlockingReads);
+        } else {
+            System.clearProperty(PROP_NON_BLOCKING_READS);
+        }
+    }
+
+    /**
+     * Creates a test PTY with a simulated poll function.
+     *
+     * @param pipedIn the input stream to read from
+     * @param writerClosed set to true when the writer is closed, so the
+     *                     poll function can simulate POLLHUP
+     */
+    private AbstractPty createPtyWithPoll(
+            PipedInputStream pipedIn, java.util.concurrent.atomic.AtomicBoolean writerClosed) {
+        return new AbstractPty(null, null) {
+            @Override
+            protected IntUnaryOperator createSlavePollFunction() {
+                // Simulate poll(2):
+                // data available → return 1 (POLLIN)
+                // writer closed  → return 1 (POLLHUP — let read() discover EOF)
+                // no data, open  → sleep up to timeout, return 0
+                return timeoutMs -> {
+                    try {
+                        long deadline = System.currentTimeMillis() + timeoutMs;
+                        do {
+                            if (pipedIn.available() > 0 || writerClosed.get()) {
+                                return 1;
+                            }
+                            Thread.sleep(Math.min(5, Math.max(1, deadline - System.currentTimeMillis())));
+                        } while (System.currentTimeMillis() < deadline);
+                        return writerClosed.get() ? 1 : 0;
+                    } catch (Exception e) {
+                        return 1;
+                    }
+                };
+            }
+
+            @Override
+            protected void doSetAttr(Attributes attr) {}
+
+            @Override
+            protected InputStream doGetSlaveInput() {
+                return pipedIn;
+            }
+
+            @Override
+            public InputStream getMasterInput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getMasterOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getSlaveOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Attributes getAttr() {
+                return new Attributes();
+            }
+
+            @Override
+            public Size getSize() {
+                return Size.of(80, 24);
+            }
+
+            @Override
+            public void setSize(Sized size) {}
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    @Test
+    @Timeout(10)
+    void pollBasedReadReturnsData() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
+        java.util.concurrent.atomic.AtomicBoolean writerClosed = new java.util.concurrent.atomic.AtomicBoolean();
+
+        AbstractPty pty = createPtyWithPoll(pipedIn, writerClosed);
+        // Initialize terminal attributes (normally done by PosixPtyTerminal)
+        pty.setAttr(new Attributes());
+        InputStream slaveInput = pty.getSlaveInput();
+        assertTrue(slaveInput instanceof NonBlockingInputStream);
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        // Write data and verify it's read correctly via poll path
+        pipedOut.write('X');
+        int ch = nbis.read(1000);
+        assertEquals('X', ch);
+    }
+
+    @Test
+    @Timeout(10)
+    void pollBasedReadTimeoutReturnsExpired() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        new PipedOutputStream(pipedIn); // keep pipe open
+        java.util.concurrent.atomic.AtomicBoolean writerClosed = new java.util.concurrent.atomic.AtomicBoolean();
+
+        AbstractPty pty = createPtyWithPoll(pipedIn, writerClosed);
+        // Initialize terminal attributes (normally done by PosixPtyTerminal)
+        pty.setAttr(new Attributes());
+        InputStream slaveInput = pty.getSlaveInput();
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        // No data written — should timeout and return READ_EXPIRED
+        long start = System.currentTimeMillis();
+        int result = nbis.read(100);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertEquals(NonBlockingInputStream.READ_EXPIRED, result);
+        assertTrue(elapsed >= 50, "Timeout should have waited at least 50ms, was " + elapsed + "ms");
+    }
+
+    @Test
+    @Timeout(10)
+    void pollBasedReadDetectsEof() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
+        java.util.concurrent.atomic.AtomicBoolean writerClosed = new java.util.concurrent.atomic.AtomicBoolean();
+
+        AbstractPty pty = createPtyWithPoll(pipedIn, writerClosed);
+        // Initialize terminal attributes (normally done by PosixPtyTerminal)
+        pty.setAttr(new Attributes());
+        InputStream slaveInput = pty.getSlaveInput();
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        // Write, close, then read should get data followed by EOF
+        pipedOut.write('A');
+        pipedOut.close();
+        writerClosed.set(true);
+
+        int ch = nbis.read(1000);
+        assertEquals('A', ch);
+
+        int eof = nbis.read(1000);
+        assertEquals(-1, eof, "Expected EOF (-1) after pipe closed");
+    }
+}


### PR DESCRIPTION
## Summary

Use the `poll(2)` bindings added in #2222 to replace VMIN/VTIME workarounds in probe and PTY read paths.

## Changes

### PtyInputStream: poll-based reads

`AbstractPty.PtyInputStream` now uses `poll(2)` when available instead of the VMIN/VTIME timing heuristic. Previously, it set `VMIN=0/VTIME=1` and used elapsed time (`< 50ms` = real EOF, `>= 50ms` = timeout) to distinguish real EOF from timeout — a heuristic that breaks under CPU pressure. With poll, there's no VMIN/VTIME manipulation and no timing guesswork:

- `poll(fd, timeout)` returns positive → `read()` won't block
- `poll(fd, timeout)` returns 0 → timeout, return `READ_EXPIRED`
- `poll(fd, timeout)` returns negative → error, treat as EOF

Falls back to the existing VMIN/VTIME approach when poll is not available (`ExecPty`, etc.).

### Poll function for slave fd

`AbstractPty.createSlavePollFunction()` is a new protected hook. Overridden in:
- `FfmNativePty`: `timeoutMs -> CLibrary.pollForInput(slave, timeoutMs)`
- `JniNativePty`: same, with `UnsatisfiedLinkError` guard for older native binaries

### Simplified probe code

`AbstractTerminal.ensureModesProbed()` now probes synchronously when poll is available, because `poll(2)` guarantees that read timeouts are enforced even on PTY file descriptors. The daemon thread + hard deadline workaround (from #2210) is only used as a fallback when poll is not available.

`AbstractTerminal.hasPollSupport()` is a new protected hook, overridden by `AbstractUnixSysTerminal` and `PosixPtyTerminal`.

## Test plan

- [x] All 603 terminal module tests pass
- [x] New `PtyInputStreamPollTest`: verifies data read, timeout, and EOF detection via the poll path
- [x] Full build succeeds (`./mvx mvn install -DskipTests`)

Fixes #2223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-blocking terminal input handling by using operating-system readiness polling when available.
  * Improved detection of input timeouts and end-of-stream conditions.
  * Retained a fallback timing-based approach on terminals without polling support.
* **Tests**
  * Added coverage for non-blocking reads, input timeouts, and EOF detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->