### PR TITLE
fix: address remaining security vulnerabilities reported by AFINE/CERT.PL (3.x backport)

### DIFF
--- a/native/src/main/java/org/jline/nativ/Kernel32.java
+++ b/native/src/main/java/org/jline/nativ/Kernel32.java
@@ -433,7 +433,7 @@ public class Kernel32 {
         public MENU_EVENT_RECORD menuEvent = new MENU_EVENT_RECORD();
         public FOCUS_EVENT_RECORD focusEvent = new FOCUS_EVENT_RECORD();
 
-        public static native void memmove(INPUT_RECORD dest, long src, long size);
+        static native void memmove(INPUT_RECORD dest, long src, long size);
     }
 
     /**

--- a/native/src/main/native/kernel32.c
+++ b/native/src/main/native/kernel32.c
@@ -818,6 +818,7 @@ JNIEXPORT void JNICALL INPUT_RECORD_NATIVE(memmove)
 	(JNIEnv *env, jclass that, jobject arg0, jlong arg1, jlong arg2)
 {
 	INPUT_RECORD _arg0, *lparg0=NULL;
+	if ((size_t)arg2 > sizeof(INPUT_RECORD)) return;
 	if (arg0) if ((lparg0 = &_arg0) == NULL) goto fail;
 	memmove((void *)lparg0, (const void *)(intptr_t)arg1, (size_t)arg2);
 fail:

--- a/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
+++ b/remote-ssh/src/main/java/org/jline/builtins/ssh/ShellFactoryImpl.java
@@ -186,14 +186,14 @@ public class ShellFactoryImpl implements ShellFactory {
                         .streams(in, out)
                         .attributes(attributes)
                         .size(new Size(
-                                Integer.parseInt(env.getEnv().get("COLUMNS")),
-                                Integer.parseInt(env.getEnv().get("LINES"))))
+                                parseTerminalDimension(env.getEnv().get("COLUMNS"), 80),
+                                parseTerminalDimension(env.getEnv().get("LINES"), 24)))
                         .build();
                 env.addSignalListener(
                         (channel, signals) -> {
                             terminal.setSize(new Size(
-                                    Integer.parseInt(env.getEnv().get("COLUMNS")),
-                                    Integer.parseInt(env.getEnv().get("LINES"))));
+                                    parseTerminalDimension(env.getEnv().get("COLUMNS"), 80),
+                                    parseTerminalDimension(env.getEnv().get("LINES"), 24)));
                             terminal.raise(Terminal.Signal.WINCH);
                         },
                         Signal.WINCH);
@@ -203,16 +203,38 @@ public class ShellFactoryImpl implements ShellFactory {
                 if (!closed) {
                     LOGGER.error("Error occured while executing shell", t);
                 }
+                destroy(1);
             }
         }
 
         public void destroy(ChannelSession session) {
+            destroy(0);
+        }
+
+        private void destroy(int exitCode) {
             if (!closed) {
                 closed = true;
                 flush(out, err);
                 close(in, out, err);
-                callback.onExit(0);
+                callback.onExit(exitCode);
             }
+        }
+    }
+
+    private static final int MAX_TERMINAL_DIMENSION = 1000;
+
+    static int parseTerminalDimension(String value, int defaultVal) {
+        if (value == null) {
+            return defaultVal;
+        }
+        try {
+            int n = Integer.parseInt(value);
+            if (n < 1 || n > MAX_TERMINAL_DIMENSION) {
+                return defaultVal;
+            }
+            return n;
+        } catch (NumberFormatException e) {
+            return defaultVal;
         }
     }
 

--- a/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
+++ b/remote-telnet/src/main/java/org/jline/builtins/telnet/ConnectionManager.java
@@ -216,6 +216,13 @@ public abstract class ConnectionManager implements Runnable {
                 }
                 // start it
                 con.start();
+            } else {
+                LOG.log(Level.WARNING, "makeConnection():: Maximum number of connections reached.");
+                try {
+                    insock.close();
+                } catch (IOException ex) {
+                    LOG.log(Level.WARNING, "makeConnection():: Failed to close refused connection socket.", ex);
+                }
             }
         } else {
             LOG.info("makeConnection():: Active Filter blocked incoming connection.");


### PR DESCRIPTION
Backport of #2235 to jline-3.x.

Addresses 4 remaining vulnerabilities reported by AFINE/CERT.PL:
- **ConnectionManager**: close socket when max connections reached (FD leak)
- **ShellFactoryImpl**: validate and clamp SSH terminal dimensions (DoS) — adapted to use `new Size()` and `env.getEnv()` (3.x API, no `Size.of()` or `.env()` builder)
- **ShellFactoryImpl**: handle null/non-numeric PTY dimensions, call destroy on failure (resource leak)
- **kernel32.c**: add bounds check to INPUT_RECORD.memmove (stack buffer overflow)

Cherry-picked from 0cb3afdb with conflict resolution in ShellFactoryImpl.java.