### PR TITLE
fix: address remaining security vulnerabilities reported by AFINE/CERT.PL

### DIFF
--- a/native/src/main/java/org/jline/nativ/Kernel32.java
+++ b/native/src/main/java/org/jline/nativ/Kernel32.java
@@ -510,7 +510,7 @@ public class Kernel32 {
         public MENU_EVENT_RECORD menuEvent = new MENU_EVENT_RECORD();
         public FOCUS_EVENT_RECORD focusEvent = new FOCUS_EVENT_RECORD();
 
-        public static native void memmove(INPUT_RECORD dest, long src, long size);
+        static native void memmove(INPUT_RECORD dest, long src, long size);
     }
 
     /**

--- a/native/src/main/native/kernel32.c
+++ b/native/src/main/native/kernel32.c
@@ -818,6 +818,7 @@ JNIEXPORT void JNICALL INPUT_RECORD_NATIVE(memmove)
 	(JNIEnv *env, jclass that, jobject arg0, jlong arg1, jlong arg2)
 {
 	INPUT_RECORD _arg0, *lparg0=NULL;
+	if ((size_t)arg2 > sizeof(INPUT_RECORD)) return;
 	if (arg0) if ((lparg0 = &_arg0) == NULL) goto fail;
 	memmove((void *)lparg0, (const void *)(intptr_t)arg1, (size_t)arg2);
 fail:

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
@@ -187,12 +187,15 @@ public class ShellFactoryImpl implements ShellFactory {
                         .streams(in, out)
                         .attributes(attributes)
                         .env(sshEnv::get)
-                        .size(Size.of(Integer.parseInt(sshEnv.get("COLUMNS")), Integer.parseInt(sshEnv.get("LINES"))))
+                        .size(Size.of(
+                                parseTerminalDimension(sshEnv.get("COLUMNS"), 80),
+                                parseTerminalDimension(sshEnv.get("LINES"), 24)))
                         .build();
                 env.addSignalListener(
                         (channel, signals) -> {
                             terminal.setSize(Size.of(
-                                    Integer.parseInt(sshEnv.get("COLUMNS")), Integer.parseInt(sshEnv.get("LINES"))));
+                                    parseTerminalDimension(sshEnv.get("COLUMNS"), 80),
+                                    parseTerminalDimension(sshEnv.get("LINES"), 24)));
                             terminal.raise(Terminal.Signal.WINCH);
                         },
                         Signal.WINCH);
@@ -202,6 +205,7 @@ public class ShellFactoryImpl implements ShellFactory {
                 if (!closed) {
                     LOGGER.error("Error occured while executing shell", t);
                 }
+                destroy(session);
             }
         }
 
@@ -212,6 +216,23 @@ public class ShellFactoryImpl implements ShellFactory {
                 close(in, out, err);
                 callback.onExit(0);
             }
+        }
+    }
+
+    private static final int MAX_TERMINAL_DIMENSION = 1000;
+
+    static int parseTerminalDimension(String value, int defaultVal) {
+        if (value == null) {
+            return defaultVal;
+        }
+        try {
+            int n = Integer.parseInt(value);
+            if (n < 1 || n > MAX_TERMINAL_DIMENSION) {
+                return defaultVal;
+            }
+            return n;
+        } catch (NumberFormatException e) {
+            return defaultVal;
         }
     }
 

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
@@ -205,16 +205,20 @@ public class ShellFactoryImpl implements ShellFactory {
                 if (!closed) {
                     LOGGER.error("Error occured while executing shell", t);
                 }
-                destroy(session);
+                destroy(1);
             }
         }
 
         public void destroy(ChannelSession session) {
+            destroy(0);
+        }
+
+        private void destroy(int exitCode) {
             if (!closed) {
                 closed = true;
                 flush(out, err);
                 close(in, out, err);
-                callback.onExit(0);
+                callback.onExit(exitCode);
             }
         }
     }

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
@@ -218,6 +218,13 @@ public abstract class ConnectionManager implements Runnable {
                 }
                 // start it
                 con.start();
+            } else {
+                LOG.log(Level.WARNING, "makeConnection():: Maximum number of connections reached.");
+                try {
+                    insock.close();
+                } catch (IOException ex) {
+                    LOG.log(Level.WARNING, "makeConnection():: Failed to close refused connection socket.", ex);
+                }
             }
         } else {
             LOG.log(Level.INFO, "makeConnection():: Active Filter blocked incoming connection.");


### PR DESCRIPTION
## Summary

Fixes 4 remaining security vulnerabilities from the AFINE/CERT.PL responsible disclosure (#1945).

### Vuln 07 — TCP Socket FD Leak (CWE-775)
`ConnectionManager.makeConnection()` silently discards the incoming socket when the max connections limit is reached without closing it. Each refused connection leaks one OS file descriptor.

**Fix:** Added `else` branch to close the socket when the connection limit is reached, mirroring the cleanup already present in the connection-filter rejection path.

### Vuln 08 — SSH DoS via Unbounded Window-Change Geometry (CWE-400)
`ShellFactoryImpl`'s WINCH signal listener uses raw `Integer.parseInt()` on SSH-supplied COLUMNS/LINES values with no upper bound, allowing a 65535×65535 terminal size that triggers expensive rendering loops.

**Fix:** Added `parseTerminalDimension()` helper that validates and clamps values to [1, 1000], returning a safe default for null, non-numeric, or out-of-range input.

### Vuln 09 — SSH Channel Resource Leak via Null/Non-Numeric PTY Dimensions (CWE-755)
`ShellFactoryImpl.run()` calls `Integer.parseInt()` on potentially null/non-numeric COLUMNS/LINES. The resulting exception is caught but `destroy()` is never called, leaking SSH channel resources.

**Fix:** Same `parseTerminalDimension()` helper prevents the exception, and `destroy(session)` is now called in the catch block to guarantee cleanup.

### Vuln 10 — Native Stack Buffer Overflow in INPUT_RECORD.memmove (CWE-787, Windows)
The public JNI method `INPUT_RECORD.memmove()` copies an attacker-controlled number of bytes into a fixed-size stack-allocated `INPUT_RECORD` without bounds checking.

**Fix:** Added `sizeof(INPUT_RECORD)` bounds check in the native C code, and reduced Java method visibility from `public` to package-private.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented oversized native memory operations during input handling.
  * Improved SSH terminal sizing with validated default dimensions.
  * Ensured SSH sessions report appropriate exit statuses after startup failures or normal closure.
  * Improved Telnet connection-limit handling by closing excess connections and logging the event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->