### PR TITLE
fix: verify server host keys in the ssh client builtin

### DIFF
--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
@@ -10,6 +10,7 @@ package org.jline.builtins.ssh;
 
 import java.io.*;
 import java.net.SocketAddress;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.PublicKey;
@@ -335,15 +336,40 @@ public class Ssh {
     }
 
     /**
+     * Property key stored on the client to track that this class installed a
+     * {@link KnownHostsServerKeyVerifier}. Used to detect when a caller explicitly
+     * reconfigures the verifier after our setup (even back to
+     * {@link AcceptAllServerKeyVerifier#INSTANCE}).
+     */
+    static final String VERIFIER_INSTALLED_PROP = "jline.ssh.verifierInstalled";
+
+    /**
      * Installs an OpenSSH-style host key check when the client is still on the library's
      * accept-everything default: a key recorded in the known-hosts file is matched, an unknown key
      * must be confirmed by the user before it is recorded, and a changed key is refused. A verifier
-     * explicitly configured by the caller is left in place.
+     * explicitly configured by the caller — including {@link AcceptAllServerKeyVerifier#INSTANCE}
+     * set after a previous {@code setupServerKeyVerifier} call — is left in place.
      */
     static void setupServerKeyVerifier(SshClient client, LineReader reader, PrintStream stderr, Path knownHosts) {
         ServerKeyVerifier current = client.getServerKeyVerifier();
         if (current != null && current != AcceptAllServerKeyVerifier.INSTANCE) {
             return;
+        }
+        // AcceptAllServerKeyVerifier.INSTANCE is MINA SSHD's default.  However, if
+        // this method previously installed a KnownHostsServerKeyVerifier and the
+        // caller explicitly reverted to AcceptAll, that is a deliberate choice.
+        if (current == AcceptAllServerKeyVerifier.INSTANCE
+                && Boolean.TRUE.equals(client.getProperties().get(VERIFIER_INSTALLED_PROP))) {
+            return;
+        }
+        Path knownHostsDir = knownHosts.getParent();
+        if (knownHostsDir != null && !Files.isDirectory(knownHostsDir)) {
+            try {
+                Files.createDirectories(knownHostsDir);
+            } catch (IOException e) {
+                // best-effort — KnownHostsServerKeyVerifier will fail later with
+                // a clearer message if the path is truly unusable
+            }
         }
         KnownHostsServerKeyVerifier verifier = new KnownHostsServerKeyVerifier(
                 (session, address, key) -> confirmUnknownKey(reader, address, key), knownHosts);
@@ -356,6 +382,7 @@ public class Ssh {
             return false;
         });
         client.setServerKeyVerifier(verifier);
+        client.getProperties().put(VERIFIER_INSTALLED_PROP, Boolean.TRUE);
     }
 
     private static boolean confirmUnknownKey(LineReader reader, SocketAddress address, PublicKey key) {

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/Ssh.java
@@ -9,6 +9,10 @@
 package org.jline.builtins.ssh;
 
 import java.io.*;
+import java.net.SocketAddress;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.PublicKey;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -19,10 +23,14 @@ import org.apache.sshd.client.channel.ChannelShell;
 import org.apache.sshd.client.channel.ClientChannel;
 import org.apache.sshd.client.channel.ClientChannelEvent;
 import org.apache.sshd.client.future.ConnectFuture;
+import org.apache.sshd.client.keyverifier.AcceptAllServerKeyVerifier;
+import org.apache.sshd.client.keyverifier.KnownHostsServerKeyVerifier;
+import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.common.NamedResource;
 import org.apache.sshd.common.channel.PtyMode;
 import org.apache.sshd.common.config.keys.FilePasswordProvider;
+import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.session.SessionContext;
 import org.apache.sshd.common.util.io.input.NoCloseInputStream;
 import org.apache.sshd.common.util.io.output.NoCloseOutputStream;
@@ -205,6 +213,8 @@ public class Ssh {
             JLineUserInteraction ui = new JLineUserInteraction(terminal, reader, stderr);
             client.setFilePasswordProvider(ui);
             client.setUserInteraction(ui);
+            setupServerKeyVerifier(
+                    client, reader, stderr, Paths.get(System.getProperty("user.home"), ".ssh", "known_hosts"));
             client.start();
 
             try (ClientSession sshSession =
@@ -321,6 +331,41 @@ public class Ssh {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Installs an OpenSSH-style host key check when the client is still on the library's
+     * accept-everything default: a key recorded in the known-hosts file is matched, an unknown key
+     * must be confirmed by the user before it is recorded, and a changed key is refused. A verifier
+     * explicitly configured by the caller is left in place.
+     */
+    static void setupServerKeyVerifier(SshClient client, LineReader reader, PrintStream stderr, Path knownHosts) {
+        ServerKeyVerifier current = client.getServerKeyVerifier();
+        if (current != null && current != AcceptAllServerKeyVerifier.INSTANCE) {
+            return;
+        }
+        KnownHostsServerKeyVerifier verifier = new KnownHostsServerKeyVerifier(
+                (session, address, key) -> confirmUnknownKey(reader, address, key), knownHosts);
+        verifier.setModifiedServerKeyAcceptor((session, address, entry, expected, actual) -> {
+            stderr.println("WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!");
+            stderr.println("The " + KeyUtils.getKeyType(actual) + " key sent by " + address + " is "
+                    + KeyUtils.getFingerPrint(actual) + ", but " + KeyUtils.getFingerPrint(expected)
+                    + " was expected. Refusing to connect.");
+            stderr.flush();
+            return false;
+        });
+        client.setServerKeyVerifier(verifier);
+    }
+
+    private static boolean confirmUnknownKey(LineReader reader, SocketAddress address, PublicKey key) {
+        try {
+            String answer = reader.readLine("The authenticity of host '" + address + "' can't be established.\n"
+                    + KeyUtils.getKeyType(key) + " key fingerprint is " + KeyUtils.getFingerPrint(key) + ".\n"
+                    + "Are you sure you want to continue connecting (yes/no)? ");
+            return answer != null && answer.trim().equalsIgnoreCase("yes");
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/remote-ssh/src/test/java/org/jline/builtins/ssh/SshAgentForwardingTest.java
+++ b/remote-ssh/src/test/java/org/jline/builtins/ssh/SshAgentForwardingTest.java
@@ -85,7 +85,7 @@ class SshAgentForwardingTest {
                 "agent-forwarding-test", "xterm", new ByteArrayOutputStream(), StandardCharsets.UTF_8);
         try {
             LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
-            Ssh ssh = new Ssh(null, null, null, SshClient::setUpDefaultClient);
+            Ssh ssh = new Ssh(null, null, null, SshAgentForwardingTest::newTrustingClient);
             String target = "localhost:" + sshd.getPort();
             String[] argv = forwardAgent ? new String[] {"ssh", "-A", target} : new String[] {"ssh", target};
             PrintStream out = new PrintStream(new ByteArrayOutputStream());
@@ -109,6 +109,13 @@ class SshAgentForwardingTest {
             terminal.close();
             sshd.stop(true);
         }
+    }
+
+    /** Client that trusts the in-process test server's host key, which is not what this test exercises. */
+    private static SshClient newTrustingClient() {
+        SshClient client = SshClient.setUpDefaultClient();
+        client.setServerKeyVerifier((session, address, key) -> true);
+        return client;
     }
 
     /** Server shell that closes the channel as soon as it starts, so the client's shell loop returns. */

--- a/remote-ssh/src/test/java/org/jline/builtins/ssh/SshHostKeyVerificationTest.java
+++ b/remote-ssh/src/test/java/org/jline/builtins/ssh/SshHostKeyVerificationTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 
 import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.keyverifier.AcceptAllServerKeyVerifier;
 import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.server.SshServer;
@@ -109,6 +110,43 @@ class SshHostKeyVerificationTest {
                         client, reader, new PrintStream(new ByteArrayOutputStream()), tempDir.resolve("known_hosts"));
             }
             assertSame(custom, client.getServerKeyVerifier(), "an explicitly configured verifier must be kept");
+        }
+        // AcceptAllServerKeyVerifier.INSTANCE set explicitly after a previous
+        // setupServerKeyVerifier call must also be left in place
+        try (SshClient client = SshClient.setUpDefaultClient()) {
+            try (Terminal terminal = newTerminal("", new ByteArrayOutputStream())) {
+                LineReader reader =
+                        LineReaderBuilder.builder().terminal(terminal).build();
+                PrintStream ps = new PrintStream(new ByteArrayOutputStream());
+                // first call installs the KnownHostsServerKeyVerifier
+                Ssh.setupServerKeyVerifier(client, reader, ps, tempDir.resolve("known_hosts"));
+                assertFalse(
+                        client.getServerKeyVerifier() instanceof AcceptAllServerKeyVerifier,
+                        "first call must install KnownHostsServerKeyVerifier");
+                // caller explicitly reverts to AcceptAll
+                client.setServerKeyVerifier(AcceptAllServerKeyVerifier.INSTANCE);
+                // second call must respect the explicit choice
+                Ssh.setupServerKeyVerifier(client, reader, ps, tempDir.resolve("known_hosts"));
+                assertSame(
+                        AcceptAllServerKeyVerifier.INSTANCE,
+                        client.getServerKeyVerifier(),
+                        "AcceptAllServerKeyVerifier.INSTANCE set after our install must be kept");
+            }
+        }
+    }
+
+    @Test
+    void missingParentDirectoryIsCreatedForKnownHosts() throws Exception {
+        Path knownHosts = tempDir.resolve("missing/.ssh/known_hosts");
+        assertFalse(Files.isDirectory(knownHosts.getParent()), "parent must not exist yet");
+        try (SshServer sshd = newServer(tempDir.resolve("keyMissing.ser"), 0)) {
+            sshd.start();
+            assertTrue(
+                    authenticates(sshd.getPort(), knownHosts, "yes\n", new ByteArrayOutputStream()),
+                    "connection must succeed even when the known_hosts parent is missing");
+            assertTrue(Files.isDirectory(knownHosts.getParent()), "parent directory must have been created");
+            assertTrue(Files.exists(knownHosts), "confirmed key must be recorded");
+            assertTrue(Files.size(knownHosts) > 0, "known-hosts file must not be empty");
         }
     }
 

--- a/remote-ssh/src/test/java/org/jline/builtins/ssh/SshHostKeyVerificationTest.java
+++ b/remote-ssh/src/test/java/org/jline/builtins/ssh/SshHostKeyVerificationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.builtins.ssh;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.keyverifier.ServerKeyVerifier;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.UserAuthNoneFactory;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.LineDisciplineTerminal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the host key verification installed by {@link Ssh#setupServerKeyVerifier}: an unknown
+ * key needs the user's confirmation and is then recorded in the known-hosts file, a recorded key is
+ * accepted without a prompt, and a changed key is refused.
+ */
+@Timeout(60)
+class SshHostKeyVerificationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void unknownKeyIsRecordedAfterConfirmationAndReusedSilently() throws Exception {
+        Path knownHosts = tempDir.resolve("known_hosts");
+        try (SshServer sshd = newServer(tempDir.resolve("keyA.ser"), 0)) {
+            sshd.start();
+            assertTrue(
+                    authenticates(sshd.getPort(), knownHosts, "yes\n", new ByteArrayOutputStream()),
+                    "connection must succeed once the user confirms the key");
+            assertTrue(Files.exists(knownHosts), "confirmed key must be recorded");
+            assertTrue(Files.size(knownHosts) > 0, "known-hosts file must not be empty");
+            // second connection: the key is known, so no confirmation is needed
+            assertTrue(
+                    authenticates(sshd.getPort(), knownHosts, "", new ByteArrayOutputStream()),
+                    "a recorded key must be accepted without prompting");
+        }
+    }
+
+    @Test
+    void unknownKeyIsRefusedWithoutConfirmation() throws Exception {
+        Path knownHosts = tempDir.resolve("known_hosts");
+        try (SshServer sshd = newServer(tempDir.resolve("keyA.ser"), 0)) {
+            sshd.start();
+            assertFalse(
+                    authenticates(sshd.getPort(), knownHosts, "no\n", new ByteArrayOutputStream()),
+                    "connection must fail when the user does not confirm the key");
+            assertFalse(Files.exists(knownHosts), "a refused key must not be recorded");
+        }
+    }
+
+    @Test
+    void changedKeyIsRefused() throws Exception {
+        Path knownHosts = tempDir.resolve("known_hosts");
+        int port;
+        try (SshServer sshd = newServer(tempDir.resolve("keyA.ser"), 0)) {
+            sshd.start();
+            port = sshd.getPort();
+            assertTrue(authenticates(port, knownHosts, "yes\n", new ByteArrayOutputStream()));
+            sshd.stop(true);
+        }
+        // same endpoint, different host key: must be refused even if the user would confirm
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        try (SshServer sshd = newServer(tempDir.resolve("keyB.ser"), port)) {
+            sshd.start();
+            assertFalse(
+                    authenticates(port, knownHosts, "yes\n", stderr),
+                    "a host key that differs from the recorded one must be refused");
+        }
+        String warning = stderr.toString(StandardCharsets.UTF_8);
+        assertTrue(
+                warning.contains("REMOTE HOST IDENTIFICATION HAS CHANGED"),
+                "the user must be warned about the changed key: " + warning);
+    }
+
+    @Test
+    void callerConfiguredVerifierIsLeftInPlace() throws Exception {
+        ServerKeyVerifier custom = (session, address, key) -> true;
+        try (SshClient client = SshClient.setUpDefaultClient()) {
+            client.setServerKeyVerifier(custom);
+            try (Terminal terminal = newTerminal("", new ByteArrayOutputStream())) {
+                LineReader reader =
+                        LineReaderBuilder.builder().terminal(terminal).build();
+                Ssh.setupServerKeyVerifier(
+                        client, reader, new PrintStream(new ByteArrayOutputStream()), tempDir.resolve("known_hosts"));
+            }
+            assertSame(custom, client.getServerKeyVerifier(), "an explicitly configured verifier must be kept");
+        }
+    }
+
+    private static SshServer newServer(Path hostKey, int port) {
+        SshServer sshd = SshServer.setUpDefaultServer();
+        sshd.setPort(port);
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(hostKey));
+        sshd.setUserAuthFactories(Collections.singletonList(UserAuthNoneFactory.INSTANCE));
+        return sshd;
+    }
+
+    /**
+     * Connects and authenticates with a client whose verifier was installed by
+     * {@link Ssh#setupServerKeyVerifier}, answering a possible confirmation prompt with
+     * {@code terminalInput}.
+     */
+    private static boolean authenticates(int port, Path knownHosts, String terminalInput, ByteArrayOutputStream stderr)
+            throws Exception {
+        try (Terminal terminal = newTerminal(terminalInput, new ByteArrayOutputStream());
+                SshClient client = SshClient.setUpDefaultClient()) {
+            LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
+            Ssh.setupServerKeyVerifier(client, reader, new PrintStream(stderr), knownHosts);
+            client.start();
+            try (ClientSession session =
+                    client.connect("test", "localhost", port).verify(10000).getSession()) {
+                session.auth().verify(10000);
+                return session.isAuthenticated();
+            } catch (Exception e) {
+                return false;
+            }
+        }
+    }
+
+    private static Terminal newTerminal(String input, ByteArrayOutputStream output) throws Exception {
+        LineDisciplineTerminal terminal =
+                new LineDisciplineTerminal("host-key-test", "xterm", output, StandardCharsets.UTF_8);
+        if (!input.isEmpty()) {
+            terminal.processInputBytes(input.getBytes(StandardCharsets.UTF_8));
+        }
+        return terminal;
+    }
+}

--- a/remote-ssh/src/test/java/org/jline/builtins/ssh/SshServerTextTest.java
+++ b/remote-ssh/src/test/java/org/jline/builtins/ssh/SshServerTextTest.java
@@ -73,7 +73,7 @@ class SshServerTextTest {
         Terminal terminal = new LineDisciplineTerminal("banner-test", "xterm", terminalOut, StandardCharsets.UTF_8);
         try {
             LineReader reader = LineReaderBuilder.builder().terminal(terminal).build();
-            Ssh ssh = new Ssh(null, null, null, SshClient::setUpDefaultClient);
+            Ssh ssh = new Ssh(null, null, null, SshServerTextTest::newTrustingClient);
             String[] argv = new String[] {"ssh", "localhost:" + sshd.getPort()};
             PrintStream out = new PrintStream(new ByteArrayOutputStream());
 
@@ -97,6 +97,13 @@ class SshServerTextTest {
             terminal.close();
             sshd.stop(true);
         }
+    }
+
+    /** Client that trusts the in-process test server's host key, which is not what this test exercises. */
+    private static SshClient newTrustingClient() {
+        SshClient client = SshClient.setUpDefaultClient();
+        client.setServerKeyVerifier((session, address, key) -> true);
+        return client;
     }
 
     /** Server shell that closes the channel as soon as it starts, so the client's shell loop returns. */


### PR DESCRIPTION
`Ssh.ssh()` builds its client via `clientBuilder.get()`, and the MINA `ClientBuilder` default is `AcceptAllServerKeyVerifier.INSTANCE`, so the `ssh` builtin accepts any host key without prompting.

This PR installs a `KnownHostsServerKeyVerifier` over `~/.ssh/known_hosts` when the client still has the accept-all default:
- a recorded key matches silently,
- an unknown key prompts the user for fingerprint confirmation before being recorded,
- a changed key is refused with a warning on stderr.

A verifier explicitly configured by the caller is left in place. A client property (`jline.ssh.verifierInstalled`) tracks whether `setupServerKeyVerifier` previously installed the verifier, so an `AcceptAllServerKeyVerifier.INSTANCE` deliberately (re)set by the caller after setup is not replaced on subsequent calls.

The `~/.ssh` parent directory is created if missing before constructing the `KnownHostsServerKeyVerifier`.

Existing tests (`SshAgentForwardingTest`, `SshServerTextTest`) that exercise other features now supply their own trusting client to avoid host key prompts.