### PR TITLE
chore: add explicit workflow permissions and drop 4.0.x from supported versions

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -23,6 +23,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   compile:
     runs-on: ${{ matrix.os }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,23 +77,22 @@ Spotless enforces this header automatically via `spotless:apply`.
 ### Branch Structure
 
 - **`master`** — main development branch for 4.x. All new features and refactoring land here first.
-- **`4.0.x`** — maintenance branch for 4.0.x patch releases. Only bugfixes are cherry-picked here from master.
+- **`4.0.x`** — EOL. No longer maintained.
 - **`jline-3.x`** — maintenance branch for 3.x patch releases. Only bugfixes are backported here.
 
 ### Build Wrappers
 
-- `master` and `4.0.x`: use `./mvx` (Maven 4 with nisse extension for version derivation from git tags)
+- `master`: use `./mvx` (Maven 4 with nisse extension for version derivation from git tags)
 - `jline-3.x`: use `./mvnw` (standard Maven wrapper)
 
 ### Release Process
 
-**4.x releases (master and 4.0.x):**
+**4.x releases (master):**
 1. Create and push a tag matching `[0-9]*.[0-9]*.[0-9]*` on the correct branch
 2. The `Manual Maven Release` workflow triggers on tag push
 3. Version is derived from the tag by the nisse Maven extension
-4. **Important**: tag `4.0.x` patch releases on the `4.0.x` branch, NOT on `master`
-5. Artifacts must be manually published through central.sonatype.com portal after the workflow completes
-6. Create GitHub release notes via `gh release create`
+4. Artifacts must be manually published through central.sonatype.com portal after the workflow completes
+5. Create GitHub release notes via `gh release create`
 
 **3.x releases (jline-3.x):**
 1. Trigger the `Manual Maven Release` workflow via `workflow_dispatch` on branch `jline-3.x`
@@ -111,7 +110,7 @@ Spotless enforces this header automatically via `spotless:apply`.
 
 ### Backporting Workflow
 
-1. Cherry-pick bugfix commits from `master` to `4.0.x` and/or `jline-3.x`
+1. Cherry-pick bugfix commits from `master` to `jline-3.x`
 2. Create a PR against the target branch for CI validation
 3. Merge, then release from the maintenance branch
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Version | Supported          |
 |---------|--------------------|
 | 4.1.x   | ✅ Yes             |
-| 4.0.x   | ✅ Yes             |
+| 4.0.x   | ❌ No              |
 | 3.x     | ✅ Security fixes  |
 | < 3.0   | ❌ No              |
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -103,8 +103,8 @@ const config: Config = {
           label: `v${jlineVersion}`,
           position: 'right',
           items: [
-            {label: '4.4.x (current)', href: 'https://jline.org/'},
-            {label: '3.30.x (legacy)', href: 'https://jline.org/versions/3.x/'},
+            {label: '4.x (current)', href: 'https://jline.org/'},
+            {label: '3.30.x', href: 'https://jline.org/versions/3.x/'},
           ],
         },
         {


### PR DESCRIPTION
- Add `permissions: contents: read` to `master-build.yml` to satisfy the code scanning requirement for explicit workflow permissions.
- Update `SECURITY.md` to mark 4.0.x as no longer maintained.

Fixes code scanning alerts [#1](https://github.com/jline/jline3/security/code-scanning/1) and [#2](https://github.com/jline/jline3/security/code-scanning/2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the security policy to indicate that version 4.0.x is no longer supported.
  - Updated branch, release, and backporting guidance to reflect current supported workflows.
  - Updated the website’s version selector to display 4.x as the current version.
  - Please review the supported-versions table when planning upgrades or requesting security assistance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->