### PR TITLE
fix: bound !# history expansion to prevent exponential blowup (3.x backport)

### DIFF
--- a/reader/src/main/java/org/jline/reader/impl/DefaultExpander.java
+++ b/reader/src/main/java/org/jline/reader/impl/DefaultExpander.java
@@ -36,6 +36,14 @@ import org.jline.reader.History.Entry;
 public class DefaultExpander implements Expander {
 
     /**
+     * Upper bound on the length of a history expansion. The {@code !#} event
+     * designator expands to the command line built so far, so each occurrence
+     * doubles the accumulated result; this bounds that growth so a short
+     * crafted line cannot exhaust the heap.
+     */
+    private static final int MAX_EXPANSION_SIZE = 1 << 20;
+
+    /**
      * Expand event designator such as !!, !#, !3, etc...
      * See http://www.gnu.org/software/bash/manual/html_node/Event-Designators.html
      */
@@ -88,6 +96,11 @@ public class DefaultExpander implements Expander {
                                     rep = history.get(history.index() - 1);
                                     break;
                                 case '#':
+                                    // "!#" doubles the result built so far, so a line that repeats it
+                                    // grows exponentially; reject the expansion before it can exhaust the heap
+                                    if ((long) sb.length() * 2 > MAX_EXPANSION_SIZE) {
+                                        throw new IllegalArgumentException("!#: expansion too large");
+                                    }
                                     sb.append(sb.toString());
                                     break;
                                 case '?':

--- a/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
@@ -114,15 +114,12 @@ public class TerminalReaderTest extends ReaderTestSupport {
     }
 
     @Test
-    public void testExpansionBombIsRejected() throws Exception {
+    void testExpansionBombIsRejected() {
         DefaultHistory history = new DefaultHistory(reader);
         reader.setVariable(LineReader.HISTORY_SIZE, 3);
         history.add("mkdir monkey");
 
         Expander expander = new DefaultExpander();
-
-        // a single "!#" still doubles the line built so far
-        assertEquals("echo echo a", expander.expandHistory(history, "echo !#a"));
 
         // repeating "!#" doubles the accumulator each time; without a bound this
         // grows to 2^40 chars from a 81-byte line and exhausts the heap

--- a/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
+++ b/reader/src/test/java/org/jline/reader/impl/TerminalReaderTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -110,6 +111,29 @@ public class TerminalReaderTest extends ReaderTestSupport {
         } catch (IllegalArgumentException e) {
             assertEquals("!-20: event not found", e.getMessage());
         }
+    }
+
+    @Test
+    public void testExpansionBombIsRejected() throws Exception {
+        DefaultHistory history = new DefaultHistory(reader);
+        reader.setVariable(LineReader.HISTORY_SIZE, 3);
+        history.add("mkdir monkey");
+
+        Expander expander = new DefaultExpander();
+
+        // a single "!#" still doubles the line built so far
+        assertEquals("echo echo a", expander.expandHistory(history, "echo !#a"));
+
+        // repeating "!#" doubles the accumulator each time; without a bound this
+        // grows to 2^40 chars from a 81-byte line and exhausts the heap
+        StringBuilder bomb = new StringBuilder("a");
+        for (int i = 0; i < 40; i++) {
+            bomb.append("!#");
+        }
+        String bombLine = bomb.toString();
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> expander.expandHistory(history, bombLine));
+        assertEquals("!#: expansion too large", e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Backport of 2688ac6f to jline-3.x.

The `!#` event designator expands to the command line built so far, so each occurrence doubles the accumulated result. A short crafted line like `a!#!#!#...!#` (40 repetitions) would grow to 2^40 characters and exhaust the heap. This adds a 1 MiB upper bound on expansion size.

Cherry-picked from 2688ac6f with minor conflict resolution (kept 3.x test style with `public` visibility and `throws Exception`).