### PR TITLE
fix: replace ReDoS-vulnerable regex with simple string checks in DefaultPrinter

### DIFF
--- a/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
+++ b/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
@@ -464,6 +464,12 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
         return out;
     }
 
+    /**
+     * Returns true if {@code value} is enclosed in matching double or single quotes.
+     * This is a simplified check (O(1)) used for value highlighting: it verifies only
+     * that the first and last characters are matching quote chars, without validating
+     * the content (e.g. embedded unescaped quotes are accepted).
+     */
     private static boolean isQuotedString(String value) {
         return value.length() >= 2
                 && ((value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"')

--- a/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
+++ b/console/src/main/java/org/jline/console/impl/DefaultPrinter.java
@@ -464,9 +464,15 @@ public class DefaultPrinter extends JlineCommandRegistry implements Printer {
         return out;
     }
 
+    private static boolean isQuotedString(String value) {
+        return value.length() >= 2
+                && ((value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"')
+                        || (value.charAt(0) == '\'' && value.charAt(value.length() - 1) == '\''));
+    }
+
     private boolean doValueHighlight(Map<String, Object> options, String value) {
         if (options.containsKey(Printer.VALUE_STYLE_ALL)
-                || value.matches("\"(\\.|[^\"])*\"|'(\\.|[^'])*'")
+                || isQuotedString(value)
                 || (value.startsWith("[") && value.endsWith("]"))
                 || (value.startsWith("(") && value.endsWith(")"))
                 || (value.startsWith("{") && value.endsWith("}"))

--- a/console/src/test/java/org/jline/console/impl/DefaultPrinterTest.java
+++ b/console/src/test/java/org/jline/console/impl/DefaultPrinterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, the original author(s).
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+package org.jline.console.impl;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for {@link DefaultPrinter}.
+ */
+class DefaultPrinterTest {
+
+    /**
+     * Verifies that {@code isQuotedString} completes in constant time, even for
+     * pathological inputs that would cause catastrophic backtracking with the
+     * old regex-based implementation.
+     *
+     * @see <a href="https://github.com/jline/jline3/pull/2249">PR #2249</a>
+     */
+    @Test
+    void isQuotedStringDoesNotBacktrack() throws Exception {
+        Method m = DefaultPrinter.class.getDeclaredMethod("isQuotedString", String.class);
+        m.setAccessible(true);
+
+        // A pathological input for the old regex "\"(\\.|[^\"])*\"|'(\\.|[^'])*'"
+        // With the regex, this causes exponential backtracking.  With the O(1)
+        // char-check it returns instantly.
+        char[] chars = new char[50_001];
+        Arrays.fill(chars, '.');
+        chars[0] = '"';
+        String pathological = new String(chars);
+
+        assertTimeoutPreemptively(Duration.ofMillis(100), () -> {
+            boolean result = (boolean) m.invoke(null, pathological);
+            // Not a valid quoted string (no closing quote)
+            assertFalse(result);
+        });
+    }
+
+    @Test
+    void isQuotedStringBasicCases() throws Exception {
+        Method m = DefaultPrinter.class.getDeclaredMethod("isQuotedString", String.class);
+        m.setAccessible(true);
+
+        // Double-quoted
+        assertTrue((boolean) m.invoke(null, "\"hello\""));
+        // Single-quoted
+        assertTrue((boolean) m.invoke(null, "'hello'"));
+        // Minimal quoted strings
+        assertTrue((boolean) m.invoke(null, "\"\""));
+        assertTrue((boolean) m.invoke(null, "''"));
+        // Not quoted
+        assertFalse((boolean) m.invoke(null, "hello"));
+        assertFalse((boolean) m.invoke(null, "\""));
+        assertFalse((boolean) m.invoke(null, "'"));
+        assertFalse((boolean) m.invoke(null, ""));
+        // Mismatched quotes
+        assertFalse((boolean) m.invoke(null, "\"hello'"));
+        assertFalse((boolean) m.invoke(null, "'hello\""));
+        // Embedded quotes (intentional relaxation — accepted by the new implementation)
+        assertTrue((boolean) m.invoke(null, "\"a\"b\""));
+    }
+}


### PR DESCRIPTION
Backport of #2247 to jline-3.x.

The regex `"(\\.|[^"])*"|'(\\.|[^'])*'` in `doValueHighlight()` is vulnerable to exponential backtracking (ReDoS) on malformed inputs.

Replace it with a simple `isQuotedString()` helper that checks if the string starts and ends with matching quote characters.