### PR TITLE
docs: make 4.x the default website version

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,7 +25,23 @@ jobs:
         with:
           node-version: 20
 
-      # Build 3.x (main site at /)
+      # Build 4.x (main site at /)
+      - name: Checkout master
+        uses: actions/checkout@v7
+        with:
+          ref: master
+          path: master
+      - name: Build 4.x website
+        working-directory: master/website
+        run: npm install && npm run build
+        env:
+          BASE_URL: /
+      - name: Copy 4.x build
+        run: |
+          mkdir -p combined-site
+          cp -r master/website/target/build/. combined-site/
+
+      # Build 3.x (at /versions/3.x/)
       - name: Checkout jline-3.x
         uses: actions/checkout@v7
         with:
@@ -35,27 +51,11 @@ jobs:
         working-directory: jline-3.x/website
         run: npm install && npm run build
         env:
-          BASE_URL: /
+          BASE_URL: /versions/3.x/
       - name: Copy 3.x build
         run: |
-          mkdir -p combined-site
-          cp -r jline-3.x/website/target/build/. combined-site/
-
-      # Build 4.0 (at /versions/4.0/)
-      - name: Checkout master
-        uses: actions/checkout@v7
-        with:
-          ref: master
-          path: master
-      - name: Build 4.0 website
-        working-directory: master/website
-        run: npm install && npm run build
-        env:
-          BASE_URL: /versions/4.0/
-      - name: Copy 4.0 build
-        run: |
-          mkdir -p combined-site/versions/4.0
-          cp -r master/website/target/build/. combined-site/versions/4.0/
+          mkdir -p combined-site/versions/3.x
+          cp -r jline-3.x/website/target/build/. combined-site/versions/3.x/
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,7 +6,7 @@ import path from 'path';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 // JLine version - update this when releasing a new version
-const jlineVersion = '4.0.0';
+const jlineVersion = '4.4.3';
 
 // Allow overriding baseUrl via environment variable for multi-version deployment
 const baseUrl = process.env.BASE_URL || '/';
@@ -103,8 +103,8 @@ const config: Config = {
           label: `v${jlineVersion}`,
           position: 'right',
           items: [
-            {label: '4.0.x (current)', href: 'https://jline.org/'},
-            {label: '3.30.x', href: 'https://jline.org/versions/3.x/'},
+            {label: '4.4.x (current)', href: 'https://jline.org/'},
+            {label: '3.30.x (legacy)', href: 'https://jline.org/versions/3.x/'},
           ],
         },
         {


### PR DESCRIPTION
The website currently serves 3.x docs at the root (`/`) and 4.x at `/versions/4.0/`. Since 4.x is the actively developed version, this swaps them:

- **4.x (master)** → served at `/` (root)
- **3.x (jline-3.x)** → served at `/versions/3.x/`

Changes:
- **`website.yml`**: swap build order so master builds at `/` and jline-3.x builds at `/versions/3.x/`
- **`docusaurus.config.ts`**: bump displayed version from `4.0.0` to `4.4.3`, update dropdown labels (`4.4.x (current)` / `3.30.x (legacy)`)

The corresponding `docusaurus.config.ts` change on `jline-3.x` (pointing the dropdown to the new paths) should be pushed separately to that branch after this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the website to feature the 4.4.x documentation as the current version.
  * Added access to 3.30.x documentation as a legacy version.

* **Bug Fixes**
  * Corrected website version routing so current and legacy documentation are served from their intended locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->