### PR TITLE
fix: use poll(2) for probe and PTY reads (fixes #2223)

### DIFF
--- a/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmNativePty.java
+++ b/terminal-ffm/src/main/java/org/jline/terminal/impl/ffm/FfmNativePty.java
@@ -14,6 +14,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.function.IntUnaryOperator;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
@@ -72,6 +73,11 @@ class FfmNativePty extends AbstractPty {
         if (slave > 0) {
             getSlaveInput().close();
         }
+    }
+
+    @Override
+    protected IntUnaryOperator createSlavePollFunction() {
+        return timeoutMs -> CLibrary.pollForInput(slave, timeoutMs);
     }
 
     public int getMaster() {

--- a/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniNativePty.java
+++ b/terminal-jni/src/main/java/org/jline/terminal/impl/jni/JniNativePty.java
@@ -14,6 +14,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.function.IntUnaryOperator;
 
 import org.jline.nativ.CLibrary;
 import org.jline.nativ.Kernel32;
@@ -91,6 +92,18 @@ public abstract class JniNativePty extends AbstractPty implements Pty {
         if (slave > 0) {
             getSlaveInput().close();
         }
+    }
+
+    @Override
+    protected IntUnaryOperator createSlavePollFunction() {
+        try {
+            // Verify the native method is available in the loaded library.
+            // Older pre-compiled binaries may not contain pollForInput yet.
+            CLibrary.pollForInput(slave, 0);
+        } catch (UnsatisfiedLinkError e) {
+            return null; // fall back to VMIN/VTIME heuristic
+        }
+        return timeoutMs -> CLibrary.pollForInput(slave, timeoutMs);
     }
 
     public int getMaster() {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -17,7 +17,7 @@ import java.io.InterruptedIOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.function.IntUnaryOperator;
 
 import org.jline.nativ.JLineLibrary;
 import org.jline.nativ.JLineNativeLoader;
@@ -129,12 +129,35 @@ public abstract class AbstractPty implements Pty {
         return systemStream;
     }
 
+    /**
+     * Creates a poll function for the slave file descriptor.
+     *
+     * <p>When non-null, the returned function checks the slave fd for input
+     * readiness using an OS-level mechanism such as {@code poll(2)}.  This
+     * replaces the fragile VMIN/VTIME timing heuristic in {@link PtyInputStream}
+     * with a kernel-enforced timeout that works reliably on PTY file descriptors.</p>
+     *
+     * <p>Subclasses that have access to the slave fd number should override this
+     * to provide a platform-specific binding (FFM or JNI).  The default returns
+     * {@code null}, which falls back to the VMIN/VTIME heuristic for backward
+     * compatibility.</p>
+     *
+     * @return {@code (timeoutMs) → poll result}: positive if data is ready,
+     *         0 on timeout, negative on error; or {@code null} if poll is
+     *         not available
+     */
+    protected IntUnaryOperator createSlavePollFunction() {
+        return null;
+    }
+
     class PtyInputStream extends NonBlockingInputStream {
         final InputStream in;
+        final IntUnaryOperator pollFn;
         int c = 0;
 
         PtyInputStream(InputStream in) {
             this.in = in;
+            this.pollFn = createSlavePollFunction();
         }
 
         @Override
@@ -147,11 +170,31 @@ public abstract class AbstractPty implements Pty {
                     c = 0;
                 }
                 return r;
+            }
+            if (pollFn != null) {
+                return readWithPoll(timeout, isPeek);
             } else {
-                setNonBlocking();
-                long start = System.nanoTime();
-                while (true) {
-                    long readStart = System.nanoTime();
+                return readWithVtime(timeout, isPeek);
+            }
+        }
+
+        /**
+         * Poll-based read: uses {@code poll(2)} to wait for data readiness,
+         * then reads without risk of blocking. No VMIN/VTIME manipulation
+         * needed — poll provides its own kernel-enforced timeout.
+         */
+        private int readWithPoll(long timeout, boolean isPeek) throws IOException {
+            long deadline = timeout > 0 ? System.currentTimeMillis() + timeout : 0;
+            while (true) {
+                int remaining = timeout > 0 ? (int) Math.max(1, deadline - System.currentTimeMillis()) : 100;
+                int pollResult;
+                try {
+                    pollResult = pollFn.applyAsInt(remaining);
+                } catch (RuntimeException e) {
+                    return -1; // poll error → treat as EOF
+                }
+                if (pollResult > 0) {
+                    // Data ready — read() will not block
                     int r = in.read();
                     if (r >= 0) {
                         if (isPeek) {
@@ -159,18 +202,48 @@ public abstract class AbstractPty implements Pty {
                         }
                         return r;
                     }
-                    // r == -1: could be real EOF or VMIN=0/VTIME=1 timeout on a real PTY.
-                    // With VTIME=1 (100ms), a timeout takes ~100ms to return -1.
-                    // Real EOF (pipe closed, PTY slave closed) returns -1 instantly.
-                    long readElapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - readStart);
-                    if (readElapsed < 50) {
-                        return -1;
+                    return -1; // EOF
+                } else if (pollResult < 0) {
+                    return -1; // poll error → EOF
+                }
+                // pollResult == 0: timeout
+                checkInterrupted();
+                if (timeout > 0 && System.currentTimeMillis() >= deadline) {
+                    return NonBlockingInputStream.READ_EXPIRED;
+                }
+                if (timeout == 0) {
+                    return NonBlockingInputStream.READ_EXPIRED;
+                }
+            }
+        }
+
+        /**
+         * Legacy VMIN/VTIME-based read for terminals without poll(2) support.
+         * Uses a timing heuristic: real EOF returns from {@code read()} in
+         * under 50ms, while a VTIME=1 timeout takes ~100ms.
+         */
+        private int readWithVtime(long timeout, boolean isPeek) throws IOException {
+            setNonBlocking();
+            long startMs = System.currentTimeMillis();
+            while (true) {
+                long readStart = System.nanoTime();
+                int r = in.read();
+                if (r >= 0) {
+                    if (isPeek) {
+                        c = r;
                     }
-                    checkInterrupted();
-                    long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-                    if (timeout > 0 && elapsed > timeout) {
-                        return NonBlockingInputStream.READ_EXPIRED;
-                    }
+                    return r;
+                }
+                // r == -1: could be real EOF or VMIN=0/VTIME=1 timeout on a real PTY.
+                // With VTIME=1 (100ms), a timeout takes ~100ms to return -1.
+                // Real EOF (pipe closed, PTY slave closed) returns -1 instantly.
+                long readElapsedMs = (System.nanoTime() - readStart) / 1_000_000L;
+                if (readElapsedMs < 50) {
+                    return -1;
+                }
+                checkInterrupted();
+                if (timeout > 0 && (System.currentTimeMillis() - startMs) > timeout) {
+                    return NonBlockingInputStream.READ_EXPIRED;
                 }
             }
         }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -65,7 +65,8 @@ public abstract class AbstractPty implements Pty {
     protected final SystemStream systemStream;
     private Attributes current;
     private boolean skipNextLf;
-    private Boolean slavePollAvailable;
+    private IntUnaryOperator cachedPollFn;
+    private boolean pollFnResolved;
 
     public AbstractPty(TerminalProvider provider, SystemStream systemStream) {
         this.provider = provider;
@@ -152,14 +153,22 @@ public abstract class AbstractPty implements Pty {
     }
 
     /**
+     * Returns the cached poll function, resolving it on first call.
+     */
+    private IntUnaryOperator getSlavePollFunction() {
+        if (!pollFnResolved) {
+            cachedPollFn = createSlavePollFunction();
+            pollFnResolved = true;
+        }
+        return cachedPollFn;
+    }
+
+    /**
      * Returns {@code true} if this PTY has {@code poll(2)} support for its
      * slave file descriptor.  The result is cached after the first call.
      */
     boolean hasSlavePollSupport() {
-        if (slavePollAvailable == null) {
-            slavePollAvailable = createSlavePollFunction() != null;
-        }
-        return slavePollAvailable;
+        return getSlavePollFunction() != null;
     }
 
     class PtyInputStream extends NonBlockingInputStream {
@@ -169,7 +178,7 @@ public abstract class AbstractPty implements Pty {
 
         PtyInputStream(InputStream in) {
             this.in = in;
-            this.pollFn = createSlavePollFunction();
+            this.pollFn = getSlavePollFunction();
         }
 
         @Override

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -198,7 +198,8 @@ public abstract class AbstractPty implements Pty {
         private int readWithPoll(long timeout, boolean isPeek) throws IOException {
             long deadline = timeout > 0 ? System.currentTimeMillis() + timeout : 0;
             while (true) {
-                int remaining = timeout > 0 ? (int) Math.max(1, deadline - System.currentTimeMillis()) : 100;
+                long remainingMs = timeout > 0 ? Math.max(1, deadline - System.currentTimeMillis()) : 100;
+                int remaining = (int) Math.min(remainingMs, Integer.MAX_VALUE);
                 int pollResult = doPoll(remaining);
                 if (pollResult > 0) {
                     return readAvailable(isPeek);

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -65,6 +65,7 @@ public abstract class AbstractPty implements Pty {
     protected final SystemStream systemStream;
     private Attributes current;
     private boolean skipNextLf;
+    private Boolean slavePollAvailable;
 
     public AbstractPty(TerminalProvider provider, SystemStream systemStream) {
         this.provider = provider;
@@ -150,6 +151,17 @@ public abstract class AbstractPty implements Pty {
         return null;
     }
 
+    /**
+     * Returns {@code true} if this PTY has {@code poll(2)} support for its
+     * slave file descriptor.  The result is cached after the first call.
+     */
+    boolean hasSlavePollSupport() {
+        if (slavePollAvailable == null) {
+            slavePollAvailable = createSlavePollFunction() != null;
+        }
+        return slavePollAvailable;
+    }
+
     class PtyInputStream extends NonBlockingInputStream {
         final InputStream in;
         final IntUnaryOperator pollFn;
@@ -187,34 +199,37 @@ public abstract class AbstractPty implements Pty {
             long deadline = timeout > 0 ? System.currentTimeMillis() + timeout : 0;
             while (true) {
                 int remaining = timeout > 0 ? (int) Math.max(1, deadline - System.currentTimeMillis()) : 100;
-                int pollResult;
-                try {
-                    pollResult = pollFn.applyAsInt(remaining);
-                } catch (RuntimeException e) {
-                    return -1; // poll error → treat as EOF
-                }
+                int pollResult = doPoll(remaining);
                 if (pollResult > 0) {
-                    // Data ready — read() will not block
-                    int r = in.read();
-                    if (r >= 0) {
-                        if (isPeek) {
-                            c = r;
-                        }
-                        return r;
-                    }
-                    return -1; // EOF
+                    return readAvailable(isPeek);
                 } else if (pollResult < 0) {
                     return -1; // poll error → EOF
                 }
-                // pollResult == 0: timeout
+                // pollResult == 0: timeout — check if we should keep waiting
                 checkInterrupted();
                 if (timeout > 0 && System.currentTimeMillis() >= deadline) {
                     return NonBlockingInputStream.READ_EXPIRED;
                 }
-                if (timeout == 0) {
-                    return NonBlockingInputStream.READ_EXPIRED;
-                }
+                // timeout <= 0 means "wait forever" — loop again
             }
+        }
+
+        /** Calls poll(2) on the slave fd, converting exceptions to EOF (-1). */
+        private int doPoll(int timeoutMs) {
+            try {
+                return pollFn.applyAsInt(timeoutMs);
+            } catch (RuntimeException e) {
+                return -1;
+            }
+        }
+
+        /** Reads one byte from the underlying stream, handling peek. */
+        private int readAvailable(boolean isPeek) throws IOException {
+            int r = in.read();
+            if (r >= 0 && isPeek) {
+                c = r;
+            }
+            return r >= 0 ? r : -1;
         }
 
         /**

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -242,7 +242,7 @@ public abstract class AbstractPty implements Pty {
          */
         private int readWithVtime(long timeout, boolean isPeek) throws IOException {
             setNonBlocking();
-            long startMs = System.currentTimeMillis();
+            long startNanos = System.nanoTime();
             while (true) {
                 long readStart = System.nanoTime();
                 int r = in.read();
@@ -260,7 +260,7 @@ public abstract class AbstractPty implements Pty {
                     return -1;
                 }
                 checkInterrupted();
-                if (timeout > 0 && (System.currentTimeMillis() - startMs) > timeout) {
+                if (timeout > 0 && (System.nanoTime() - startNanos) / 1_000_000L > timeout) {
                     return NonBlockingInputStream.READ_EXPIRED;
                 }
             }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -196,9 +196,11 @@ public abstract class AbstractPty implements Pty {
          * needed — poll provides its own kernel-enforced timeout.
          */
         private int readWithPoll(long timeout, boolean isPeek) throws IOException {
-            long deadline = timeout > 0 ? System.currentTimeMillis() + timeout : 0;
+            long timeoutNanos = timeout > 0 ? timeout * 1_000_000L : 0;
+            long deadline = timeout > 0 ? System.nanoTime() + timeoutNanos : 0;
             while (true) {
-                long remainingMs = timeout > 0 ? Math.max(1, deadline - System.currentTimeMillis()) : 100;
+                long remainingMs =
+                        timeout > 0 ? Math.max(1, (deadline - System.nanoTime() + 999_999) / 1_000_000) : 100;
                 int remaining = (int) Math.min(remainingMs, Integer.MAX_VALUE);
                 int pollResult = doPoll(remaining);
                 if (pollResult > 0) {
@@ -208,7 +210,7 @@ public abstract class AbstractPty implements Pty {
                 }
                 // pollResult == 0: timeout — check if we should keep waiting
                 checkInterrupted();
-                if (timeout > 0 && System.currentTimeMillis() >= deadline) {
+                if (timeout > 0 && System.nanoTime() >= deadline) {
                     return NonBlockingInputStream.READ_EXPIRED;
                 }
                 // timeout <= 0 means "wait forever" — loop again

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractPty.java
@@ -192,10 +192,11 @@ public abstract class AbstractPty implements Pty {
                 }
                 return r;
             }
+            long timeoutNanos = timeout > 0 ? timeout * 1_000_000L : 0;
             if (pollFn != null) {
-                return readWithPoll(timeout, isPeek);
+                return readWithPoll(timeoutNanos, isPeek);
             } else {
-                return readWithVtime(timeout, isPeek);
+                return readWithVtime(timeoutNanos, isPeek);
             }
         }
 
@@ -203,15 +204,17 @@ public abstract class AbstractPty implements Pty {
          * Poll-based read: uses {@code poll(2)} to wait for data readiness,
          * then reads without risk of blocking. No VMIN/VTIME manipulation
          * needed — poll provides its own kernel-enforced timeout.
+         *
+         * @param timeoutNanos timeout in nanoseconds; {@code 0} means wait forever
          */
-        private int readWithPoll(long timeout, boolean isPeek) throws IOException {
-            long timeoutNanos = timeout > 0 ? timeout * 1_000_000L : 0;
-            long deadline = timeout > 0 ? System.nanoTime() + timeoutNanos : 0;
+        private int readWithPoll(long timeoutNanos, boolean isPeek) throws IOException {
+            long deadline = timeoutNanos > 0 ? System.nanoTime() + timeoutNanos : 0;
             while (true) {
-                long remainingMs =
-                        timeout > 0 ? Math.max(1, (deadline - System.nanoTime() + 999_999) / 1_000_000) : 100;
-                int remaining = (int) Math.min(remainingMs, Integer.MAX_VALUE);
-                int pollResult = doPoll(remaining);
+                long remainingNanos = timeoutNanos > 0 ? Math.max(1_000_000L, deadline - System.nanoTime()) : 0;
+                int remainingMs = timeoutNanos > 0
+                        ? (int) Math.min((remainingNanos + 999_999) / 1_000_000, Integer.MAX_VALUE)
+                        : 100;
+                int pollResult = doPoll(remainingMs);
                 if (pollResult > 0) {
                     return readAvailable(isPeek);
                 } else if (pollResult < 0) {
@@ -219,10 +222,10 @@ public abstract class AbstractPty implements Pty {
                 }
                 // pollResult == 0: timeout — check if we should keep waiting
                 checkInterrupted();
-                if (timeout > 0 && System.nanoTime() >= deadline) {
+                if (timeoutNanos > 0 && System.nanoTime() >= deadline) {
                     return NonBlockingInputStream.READ_EXPIRED;
                 }
-                // timeout <= 0 means "wait forever" — loop again
+                // timeoutNanos <= 0 means "wait forever" — loop again
             }
         }
 
@@ -248,10 +251,12 @@ public abstract class AbstractPty implements Pty {
          * Legacy VMIN/VTIME-based read for terminals without poll(2) support.
          * Uses a timing heuristic: real EOF returns from {@code read()} in
          * under 50ms, while a VTIME=1 timeout takes ~100ms.
+         *
+         * @param timeoutNanos timeout in nanoseconds; {@code 0} means wait forever
          */
-        private int readWithVtime(long timeout, boolean isPeek) throws IOException {
+        private int readWithVtime(long timeoutNanos, boolean isPeek) throws IOException {
             setNonBlocking();
-            long startNanos = System.nanoTime();
+            long deadline = timeoutNanos > 0 ? System.nanoTime() + timeoutNanos : 0;
             while (true) {
                 long readStart = System.nanoTime();
                 int r = in.read();
@@ -264,12 +269,12 @@ public abstract class AbstractPty implements Pty {
                 // r == -1: could be real EOF or VMIN=0/VTIME=1 timeout on a real PTY.
                 // With VTIME=1 (100ms), a timeout takes ~100ms to return -1.
                 // Real EOF (pipe closed, PTY slave closed) returns -1 instantly.
-                long readElapsedMs = (System.nanoTime() - readStart) / 1_000_000L;
-                if (readElapsedMs < 50) {
+                long readElapsedNanos = System.nanoTime() - readStart;
+                if (readElapsedNanos < 50_000_000L) {
                     return -1;
                 }
                 checkInterrupted();
-                if (timeout > 0 && (System.nanoTime() - startNanos) / 1_000_000L > timeout) {
+                if (timeoutNanos > 0 && System.nanoTime() >= deadline) {
                     return NonBlockingInputStream.READ_EXPIRED;
                 }
             }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -442,6 +442,23 @@ public abstract class AbstractTerminal implements TerminalExt {
 
     // ---- Terminal mode batch probing ----
 
+    /**
+     * Returns {@code true} if the terminal's input stream uses {@code poll(2)}
+     * or an equivalent mechanism to enforce read timeouts.
+     *
+     * <p>When poll is available, the probe code can run synchronously on the
+     * calling thread because {@code read(timeout)} will reliably return within
+     * the specified time even on PTY file descriptors. When poll is NOT available,
+     * the probe must use a daemon thread with a hard deadline to break out of
+     * potentially blocking reads (see {@link #ensureModesProbed()}).</p>
+     *
+     * <p>The default returns {@code false}. Subclasses that wire poll into
+     * their input streams should override.</p>
+     */
+    protected boolean hasPollSupport() {
+        return false;
+    }
+
     @Override
     public boolean isModeSupported(Mode mode) {
         ensureModesProbed();
@@ -505,13 +522,6 @@ public abstract class AbstractTerminal implements TerminalExt {
 
                 long probeTimeout = getLongProperty(TerminalBuilder.PROP_PROBE_TIMEOUT, 200);
                 long drainTimeout = getLongProperty(TerminalBuilder.PROP_DRAIN_TIMEOUT, 25);
-                // Hard deadline = probe timeout + drain timeout + 500 ms safety margin.
-                // The Java-level timeouts inside readProbeChar/readTerminalResponse should
-                // normally be sufficient, but when the native read() on a PTY fd blocks
-                // despite VMIN=0/VTIME=0 (#2209), the Java timeout is never reached.
-                // The hard deadline breaks out of that state via Thread.join(timeout).
-                // Saturating addition prevents overflow when properties are very large.
-                long hardDeadline = saturatingAdd(probeTimeout, drainTimeout, 500);
 
                 Attributes prev = getAttributes();
                 Attributes probeAttrs = new Attributes(prev);
@@ -520,50 +530,51 @@ public abstract class AbstractTerminal implements TerminalExt {
                 probeAttrs.setControlChar(ControlChar.VTIME, 0);
                 setAttributes(probeAttrs);
 
-                // Track whether the probe completed before the hard deadline.
-                // The probe thread only publishes results and restores attributes
-                // when it finishes cleanly; a timed-out/interrupted probe leaves
-                // cleanup to the calling thread.
-                AtomicBoolean probeCompleted = new AtomicBoolean(false);
-                Thread probeThread = new Thread(
-                        () -> {
-                            try {
-                                probeModes();
-                                // Only mark completed if the calling thread has not
-                                // interrupted us. The interrupt flag signals that the
-                                // caller timed out and has taken over cleanup.
-                                if (!Thread.currentThread().isInterrupted()) {
-                                    probeCompleted.set(true);
+                if (hasPollSupport()) {
+                    // poll(2) guarantees that read timeouts are enforced even on
+                    // PTY fds, so we can probe synchronously without a daemon thread.
+                    try {
+                        probeModes();
+                    } finally {
+                        drainInput(reader(), drainTimeout, -1);
+                        setAttributes(prev);
+                    }
+                } else {
+                    // Without poll, native read() on a PTY fd may block despite
+                    // VMIN=0/VTIME=0 (#2209).  Use a daemon thread with a hard
+                    // deadline to break out of that state.
+                    long hardDeadline = saturatingAdd(probeTimeout, drainTimeout, 500);
+                    AtomicBoolean probeCompleted = new AtomicBoolean(false);
+                    Thread probeThread = new Thread(
+                            () -> {
+                                try {
+                                    probeModes();
+                                    if (!Thread.currentThread().isInterrupted()) {
+                                        probeCompleted.set(true);
+                                    }
+                                } finally {
+                                    if (probeCompleted.get()) {
+                                        drainInput(reader(), drainTimeout, -1);
+                                        setAttributes(prev);
+                                    }
                                 }
-                            } finally {
-                                // Drain and restore only when the probe completed
-                                // before the caller's hard deadline. A timed-out
-                                // probe must not restore stale attributes that the
-                                // calling thread has already corrected.
-                                if (probeCompleted.get()) {
-                                    drainInput(reader(), drainTimeout, -1);
-                                    setAttributes(prev);
-                                }
-                            }
-                        },
-                        getName() + " probe");
-                probeThread.setDaemon(true);
-                probeThread.start();
-                try {
-                    probeThread.join(hardDeadline);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-                if (!probeCompleted.get()) {
-                    // Probe did not complete in time — interrupt the thread
-                    // (best effort), discard any partial results, and restore
-                    // terminal attributes from the calling thread.
-                    probeThread.interrupt();
-                    modeProbeResults.clear();
-                    setAttributes(prev);
-                    if (probeThread.isAlive()) {
-                        Log.debug("Terminal probe timed out on " + getName()
-                                + " — native read may be stuck on a PTY fd (#2209)");
+                            },
+                            getName() + " probe");
+                    probeThread.setDaemon(true);
+                    probeThread.start();
+                    try {
+                        probeThread.join(hardDeadline);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    if (!probeCompleted.get()) {
+                        probeThread.interrupt();
+                        modeProbeResults.clear();
+                        setAttributes(prev);
+                        if (probeThread.isAlive()) {
+                            Log.debug("Terminal probe timed out on " + getName()
+                                    + " — native read may be stuck on a PTY fd (#2209)");
+                        }
                     }
                 }
             } finally {

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -540,45 +540,51 @@ public abstract class AbstractTerminal implements TerminalExt {
                         setAttributes(prev);
                     }
                 } else {
-                    // Without poll, native read() on a PTY fd may block despite
-                    // VMIN=0/VTIME=0 (#2209).  Use a daemon thread with a hard
-                    // deadline to break out of that state.
-                    long hardDeadline = saturatingAdd(probeTimeout, drainTimeout, 500);
-                    AtomicBoolean probeCompleted = new AtomicBoolean(false);
-                    Thread probeThread = new Thread(
-                            () -> {
-                                try {
-                                    probeModes();
-                                    if (!Thread.currentThread().isInterrupted()) {
-                                        probeCompleted.set(true);
-                                    }
-                                } finally {
-                                    if (probeCompleted.get()) {
-                                        drainInput(reader(), drainTimeout, -1);
-                                        setAttributes(prev);
-                                    }
-                                }
-                            },
-                            getName() + " probe");
-                    probeThread.setDaemon(true);
-                    probeThread.start();
-                    try {
-                        probeThread.join(hardDeadline);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                    if (!probeCompleted.get()) {
-                        probeThread.interrupt();
-                        modeProbeResults.clear();
-                        setAttributes(prev);
-                        if (probeThread.isAlive()) {
-                            Log.debug("Terminal probe timed out on " + getName()
-                                    + " — native read may be stuck on a PTY fd (#2209)");
-                        }
-                    }
+                    probeWithDaemonThread(prev, probeTimeout, drainTimeout);
                 }
             } finally {
                 modesProbed = true;
+            }
+        }
+    }
+
+    /**
+     * Runs the mode probe on a daemon thread with a hard deadline, for terminals
+     * without poll(2) support where native read() may block despite VMIN=0/VTIME=0
+     * (see <a href="https://github.com/jline/jline3/issues/2209">#2209</a>).
+     */
+    private void probeWithDaemonThread(Attributes prev, long probeTimeout, long drainTimeout) {
+        long hardDeadline = saturatingAdd(probeTimeout, drainTimeout, 500);
+        AtomicBoolean probeCompleted = new AtomicBoolean(false);
+        Thread probeThread = new Thread(
+                () -> {
+                    try {
+                        probeModes();
+                        if (!Thread.currentThread().isInterrupted()) {
+                            probeCompleted.set(true);
+                        }
+                    } finally {
+                        if (probeCompleted.get()) {
+                            drainInput(reader(), drainTimeout, -1);
+                            setAttributes(prev);
+                        }
+                    }
+                },
+                getName() + " probe");
+        probeThread.setDaemon(true);
+        probeThread.start();
+        try {
+            probeThread.join(hardDeadline);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        if (!probeCompleted.get()) {
+            probeThread.interrupt();
+            modeProbeResults.clear();
+            setAttributes(prev);
+            if (probeThread.isAlive()) {
+                Log.debug(
+                        "Terminal probe timed out on " + getName() + " — native read may be stuck on a PTY fd (#2209)");
             }
         }
     }

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -79,6 +79,7 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
     final Map<Signal, Object> nativeHandlers = new ConcurrentHashMap<>();
     private volatile Attributes cachedAttributes;
     private final Task closer;
+    private final boolean pollAvailable;
 
     @SuppressWarnings({"this-escape", "squid:S107"})
     protected AbstractUnixSysTerminal(
@@ -107,6 +108,9 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
         IntUnaryOperator pollFn = createPollFunction();
         if (pollFn != null) {
             this.input.setPollFunction(pollFn);
+            this.pollAvailable = true;
+        } else {
+            this.pollAvailable = false;
         }
         cachedAttributes = new Attributes(originalAttributes);
         FileDescriptor outFd;
@@ -193,6 +197,11 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
      */
     protected IntUnaryOperator createPollFunction() {
         return null;
+    }
+
+    @Override
+    protected boolean hasPollSupport() {
+        return pollAvailable;
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractUnixSysTerminal.java
@@ -127,6 +127,13 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
 
         parseInfoCmp();
 
+        registerNativeSignals(signalHandler);
+
+        closer = this::close;
+        ShutdownHooks.add(closer);
+    }
+
+    private void registerNativeSignals(SignalHandler signalHandler) {
         if (nativeSignals) {
             for (Signal signal : Signal.values()) {
                 Object nativeHandler;
@@ -141,9 +148,6 @@ public abstract class AbstractUnixSysTerminal extends AbstractTerminal {
                 }
             }
         }
-
-        closer = this::close;
-        ShutdownHooks.add(closer);
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -67,6 +67,7 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
     private Thread inputPumpThread;
     private Thread outputPumpThread;
     private boolean paused = true;
+    private final boolean pollAvailable;
 
     public PosixPtyTerminal(String name, String type, Pty pty, InputStream in, OutputStream out, Charset encoding)
             throws IOException {
@@ -121,6 +122,7 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
         this.output = pty.getSlaveOutput();
         this.reader = NonBlocking.nonBlocking(name, input, inputEncoding());
         this.writer = new PrintWriter(new OutputStreamWriter(output, outputEncoding()));
+        this.pollAvailable = pty instanceof AbstractPty && ((AbstractPty) pty).createSlavePollFunction() != null;
         parseInfoCmp();
         if (!paused) {
             resume();
@@ -145,6 +147,11 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
     public PrintWriter writer() {
         checkClosed();
         return writer;
+    }
+
+    @Override
+    protected boolean hasPollSupport() {
+        return pollAvailable;
     }
 
     @Override

--- a/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/PosixPtyTerminal.java
@@ -122,7 +122,7 @@ public class PosixPtyTerminal extends AbstractPosixTerminal {
         this.output = pty.getSlaveOutput();
         this.reader = NonBlocking.nonBlocking(name, input, inputEncoding());
         this.writer = new PrintWriter(new OutputStreamWriter(output, outputEncoding()));
-        this.pollAvailable = pty instanceof AbstractPty && ((AbstractPty) pty).createSlavePollFunction() != null;
+        this.pollAvailable = pty instanceof AbstractPty && ((AbstractPty) pty).hasSlavePollSupport();
         parseInfoCmp();
         if (!paused) {
             resume();

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.terminal.impl;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.function.IntUnaryOperator;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Size;
+import org.jline.terminal.Sized;
+import org.jline.utils.NonBlockingInputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.jline.terminal.TerminalBuilder.PROP_NON_BLOCKING_READS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that {@code PtyInputStream} uses {@code poll(2)} when available,
+ * falling back to the VMIN/VTIME heuristic when not.
+ */
+class PtyInputStreamPollTest {
+
+    private String savedNonBlockingReads;
+
+    @BeforeEach
+    void setUp() {
+        savedNonBlockingReads = System.getProperty(PROP_NON_BLOCKING_READS);
+        System.setProperty(PROP_NON_BLOCKING_READS, "true");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (savedNonBlockingReads != null) {
+            System.setProperty(PROP_NON_BLOCKING_READS, savedNonBlockingReads);
+        } else {
+            System.clearProperty(PROP_NON_BLOCKING_READS);
+        }
+    }
+
+    /**
+     * Creates a test PTY with a simulated poll function.
+     *
+     * @param pipedIn the input stream to read from
+     * @param writerClosed set to true when the writer is closed, so the
+     *                     poll function can simulate POLLHUP
+     */
+    private AbstractPty createPtyWithPoll(
+            PipedInputStream pipedIn, java.util.concurrent.atomic.AtomicBoolean writerClosed) {
+        return new AbstractPty(null, null) {
+            @Override
+            protected IntUnaryOperator createSlavePollFunction() {
+                // Simulate poll(2):
+                // data available → return 1 (POLLIN)
+                // writer closed  → return 1 (POLLHUP — let read() discover EOF)
+                // no data, open  → sleep up to timeout, return 0
+                return timeoutMs -> {
+                    try {
+                        long deadline = System.currentTimeMillis() + timeoutMs;
+                        do {
+                            if (pipedIn.available() > 0 || writerClosed.get()) {
+                                return 1;
+                            }
+                            Thread.sleep(Math.min(5, Math.max(1, deadline - System.currentTimeMillis())));
+                        } while (System.currentTimeMillis() < deadline);
+                        return writerClosed.get() ? 1 : 0;
+                    } catch (Exception e) {
+                        return 1;
+                    }
+                };
+            }
+
+            @Override
+            protected void doSetAttr(Attributes attr) {}
+
+            @Override
+            protected InputStream doGetSlaveInput() {
+                return pipedIn;
+            }
+
+            @Override
+            public InputStream getMasterInput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getMasterOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream getSlaveOutput() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Attributes getAttr() {
+                return new Attributes();
+            }
+
+            @Override
+            public Size getSize() {
+                return Size.of(80, 24);
+            }
+
+            @Override
+            public void setSize(Sized size) {}
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    @Test
+    @Timeout(10)
+    void pollBasedReadReturnsData() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
+        java.util.concurrent.atomic.AtomicBoolean writerClosed = new java.util.concurrent.atomic.AtomicBoolean();
+
+        AbstractPty pty = createPtyWithPoll(pipedIn, writerClosed);
+        // Initialize terminal attributes (normally done by PosixPtyTerminal)
+        pty.setAttr(new Attributes());
+        InputStream slaveInput = pty.getSlaveInput();
+        assertTrue(slaveInput instanceof NonBlockingInputStream);
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        // Write data and verify it's read correctly via poll path
+        pipedOut.write('X');
+        int ch = nbis.read(1000);
+        assertEquals('X', ch);
+    }
+
+    @Test
+    @Timeout(10)
+    void pollBasedReadTimeoutReturnsExpired() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        new PipedOutputStream(pipedIn); // keep pipe open
+        java.util.concurrent.atomic.AtomicBoolean writerClosed = new java.util.concurrent.atomic.AtomicBoolean();
+
+        AbstractPty pty = createPtyWithPoll(pipedIn, writerClosed);
+        // Initialize terminal attributes (normally done by PosixPtyTerminal)
+        pty.setAttr(new Attributes());
+        InputStream slaveInput = pty.getSlaveInput();
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        // No data written — should timeout and return READ_EXPIRED
+        long start = System.currentTimeMillis();
+        int result = nbis.read(100);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertEquals(NonBlockingInputStream.READ_EXPIRED, result);
+        assertTrue(elapsed >= 50, "Timeout should have waited at least 50ms, was " + elapsed + "ms");
+    }
+
+    @Test
+    @Timeout(10)
+    void pollBasedReadDetectsEof() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
+        java.util.concurrent.atomic.AtomicBoolean writerClosed = new java.util.concurrent.atomic.AtomicBoolean();
+
+        AbstractPty pty = createPtyWithPoll(pipedIn, writerClosed);
+        // Initialize terminal attributes (normally done by PosixPtyTerminal)
+        pty.setAttr(new Attributes());
+        InputStream slaveInput = pty.getSlaveInput();
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        // Write, close, then read should get data followed by EOF
+        pipedOut.write('A');
+        pipedOut.close();
+        writerClosed.set(true);
+
+        int ch = nbis.read(1000);
+        assertEquals('A', ch);
+
+        int eof = nbis.read(1000);
+        assertEquals(-1, eof, "Expected EOF (-1) after pipe closed");
+    }
+}

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
@@ -69,14 +69,14 @@ class PtyInputStreamPollTest {
                 // no data, open  → sleep up to timeout, return 0
                 return timeoutMs -> {
                     try {
-                        long deadline = System.currentTimeMillis() + timeoutMs;
+                        long deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000L;
                         do {
                             if (pipedIn.available() > 0 || writerClosed.get()) {
                                 return 1;
                             }
-                            LockSupport.parkNanos(
-                                    Math.min(5, Math.max(1, deadline - System.currentTimeMillis())) * 1_000_000L);
-                        } while (System.currentTimeMillis() < deadline);
+                            long remainNanos = deadlineNanos - System.nanoTime();
+                            LockSupport.parkNanos(Math.min(5_000_000L, Math.max(1_000_000L, remainNanos)));
+                        } while (System.nanoTime() < deadlineNanos);
                         return writerClosed.get() ? 1 : 0;
                     } catch (Exception e) {
                         return 1;
@@ -165,12 +165,12 @@ class PtyInputStreamPollTest {
         NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
 
         // No data written — should timeout and return READ_EXPIRED
-        long start = System.currentTimeMillis();
+        long startNanos = System.nanoTime();
         int result = nbis.read(100);
-        long elapsed = System.currentTimeMillis() - start;
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
 
         assertEquals(NonBlockingInputStream.READ_EXPIRED, result);
-        assertTrue(elapsed >= 50, "Timeout should have waited at least 50ms, was " + elapsed + "ms");
+        assertTrue(elapsedMs >= 50, "Timeout should have waited at least 50ms, was " + elapsedMs + "ms");
     }
 
     @Test

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.IntUnaryOperator;
 
 import org.jline.terminal.Attributes;
@@ -73,7 +74,8 @@ class PtyInputStreamPollTest {
                             if (pipedIn.available() > 0 || writerClosed.get()) {
                                 return 1;
                             }
-                            Thread.sleep(Math.min(5, Math.max(1, deadline - System.currentTimeMillis())));
+                            LockSupport.parkNanos(
+                                    Math.min(5, Math.max(1, deadline - System.currentTimeMillis())) * 1_000_000L);
                         } while (System.currentTimeMillis() < deadline);
                         return writerClosed.get() ? 1 : 0;
                     } catch (Exception e) {
@@ -83,7 +85,9 @@ class PtyInputStreamPollTest {
             }
 
             @Override
-            protected void doSetAttr(Attributes attr) {}
+            protected void doSetAttr(Attributes attr) {
+                // no-op: test PTY does not manage real terminal attributes
+            }
 
             @Override
             protected InputStream doGetSlaveInput() {
@@ -116,10 +120,14 @@ class PtyInputStreamPollTest {
             }
 
             @Override
-            public void setSize(Sized size) {}
+            public void setSize(Sized size) {
+                // no-op: test PTY has a fixed size
+            }
 
             @Override
-            public void close() {}
+            public void close() {
+                // no-op: nothing to release in test
+            }
         };
     }
 

--- a/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/PtyInputStreamPollTest.java
@@ -197,4 +197,30 @@ class PtyInputStreamPollTest {
         int eof = nbis.read(1000);
         assertEquals(-1, eof, "Expected EOF (-1) after pipe closed");
     }
+
+    /**
+     * Regression test: a timeout exceeding {@code Integer.MAX_VALUE} must not
+     * overflow into a negative poll interval.  With data already available,
+     * the read must return immediately regardless of the large timeout.
+     */
+    @Test
+    @Timeout(10)
+    void largeTimeoutDoesNotOverflow() throws Exception {
+        PipedInputStream pipedIn = new PipedInputStream();
+        PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
+        java.util.concurrent.atomic.AtomicBoolean writerClosed = new java.util.concurrent.atomic.AtomicBoolean();
+
+        AbstractPty pty = createPtyWithPoll(pipedIn, writerClosed);
+        pty.setAttr(new Attributes());
+        InputStream slaveInput = pty.getSlaveInput();
+        NonBlockingInputStream nbis = (NonBlockingInputStream) slaveInput;
+
+        // Write data first so poll returns immediately
+        pipedOut.write('Z');
+
+        // Use a timeout larger than Integer.MAX_VALUE — must not overflow
+        long hugeTimeout = 2_147_483_648L; // Integer.MAX_VALUE + 1
+        int ch = nbis.read(hugeTimeout, false);
+        assertEquals('Z', ch, "Large timeout must not cause overflow — data was available");
+    }
 }


### PR DESCRIPTION
## Summary

Use the `poll(2)` bindings added in #2222 to replace VMIN/VTIME workarounds in probe and PTY read paths.

> **Note:** This replaces #2228 which was merged and reverted.

## Changes

### PtyInputStream: poll-based reads

`AbstractPty.PtyInputStream` now uses `poll(2)` when available instead of the VMIN/VTIME timing heuristic. Previously, it set `VMIN=0/VTIME=1` and used elapsed time (`< 50ms` = real EOF, `>= 50ms` = timeout) to distinguish real EOF from timeout — a heuristic that breaks under CPU pressure. With poll, there's no VMIN/VTIME manipulation and no timing guesswork:

- `poll(fd, timeout)` returns positive → `read()` won't block
- `poll(fd, timeout)` returns 0 → timeout, return `READ_EXPIRED`
- `poll(fd, timeout)` returns negative → error, treat as EOF

Falls back to the existing VMIN/VTIME approach when poll is not available (`ExecPty`, etc.).

### Poll function for slave fd

`AbstractPty.createSlavePollFunction()` is a new protected hook. Overridden in:
- `FfmNativePty`: `timeoutMs -> CLibrary.pollForInput(slave, timeoutMs)`
- `JniNativePty`: same, with `UnsatisfiedLinkError` guard for older native binaries

### Simplified probe code

`AbstractTerminal.ensureModesProbed()` now probes synchronously when poll is available, because `poll(2)` guarantees that read timeouts are enforced even on PTY file descriptors. The daemon thread + hard deadline workaround (from #2210) is only used as a fallback when poll is not available.

`AbstractTerminal.hasPollSupport()` is a new protected hook, overridden by `AbstractUnixSysTerminal` and `PosixPtyTerminal`.

## Test plan

- [x] All 603 terminal module tests pass
- [x] New `PtyInputStreamPollTest`: verifies data read, timeout, and EOF detection via the poll path
- [x] Full build succeeds (`./mvx mvn install -DskipTests`)

Fixes #2223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved non-blocking terminal reads with more reliable input readiness detection and timeout handling.
  * Reading now responds more consistently to available data, expired timeouts, and end-of-file conditions.
  * Added a compatibility fallback for environments without native polling support.
  * Zero-timeout reads now wait for input or end-of-file instead of expiring immediately.
  * Large timeout values are handled safely without overflow.

* **Tests**
  * Added coverage for available data, read timeouts, end-of-file behavior, and large timeout values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->