### PR TITLE
docs: update website version dropdown for 4.x as default

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,7 +25,23 @@ jobs:
         with:
           node-version: 20
 
-      # Build 3.x (main site at /)
+      # Build 4.x (main site at /)
+      - name: Checkout master
+        uses: actions/checkout@v7
+        with:
+          ref: master
+          path: master
+      - name: Build 4.x website
+        working-directory: master/website
+        run: npm install && npm run build
+        env:
+          BASE_URL: /
+      - name: Copy 4.x build
+        run: |
+          mkdir -p combined-site
+          cp -r master/website/target/build/. combined-site/
+
+      # Build 3.x (at /versions/3.x/)
       - name: Checkout jline-3.x
         uses: actions/checkout@v7
         with:
@@ -35,27 +51,11 @@ jobs:
         working-directory: jline-3.x/website
         run: npm install && npm run build
         env:
-          BASE_URL: /
+          BASE_URL: /versions/3.x/
       - name: Copy 3.x build
         run: |
-          mkdir -p combined-site
-          cp -r jline-3.x/website/target/build/* combined-site/
-
-      # Build 4.0 (at /versions/4.0/)
-      - name: Checkout master
-        uses: actions/checkout@v7
-        with:
-          ref: master
-          path: master
-      - name: Build 4.0 website
-        working-directory: master/website
-        run: npm install && npm run build
-        env:
-          BASE_URL: /versions/4.0/
-      - name: Copy 4.0 build
-        run: |
-          mkdir -p combined-site/versions/4.0
-          cp -r master/website/target/build/* combined-site/versions/4.0/
+          mkdir -p combined-site/versions/3.x
+          cp -r jline-3.x/website/target/build/. combined-site/versions/3.x/
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -103,8 +103,8 @@ const config: Config = {
           label: `v${jlineVersion}`,
           position: 'right',
           items: [
-            {label: '3.30.x', href: 'https://jline.org/'},
-            {label: '4.0.x', href: 'https://jline.org/versions/4.0/'},
+            {label: '4.4.x (current)', href: 'https://jline.org/'},
+            {label: '3.30.x', href: 'https://jline.org/versions/3.x/'},
           ],
         },
         {


### PR DESCRIPTION
Companion to #2250 (master branch).

Updates the `jline-3.x` branch to match the new website URL structure:
- **4.x** → root (`/`)
- **3.x** → `/versions/3.x/`

Changes:
- **`docusaurus.config.ts`**: version dropdown now points `4.4.x (current)` to `/` and `3.30.x` to `/versions/3.x/`
- **`website.yml`**: synced with master so both branches produce the same deployment regardless of which triggers the workflow