### PR TITLE
docs: update website for post-4.0 releases

### DIFF
--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -40,9 +40,9 @@ JLine is organized into several core components that work together to provide a 
 ┌─────────────────────────────────────────────────────────────────┐
 │                        Higher-Level APIs                        │
 │                                                                 │
-│  ┌─────────────┐  ┌─────────────┐  ┌────────────┐  ┌──────────┐ │
-│  │    Style    │  │   Builtins  │  │  Console   │  │Console UI│ │
-│  └─────────────┘  └─────────────┘  └────────────┘  └──────────┘ │
+│  ┌─────────┐  ┌──────────┐  ┌────────┐  ┌────────┐  ┌────────┐ │
+│  │  Style  │  │ Builtins │  │ Shell  │  │ Prompt │  │Console │ │
+│  └─────────┘  └──────────┘  └────────┘  └────────┘  └────────┘ │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -78,8 +78,9 @@ JLine includes several higher-level modules that provide additional functionalit
 
 - **Style**: Styling API for terminal output
 - **Builtins**: Ready-to-use commands and utilities
-- **Console**: Framework for building interactive console applications
-- **Console UI**: UI components like progress bars, tables, and forms
+- **Shell**: Modern framework for building interactive command-line applications with pipelines, aliases, and job control
+- **Prompt**: Interactive prompt components (lists, checkboxes, choices, inputs, etc.)
+- **Console**: Legacy framework for building interactive console applications; new applications should prefer Shell
 
 ## Data Flow
 
@@ -102,11 +103,15 @@ jline-reader
     ↑
 jline-style
     ↑
+jline-shell
+    ↑
 jline-builtins
     ↑
-jline-console
+jline-console-ui (legacy, prefer jline-prompt)
     ↑
-jline-console-ui
+jline-console (legacy bridge)
+
+jline-prompt (depends on jline-reader + jline-builtins)
 ```
 
 ## Key Interfaces

--- a/website/docs/contributing/version-management.md
+++ b/website/docs/contributing/version-management.md
@@ -8,7 +8,7 @@ This document explains how version numbers are managed in the JLine documentatio
 
 ## Version Placeholders
 
-The JLine documentation uses a placeholder system to ensure that version numbers are consistent throughout the documentation. Instead of hardcoding version numbers, we use the placeholder `4.0.0` which is automatically replaced with the actual version during the build process.
+The JLine documentation uses a placeholder system to ensure that version numbers are consistent throughout the documentation. Instead of hardcoding version numbers, we use the placeholder `%%JLINE_VERSION%%` which is automatically replaced with the actual version during the build process.
 
 ### How It Works
 
@@ -19,17 +19,17 @@ The JLine documentation uses a placeholder system to ensure that version numbers
 const jlineVersion = '...';
 ```
 
-2. During the build process, all instances of `4.0.0` in the documentation files are replaced with the actual version.
+2. During the build process, all instances of `%%JLINE_VERSION%%` in the documentation files are replaced with the actual version.
 
 ## Using Version Placeholders
 
-When adding version numbers to the documentation, use the `4.0.0` placeholder instead of hardcoding the version:
+When adding version numbers to the documentation, use the `%%JLINE_VERSION%%` placeholder instead of hardcoding the version:
 
 ```xml
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 ```
 
@@ -57,7 +57,7 @@ When releasing a new version of JLine, update the version in `docusaurus.config.
 
 ```javascript
 // JLine version - update this when releasing a new version
-const jlineVersion = '4.0.0'; // Updated version
+const jlineVersion = '4.4.3'; // Updated version
 ```
 
 The build process will automatically use the new version when replacing the placeholders.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -30,7 +30,7 @@ JLine 4.x requires **Java 11 or higher** as the minimum runtime version.
 
 :::note Version Requirements
 - **JLine 3.x**: Supports Java 8+, Maven 3.x+
-- **JLine 4.x**: Requires Java 11+, Maven 4.0+
+- **JLine 4.x**: Requires Java 11+, Maven 3.9+
 :::
 
 ## Installation
@@ -43,7 +43,7 @@ Add JLine to your project using Maven:
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 ```
 
@@ -52,7 +52,7 @@ Add JLine to your project using Maven:
 Or if you're using Gradle:
 
 ```groovy
-implementation 'org.jline:jline:4.0.0'
+implementation 'org.jline:jline:%%JLINE_VERSION%%'
 ```
 
 ### Java 11-21 Compatibility (JDK11 Classifier)
@@ -69,7 +69,7 @@ Note: JLine 4.x requires Java 11+ as the minimum runtime version. For Java 8 sup
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
     <classifier>jdk11</classifier>
 </dependency>
 ```
@@ -77,7 +77,7 @@ Note: JLine 4.x requires Java 11+ as the minimum runtime version. For Java 8 sup
 **Gradle:**
 
 ```groovy
-implementation 'org.jline:jline:4.0.0:jdk11'
+implementation 'org.jline:jline:%%JLINE_VERSION%%:jdk11'
 ```
 
 The `jdk11` classifier artifact:

--- a/website/docs/modules/jpms.md
+++ b/website/docs/modules/jpms.md
@@ -181,19 +181,19 @@ When using Maven or Gradle, you can depend on individual modules:
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-terminal</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-reader</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 ```
 
 #### Gradle
 ```groovy
-implementation 'org.jline:jline-terminal:4.0.0'
-implementation 'org.jline:jline-reader:4.0.0'
+implementation 'org.jline:jline-terminal:%%JLINE_VERSION%%'
+implementation 'org.jline:jline-reader:%%JLINE_VERSION%%'
 ```
 
 ## Migration from JLine 3.x
@@ -222,17 +222,17 @@ When migrating from JLine 3.x to 4.x in a modular application:
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-terminal</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-reader</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-terminal-jni</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 ```
 

--- a/website/docs/modules/overview.md
+++ b/website/docs/modules/overview.md
@@ -108,20 +108,20 @@ To use these modules in your Maven project, add the appropriate dependencies:
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 
 <!-- Or individual modules -->
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-builtins</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-style</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 
 <dependency>
@@ -133,13 +133,13 @@ To use these modules in your Maven project, add the appropriate dependencies:
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-console</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-console-ui</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 ```
 

--- a/website/docs/modules/terminal-providers.md
+++ b/website/docs/modules/terminal-providers.md
@@ -59,7 +59,7 @@ If you're building your project with Java 11-21 and want to avoid Java 22 class 
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
     <classifier>jdk11</classifier>
 </dependency>
 ```
@@ -67,7 +67,7 @@ If you're building your project with Java 11-21 and want to avoid Java 22 class 
 **Gradle:**
 
 ```groovy
-implementation 'org.jline:jline:4.0.0:jdk11'
+implementation 'org.jline:jline:%%JLINE_VERSION%%:jdk11'
 ```
 
 The `jdk11` classifier artifact:

--- a/website/docs/reference/diagnostic.md
+++ b/website/docs/reference/diagnostic.md
@@ -11,7 +11,7 @@ When troubleshooting issues with JLine, especially when dealing with system term
 JLine provides a built-in diagnostic tool that can help identify issues with terminal detection and configuration. To run the JLine diagnostic tool, use the following command:
 
 ```bash
-java -cp jline-4.0.0.jar org.jline.terminal.impl.Diag
+java -cp jline-%%JLINE_VERSION%%.jar org.jline.terminal.impl.Diag
 ```
 
 This will output a full diagnosis for JLine. You may want to add some dependencies if you want specific providers to be loaded.

--- a/website/docs/remote-terminals.md
+++ b/website/docs/remote-terminals.md
@@ -33,7 +33,7 @@ import VersionDisplay from '@site/src/components/VersionDisplay';
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-remote-telnet</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 ```
 
@@ -91,7 +91,7 @@ To use the SSH support, add the following dependency to your project:
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline-remote-ssh</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
 </dependency>
 ```
 

--- a/website/docs/terminal.md
+++ b/website/docs/terminal.md
@@ -38,7 +38,7 @@ Terminal terminal = TerminalBuilder.builder()
                     .build();
 ```
 
-The `TerminalBuilder` will figure out the current Operating System and which actual `Terminal` implementation to use. Note that on the Windows platform you need to have either Jansi or JNA library in your classpath.
+The `TerminalBuilder` will figure out the current Operating System and which actual `Terminal` implementation to use. On Windows, JLine uses the JNI or FFM providers for native terminal access (see [Terminal Providers](./modules/terminal-providers.md)).
 
 <CodeSnippet name="TerminalCreationExample" />
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -32,7 +32,7 @@ The standard `jline` bundle includes the FFM terminal provider which is compiled
 <dependency>
     <groupId>org.jline</groupId>
     <artifactId>jline</artifactId>
-    <version>4.0.0</version>
+    <version>%%JLINE_VERSION%%</version>
     <classifier>jdk11</classifier>
 </dependency>
 ```
@@ -40,7 +40,7 @@ The standard `jline` bundle includes the FFM terminal provider which is compiled
 **Gradle:**
 
 ```groovy
-implementation 'org.jline:jline:4.0.0:jdk11'
+implementation 'org.jline:jline:%%JLINE_VERSION%%:jdk11'
 ```
 
 The `jdk11` classifier artifact excludes the FFM terminal provider and is compatible with Java 11-21. You'll still have full JLine functionality using the JNI or Exec terminal providers instead.
@@ -129,14 +129,14 @@ This error occurs when JLine cannot initialize a terminal for the current enviro
    <dependency>
        <groupId>org.jline</groupId>
        <artifactId>jline-terminal-jni</artifactId>
-       <version>4.0.0</version>
+       <version>%%JLINE_VERSION%%</version>
    </dependency>
 
    <!-- For FFM support (recommended for Java 22+) -->
    <dependency>
        <groupId>org.jline</groupId>
        <artifactId>jline-terminal-ffm</artifactId>
-       <version>4.0.0</version>
+       <version>%%JLINE_VERSION%%</version>
    </dependency>
    ```
 

--- a/website/docs/whats-new.md
+++ b/website/docs/whats-new.md
@@ -140,7 +140,7 @@ Still functional but superseded by the [Prompt Module](./modules/prompt.md), whi
    <dependency>
        <groupId>org.jline</groupId>
        <artifactId>jline</artifactId>
-       <version>4.0.0</version>
+       <version>%%JLINE_VERSION%%</version>
    </dependency>
    ```
    Use `<classifier>jdk11</classifier>` if targeting Java 11-21.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,7 +6,7 @@ import path from 'path';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 // JLine version - update this when releasing a new version
-const jlineVersion = '4.0.0';
+const jlineVersion = '4.4.3';
 
 // Allow overriding baseUrl via environment variable for multi-version deployment
 const baseUrl = process.env.BASE_URL || '/';
@@ -103,7 +103,7 @@ const config: Config = {
           label: `v${jlineVersion}`,
           position: 'right',
           items: [
-            {label: '4.0.x (current)', href: 'https://jline.org/'},
+            {label: '4.x (current)', href: 'https://jline.org/'},
             {label: '3.30.x', href: 'https://jline.org/versions/3.x/'},
           ],
         },

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -35,6 +35,7 @@ const sidebars: SidebarsConfig = {
       label: 'Contributing',
       items: [
         'contributing/code-snippets',
+        'contributing/version-management',
       ],
     },
     {
@@ -57,6 +58,9 @@ const sidebars: SidebarsConfig = {
         'advanced/auto-indentation-pairing',
         'advanced/theme-system',
         'advanced/nano-less-customization',
+        'advanced/grapheme-cluster-mode',
+        'advanced/unicode-support',
+        'advanced/classpath-resources',
         'advanced/web-swing-terminals',
       ],
     },
@@ -66,6 +70,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'shell-getting-started',
         'shell-commands',
+        'shell-features',
         'shell-picocli',
         'shell-migration',
       ],
@@ -80,6 +85,8 @@ const sidebars: SidebarsConfig = {
         'modules/style',
         'modules/terminal-providers',
         'modules/jpms',
+        'modules/prompt',
+        'modules/console-ui',
         'modules/repl-console',
       ],
     },


### PR DESCRIPTION
The website content has been largely frozen since the 4.0.0 release. This PR brings it up to date.

## Changes

### Version references
- Update `jlineVersion` from `4.0.0` to `4.4.3` in `docusaurus.config.ts`
- Replace all hardcoded `4.0.0` version strings with `%%JLINE_VERSION%%` placeholders across docs (intro, remote-terminals, troubleshooting, modules/overview, modules/jpms, modules/terminal-providers, reference/diagnostic, whats-new)
- Fix version dropdown label from `4.0.x (current)` to `4.x (current)`

### Content fixes
- Fix incorrect Maven version requirement: `Maven 4.0+` → `Maven 3.9+` in intro.md
- Fix outdated Jansi/JNA reference in terminal.md — replaced with JNI/FFM provider reference
- Update architecture diagram and descriptions to include Shell and Prompt modules, mark Console/Console-UI as legacy/deprecated

### Navigation (sidebar)
Add pages that existed but were not linked in the sidebar:
- `modules/prompt` and `modules/console-ui` in Modules
- `shell-features` in Shell
- `advanced/grapheme-cluster-mode`, `advanced/unicode-support`, `advanced/classpath-resources` in Advanced Features
- `contributing/version-management` in Contributing

### Contributing docs
- Fix `version-management.md` to document the actual `%%JLINE_VERSION%%` placeholder syntax instead of the misleading claim that `4.0.0` was the placeholder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated architecture diagrams and descriptions to include Shell and Prompt modules.
  - Clarified that Console and Console UI are legacy, with newer alternatives preferred.
  - Replaced fixed dependency versions with a reusable version placeholder across examples.
  - Updated Maven requirements and Windows terminal provider guidance.
  - Updated documented version information to 4.4.3 and generalized the version label.
- **Navigation**
  - Added documentation links for advanced features, shell features, prompt, console UI, and version management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->