### PR TITLE
fix: use System.nanoTime() for monotonic deadline accounting

### DIFF
--- a/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
+++ b/terminal/src/main/java/org/jline/terminal/impl/AbstractTerminal.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
@@ -42,6 +43,7 @@ import org.jline.utils.InfoCmp.Capability;
 import org.jline.utils.Log;
 import org.jline.utils.NonBlockingReader;
 import org.jline.utils.Status;
+import org.jline.utils.Timeout;
 import org.jline.utils.WCWidth;
 
 /**
@@ -951,23 +953,23 @@ public abstract class AbstractTerminal implements TerminalExt {
      */
     private int readCprColumn(long timeout) throws IOException {
         NonBlockingReader in = reader();
-        // Use a single wall-clock deadline so the spurious EOF a non-blocking
+        // Use a single monotonic deadline so the spurious EOF a non-blocking
         // slave-tty read produces while the CPR reply is in flight does not abort
         // the read early (see readProbeChar).
-        long deadline = System.currentTimeMillis() + timeout;
+        long deadlineNanos = Timeout.saturatingAddNanos(System.nanoTime(), TimeUnit.MILLISECONDS.toNanos(timeout));
         int c;
         // Skip until ESC
-        while ((c = readProbeChar(in, deadline)) != '\033') {
+        while ((c = readProbeChar(in, deadlineNanos)) != '\033') {
             if (c < 0) return -1;
         }
-        if (readProbeChar(in, deadline) != '[') return -1;
+        if (readProbeChar(in, deadlineNanos) != '[') return -1;
         // Skip row digits until ';'
-        while ((c = readProbeChar(in, deadline)) != ';') {
+        while ((c = readProbeChar(in, deadlineNanos)) != ';') {
             if (c < 0 || c == 'R') return -1;
         }
         // Read column digits until 'R'
         int col = 0;
-        while ((c = readProbeChar(in, deadline)) != 'R') {
+        while ((c = readProbeChar(in, deadlineNanos)) != 'R') {
             if (c < '0' || c > '9') return -1;
             col = col * 10 + (c - '0');
         }
@@ -1003,16 +1005,18 @@ public abstract class AbstractTerminal implements TerminalExt {
      *
      * @return a character {@code >= 0}, or {@code -1} once the deadline elapses
      */
-    static int readProbeChar(NonBlockingReader in, long deadline) throws IOException {
-        long remaining;
-        while ((remaining = deadline - System.currentTimeMillis()) > 0) {
-            int c = in.read(remaining);
+    static int readProbeChar(NonBlockingReader in, long deadlineNanos) throws IOException {
+        long remainingNanos;
+        while ((remainingNanos = deadlineNanos - System.nanoTime()) > 0) {
+            long remainingMs = TimeUnit.NANOSECONDS.toMillis(remainingNanos);
+            int c = in.read(Math.max(1, remainingMs));
             if (c >= 0) {
                 return c;
             }
             // EOF (-1) or READ_EXPIRED (-2): no data yet, pace the poll and retry.
             try {
-                Thread.sleep(Math.min(2, remaining));
+                long paceMs = Math.max(1, Math.min(2, remainingMs));
+                Thread.sleep(paceMs);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return -1;
@@ -1024,11 +1028,12 @@ public abstract class AbstractTerminal implements TerminalExt {
     String readTerminalResponse() {
         long initialTimeout = getLongProperty(TerminalBuilder.PROP_PROBE_TIMEOUT, 200);
         NonBlockingReader in = reader();
-        long deadline = System.currentTimeMillis() + initialTimeout;
+        long deadlineNanos =
+                Timeout.saturatingAddNanos(System.nanoTime(), TimeUnit.MILLISECONDS.toNanos(initialTimeout));
         StringBuilder response = new StringBuilder();
         try {
             int c;
-            while ((c = readProbeChar(in, deadline)) >= 0) {
+            while ((c = readProbeChar(in, deadlineNanos)) >= 0) {
                 response.append((char) c);
 
                 // Complete DA1 response: ESC[?...c or ESC[...c
@@ -1047,9 +1052,10 @@ public abstract class AbstractTerminal implements TerminalExt {
 
     static void drainInput(NonBlockingReader reader, long overallTimeoutMs, int stopChar) {
         try {
-            long deadline = System.currentTimeMillis() + overallTimeoutMs;
+            long deadlineNanos =
+                    Timeout.saturatingAddNanos(System.nanoTime(), TimeUnit.MILLISECONDS.toNanos(overallTimeoutMs));
             int c;
-            while ((c = readProbeChar(reader, deadline)) >= 0) {
+            while ((c = readProbeChar(reader, deadlineNanos)) >= 0) {
                 if (c == stopChar) return;
             }
         } catch (IOException ignored) {

--- a/terminal/src/main/java/org/jline/utils/Timeout.java
+++ b/terminal/src/main/java/org/jline/utils/Timeout.java
@@ -8,6 +8,8 @@
  */
 package org.jline.utils;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Helper class for managing timeouts during I/O operations.
  *
@@ -49,8 +51,8 @@ package org.jline.utils;
 public class Timeout {
 
     private final long timeout;
-    private long cur = 0;
-    private long end = Long.MAX_VALUE;
+    private long curNanos = 0;
+    private long endNanos = Long.MAX_VALUE;
 
     public Timeout(long timeout) {
         this.timeout = timeout;
@@ -66,17 +68,38 @@ public class Timeout {
 
     public boolean elapsed() {
         if (timeout > 0) {
-            cur = System.currentTimeMillis();
-            if (end == Long.MAX_VALUE) {
-                end = cur + timeout;
+            curNanos = System.nanoTime();
+            if (endNanos == Long.MAX_VALUE) {
+                long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeout);
+                endNanos = saturatingAddNanos(curNanos, timeoutNanos);
             }
-            return cur >= end;
+            // Use sub-millisecond threshold: if less than 1ms remains,
+            // treat as elapsed since the API contract is in milliseconds
+            return (endNanos - curNanos) < 1_000_000L;
         } else {
             return false;
         }
     }
 
     public long timeout() {
-        return timeout > 0 ? Math.max(1, end - cur) : timeout;
+        if (timeout > 0) {
+            long remainingMs = (endNanos - curNanos) / 1_000_000L;
+            return Math.max(1, remainingMs);
+        }
+        return timeout;
+    }
+
+    /**
+     * Adds a nanoTime base and a non-negative duration, clamping to
+     * {@code Long.MAX_VALUE} on overflow.
+     */
+    public static long saturatingAddNanos(long baseNanos, long deltaNanos) {
+        long sum = baseNanos + deltaNanos;
+        // Overflow: both operands positive-ish but sum wrapped negative,
+        // or deltaNanos is Long.MAX_VALUE (saturated by TimeUnit conversion)
+        if (deltaNanos > 0 && sum < baseNanos) {
+            return Long.MAX_VALUE;
+        }
+        return sum;
     }
 }

--- a/terminal/src/test/java/org/jline/terminal/impl/TerminalProbeResponseLeakTest.java
+++ b/terminal/src/test/java/org/jline/terminal/impl/TerminalProbeResponseLeakTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.concurrent.TimeUnit;
 
 import org.jline.utils.NonBlockingReader;
 import org.junit.jupiter.api.Test;
@@ -82,7 +83,7 @@ class TerminalProbeResponseLeakTest {
                 NonBlockingReader.EOF,
                 NonBlockingReader.EOF,
                 'X');
-        long deadline = System.currentTimeMillis() + 1000;
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
         assertEquals('X', AbstractTerminal.readProbeChar(in, deadline));
     }
 
@@ -91,10 +92,10 @@ class TerminalProbeResponseLeakTest {
         // Nothing but spurious EOFs: poll until the deadline, then report -1
         // rather than bailing on the first one.
         ScriptedReader in = new ScriptedReader(NonBlockingReader.EOF);
-        long start = System.currentTimeMillis();
-        assertEquals(-1, AbstractTerminal.readProbeChar(in, start + 50));
+        long start = System.nanoTime();
+        assertEquals(-1, AbstractTerminal.readProbeChar(in, start + TimeUnit.MILLISECONDS.toNanos(50)));
         assertTrue(
-                System.currentTimeMillis() - start >= 40,
+                TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start) >= 40,
                 "should have polled until the deadline, not returned on the first EOF");
     }
 


### PR DESCRIPTION
Replace `System.currentTimeMillis()` with `System.nanoTime()` in `AbstractTerminal` probe/CPR read methods and the `Timeout` utility class.

`currentTimeMillis()` is subject to wall-clock adjustments (NTP steps, daylight saving, manual changes), which can cause deadlines to fire too early or never fire at all. `nanoTime()` provides a monotonic clock suitable for elapsed-time measurement.

### Changes

- **`Timeout`**: switch internal tracking from millis to nanoTime; treat <1ms remaining as elapsed (the public API contract remains in milliseconds)
- **`AbstractTerminal`**: `readProbeChar`, `readCprColumn`, `readTerminalResponse`, and `drainInput` now use nanos-based deadlines
- **`TerminalProbeResponseLeakTest`**: update to match the new nanos deadline API

Fixes #2230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal response probing and input handling with more precise timing.
  - Reduced premature termination when transient timeouts or end-of-file results occur.
  - Increased reliability for short-duration terminal operations and deadline handling, including cases where timing intervals are below one millisecond.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->